### PR TITLE
chore: switch core pipeline to use ubuntu-latest

### DIFF
--- a/core-infrastructure/pipelines/build.yaml
+++ b/core-infrastructure/pipelines/build.yaml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: 'windows-2022'
+  vmImage: 'ubuntu-latest'
 
 trigger:
   batch: true


### PR DESCRIPTION
Switch core pipeline to use ubuntu-latest