### PR TITLE
api changes to allow post and get icfp prepopulated data plan

### DIFF
--- a/platform/src/abstractions/EducationBenchmarking.Platform.Domain/DataObjects/FinancialPlanDataObject.cs
+++ b/platform/src/abstractions/EducationBenchmarking.Platform.Domain/DataObjects/FinancialPlanDataObject.cs
@@ -12,10 +12,10 @@ public record FinancialPlanDataObject
     [JsonProperty("updatedBy")] public string? UpdatedBy { get; set; }
     [JsonProperty("createdBy")] public string? CreatedBy { get; set; }
     [JsonProperty("version")] public int Version { get; set; }
-    [JsonProperty("totalIncome")] public string? TotalIncome { get; set; }
-    [JsonProperty("totalExpenditure")] public string? TotalExpenditure { get; set; }
-    [JsonProperty("totalTeacherCosts")] public string? TotalTeacherCosts { get; set; }
-    [JsonProperty("totalNumberOfTeachersFte")] public string? TotalNumberOfTeachersFte { get; set; }
-    [JsonProperty("educationSupportStaffCosts")] public string? EducationSupportStaffCosts { get; set; }
+    [JsonProperty("totalIncome")] public decimal? TotalIncome { get; set; }
+    [JsonProperty("totalExpenditure")] public decimal? TotalExpenditure { get; set; }
+    [JsonProperty("totalTeacherCosts")] public decimal? TotalTeacherCosts { get; set; }
+    [JsonProperty("totalNumberOfTeachersFte")] public decimal? TotalNumberOfTeachersFte { get; set; }
+    [JsonProperty("educationSupportStaffCosts")] public decimal? EducationSupportStaffCosts { get; set; }
     [JsonProperty("useFigures")] public bool UseFigures { get; set; }
 }

--- a/platform/src/abstractions/EducationBenchmarking.Platform.Domain/DataObjects/FinancialPlanDataObject.cs
+++ b/platform/src/abstractions/EducationBenchmarking.Platform.Domain/DataObjects/FinancialPlanDataObject.cs
@@ -12,4 +12,10 @@ public record FinancialPlanDataObject
     [JsonProperty("updatedBy")] public string? UpdatedBy { get; set; }
     [JsonProperty("createdBy")] public string? CreatedBy { get; set; }
     [JsonProperty("version")] public int Version { get; set; }
+    [JsonProperty("totalIncome")] public string? TotalIncome { get; set; }
+    [JsonProperty("totalExpenditure")] public string? TotalExpenditure { get; set; }
+    [JsonProperty("totalTeacherCosts")] public string? TotalTeacherCosts { get; set; }
+    [JsonProperty("totalNumberOfTeachersFte")] public string? TotalNumberOfTeachersFte { get; set; }
+    [JsonProperty("educationSupportStaffCosts")] public string? EducationSupportStaffCosts { get; set; }
+    [JsonProperty("useFigures")] public bool UseFigures { get; set; }
 }

--- a/platform/src/abstractions/EducationBenchmarking.Platform.Domain/Requests/FinancialPlanRequest.cs
+++ b/platform/src/abstractions/EducationBenchmarking.Platform.Domain/Requests/FinancialPlanRequest.cs
@@ -4,9 +4,9 @@ public record FinancialPlanRequest
 {
     public string? User { get; set; }
     public bool UseFigures { get; set; }
-    public string TotalIncome { get; set; }
-    public string TotalExpenditure { get; set; }
-    public string TotalTeacherCosts { get; set; }
-    public string TotalNumberOfTeachersFte { get; set; }
-    public string EducationSupportStaffCosts { get; set; }
+    public decimal? TotalIncome { get; set; }
+    public decimal? TotalExpenditure { get; set; }
+    public decimal? TotalTeacherCosts { get; set; }
+    public decimal? TotalNumberOfTeachersFte { get; set; }
+    public decimal? EducationSupportStaffCosts { get; set; }
 }

--- a/platform/src/abstractions/EducationBenchmarking.Platform.Domain/Requests/FinancialPlanRequest.cs
+++ b/platform/src/abstractions/EducationBenchmarking.Platform.Domain/Requests/FinancialPlanRequest.cs
@@ -3,4 +3,10 @@ namespace EducationBenchmarking.Platform.Domain.Requests;
 public record FinancialPlanRequest
 {
     public string? User { get; set; }
+    public bool UseFigures { get; set; }
+    public string TotalIncome { get; set; }
+    public string TotalExpenditure { get; set; }
+    public string TotalTeacherCosts { get; set; }
+    public string TotalNumberOfTeachersFte { get; set; }
+    public string EducationSupportStaffCosts { get; set; }
 }

--- a/platform/src/abstractions/EducationBenchmarking.Platform.Domain/Responses/FinancialPlan.cs
+++ b/platform/src/abstractions/EducationBenchmarking.Platform.Domain/Responses/FinancialPlan.cs
@@ -12,7 +12,13 @@ public record FinancialPlan
     public string? UpdatedBy { get; set; }
     public string? CreatedBy { get; set; }
     public int Version { get; set; }
