### PR TITLE
post and get to display figures for icfp pre populate data page

### DIFF
--- a/web/src/EducationBenchmarking.Web/Domain/FinancialPlan.cs
+++ b/web/src/EducationBenchmarking.Web/Domain/FinancialPlan.cs
@@ -1,0 +1,15 @@
+﻿namespace EducationBenchmarking.Web.Domain
+{
+    public class FinancialPlan
+    {
+        public int Year { get; set; }
+        public string? Urn { get; set; }
+        public bool UseFigures { get; set; }
+        public decimal? TotalIncome { get; set; }
+        public decimal? TotalExpenditure { get; set; }
+        public decimal? TotalTeacherCosts { get; set; }
+        public decimal? TotalNumberOfTeachersFte { get; set; }
+        public decimal? EducationSupportStaffCosts { get; set; }
+    }
+}
+

--- a/web/src/EducationBenchmarking.Web/Infrastructure/Apis/Requests/PutFinancialPlanRequest.cs
+++ b/web/src/EducationBenchmarking.Web/Infrastructure/Apis/Requests/PutFinancialPlanRequest.cs
@@ -5,13 +5,11 @@ namespace EducationBenchmarking.Web.Infrastructure.Apis;
 public class PutFinancialPlanRequest
 {
     public int Year { get; set; }
-    public string Urn { get; set; }
-    public bool? UseFigures { get; set; } 
-    public int? SelectedYear { get; set; }
-    public string Name { get; set; }
-    public string TotalIncome { get; set; }
-    public string TotalExpenditure { get; set; }
-    public string TotalTeacherCosts { get; set; }
-    public string TotalNumberOfTeachersFte { get; set; }
-    public string EducationSupportStaffCosts { get; set; }
+    public string? Urn { get; set; }
+    public bool UseFigures { get; set; } 
+    public decimal? TotalIncome { get; set; }
+    public decimal? TotalExpenditure { get; set; }
+    public decimal? TotalTeacherCosts { get; set; }
+    public decimal? TotalNumberOfTeachersFte { get; set; }
+    public decimal? EducationSupportStaffCosts { get; set; }
 }

--- a/web/src/EducationBenchmarking.Web/ViewModels/SchoolPlanViewModel.cs
+++ b/web/src/EducationBenchmarking.Web/ViewModels/SchoolPlanViewModel.cs
@@ -5,25 +5,28 @@ namespace EducationBenchmarking.Web.ViewModels;
 public class SchoolPlanViewModel(School school)
 {
     private readonly Finances? _finances;
+    private readonly FinancialPlan? _plan;
     public SchoolPlanViewModel(School school, int? year) : this(school)
     {
         SelectedYear = year;
     }
 
-    public SchoolPlanViewModel(School school, Finances finances, int year) : this(school)
+    public SchoolPlanViewModel(School school, Finances finances, FinancialPlan? plan, int year) : this(school)
     {
         SelectedYear = year;
+        _plan = plan;
         _finances = finances;
     }
 
     public int? SelectedYear { get; set; }
     public string Name => school.Name;
     public string Urn => school.Urn;
-    public string CurrentTotalIncome => $"{_finances.TotalIncome:C}";
-    public string CurrentTotalExpenditure => $"{_finances.TotalExpenditure:C}";
-    public string CurrentTotalTeacherCosts => $"{_finances.TeachingStaffCosts:C}";
-    public string CurrentTotalNumberOfTeachersFte => $"{_finances.TotalNumberOfTeachersFte}";
-    public string CurrentEducationSupportStaffCosts => $"{_finances.EducationSupportStaffCosts:C}";
-    public int CurrentYearEnd => _finances.YearEnd;
-    public bool IsPrimary => _finances.OverallPhase == "Primary";
+    public decimal CurrentTotalIncome => _finances?.TotalIncome ?? throw new ArgumentNullException(nameof(_finances));
+    public decimal CurrentTotalExpenditure => _finances?.TotalExpenditure ?? throw new ArgumentNullException(nameof(_finances));
+    public decimal CurrentTotalTeacherCosts => _finances?.TeachingStaffCosts ?? throw new ArgumentNullException(nameof(_finances));
+    public decimal CurrentTotalNumberOfTeachersFte => _finances?.TotalNumberOfTeachersFte ?? throw new ArgumentNullException(nameof(_finances));
+    public decimal CurrentEducationSupportStaffCosts => _finances?.EducationSupportStaffCosts ?? throw new ArgumentNullException(nameof(_finances));
+    public int CurrentYearEnd => _finances?.YearEnd ?? throw new ArgumentNullException(nameof(_finances));
+    public bool IsPrimary => _finances?.OverallPhase == "Primary";
+    public bool? UseFigures => _plan?.UseFigures;
 }

