### PR TITLE
Fixed AzureRm provider to version 3.87

### DIFF
--- a/core-infrastructure/terraform/provider.tf
+++ b/core-infrastructure/terraform/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.32"
+      version = "= 3.87.0"
     }
   }
   backend "azurerm" {}

--- a/platform/terraform/provider.tf
+++ b/platform/terraform/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.32"
+      version = "= 3.87.0"
     }
   }
   backend "azurerm" {}

--- a/web/terraform/provider.tf
+++ b/web/terraform/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.32"
+      version = "= 3.87.0"
     }
   }
   backend "azurerm" {}


### PR DESCRIPTION
Fixed AzureRm provider to version 3.87 as a bug has been introduced in v3.88 that causes validation fails due to camel casing. There is an open bug report with terraform so this should be a temporary fix