### PR TITLE
icfp prepopulated data - adds post financial plan to api from web app

### DIFF
--- a/web/src/EducationBenchmarking.Web/Infrastructure/Apis/Requests/PutFinancialPlanRequest.cs
+++ b/web/src/EducationBenchmarking.Web/Infrastructure/Apis/Requests/PutFinancialPlanRequest.cs
@@ -1,9 +1,17 @@
+using EducationBenchmarking.Web.Domain;
+
 namespace EducationBenchmarking.Web.Infrastructure.Apis;
 
 public class PutFinancialPlanRequest
 {
     public int Year { get; set; }
-    public string? Urn { get; set; }
-    
-    public bool? UseFigures { get; set; }
+    public string Urn { get; set; }
+    public bool? UseFigures { get; set; } 
+    public int? SelectedYear { get; set; }
+    public string Name { get; set; }
+    public string TotalIncome { get; set; }
+    public string TotalExpenditure { get; set; }
+    public string TotalTeacherCosts { get; set; }
+    public string TotalNumberOfTeachersFte { get; set; }
+    public string EducationSupportStaffCosts { get; set; }
 }

--- a/web/src/EducationBenchmarking.Web/ViewModels/SchoolPlanViewModel.cs
+++ b/web/src/EducationBenchmarking.Web/ViewModels/SchoolPlanViewModel.cs
@@ -24,5 +24,6 @@ public class SchoolPlanViewModel(School school)
     public string CurrentTotalTeacherCosts => $"{_finances.TeachingStaffCosts:C}";
     public string CurrentTotalNumberOfTeachersFte => $"{_finances.TotalNumberOfTeachersFte}";
     public string CurrentEducationSupportStaffCosts => $"{_finances.EducationSupportStaffCosts:C}";
+    public int CurrentYearEnd => _finances.YearEnd;
     public bool IsPrimary => _finances.OverallPhase == "Primary";
 }

--- a/web/src/EducationBenchmarking.Web/Views/SchoolPlanningYear/Index.cshtml
+++ b/web/src/EducationBenchmarking.Web/Views/SchoolPlanningYear/Index.cshtml
@@ -1,7 +1,7 @@
 @model EducationBenchmarking.Web.ViewModels.SchoolPlanViewModel
 @{
     ViewBag.Title = PageTitleConstants.SchoolPlanningYear;
-    var previousYear = Model.SelectedYear - 1;
+    var previousYear = Model.CurrentYearEnd - 1;
 }
 
 <div class="govuk-grid-row">
@@ -9,7 +9,7 @@
         <span class="govuk-caption-l">@Model.Name</span>
         <h1 class="govuk-heading-l">@ViewBag.Title</h1>
         <p class="govuk-body">Here is some information we hold about your school.</p>
-        <h2 class="govuk-heading-m">Figures from @previousYear - @Model.SelectedYear</h2>
+        <h2 class="govuk-heading-m">Figures from @previousYear - @Model.CurrentYearEnd</h2>
         <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">


### PR DESCRIPTION
### Context
part of the icfp journey - this is for the prepopulated data page 
Task - [AB#191733](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/191733)
Story - [AB#191578](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/191578)
### Change proposed in this pull request
this PR adds:
- required logic to post a financial plan from prepopulated data to the api
- fixes error with how year is displayed on page

outstanding to complete the ticket
- logic for backend to post relevant data to Cosmos
- validation
- get the financial plan when it exists for the page 

### Guidance to review 
N/A

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

