### PR TITLE
Added `ITestOutputHelper` to A11y tests

### DIFF
--- a/web/tests/EducationBenchmarking.Web.A11yTests/PageBase.cs
+++ b/web/tests/EducationBenchmarking.Web.A11yTests/PageBase.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Deque.AxeCore.Commons;
 using Deque.AxeCore.Playwright;
 using Microsoft.Playwright;
@@ -9,43 +6,56 @@ using Xunit.Abstractions;
 
 namespace EducationBenchmarking.Web.A11yTests;
 
-public abstract class PageBase(ITestOutputHelper outputHelper)
+public abstract class PageBase : IDisposable
 {
+    protected PageBase(ITestOutputHelper testOutputHelper)
+    {
+        TestOutputHelper = testOutputHelper;
+        Driver = new WebDriver(TestOutputHelper);
+    }
+
     protected abstract string PageUrl { get; }
     protected IPage? Page { get; set; }
+    protected WebDriver Driver { get; }
+    protected ITestOutputHelper TestOutputHelper { get; }
+
+    public void Dispose()
+    {
+        Driver.Dispose();
+    }
 
     protected async Task EvaluatePage(AxeRunContext? context = null)
     {
         Assert.NotNull(Page);
-        Assert.Equal( PageUrl, Page.Url);
-        
+        Assert.Equal(PageUrl, Page.Url);
+
         var results = context != null ? await Page.RunAxe(context) : await Page.RunAxe();
         var violations = results.Violations
             .Where(violation => TestConfiguration.Impacts.Contains(violation.Impact))
             .ToArray();
-        
+
         PrintViolations(violations);
-        
+
         Assert.True(violations.Length == 0, "There are violations on the page");
     }
-    
+
     private void PrintViolations(IReadOnlyList<AxeResultItem> violations)
     {
         if (violations.Any())
         {
             foreach (var impact in TestConfiguration.Impacts)
             {
-                outputHelper.WriteLine($"{impact} issues: {violations.Count(x => x.Impact == impact)}");    
+                TestOutputHelper.WriteLine($"{impact} issues: {violations.Count(x => x.Impact == impact)}");
             }
-        
+
             for (var i = 0; i < violations.Count; i++)
             {
                 var violation = violations[i];
-                outputHelper.WriteLine($"Issue {i + 1}: {violation.Description}");
+                TestOutputHelper.WriteLine($"Issue {i + 1}: {violation.Description}");
                 for (var j = 0; j < violation.Nodes.Length; j++)
                 {
                     var node = violation.Nodes[j];
-                    outputHelper.WriteLine($"  Occurrence {j + 1}: {node.Html}");
+                    TestOutputHelper.WriteLine($"  Occurrence {j + 1}: {node.Html}");
                 }
             }
         }

--- a/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/FinancialPlanning/WhenViewingSchoolFinancialPlanning.cs
+++ b/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/FinancialPlanning/WhenViewingSchoolFinancialPlanning.cs
@@ -3,14 +3,15 @@ using Xunit.Abstractions;
 
 namespace EducationBenchmarking.Web.A11yTests.Pages.School.FinancialPlanning;
 
-public class WhenViewingSchoolFinancialPlanning(WebDriver driver, ITestOutputHelper outputHelper) : PageBase(outputHelper), IClassFixture<WebDriver>
+public class WhenViewingSchoolFinancialPlanning(ITestOutputHelper outputHelper) : PageBase(outputHelper)
 {
+    protected override string PageUrl =>
+        $"{TestConfiguration.ServiceUrl}/school/{TestConfiguration.School}/financial-planning";
+
     [Fact]
     public async Task ThenThereAreNoAccessibilityIssues()
     {
-        Page = await driver.GetPage(PageUrl);
+        Page = await Driver.GetPage(PageUrl);
         await EvaluatePage();
     }
-
-    protected override string PageUrl => $"{TestConfiguration.ServiceUrl}/school/{TestConfiguration.School}/financial-planning";
 }

--- a/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/FinancialPlanning/WhenViewingSchoolFinancialPlanningHelp.cs
+++ b/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/FinancialPlanning/WhenViewingSchoolFinancialPlanningHelp.cs
@@ -3,14 +3,15 @@ using Xunit.Abstractions;
 
 namespace EducationBenchmarking.Web.A11yTests.Pages.School.FinancialPlanning;
 
-public class WhenViewingSchoolFinancialPlanningHelp(WebDriver driver, ITestOutputHelper outputHelper) : PageBase(outputHelper), IClassFixture<WebDriver>
+public class WhenViewingSchoolFinancialPlanningHelp(ITestOutputHelper outputHelper) : PageBase(outputHelper)
 {
+    protected override string PageUrl =>
+        $"{TestConfiguration.ServiceUrl}/school/{TestConfiguration.School}/financial-planning/steps/help";
+
     [Fact]
     public async Task ThenThereAreNoAccessibilityIssues()
     {
-        Page = await driver.GetPage(PageUrl);
+        Page = await Driver.GetPage(PageUrl);
         await EvaluatePage();
     }
-
-    protected override string PageUrl => $"{TestConfiguration.ServiceUrl}/school/{TestConfiguration.School}/financial-planning/steps/help";
 }

--- a/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/FinancialPlanning/WhenViewingSchoolFinancialPlanningPrePopulatedData.cs
+++ b/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/FinancialPlanning/WhenViewingSchoolFinancialPlanningPrePopulatedData.cs
@@ -4,22 +4,25 @@ using Xunit.Abstractions;
 namespace EducationBenchmarking.Web.A11yTests.Pages.School.FinancialPlanning;
 
 [Collection(nameof(FinancialPlanCollection))]
-public class WhenViewingSchoolFinancialPlanningPrePopulatedData(WebDriver driver, ITestOutputHelper outputHelper, FinancialPlanFixture plan) : PageBase(outputHelper), IClassFixture<WebDriver>
+public class WhenViewingSchoolFinancialPlanningPrePopulatedData(
+    ITestOutputHelper outputHelper,
+    FinancialPlanFixture plan) : PageBase(outputHelper)
 {
+    protected override string PageUrl =>
+        $"{TestConfiguration.ServiceUrl}/school/{plan.Urn}/financial-planning/steps/pre-populate-data?year={plan.Year}";
+
     [Fact]
     public async Task ThenThereAreNoAccessibilityIssues()
     {
-        Page = await driver.GetPage(PageUrl);
-        await EvaluatePage();
-    }
-    
-    [Fact]
-    public async Task ValidationErrorThenThereAreNoAccessibilityIssues()
-    {
-        Page = await driver.GetPage(PageUrl);
-        await Page.Locator(":text('Continue')").ClickAsync();
+        Page = await Driver.GetPage(PageUrl);
         await EvaluatePage();
     }
 
-    protected override string PageUrl => $"{TestConfiguration.ServiceUrl}/school/{plan.Urn}/financial-planning/steps/pre-populate-data?year={plan.Year}";
+    [Fact]
+    public async Task ValidationErrorThenThereAreNoAccessibilityIssues()
+    {
+        Page = await Driver.GetPage(PageUrl);
+        await Page.Locator(":text('Continue')").ClickAsync();
+        await EvaluatePage();
+    }
 }

--- a/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/FinancialPlanning/WhenViewingSchoolFinancialPlanningSelectYear.cs
+++ b/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/FinancialPlanning/WhenViewingSchoolFinancialPlanningSelectYear.cs
@@ -3,22 +3,23 @@ using Xunit.Abstractions;
 
 namespace EducationBenchmarking.Web.A11yTests.Pages.School.FinancialPlanning;
 
-public class WhenViewingSchoolFinancialPlanningSelectYear(WebDriver driver, ITestOutputHelper outputHelper) : PageBase(outputHelper), IClassFixture<WebDriver>
+public class WhenViewingSchoolFinancialPlanningSelectYear(ITestOutputHelper outputHelper) : PageBase(outputHelper)
 {
+    protected override string PageUrl =>
+        $"{TestConfiguration.ServiceUrl}/school/{TestConfiguration.School}/financial-planning/steps/select-year";
+
     [Fact]
     public async Task ThenThereAreNoAccessibilityIssues()
     {
-        Page = await driver.GetPage(PageUrl);
+        Page = await Driver.GetPage(PageUrl);
         await EvaluatePage();
     }
 
     [Fact]
     public async Task ValidationErrorThenThereAreNoAccessibilityIssues()
     {
-        Page = await driver.GetPage(PageUrl);
+        Page = await Driver.GetPage(PageUrl);
         await Page.Locator(":text('Continue')").ClickAsync();
         await EvaluatePage();
     }
-
-    protected override string PageUrl => $"{TestConfiguration.ServiceUrl}/school/{TestConfiguration.School}/financial-planning/steps/select-year";
 }

--- a/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/FinancialPlanning/WhenViewingSchoolFinancialPlanningStart.cs
+++ b/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/FinancialPlanning/WhenViewingSchoolFinancialPlanningStart.cs
@@ -3,14 +3,15 @@ using Xunit.Abstractions;
 
 namespace EducationBenchmarking.Web.A11yTests.Pages.School.FinancialPlanning;
 
-public class WhenViewingSchoolFinancialPlanningStart(WebDriver driver, ITestOutputHelper outputHelper) : PageBase(outputHelper), IClassFixture<WebDriver>
+public class WhenViewingSchoolFinancialPlanningStart(ITestOutputHelper outputHelper) : PageBase(outputHelper)
 {
+    protected override string PageUrl =>
+        $"{TestConfiguration.ServiceUrl}/school/{TestConfiguration.School}/financial-planning/steps/start";
+
     [Fact]
     public async Task ThenThereAreNoAccessibilityIssues()
     {
-        Page = await driver.GetPage(PageUrl);
+        Page = await Driver.GetPage(PageUrl);
         await EvaluatePage();
     }
-
-    protected override string PageUrl => $"{TestConfiguration.ServiceUrl}/school/{TestConfiguration.School}/financial-planning/steps/start";
 }

--- a/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/FinancialPlanning/WhenViewingSchoolFinancialPlanningTotalExpenditure.cs
+++ b/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/FinancialPlanning/WhenViewingSchoolFinancialPlanningTotalExpenditure.cs
@@ -4,22 +4,25 @@ using Xunit.Abstractions;
 namespace EducationBenchmarking.Web.A11yTests.Pages.School.FinancialPlanning;
 
 [Collection(nameof(FinancialPlanCollection))]
-public class WhenViewingSchoolFinancialPlanningTotalExpenditure(WebDriver driver, ITestOutputHelper outputHelper, FinancialPlanFixture plan) : PageBase(outputHelper), IClassFixture<WebDriver>
+public class WhenViewingSchoolFinancialPlanningTotalExpenditure(
+    ITestOutputHelper outputHelper,
+    FinancialPlanFixture plan) : PageBase(outputHelper)
 {
+    protected override string PageUrl =>
+        $"{TestConfiguration.ServiceUrl}/school/{plan.Urn}/financial-planning/steps/total-expenditure?year={plan.Year}";
+
     [Fact]
     public async Task ThenThereAreNoAccessibilityIssues()
     {
-        Page = await driver.GetPage(PageUrl);
-        await EvaluatePage();
-    }
-    
-    [Fact]
-    public async Task ValidationErrorThenThereAreNoAccessibilityIssues()
-    {
-        Page = await driver.GetPage(PageUrl);
-        await Page.Locator(":text('Continue')").ClickAsync();
+        Page = await Driver.GetPage(PageUrl);
         await EvaluatePage();
     }
 
-    protected override string PageUrl => $"{TestConfiguration.ServiceUrl}/school/{plan.Urn}/financial-planning/steps/total-expenditure?year={plan.Year}";
+    [Fact]
+    public async Task ValidationErrorThenThereAreNoAccessibilityIssues()
+    {
+        Page = await Driver.GetPage(PageUrl);
+        await Page.Locator(":text('Continue')").ClickAsync();
+        await EvaluatePage();
+    }
 }

--- a/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/FinancialPlanning/WhenViewingSchoolFinancialPlanningTotalIncome.cs
+++ b/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/FinancialPlanning/WhenViewingSchoolFinancialPlanningTotalIncome.cs
@@ -4,22 +4,24 @@ using Xunit.Abstractions;
 namespace EducationBenchmarking.Web.A11yTests.Pages.School.FinancialPlanning;
 
 [Collection(nameof(FinancialPlanCollection))]
-public class WhenViewingSchoolFinancialPlanningTotalIncome(WebDriver driver, ITestOutputHelper outputHelper, FinancialPlanFixture plan) : PageBase(outputHelper), IClassFixture<WebDriver>
+public class WhenViewingSchoolFinancialPlanningTotalIncome(ITestOutputHelper outputHelper, FinancialPlanFixture plan)
+    : PageBase(outputHelper)
 {
+    protected override string PageUrl =>
+        $"{TestConfiguration.ServiceUrl}/school/{plan.Urn}/financial-planning/steps/total-income?year={plan.Year}";
+
     [Fact]
     public async Task ThenThereAreNoAccessibilityIssues()
     {
-        Page = await driver.GetPage(PageUrl);
-        await EvaluatePage();
-    }
-    
-    [Fact]
-    public async Task ValidationErrorThenThereAreNoAccessibilityIssues()
-    {
-        Page = await driver.GetPage(PageUrl);
-        await Page.Locator(":text('Continue')").ClickAsync();
+        Page = await Driver.GetPage(PageUrl);
         await EvaluatePage();
     }
 
-    protected override string PageUrl => $"{TestConfiguration.ServiceUrl}/school/{plan.Urn}/financial-planning/steps/total-income?year={plan.Year}";
+    [Fact]
+    public async Task ValidationErrorThenThereAreNoAccessibilityIssues()
+    {
+        Page = await Driver.GetPage(PageUrl);
+        await Page.Locator(":text('Continue')").ClickAsync();
+        await EvaluatePage();
+    }
 }

--- a/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/FinancialPlanning/WhenViewingSchoolFinancialPlanningTotalNumberTeachers.cs
+++ b/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/FinancialPlanning/WhenViewingSchoolFinancialPlanningTotalNumberTeachers.cs
@@ -4,22 +4,25 @@ using Xunit.Abstractions;
 namespace EducationBenchmarking.Web.A11yTests.Pages.School.FinancialPlanning;
 
 [Collection(nameof(FinancialPlanCollection))]
-public class WhenViewingSchoolFinancialPlanningTotalNumberTeachers(WebDriver driver, ITestOutputHelper outputHelper, FinancialPlanFixture plan) : PageBase(outputHelper), IClassFixture<WebDriver>
+public class WhenViewingSchoolFinancialPlanningTotalNumberTeachers(
+    ITestOutputHelper outputHelper,
+    FinancialPlanFixture plan) : PageBase(outputHelper)
 {
+    protected override string PageUrl =>
+        $"{TestConfiguration.ServiceUrl}/school/{plan.Urn}/financial-planning/steps/total-number-teachers?year={plan.Year}";
+
     [Fact]
     public async Task ThenThereAreNoAccessibilityIssues()
     {
-        Page = await driver.GetPage(PageUrl);
-        await EvaluatePage();
-    }
-    
-    [Fact]
-    public async Task ValidationErrorThenThereAreNoAccessibilityIssues()
-    {
-        Page = await driver.GetPage(PageUrl);
-        await Page.Locator(":text('Continue')").ClickAsync();
+        Page = await Driver.GetPage(PageUrl);
         await EvaluatePage();
     }
 
-    protected override string PageUrl => $"{TestConfiguration.ServiceUrl}/school/{plan.Urn}/financial-planning/steps/total-number-teachers?year={plan.Year}";
+    [Fact]
+    public async Task ValidationErrorThenThereAreNoAccessibilityIssues()
+    {
+        Page = await Driver.GetPage(PageUrl);
+        await Page.Locator(":text('Continue')").ClickAsync();
+        await EvaluatePage();
+    }
 }

--- a/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/FinancialPlanning/WhenViewingSchoolFinancialPlanningTotalTeacherCosts.cs
+++ b/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/FinancialPlanning/WhenViewingSchoolFinancialPlanningTotalTeacherCosts.cs
@@ -4,22 +4,25 @@ using Xunit.Abstractions;
 namespace EducationBenchmarking.Web.A11yTests.Pages.School.FinancialPlanning;
 
 [Collection(nameof(FinancialPlanCollection))]
-public class WhenViewingSchoolFinancialPlanningTotalTeacherCosts(WebDriver driver, ITestOutputHelper outputHelper, FinancialPlanFixture plan) : PageBase(outputHelper), IClassFixture<WebDriver>
+public class WhenViewingSchoolFinancialPlanningTotalTeacherCosts(
+    ITestOutputHelper outputHelper,
+    FinancialPlanFixture plan) : PageBase(outputHelper)
 {
+    protected override string PageUrl =>
+        $"{TestConfiguration.ServiceUrl}/school/{plan.Urn}/financial-planning/steps/total-teacher-costs?year={plan.Year}";
+
     [Fact]
     public async Task ThenThereAreNoAccessibilityIssues()
     {
-        Page = await driver.GetPage(PageUrl);
-        await EvaluatePage();
-    }
-    
-    [Fact]
-    public async Task ValidationErrorThenThereAreNoAccessibilityIssues()
-    {
-        Page = await driver.GetPage(PageUrl);
-        await Page.Locator(":text('Continue')").ClickAsync();
+        Page = await Driver.GetPage(PageUrl);
         await EvaluatePage();
     }
 
-    protected override string PageUrl => $"{TestConfiguration.ServiceUrl}/school/{plan.Urn}/financial-planning/steps/total-teacher-costs?year={plan.Year}";
+    [Fact]
+    public async Task ValidationErrorThenThereAreNoAccessibilityIssues()
+    {
+        Page = await Driver.GetPage(PageUrl);
+        await Page.Locator(":text('Continue')").ClickAsync();
+        await EvaluatePage();
+    }
 }

--- a/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/WhenViewingSchoolBenchmarkWorkforceData.cs
+++ b/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/WhenViewingSchoolBenchmarkWorkforceData.cs
@@ -3,16 +3,17 @@ using Xunit.Abstractions;
 
 namespace EducationBenchmarking.Web.A11yTests.Pages.School;
 
-public class WhenViewingSchoolBenchmarkWorkforceData(WebDriver driver, ITestOutputHelper outputHelper) : PageBase(outputHelper), IClassFixture<WebDriver>
+public class WhenViewingSchoolBenchmarkWorkforceData(ITestOutputHelper outputHelper) : PageBase(outputHelper)
 {
+    protected override string PageUrl => $"{TestConfiguration.ServiceUrl}/school/{TestConfiguration.School}/workforce";
+
     [Theory]
     [InlineData("table")]
     [InlineData("chart")]
     public async Task ThenThereAreNoAccessibilityIssues(string mode)
     {
-        Page = await driver.GetPage(PageUrl);
+        Page = await Driver.GetPage(PageUrl);
         await Page.Locator($"#mode-{mode}").ClickAsync();
         await EvaluatePage();
     }
-    protected override string PageUrl => $"{TestConfiguration.ServiceUrl}/school/{TestConfiguration.School}/workforce";
 }

--- a/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/WhenViewingSchoolCompareYourCosts.cs
+++ b/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/WhenViewingSchoolCompareYourCosts.cs
@@ -3,28 +3,28 @@ using Xunit.Abstractions;
 
 namespace EducationBenchmarking.Web.A11yTests.Pages.School;
 
-public class WhenViewingSchoolCompareYourCosts(WebDriver driver, ITestOutputHelper outputHelper) : PageBase(outputHelper), IClassFixture<WebDriver>
+public class WhenViewingSchoolCompareYourCosts(ITestOutputHelper outputHelper) : PageBase(outputHelper)
 {
+    protected override string PageUrl => $"{TestConfiguration.ServiceUrl}/school/{TestConfiguration.School}/comparison";
+
     [Theory]
     [InlineData("table")]
     [InlineData("chart")]
     public async Task ShowAllSectionsThenThereAreNoAccessibilityIssues(string mode)
     {
-        Page = await driver.GetPage(PageUrl);
+        Page = await Driver.GetPage(PageUrl);
         await Page.Locator($"#mode-{mode}").ClickAsync();
         await Page.Locator(".govuk-accordion__show-all").ClickAsync();
         await EvaluatePage();
     }
-    
+
     [Theory]
     [InlineData("table")]
     [InlineData("chart")]
     public async Task ThenThereAreNoAccessibilityIssues(string mode)
     {
-        Page = await driver.GetPage(PageUrl);
+        Page = await Driver.GetPage(PageUrl);
         await Page.Locator($"#mode-{mode}").ClickAsync();
         await EvaluatePage();
     }
-    
-    protected override string PageUrl => $"{TestConfiguration.ServiceUrl}/school/{TestConfiguration.School}/comparison";
 }

--- a/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/WhenViewingSchoolHome.cs
+++ b/web/tests/EducationBenchmarking.Web.A11yTests/Pages/School/WhenViewingSchoolHome.cs
@@ -3,14 +3,14 @@ using Xunit.Abstractions;
 
 namespace EducationBenchmarking.Web.A11yTests.Pages.School;
 
-public class WhenViewingSchoolHome(WebDriver driver, ITestOutputHelper outputHelper) : PageBase(outputHelper), IClassFixture<WebDriver>
+public class WhenViewingSchoolHome(ITestOutputHelper outputHelper) : PageBase(outputHelper)
 {
+    protected override string PageUrl => $"{TestConfiguration.ServiceUrl}/school/{TestConfiguration.School}";
+
     [Fact]
     public async Task ThenThereAreNoAccessibilityIssues()
     {
-        Page = await driver.GetPage(PageUrl);
+        Page = await Driver.GetPage(PageUrl);
         await EvaluatePage();
     }
-
-    protected override string PageUrl => $"{TestConfiguration.ServiceUrl}/school/{TestConfiguration.School}";
 }

--- a/web/tests/EducationBenchmarking.Web.A11yTests/Pages/WhenViewingFindOrganisation.cs
+++ b/web/tests/EducationBenchmarking.Web.A11yTests/Pages/WhenViewingFindOrganisation.cs
@@ -4,19 +4,22 @@ using Xunit.Abstractions;
 
 namespace EducationBenchmarking.Web.A11yTests.Pages;
 
-public class WhenViewingFindOrganisation(WebDriver driver, ITestOutputHelper outputHelper)
-    : PageBase(outputHelper), IClassFixture<WebDriver>
+public class WhenViewingFindOrganisation(ITestOutputHelper outputHelper)
+    : PageBase(outputHelper)
 {
     //known issues conditionally reveal https://design-system.service.gov.uk/components/radios/
-    private readonly AxeRunContext _context = new() { Exclude = [new AxeSelector("#school"), new AxeSelector("#trust")] };
+    private readonly AxeRunContext _context = new()
+        { Exclude = [new AxeSelector("#school"), new AxeSelector("#trust")] };
+
+    protected override string PageUrl => $"{TestConfiguration.ServiceUrl}/find-organisation";
 
     [Theory]
     [InlineData("school")]
     [InlineData("trust")]
     public async Task ThenThereAreNoAccessibilityIssues(string organisationType)
     {
-        Page = await driver.GetPage(PageUrl);
-        await Page.Locator($"#{organisationType}").ClickAsync();    
+        Page = await Driver.GetPage(PageUrl);
+        await Page.Locator($"#{organisationType}").ClickAsync();
         await EvaluatePage(_context);
     }
 
@@ -25,11 +28,9 @@ public class WhenViewingFindOrganisation(WebDriver driver, ITestOutputHelper out
     [InlineData("trust")]
     public async Task ValidationErrorThenThereAreNoAccessibilityIssues(string organisationType)
     {
-        Page = await driver.GetPage(PageUrl);
-        await Page.Locator($"#{organisationType}").ClickAsync();    
+        Page = await Driver.GetPage(PageUrl);
+        await Page.Locator($"#{organisationType}").ClickAsync();
         await Page.Locator(":text('Continue')").ClickAsync();
         await EvaluatePage(_context);
     }
-
-    protected override string PageUrl => $"{TestConfiguration.ServiceUrl}/find-organisation";
 }

--- a/web/tests/EducationBenchmarking.Web.A11yTests/Pages/WhenViewingServiceLanding.cs
+++ b/web/tests/EducationBenchmarking.Web.A11yTests/Pages/WhenViewingServiceLanding.cs
@@ -3,15 +3,14 @@ using Xunit.Abstractions;
 
 namespace EducationBenchmarking.Web.A11yTests.Pages;
 
-public class WhenViewingServiceLanding(WebDriver driver, ITestOutputHelper outputHelper) : PageBase(outputHelper), IClassFixture<WebDriver>
+public class WhenViewingServiceLanding(ITestOutputHelper outputHelper) : PageBase(outputHelper)
 {
+    protected override string PageUrl => $"{TestConfiguration.ServiceUrl}/";
 
     [Fact]
     public async Task ThenThereAreNoAccessibilityIssues()
     {
-        Page = await driver.GetPage(PageUrl);
+        Page = await Driver.GetPage(PageUrl);
         await EvaluatePage();
     }
-
-    protected override string PageUrl => $"{TestConfiguration.ServiceUrl}/";
 }


### PR DESCRIPTION
### Context
HTTP errors due to misconfigured A11y tests were being consumed by the application making debugging difficult.

### Change proposed in this pull request
Output HTTP responses to the `ITestOutputHelper` to give better visibility over what the A11y tests are doing.

### Guidance to review 
Running the A11y tests locally should output all HTTP responses. 

### Checklist
- ~~[ ] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)~~
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

