### PR TITLE
fix: workforce headcount per FTE

### DIFF
--- a/front-end-components/src/components/chart-dimensions/index.tsx
+++ b/front-end-components/src/components/chart-dimensions/index.tsx
@@ -89,7 +89,7 @@ export function CalculateWorkforceValue(
     case Total:
       return workforceValue.value;
     case HeadcountPerFTE:
-      return workforceValue.schoolWorkforceFTE / workforceValue.value;
+      return workforceValue.schoolWorkforceHeadcount / workforceValue.value;
     case PercentageOfWorkforce:
       return (workforceValue.value / workforceValue.schoolWorkforceFTE) * 100;
     case PupilsPerStaffRole:

--- a/front-end-components/src/components/chart-dimensions/types.tsx
+++ b/front-end-components/src/components/chart-dimensions/types.tsx
@@ -20,6 +20,7 @@ export type WorkforceValue = {
   schoolWorkforceFTE: number;
   numberOfPupils: bigint;
   value: number;
+  schoolWorkforceHeadcount: number;
 };
 
 export type ChartDimensionsProps = {

--- a/front-end-components/src/views/compare-your-workforce/partials/headcount.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/headcount.tsx
@@ -8,6 +8,7 @@ import {
   PupilsPerStaffRole,
   WorkforceCategories,
   HeadcountPerFTE,
+  PercentageOfWorkforce,
 } from "src/components";
 import { ChartDimensionContext } from "src/contexts";
 import { HeadcountProps } from "src/views/compare-your-workforce/partials";
@@ -58,7 +59,8 @@ export const Headcount: React.FC<HeadcountProps> = (props) => {
         <h2 className="govuk-heading-m">School workforce (Headcount)</h2>
         <ChartDimensions
           dimensions={WorkforceCategories.filter(
-            (category) => category !== HeadcountPerFTE
+            (category) =>
+              category !== HeadcountPerFTE && category !== PercentageOfWorkforce
           )}
           handleChange={handleSelectChange}
           elementId="headcount"

--- a/front-end-components/src/views/compare-your-workforce/partials/headcount.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/headcount.tsx
@@ -7,6 +7,7 @@ import {
   HorizontalBarChartWrapperData,
   PupilsPerStaffRole,
   WorkforceCategories,
+  HeadcountPerFTE,
 } from "src/components";
 import { ChartDimensionContext } from "src/contexts";
 import { HeadcountProps } from "src/views/compare-your-workforce/partials";
@@ -56,7 +57,9 @@ export const Headcount: React.FC<HeadcountProps> = (props) => {
       >
         <h2 className="govuk-heading-m">School workforce (Headcount)</h2>
         <ChartDimensions
-          dimensions={WorkforceCategories}
+          dimensions={WorkforceCategories.filter(
+            (category) => category !== HeadcountPerFTE
+          )}
           handleChange={handleSelectChange}
           elementId="headcount"
           defaultValue={dimension}

--- a/front-end-components/src/views/compare-your-workforce/partials/types.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/types.tsx
@@ -9,6 +9,7 @@ export type SchoolWorkforceData = {
   localAuthority: string;
   numberOfPupils: bigint;
   schoolWorkforceFTE: number;
+  schoolWorkforceHeadcount: number;
 };
 
 export type AuxiliaryStaffProps = {
@@ -23,6 +24,7 @@ export type AuxiliaryStaffData = {
   numberOfPupils: bigint;
   schoolWorkforceFTE: number;
   auxiliaryStaffFTE: number;
+  schoolWorkforceHeadcount: number;
 };
 
 export type HeadcountProps = {
@@ -51,6 +53,7 @@ export type NonClassroomSupportData = {
   numberOfPupils: bigint;
   schoolWorkforceFTE: number;
   nonClassroomSupportStaffFTE: number;
+  schoolWorkforceHeadcount: number;
 };
 
 export type SeniorLeadershipProps = {
@@ -65,6 +68,7 @@ export type SeniorLeadershipData = {
   numberOfPupils: bigint;
   schoolWorkforceFTE: number;
   seniorLeadershipFTE: number;
+  schoolWorkforceHeadcount: number;
 };
 
 export type TeachingAssistantsProps = {
@@ -79,6 +83,7 @@ export type TeachingAssistantsData = {
   numberOfPupils: bigint;
   schoolWorkforceFTE: number;
   teachingAssistantsFTE: number;
+  schoolWorkforceHeadcount: number;
 };
 
 export type TotalTeachersProps = {
@@ -93,6 +98,7 @@ export type TotalTeachersData = {
   numberOfPupils: bigint;
   schoolWorkforceFTE: number;
   totalNumberOfTeachersFTE: number;
+  schoolWorkforceHeadcount: number;
 };
 
 export type TotalTeachersQualifiedProps = {


### PR DESCRIPTION
- corrected calculation for HeadcountPerFTE in CalculateWorkforceValue. now this is workforce headcount / specific FTE (value)

- removed dropdown value on chart/table for School workforce (Headcount). This is now the only trivial result for the data.