### PR TITLE
Total Expenditure back link wired up and tests added

### DIFF
--- a/web/src/EducationBenchmarking.Web/Controllers/SchoolPlanningYearController.cs
+++ b/web/src/EducationBenchmarking.Web/Controllers/SchoolPlanningYearController.cs
@@ -147,6 +147,8 @@ public class SchoolPlanningYearController(
         {
             try
             {
+                ViewData[ViewDataConstants.Backlink] = new BacklinkInfo("TotalIncome", "SchoolPlanningYear", new { urn, year });
+
                 return View();
             }
             catch (Exception e)

--- a/web/src/EducationBenchmarking.Web/Views/SchoolPlanningYear/TotalExpenditure.cshtml
+++ b/web/src/EducationBenchmarking.Web/Views/SchoolPlanningYear/TotalExpenditure.cshtml
@@ -1,10 +1,10 @@
-@using EducationBenchmarking.Web.Extensions
-@model EducationBenchmarking.Web.ViewModels.SchoolPlanViewModel
+@{
+    ViewBag.Title = "Total Expenditure";
+}
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <a href="#" class="govuk-back-link">Back</a>
-        <h1 class="govuk-heading-xl">Total Expenditure</h1>
+        <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
 
         <div class="govuk-form-group">
             <label class="govuk-label govuk-label--m" for="total-expenditure">

--- a/web/tests/EducationBenchmarking.Web.Integration.Tests/Paths.cs
+++ b/web/tests/EducationBenchmarking.Web.Integration.Tests/Paths.cs
@@ -17,6 +17,7 @@ public static class Paths
     public static string SchoolCurriculumPlanningYear(string urn, int year) => $"/school/{urn}/financial-planning/{year}";
     public static string SchoolCurriculumPlanningTotalIncome(string urn, int year) => $"/school/{urn}/financial-planning/{year}/total-income";
     public static string SchoolCurriculumPlanningHelp(string urn) => $"/school/{urn}/financial-planning/help";
+    public static string SchoolCurriculumPlanningTotalExpenditure(string urn, int year) => $"/school/{urn}/financial-planning/{year}/total-expenditure";
 
     public static string ToAbsolute(this string path)
     {

--- a/web/tests/EducationBenchmarking.Web.Integration.Tests/WhenViewingSchoolPlanningTotalExpenditure.cs
+++ b/web/tests/EducationBenchmarking.Web.Integration.Tests/WhenViewingSchoolPlanningTotalExpenditure.cs
@@ -1,0 +1,58 @@
+using System.Net;
+using AngleSharp.Html.Dom;
+using AutoFixture;
+using EducationBenchmarking.Web.Domain;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace EducationBenchmarking.Web.Integration.Tests;
+
+public class WhenViewingSchoolPlanningTotalExpenditure(BenchmarkingWebAppFactory factory, ITestOutputHelper output)
+    : BenchmarkingWebAppClient(factory,
+        output)
+{
+    private static readonly int CurrentYear = DateTime.UtcNow.Month < 9 ? DateTime.UtcNow.Year - 1 : DateTime.UtcNow.Year;
+    
+    [Theory]
+    [InlineData(EstablishmentTypes.Academies)]
+    [InlineData(EstablishmentTypes.Maintained)]
+    public async Task CanDisplaySchool(string financeType)
+    {
+        var (page, school) = await SetupNavigateInitPage(financeType);
+
+        AssertPageLayout(page, school);
+    }
+    
+    [Fact]
+    public async Task CanNavigateBack()
+    {
+        var (page, school) = await SetupNavigateInitPage(EstablishmentTypes.Maintained);
+
+        var anchor = page.QuerySelector(".govuk-back-link");
+        page = await Follow(anchor);
+
+        DocumentAssert.AssertPageUrl(page, Paths.SchoolCurriculumPlanningTotalIncome(school.Urn, CurrentYear).ToAbsolute());
+    }
+    
+    private async Task<(IHtmlDocument page, School school)> SetupNavigateInitPage(string financeType)
+    {
+        var school = Fixture.Build<School>()
+            .With(x => x.FinanceType, financeType)
+            .Create();
+
+        var finances = Fixture.Build<Finances>()
+            .Create();
+
+        var page = await SetupEstablishment(school)
+            .SetupInsights(school, finances)
+            .Navigate(Paths.SchoolCurriculumPlanningTotalExpenditure(school.Urn, CurrentYear));
+
+        return (page, school);
+    }
+
+    private static void AssertPageLayout(IHtmlDocument page, School school)
+    {
+        DocumentAssert.BackLink(page, "Back", Paths.SchoolCurriculumPlanningTotalIncome(school.Urn, CurrentYear).ToAbsolute());
+        DocumentAssert.TitleAndH1(page, "Total Expenditure", "Total Expenditure");
+    }
+}


### PR DESCRIPTION
### Context
[AB#191582](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/191582)
[AB#195268](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/195268)

### Change proposed in this pull request

- Wired up back link in TotalExpenditure.cshtml
- Created integrated test: WhenViewingSchoolPlanningTotalExpenditure.cs


### Guidance to review 
NA

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