--- a/web/src/EducationBenchmarking.Web/Views/SchoolPlanningYear/Index.cshtml
+++ b/web/src/EducationBenchmarking.Web/Views/SchoolPlanningYear/Index.cshtml
@@ -1,7 +1,7 @@
+@using EducationBenchmarking.Web.Extensions
 @model EducationBenchmarking.Web.ViewModels.SchoolPlanViewModel
 @{
     ViewBag.Title = PageTitleConstants.SchoolPlanningYear;
-    var previousYear = Model.CurrentYearEnd - 1;
 }
 
 <div class="govuk-grid-row">
@@ -9,14 +9,14 @@
         <span class="govuk-caption-l">@Model.Name</span>
         <h1 class="govuk-heading-l">@ViewBag.Title</h1>
         <p class="govuk-body">Here is some information we hold about your school.</p>
-        <h2 class="govuk-heading-m">Figures from @previousYear - @Model.CurrentYearEnd</h2>
+        <h2 class="govuk-heading-m">Figures from @(Model.CurrentYearEnd-1) - @Model.CurrentYearEnd</h2>
         <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">
                     Total income
                 </dt>
                 <dd class="govuk-summary-list__value govuk-!-text-align-right">
-                    @Model.CurrentTotalIncome
+                    @($"{Model.CurrentTotalIncome:C}")
                 </dd>
             </div>
             <div class="govuk-summary-list__row">
@@ -24,7 +24,7 @@
                     Total expenditure
                 </dt>
                 <dd class="govuk-summary-list__value govuk-!-text-align-right">
-                    @Model.CurrentTotalExpenditure
+                    @($"{Model.CurrentTotalExpenditure:C}")
                 </dd>
             </div>
             <div class="govuk-summary-list__row">
@@ -32,7 +32,7 @@
                     Total teacher costs
                 </dt>
                 <dd class="govuk-summary-list__value govuk-!-text-align-right">
-                    @Model.CurrentTotalTeacherCosts
+                    @($"{Model.CurrentTotalTeacherCosts:C}")
                 </dd>
             </div>
             @if (Model.IsPrimary)
@@ -42,7 +42,7 @@
                         Total education support staff costs
                     </dt>
                     <dd class="govuk-summary-list__value govuk-!-text-align-right">
-                        @Model.CurrentEducationSupportStaffCosts
+                        @($"{Model.CurrentEducationSupportStaffCosts:C}")
                     </dd>
                 </div>
             }
@@ -64,15 +64,21 @@
                             Do you want to use these figures in your plan?
                         </h2>
                     </legend>
+                    @if (ViewData.ModelState.HasError("useFigures"))
+                    {
+                        <p id="year-error" class="govuk-error-message">
+                            <span class="govuk-visually-hidden">Error:</span> @ViewData.ModelState["useFigures"]?.Errors.First().ErrorMessage
+                        </p>
+                    }
                     <div class="govuk-radios govuk-radios govuk-radios--inline" data-module="govuk-radios">
                         <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="useFigures-yes" name="useFigures" type="radio" value="true">
+                            <input class="govuk-radios__input" id="useFigures-yes" name="useFigures" type="radio" value="true" @(Model.UseFigures == true ? "checked" : "")>
                             <label class="govuk-label govuk-radios__label" for="useFigures-yes">
                                 Yes
                             </label>
                         </div>
                         <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="useFigures-no" name="useFigures" type="radio" value="false">
+                            <input class="govuk-radios__input" id="useFigures-no" name="useFigures" type="radio" value="false" @(Model.UseFigures == false ? "checked" : "")>
                             <label class="govuk-label govuk-radios__label" for="useFigures-no">
                                 No
                             </label>


### PR DESCRIPTION
### Context
part of the icfp journey - this is for the prepopulated data page
Story - [AB#191578](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/191578)
Task - [AB#191733](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/191733)

### Change proposed in this pull request
This PR adds functionality to the pre populated data page to use a plan if it exists for display of radio button on page and post when required to not overwrite existing figures.
This PR in addition to others for this task 
- #157 
- #147
- #144 

should fulfil the AC for this task

### Guidance to review 
N/A

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

