### PR TITLE
Adds missing charts and typo fix

### DIFF
--- a/front-end-components/src/components/school-expenditure/educational-supplies.tsx
+++ b/front-end-components/src/components/school-expenditure/educational-supplies.tsx
@@ -14,6 +14,22 @@ const EducationalSupplies: React.FC<EducationalSuppliesProps> = ({schools}) => {
 
     const chartDimensions = {dimensions: CostCategories, handleChange: handleSelectChange}
 
+    const totalEducationalSuppliesBarData: ChartWrapperData = {
+        dataPoints: schools.map(school => {
+            return {
+                school: school.name,
+                urn: school.urn,
+                value: CalculateCostValue({
+                    dimension: dimension,
+                    value: school.totalEducationalSuppliesCosts,
+                    ...school
+                }),
+                additionalData: [school.localAuthority, school.schoolType, school.numberOfPupils]
+            }
+        }),
+        tableHeadings: tableHeadings
+    }
+
     const examinationFeesBarData: ChartWrapperData = {
         dataPoints: schools.map(school => {
             return {
@@ -74,10 +90,14 @@ const EducationalSupplies: React.FC<EducationalSuppliesProps> = ({schools}) => {
                 </div>
                 <div id="accordion-content-educational-supplies" className="govuk-accordion__section-content"
                      aria-labelledby="accordion-heading-educational-supplies">
+                    <ChartWrapper heading={<h3 className="govuk-heading-s">Total educational supplies costs</h3>}
+                                  data={totalEducationalSuppliesBarData}
+                                  elementId="total-educational-supplies-costs"
+                                  chartDimensions={chartDimensions}
+                    />
                     <ChartWrapper heading={<h3 className="govuk-heading-s">Examination fees costs</h3>}
                                   data={examinationFeesBarData}
                                   elementId="examination-fees-costs"
-                                  chartDimensions={chartDimensions}
                     />
                     <ChartWrapper heading={<h3 className="govuk-heading-s">Breakdown of educational supplies costs</h3>}
                                   data={breakdownEducationalBarData}
@@ -108,6 +128,7 @@ export type EducationalSuppliesData = {
     totalIncome: number
     totalExpenditure: number
     numberOfPupils: bigint
+    totalEducationalSuppliesCosts: number
     examinationFeesCosts: number
     breakdownEducationalSuppliesCosts: number
     learningResourcesNonIctCosts: number

--- a/front-end-components/src/components/school-expenditure/non-educational-support-staff.tsx
+++ b/front-end-components/src/components/school-expenditure/non-educational-support-staff.tsx
@@ -30,6 +30,23 @@ const NonEducationalSupportStaff: React.FC<NonEducationalSupportStaffProps> = ({
         tableHeadings: tableHeadings
     }
 
+
+    const totalNonEducationalBarData: ChartWrapperData = {
+        dataPoints: schools.map(school => {
+            return {
+                school: school.name,
+                urn: school.urn,
+                value: CalculateCostValue({
+                    dimension: dimension,
+                    value: school.totalNonEducationalSupportStaffCosts,
+                    ...school
+                }),
+                additionalData: [school.localAuthority, school.schoolType, school.numberOfPupils]
+            }
+        }),
+        tableHeadings: tableHeadings
+    }
+
     const auditorsCostsBarData: ChartWrapperData = {
         dataPoints: schools.map(school => {
             return {
@@ -92,10 +109,14 @@ const NonEducationalSupportStaff: React.FC<NonEducationalSupportStaffProps> = ({
                 <div id="accordion-content-non-educational-support-staff"
                      className="govuk-accordion__section-content"
                      aria-labelledby="accordion-heading-non-educational-support-staff">
+                    <ChartWrapper heading={<h3 className="govuk-heading-s">Total non-educational support staff costs</h3>}
+                                  data={totalNonEducationalBarData}
+                                  elementId="total-non-educational-support-staff-costs"
+                                  chartDimensions={chartDimensions}
+                    />
                     <ChartWrapper heading={<h3 className="govuk-heading-s">Administrative and clerical staff costs</h3>}
                                   data={administrativeClericalBarData}
                                   elementId="administrative-clerical-staff-costs"
-                                  chartDimensions={chartDimensions}
                     />
                     <ChartWrapper heading={<h3 className="govuk-heading-s">Auditors costs</h3>}
                                   data={auditorsCostsBarData}
@@ -130,6 +151,7 @@ export type NonEducationalSupportStaffData = {
     totalIncome: number
     totalExpenditure: number
     numberOfPupils: bigint
+    totalNonEducationalSupportStaffCosts: number
     administrativeClericalStaffCosts: number
     auditorsCosts: number
     otherStaffCosts: number

--- a/front-end-components/src/components/school-expenditure/other-costs.tsx
+++ b/front-end-components/src/components/school-expenditure/other-costs.tsx
@@ -255,9 +255,9 @@ const OtherCosts: React.FC<OtherCostsProps> = ({schools}) => {
                                   elementId="total-otehr-costs"
                                   chartDimensions={chartDimensions}
                     />
-                    <ChartWrapper heading={<h3 className="govuk-heading-s">Other insurance costs</h3>}
+                    <ChartWrapper heading={<h3 className="govuk-heading-s">Other insurance premiums costs</h3>}
                                   data={otherInsurancePremiumsCostsBarData}
-                                  elementId="other-insurance-costs"
+                                  elementId="other-insurance-premiums-costs"
                     />
                     <ChartWrapper heading={<h3 className="govuk-heading-s">Direct revenue financing costs</h3>}
                                   data={directRevenueFinancingCostsBarData}
@@ -275,9 +275,9 @@ const OtherCosts: React.FC<OtherCostsProps> = ({schools}) => {
                                   data={interestChargesLoanBankBarData}
                                   elementId="interest-charges-loan-bank"
                     />
-                    <ChartWrapper heading={<h3 className="govuk-heading-s">PFI costs</h3>}
+                    <ChartWrapper heading={<h3 className="govuk-heading-s">PFI charges</h3>}
                                   data={privateFinanceInitiativeChargesBarData}
-                                  elementId="pfi-costs"
+                                  elementId="pfi-charges"
                     />
                     <ChartWrapper heading={<h3 className="govuk-heading-s">Rent and rates costs</h3>}
                                   data={rentRatesCostsBarData}

--- a/front-end-components/src/components/school-expenditure/premises-staff-services.tsx
+++ b/front-end-components/src/components/school-expenditure/premises-staff-services.tsx
@@ -19,6 +19,22 @@ const PremisesStaffServices: React.FC<PremisesStaffServicesProps> = ({schools}) 
 
     const chartDimensions = {dimensions: PremisesCategories, handleChange: handleSelectChange}
 
+    const totalPremisesStaffServiceCostsBarData: ChartWrapperData = {
+        dataPoints: schools.map(school => {
+            return {
+                school: school.name,
+                urn: school.urn,
+                value: CalculatePremisesValue({
+                    dimension: dimension,
+                    value: school.totalPremisesStaffServiceCosts,
+                    ...school
+                }),
+                additionalData: [school.localAuthority, school.schoolType, school.numberOfPupils]
+            }
+        }),
+        tableHeadings: tableHeadings
+    }
+
     const cleaningCaretakingBarData: ChartWrapperData = {
         dataPoints: schools.map(school => {
             return {
@@ -96,10 +112,14 @@ const PremisesStaffServices: React.FC<PremisesStaffServicesProps> = ({schools}) 
                 </div>
                 <div id="accordion-content-premises-staff-services" className="govuk-accordion__section-content"
                      aria-labelledby="accordion-heading-premises-staff-services">
+                    <ChartWrapper heading={<h3 className="govuk-heading-s">Total premises staff and service costs</h3>}
+                                  data={totalPremisesStaffServiceCostsBarData}
+                                  elementId="total-premises-staff-service-costs"
+                                  chartDimensions={chartDimensions}
+                    />
                     <ChartWrapper heading={<h3 className="govuk-heading-s">Cleaning and caretaking costs</h3>}
                                   data={cleaningCaretakingBarData}
                                   elementId="cleaning-caretaking-costs"
-                                  chartDimensions={chartDimensions}
                     />
                     <ChartWrapper heading={<h3 className="govuk-heading-s">Maintenance of premises costs</h3>}
                                   data={maintenanceBarData}
@@ -133,6 +153,7 @@ export type PremisesStaffServicesData = {
     totalIncome: number
     totalExpenditure: number
     numberOfPupils: bigint
+    totalPremisesStaffServiceCosts: number
     cleaningCaretakingCosts: number
     maintenancePremisesCosts: number
     otherOccupationCosts: number

--- a/front-end-components/src/services/school-api.tsx
+++ b/front-end-components/src/services/school-api.tsx
@@ -54,9 +54,11 @@ export type SchoolExpenditure = {
     incomeCatering: number
     administrativeSuppliesCosts: number
     learningResourcesIctCosts: number
+    totalEducationalSuppliesCosts: number
     examinationFeesCosts: number
     breakdownEducationalSuppliesCosts: number
     learningResourcesNonIctCosts: number
+    totalNonEducationalSupportStaffCosts: number
     administrativeClericalStaffCosts: number
     auditorsCosts: number
     otherStaffCosts: number

--- a/front-end-components/src/services/school-api.tsx
+++ b/front-end-components/src/services/school-api.tsx
@@ -63,6 +63,7 @@ export type SchoolExpenditure = {
     auditorsCosts: number
     otherStaffCosts: number
     professionalServicesNonCurriculumCosts: number
+    totalPremisesStaffServiceCosts: number
     cleaningCaretakingCosts: number
     maintenancePremisesCosts: number
     otherOccupationCosts: number

--- a/platform/src/apis/EducationBenchmarking.Platform.Api.Insight/Models/PagedSchoolExpenditure.cs
+++ b/platform/src/apis/EducationBenchmarking.Platform.Api.Insight/Models/PagedSchoolExpenditure.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using EducationBenchmarking.Platform.Infrastructure.Cosmos;
+using System.Linq;
 using EducationBenchmarking.Platform.Shared;
 
 namespace EducationBenchmarking.Platform.Api.Insight.Models;
@@ -11,65 +11,7 @@ public class PagedSchoolExpenditure : PagedResults<SchoolExpenditure>
     public static PagedSchoolExpenditure Create(IEnumerable<SchoolTrustFinancialDataObject> results, int page,
         int pageSize)
     {
-        var schools = new List<SchoolExpenditure>();
-
-        foreach (var result in results)
-        {
-            schools.Add(new SchoolExpenditure
-            {
-                Urn = result.URN.ToString(),
-                Name = result.SchoolName,
-                SchoolType = result.Type,
-                LocalAuthority = result.LA.ToString(),
-                NumberOfPupils = result.NoPupils,
-                TotalExpenditure = result.TotalExpenditure,
-                TotalIncome = result.TotalIncome,
-                TotalTeachingSupportStaffCosts = result.TeachingStaff + result.SupplyTeachingStaff +
-                                                 result.EducationalConsultancy + result.EducationSupportStaff +
-                                                 result.AgencyTeachingStaff,
-                TeachingStaffCosts = result.TeachingStaff,
-                SupplyTeachingStaffCosts = result.SupplyTeachingStaff,
-                EducationalConsultancyCosts = result.EducationalConsultancy,
-                EducationSupportStaffCosts = result.EducationSupportStaff,
-                AgencySupplyTeachingStaffCosts = result.AgencyTeachingStaff,
-                NetCateringCosts = result.CateringExp,
-                CateringStaffCosts = result.CateringStaff,
-                CateringSuppliesCosts = result.CateringSupplies,
-                IncomeCatering = result.IncomeFromCatering,
-                AdministrativeSuppliesCosts = result.AdministrativeSupplies,
-                LearningResourcesIctCosts = result.ICTLearningResources,
-                ExaminationFeesCosts = result.ExaminationFees,
-                BreakdownEducationalSuppliesCosts = result.EducationalSupplies,
-                LearningResourcesNonIctCosts = result.LearningResources,
-                AdministrativeClericalStaffCosts = result.AdministrativeClericalStaff,
-                AuditorsCosts = result.AuditorCosts,
-                OtherStaffCosts = result.OtherStaffCosts,
-                ProfessionalServicesNonCurriculumCosts = result.BroughtProfessionalServices,
-                CleaningCaretakingCosts = result.CleaningCaretaking,
-                MaintenancePremisesCosts = result.Premises,
-                OtherOccupationCosts = result.OtherOccupationCosts,
-                PremisesStaffCosts = result.PremisesStaff,
-                TotalOtherCosts = result.OtherInsurancePremiums + result.DirectRevenue +
-                                  result.BuildingGroundsMaintenance + result.IndirectEmployeeExpenses +
-                                  result.InterestCharges + result.PFICharges + result.RentRates +
-                                  result.Specialfacilities + result.StaffDevelopment + result.StaffInsurance +
-                                  result.SupplyTeacherInsurance + result.CommunityFocusedStaff +
-                                  result.CommunityFocusedSchoolCosts,
-                OtherInsurancePremiumsCosts = result.OtherInsurancePremiums,
-                DirectRevenueFinancingCosts = result.DirectRevenue,
-                GroundsMaintenanceCosts = result.BuildingGroundsMaintenance,
-                IndirectEmployeeExpenses = result.IndirectEmployeeExpenses,
-                InterestChargesLoanBank = result.InterestCharges,
-                PrivateFinanceInitiativeCharges = result.PFICharges,
-                RentRatesCosts = result.RentRates,
-                SpecialFacilitiesCosts = result.Specialfacilities,
-                StaffDevelopmentTrainingCosts = result.StaffDevelopment,
-                StaffRelatedInsuranceCosts = result.StaffInsurance,
-                SupplyTeacherInsurableCosts = result.SupplyTeacherInsurance,
-                CommunityFocusedSchoolStaff = result.CommunityFocusedStaff,
-                CommunityFocusedSchoolCosts = result.CommunityFocusedSchoolCosts
-            });
-        }
+        var schools = results.Select(SchoolExpenditure.Create).ToList();
 
         return new PagedSchoolExpenditure
         {

--- a/platform/src/apis/EducationBenchmarking.Platform.Api.Insight/Models/SchoolExpenditure.cs
+++ b/platform/src/apis/EducationBenchmarking.Platform.Api.Insight/Models/SchoolExpenditure.cs
@@ -44,6 +44,8 @@ public class SchoolExpenditure
     public decimal OtherStaffCosts { get; set; }
     public decimal ProfessionalServicesNonCurriculumCosts { get; set; }
 
+    
+    public decimal TotalPremisesStaffServiceCosts { get; set; }
     public decimal CleaningCaretakingCosts { get; set; }
     public decimal MaintenancePremisesCosts { get; set; }
     public decimal OtherOccupationCosts { get; set; }
@@ -104,6 +106,8 @@ public class SchoolExpenditure
             AuditorsCosts = dataObject.AuditorCosts,
             OtherStaffCosts = dataObject.OtherStaffCosts,
             ProfessionalServicesNonCurriculumCosts = dataObject.BroughtProfessionalServices,
+            TotalPremisesStaffServiceCosts = dataObject.CleaningCaretaking + dataObject.PremisesStaff + 
+                                             dataObject.OtherOccupationCosts + dataObject.PremisesStaff, 
             CleaningCaretakingCosts = dataObject.CleaningCaretaking,
             MaintenancePremisesCosts = dataObject.Premises,
             OtherOccupationCosts = dataObject.OtherOccupationCosts,

--- a/platform/src/apis/EducationBenchmarking.Platform.Api.Insight/Models/SchoolExpenditure.cs
+++ b/platform/src/apis/EducationBenchmarking.Platform.Api.Insight/Models/SchoolExpenditure.cs
@@ -1,7 +1,5 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using EducationBenchmarking.Platform.Infrastructure.Cosmos;
+using EducationBenchmarking.Platform.Shared;
 
 namespace EducationBenchmarking.Platform.Api.Insight.Models;
 
@@ -12,41 +10,45 @@ public class SchoolExpenditure
     public string Name { get; set; }
     public string SchoolType { get; set; }
     public string LocalAuthority { get; set; }
-    
+
     public decimal TotalExpenditure { get; set; }
     public decimal NumberOfPupils { get; set; }
     public decimal TotalIncome { get; set; }
-    
+
     public decimal TotalTeachingSupportStaffCosts { get; set; }
-    public decimal TeachingStaffCosts { get; set; } 
-    public decimal SupplyTeachingStaffCosts { get; set; } 
-    public decimal EducationalConsultancyCosts { get; set; } 
-    public decimal EducationSupportStaffCosts { get; set; } 
+    public decimal TeachingStaffCosts { get; set; }
+    public decimal SupplyTeachingStaffCosts { get; set; }
+    public decimal EducationalConsultancyCosts { get; set; }
+    public decimal EducationSupportStaffCosts { get; set; }
     public decimal AgencySupplyTeachingStaffCosts { get; set; }
-    
+
     public decimal NetCateringCosts { get; set; }
     public decimal CateringStaffCosts { get; set; }
     public decimal CateringSuppliesCosts { get; set; }
     public decimal IncomeCatering { get; set; }
-    
+
     public decimal AdministrativeSuppliesCosts { get; set; }
-    
+
     public decimal LearningResourcesIctCosts { get; set; }
     
+
+    public decimal TotalEducationalSuppliesCosts { get; set; }
     public decimal ExaminationFeesCosts { get; set; }
     public decimal BreakdownEducationalSuppliesCosts { get; set; }
     public decimal LearningResourcesNonIctCosts { get; set; }
-    
+
+
+    public decimal TotalNonEducationalSupportStaffCosts { get; set; }
     public decimal AdministrativeClericalStaffCosts { get; set; }
     public decimal AuditorsCosts { get; set; }
     public decimal OtherStaffCosts { get; set; }
     public decimal ProfessionalServicesNonCurriculumCosts { get; set; }
-    
+
     public decimal CleaningCaretakingCosts { get; set; }
     public decimal MaintenancePremisesCosts { get; set; }
     public decimal OtherOccupationCosts { get; set; }
     public decimal PremisesStaffCosts { get; set; }
-    
+
     public decimal TotalOtherCosts { get; set; }
     public decimal OtherInsurancePremiumsCosts { get; set; }
     public decimal DirectRevenueFinancingCosts { get; set; }
@@ -65,6 +67,66 @@ public class SchoolExpenditure
 //     public decimal? TotalUtilitiesCostPerMetreSq { get; set; }
 //     public decimal? EnergyCostPerMetreSq { get; set; }
 //     public decimal? WaterSewerageCostsPerMetreSq { get; set; }
+
+    public static SchoolExpenditure Create(SchoolTrustFinancialDataObject dataObject)
+    {
+        return new SchoolExpenditure
+        {
+            Urn = dataObject.URN.ToString(),
+            Name = dataObject.SchoolName,
+            SchoolType = dataObject.Type,
+            LocalAuthority = dataObject.LA.ToString(),
+            NumberOfPupils = dataObject.NoPupils,
+            TotalExpenditure = dataObject.TotalExpenditure,
+            TotalIncome = dataObject.TotalIncome,
+            TotalTeachingSupportStaffCosts = dataObject.TeachingStaff + dataObject.SupplyTeachingStaff +
+                                             dataObject.EducationalConsultancy + dataObject.EducationSupportStaff +
+                                             dataObject.AgencyTeachingStaff,
+            TeachingStaffCosts = dataObject.TeachingStaff,
+            SupplyTeachingStaffCosts = dataObject.SupplyTeachingStaff,
+            EducationalConsultancyCosts = dataObject.EducationalConsultancy,
+            EducationSupportStaffCosts = dataObject.EducationSupportStaff,
+            AgencySupplyTeachingStaffCosts = dataObject.AgencyTeachingStaff,
+            NetCateringCosts = dataObject.CateringExp,
+            CateringStaffCosts = dataObject.CateringStaff,
+            CateringSuppliesCosts = dataObject.CateringSupplies,
+            IncomeCatering = dataObject.IncomeFromCatering,
+            AdministrativeSuppliesCosts = dataObject.AdministrativeSupplies,
+            LearningResourcesIctCosts = dataObject.ICTLearningResources,
+            TotalEducationalSuppliesCosts = dataObject.ExaminationFees + dataObject.EducationalSupplies + 
+                                            dataObject.LearningResources,
+            ExaminationFeesCosts = dataObject.ExaminationFees,
+            BreakdownEducationalSuppliesCosts = dataObject.EducationalSupplies,
+            LearningResourcesNonIctCosts = dataObject.LearningResources,
+            TotalNonEducationalSupportStaffCosts = dataObject.AdministrativeClericalStaff + dataObject.AuditorCosts +
+                                                   dataObject.OtherStaffCosts + dataObject.BroughtProfessionalServices,
+            AdministrativeClericalStaffCosts = dataObject.AdministrativeClericalStaff,
+            AuditorsCosts = dataObject.AuditorCosts,
+            OtherStaffCosts = dataObject.OtherStaffCosts,
+            ProfessionalServicesNonCurriculumCosts = dataObject.BroughtProfessionalServices,
+            CleaningCaretakingCosts = dataObject.CleaningCaretaking,
+            MaintenancePremisesCosts = dataObject.Premises,
+            OtherOccupationCosts = dataObject.OtherOccupationCosts,
+            PremisesStaffCosts = dataObject.PremisesStaff,
+            TotalOtherCosts = dataObject.OtherInsurancePremiums + dataObject.DirectRevenue +
+                              dataObject.BuildingGroundsMaintenance + dataObject.IndirectEmployeeExpenses +
+                              dataObject.InterestCharges + dataObject.PFICharges + dataObject.RentRates +
+                              dataObject.Specialfacilities + dataObject.StaffDevelopment + dataObject.StaffInsurance +
+                              dataObject.SupplyTeacherInsurance + dataObject.CommunityFocusedStaff +
+                              dataObject.CommunityFocusedSchoolCosts,
+            OtherInsurancePremiumsCosts = dataObject.OtherInsurancePremiums,
+            DirectRevenueFinancingCosts = dataObject.DirectRevenue,
+            GroundsMaintenanceCosts = dataObject.BuildingGroundsMaintenance,
+            IndirectEmployeeExpenses = dataObject.IndirectEmployeeExpenses,
+            InterestChargesLoanBank = dataObject.InterestCharges,
+            PrivateFinanceInitiativeCharges = dataObject.PFICharges,
+            RentRatesCosts = dataObject.RentRates,
+            SpecialFacilitiesCosts = dataObject.Specialfacilities,
+            StaffDevelopmentTrainingCosts = dataObject.StaffDevelopment,
+            StaffRelatedInsuranceCosts = dataObject.StaffInsurance,
+            SupplyTeacherInsurableCosts = dataObject.SupplyTeacherInsurance,
+            CommunityFocusedSchoolStaff = dataObject.CommunityFocusedStaff,
+            CommunityFocusedSchoolCosts = dataObject.CommunityFocusedSchoolCosts
+        };
+    }
 }
-
-

--- a/web/src/EducationBenchmarking.Web/Domain/SchoolExpenditure.cs
+++ b/web/src/EducationBenchmarking.Web/Domain/SchoolExpenditure.cs
@@ -27,10 +27,12 @@ public record SchoolExpenditure
     
     public decimal LearningResourcesIctCosts { get; set; }
     
+    public decimal TotalEducationalSuppliesCosts { get; set; }
     public decimal ExaminationFeesCosts { get; set; }
     public decimal BreakdownEducationalSuppliesCosts { get; set; }
     public decimal LearningResourcesNonIctCosts { get; set; }
     
+    public decimal TotalNonEducationalSupportStaffCosts { get; set; }    
     public decimal AdministrativeClericalStaffCosts { get; set; }
     public decimal AuditorsCosts { get; set; }
     public decimal OtherStaffCosts { get; set; }

--- a/web/src/EducationBenchmarking.Web/Domain/SchoolExpenditure.cs
+++ b/web/src/EducationBenchmarking.Web/Domain/SchoolExpenditure.cs
@@ -38,6 +38,7 @@ public record SchoolExpenditure
     public decimal OtherStaffCosts { get; set; }
     public decimal ProfessionalServicesNonCurriculumCosts { get; set; }
     
+    public decimal TotalPremisesStaffServiceCosts { get; set; }
     public decimal CleaningCaretakingCosts { get; set; }
     public decimal MaintenancePremisesCosts { get; set; }
     public decimal OtherOccupationCosts { get; set; }


### PR DESCRIPTION
Adds missing chart and fixes typo on heading.

1. Total educational supplies costs
2. Total non-educational support staff costs
3. Total premises staff and service costs table/chart