### PR TITLE
Added default sorting of `data` provided to `HorizontalBarChartWrapper`

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -5,11 +5,23 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>DfE</title>
-    <link rel="stylesheet" href="/node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.css" asp-append-version="true"/>
+    <link
+      rel="stylesheet"
+      href="/node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.css"
+      asp-append-version="true"
+    />
   </head>
   <body class="govuk-template__body govuk-frontend-supported">
-    <div id="compare-your-school" data-urn="2154665"></div>
+    <div
+      id="compare-workforce"
+      data-urn="141197"
+      data-academy-year="2021 / 2022"
+      data-maintained-year="2020 - 2021"
+    ></div>
     <script type="module" src="/src/main.tsx"></script>
-    <script type="module" src="/node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js"></script>
+    <script
+      type="module"
+      src="/node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js"
+    ></script>
   </body>
 </html>

--- a/front-end-components/package-lock.json
+++ b/front-end-components/package-lock.json
@@ -39,6 +39,7 @@
         "eslint-plugin-react-refresh": "^0.4.4",
         "jest": "^29.7.0",
         "prettier": "^3.2.4",
+        "prettier-eslint": "^16.3.0",
         "typescript": "^5.2.2",
         "vite": "^5.0.12"
       }
@@ -4539,6 +4540,15 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/common-tags": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4804,6 +4814,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -5597,6 +5613,27 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-ansi/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.0.2",
@@ -7043,6 +7080,84 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/loglevel": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz",
+      "integrity": "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/loglevel-colored-level-prefix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz",
+      "integrity": "sha512-u45Wcxxc+SdAlh4yeF/uKlC1SPUPCy0gullSNKXod5I4bmifzk+Q4lSLExNEVn19tGaJipbZ4V4jbFn79/6mVA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^1.1.3",
+        "loglevel": "^1.4.1"
+      }
+    },
+    "node_modules/loglevel-colored-level-prefix/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/loglevel-colored-level-prefix/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/loglevel-colored-level-prefix/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/loglevel-colored-level-prefix/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/loglevel-colored-level-prefix/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -7629,6 +7744,41 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-eslint": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-16.3.0.tgz",
+      "integrity": "sha512-Lh102TIFCr11PJKUMQ2kwNmxGhTsv/KzUg9QYF2Gkw259g/kPgndZDWavk7/ycbRvj2oz4BPZ1gCU8bhfZH/Xg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/parser": "^6.7.5",
+        "common-tags": "^1.4.0",
+        "dlv": "^1.1.0",
+        "eslint": "^8.7.0",
+        "indent-string": "^4.0.0",
+        "lodash.merge": "^4.6.0",
+        "loglevel-colored-level-prefix": "^1.0.0",
+        "prettier": "^3.0.1",
+        "pretty-format": "^29.7.0",
+        "require-relative": "^0.8.7",
+        "typescript": "^5.2.2",
+        "vue-eslint-parser": "^9.1.0"
+      },
+      "engines": {
+        "node": ">=16.10.0"
+      },
+      "peerDependencies": {
+        "prettier-plugin-svelte": "^3.0.0",
+        "svelte-eslint-parser": "*"
+      },
+      "peerDependenciesMeta": {
+        "prettier-plugin-svelte": {
+          "optional": true
+        },
+        "svelte-eslint-parser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prettier-linter-helpers": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
@@ -7878,6 +8028,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-relative": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+      "integrity": "sha512-AKGr4qvHiryxRb19m3PsLRGuKVAbJLUD7E6eOaHkfKhwc+vSgVOCY5xNvm9EkolBKTOf0GrQAZKLimOCz81Khg==",
+      "dev": true
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
@@ -8671,6 +8827,63 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vue-eslint-parser": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.4.2.tgz",
+      "integrity": "sha512-Ry9oiGmCAK91HrKMtCrKFWmSFWvYkpGglCeFAIqDdr9zdXmMMpJOmUJS7WWsW7fX81h6mwHmUZCQQ1E0PkSwYQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "eslint-scope": "^7.1.1",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.1",
+        "esquery": "^1.4.0",
+        "lodash": "^4.17.21",
+        "semver": "^7.3.6"
+      },
+      "engines": {
+        "node": "^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/vue-eslint-parser/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/vue-eslint-parser/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/vue-eslint-parser/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/w3c-xmlserializer": {
       "version": "4.0.0",

--- a/front-end-components/package.json
+++ b/front-end-components/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-react-refresh": "^0.4.4",
     "jest": "^29.7.0",
     "prettier": "^3.2.4",
+    "prettier-eslint": "^16.3.0",
     "typescript": "^5.2.2",
     "vite": "^5.0.12"
   }

--- a/front-end-components/src/components/charts/horizontal-bar-chart-wrapper.tsx
+++ b/front-end-components/src/components/charts/horizontal-bar-chart-wrapper.tsx
@@ -1,4 +1,4 @@
-import React, { createRef, useContext } from "react";
+import React, { createRef, useContext, useMemo } from "react";
 import {
   DownloadHandle,
   HorizontalBarChart,
@@ -6,15 +6,31 @@ import {
 import { TableChart } from "src/components/charts/table-chart";
 import { ChartModeContext } from "src/contexts";
 import { Loading } from "src/components/loading";
-import { HorizontalBarChartWrapperProps } from "src/components/charts";
+import {
+  ChartSortMode,
+  HorizontalBarChartWrapperProps,
+} from "src/components/charts";
 import { ChartModeChart, ChartModeTable } from "src/components";
+import { chartComparer } from "./utils";
+
+const defaultSort: ChartSortMode = {
+  direction: "desc",
+  dataPoint: "value",
+};
 
 export const HorizontalBarChartWrapper: React.FC<
   HorizontalBarChartWrapperProps
 > = (props) => {
-  const { data, children, chartName } = props;
+  const { data, children, chartName, sort } = props;
   const mode = useContext(ChartModeContext);
   const ref = createRef<DownloadHandle>();
+
+  // if a `sort` is not provided, the default sorting method will be used (value DESC)
+  const sortedDataPoints = useMemo(() => {
+    return data.dataPoints.sort((a, b) =>
+      chartComparer(a, b, sort ?? defaultSort)
+    );
+  }, [data.dataPoints, sort]);
 
   return (
     <>
@@ -34,7 +50,7 @@ export const HorizontalBarChartWrapper: React.FC<
       </div>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-full">
-          {data.dataPoints.length > 0 ? (
+          {sortedDataPoints.length > 0 ? (
             <>
               <div
                 className={
@@ -43,7 +59,7 @@ export const HorizontalBarChartWrapper: React.FC<
               >
                 <HorizontalBarChart
                   chartName={chartName}
-                  data={data.dataPoints}
+                  data={sortedDataPoints}
                   ref={ref}
                 />
               </div>
@@ -54,7 +70,7 @@ export const HorizontalBarChartWrapper: React.FC<
               >
                 <TableChart
                   tableHeadings={data.tableHeadings}
-                  data={data.dataPoints}
+                  data={sortedDataPoints}
                 />
               </div>
             </>

--- a/front-end-components/src/components/charts/types.tsx
+++ b/front-end-components/src/components/charts/types.tsx
@@ -4,6 +4,7 @@ export type HorizontalBarChartWrapperProps = {
   chartName: string;
   children?: React.ReactNode[] | React.ReactNode;
   data: HorizontalBarChartWrapperData;
+  sort?: ChartSortMode;
 };
 
 export type HorizontalBarChartWrapperData = {
@@ -16,4 +17,9 @@ export type ChartDataPoint = {
   urn: string;
   value: number;
   additionalData?: (string | bigint)[];
+};
+
+export type ChartSortMode = {
+  dataPoint: Exclude<keyof ChartDataPoint, "additionalData">;
+  direction: "asc" | "desc";
 };

--- a/front-end-components/src/components/charts/utils.test.ts
+++ b/front-end-components/src/components/charts/utils.test.ts
@@ -1,0 +1,68 @@
+import { ChartDataPoint, ChartSortMode } from ".";
+import { chartComparer } from "./utils";
+
+describe("Chart utils", () => {
+  describe("chartComparer()", () => {
+    const data: ChartDataPoint[] = [
+      { school: "School A", urn: "1", value: 20 },
+      { school: "School B", urn: "2", value: 30 },
+      { school: "School C", urn: "3", value: 40 },
+      { school: "School D", urn: "4", value: 10 },
+      { school: "School E", urn: "5", value: 25 },
+    ];
+
+    describe("with default sort", () => {
+      const sort: ChartSortMode = {
+        dataPoint: "value",
+        direction: "desc",
+      };
+
+      it("sorts the data points", () => {
+        const result = data.sort((a, b) => chartComparer(a, b, sort));
+        expect(result).toEqual([
+          { school: "School C", urn: "3", value: 40 },
+          { school: "School B", urn: "2", value: 30 },
+          { school: "School E", urn: "5", value: 25 },
+          { school: "School A", urn: "1", value: 20 },
+          { school: "School D", urn: "4", value: 10 },
+        ]);
+      });
+    });
+
+    describe("by value ascending", () => {
+      const sort: ChartSortMode = {
+        dataPoint: "value",
+        direction: "asc",
+      };
+
+      it("sorts the data points", () => {
+        const result = data.sort((a, b) => chartComparer(a, b, sort));
+        expect(result).toEqual([
+          { school: "School D", urn: "4", value: 10 },
+          { school: "School A", urn: "1", value: 20 },
+          { school: "School E", urn: "5", value: 25 },
+          { school: "School B", urn: "2", value: 30 },
+          { school: "School C", urn: "3", value: 40 },
+        ]);
+      });
+    });
+
+    describe("by school ascending", () => {
+      const sort: ChartSortMode = {
+        dataPoint: "school",
+        direction: "asc",
+      };
+
+      it("sorts the data points", () => {
+        const result = data.sort((a, b) => chartComparer(a, b, sort));
+        expect(result).toEqual([
+          { school: "School A", urn: "1", value: 20 },
+          { school: "School B", urn: "2", value: 30 },
+          { school: "School C", urn: "3", value: 40 },
+          { school: "School D", urn: "4", value: 10 },
+          { school: "School E", urn: "5", value: 25 },
+        ]);
+      });
+    });
+  });
+});

--- a/front-end-components/src/components/charts/utils.ts
+++ b/front-end-components/src/components/charts/utils.ts
@@ -1,0 +1,17 @@
+import { ChartDataPoint, ChartSortMode } from ".";
+
+export function chartComparer(
+  a: ChartDataPoint,
+  b: ChartDataPoint,
+  { dataPoint, direction }: ChartSortMode
+): number {
+  if (a[dataPoint] < b[dataPoint]) {
+    return direction === "asc" ? -1 : 1;
+  }
+
+  if (a[dataPoint] > b[dataPoint]) {
+    return direction === "asc" ? 1 : -1;
+  }
+
+  return 0;
+}

--- a/front-end-components/vite.config-dev.ts
+++ b/front-end-components/vite.config-dev.ts
@@ -16,4 +16,14 @@ export default defineConfig({
       ),
     },
   },
+  server: {
+    proxy: {
+      "/api": {
+        target: "https://localhost:7095/api",
+        changeOrigin: true,
+        secure: false,
+        rewrite: (path) => path.replace(/^\/api/, ""),
+      },
+    },
+  },
 });


### PR DESCRIPTION
### Context
Adds support for sorting data passed to `HorizontalBarChartWrapper`.

### Change proposed in this pull request
Adds support for sorting data passed to `HorizontalBarChartWrapper`.

### Guidance to review 
All charts and tables should render by default as `value` descending. The sort may be overridden on a chart-by-chart basis. 

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

[AB#194908](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/194908) ([AB#185925](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/185925))