-    
+    public string? TotalIncome { get; set; }
+    public string? TotalExpenditure { get; set; }
+    public string? TotalTeacherCosts { get; set; }
+    public string? TotalNumberOfTeachersFte { get; set; }
+    public string? EducationSupportStaffCosts { get; set; }
+    public bool UseFigures { get; set; }
+
     public static FinancialPlan Create(FinancialPlanDataObject dataObject)
     {
         return new FinancialPlan
@@ -23,8 +29,13 @@ public record FinancialPlan
             UpdatedAt = dataObject.UpdatedAt,
             UpdatedBy = dataObject.UpdatedBy,
             CreatedBy = dataObject.CreatedBy,
-            Version = dataObject.Version
-            
+            Version = dataObject.Version,
+            UseFigures = dataObject.UseFigures,
+            TotalIncome = dataObject.TotalIncome,
+            TotalExpenditure = dataObject.TotalExpenditure,
+            TotalTeacherCosts = dataObject.TotalTeacherCosts,
+            TotalNumberOfTeachersFte = dataObject.TotalNumberOfTeachersFte,
+            EducationSupportStaffCosts = dataObject.EducationSupportStaffCosts
         };
     }
 }

--- a/platform/src/abstractions/EducationBenchmarking.Platform.Domain/Responses/FinancialPlan.cs
+++ b/platform/src/abstractions/EducationBenchmarking.Platform.Domain/Responses/FinancialPlan.cs
@@ -12,11 +12,11 @@ public record FinancialPlan
     public string? UpdatedBy { get; set; }
     public string? CreatedBy { get; set; }
     public int Version { get; set; }
-    public string? TotalIncome { get; set; }
-    public string? TotalExpenditure { get; set; }
-    public string? TotalTeacherCosts { get; set; }
-    public string? TotalNumberOfTeachersFte { get; set; }
-    public string? EducationSupportStaffCosts { get; set; }
+    public decimal? TotalIncome { get; set; }
+    public decimal? TotalExpenditure { get; set; }
+    public decimal? TotalTeacherCosts { get; set; }
+    public decimal? TotalNumberOfTeachersFte { get; set; }
+    public decimal? EducationSupportStaffCosts { get; set; }
     public bool UseFigures { get; set; }
 
     public static FinancialPlan Create(FinancialPlanDataObject dataObject)

--- a/platform/src/apis/EducationBenchmarking.Platform.Api.Benchmark/Db/FinancialPlanDb.cs
+++ b/platform/src/apis/EducationBenchmarking.Platform.Api.Benchmark/Db/FinancialPlanDb.cs
@@ -76,6 +76,12 @@ public class FinancialPlanDb : CosmosDatabase, IFinancialPlanDb
         existing.UpdatedAt = DateTimeOffset.UtcNow;
         existing.UpdatedBy = request.User;
         existing.Version += 1;
+        existing.UseFigures = request.UseFigures;
+        existing.TotalIncome = request.TotalIncome;
+        existing.TotalExpenditure = request.TotalExpenditure;
+        existing.TotalTeacherCosts = request.TotalTeacherCosts;
+        existing.TotalNumberOfTeachersFte = request.TotalNumberOfTeachersFte;
+        existing.EducationSupportStaffCosts = request.EducationSupportStaffCosts;
 
         await UpsertItemAsync(_options.FinancialPlanCollectionName, existing, new PartitionKey(existing.PartitionKey));
 
@@ -85,7 +91,7 @@ public class FinancialPlanDb : CosmosDatabase, IFinancialPlanDb
     private async Task<DbResult> Create(string urn, int year, FinancialPlanRequest request)
     {
         ArgumentNullException.ThrowIfNull(_options.FinancialPlanCollectionName);
-
+        
         var plan = new FinancialPlanDataObject
         {
             Id = year.ToString(),
@@ -94,7 +100,13 @@ public class FinancialPlanDb : CosmosDatabase, IFinancialPlanDb
             UpdatedAt = DateTimeOffset.UtcNow,
             UpdatedBy = request.User,
             CreatedBy = request.User,
-            Version = 1
+            Version = 1,
+            UseFigures = request.UseFigures,
+            TotalIncome = request.TotalIncome,
+            TotalExpenditure = request.TotalExpenditure,
+            TotalTeacherCosts = request.TotalTeacherCosts,
+            TotalNumberOfTeachersFte = request.TotalNumberOfTeachersFte,
+            EducationSupportStaffCosts = request.EducationSupportStaffCosts,
         };
 
         await UpsertItemAsync(_options.FinancialPlanCollectionName, plan, new PartitionKey(urn));


### PR DESCRIPTION
### Context
part of the icfp journey - this is for the prepopulated data page
Story - [AB#191578](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/191578)
Task - [AB#191733](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/191733)

### Change proposed in this pull request
this PR adds:
- changes records for req/res/db to allow post and get of the financial plan

outstanding to complete ticket:
- display financial plan when it exists for the page
- validation on web app


### Guidance to review 
N/A

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

