### PR TITLE
initial icfp timetable page

### DIFF
--- a/web/src/EducationBenchmarking.Web/Constants.cs
+++ b/web/src/EducationBenchmarking.Web/Constants.cs
@@ -64,6 +64,7 @@ public static class PageTitleConstants
     public const string SchoolPlanningTotalTeacherCosts = "What is your total spend on teaching staff?";
     public const string SchoolPlanningTotalNumberTeachers = "How many full-time equivalent teachers do you have?";
     public const string SchoolPlanningTotalEducationSupport = "What is your total spend on education support staff?";
+    public const string SchoolPlanningTimetableCycle = "Timetable cycle";
     public const string SchoolComparatorSet = "Comparator set";
     public const string TrustHome = "Your trust";
     public const string HistoricData = "Historic data";

--- a/web/src/EducationBenchmarking.Web/Domain/FinancialPlan.cs
+++ b/web/src/EducationBenchmarking.Web/Domain/FinancialPlan.cs
@@ -10,6 +10,7 @@ namespace EducationBenchmarking.Web.Domain
         public decimal? TotalTeacherCosts { get; set; }
         public decimal? TotalNumberOfTeachersFte { get; set; }
         public decimal? EducationSupportStaffCosts { get; set; }
+        public int? TimetablePeriods { get; set; }
     }
 }
 

--- a/web/src/EducationBenchmarking.Web/Infrastructure/Apis/Requests/PutFinancialPlanRequest.cs
+++ b/web/src/EducationBenchmarking.Web/Infrastructure/Apis/Requests/PutFinancialPlanRequest.cs
@@ -12,6 +12,7 @@ public class PutFinancialPlanRequest
     public decimal? TotalTeacherCosts { get; set; }
     public decimal? TotalNumberOfTeachersFte { get; set; }
     public decimal? EducationSupportStaffCosts { get; set; }
+    public int? TimetablePeriods { get; set; }
 
     public static PutFinancialPlanRequest Create(FinancialPlan plan)
     {
@@ -24,7 +25,8 @@ public class PutFinancialPlanRequest
             TotalExpenditure = plan.TotalExpenditure,
             TotalTeacherCosts = plan.TotalTeacherCosts,
             TotalNumberOfTeachersFte = plan.TotalNumberOfTeachersFte,
-            EducationSupportStaffCosts = plan.EducationSupportStaffCosts
+            EducationSupportStaffCosts = plan.EducationSupportStaffCosts,
+            TimetablePeriods = plan.TimetablePeriods,
         };
     }
 }

--- a/web/src/EducationBenchmarking.Web/ViewModels/SchoolPlanViewModel.cs
+++ b/web/src/EducationBenchmarking.Web/ViewModels/SchoolPlanViewModel.cs
@@ -22,6 +22,7 @@ public class SchoolPlanViewModel(School school)
     public decimal? TotalTeacherCosts => _plan?.TotalTeacherCosts;
     public decimal? TotalNumberOfTeachersFte => _plan?.TotalNumberOfTeachersFte;
     public decimal? EducationSupportStaffCosts => _plan?.EducationSupportStaffCosts;
+    public int? TimetablePeriods => _plan?.TimetablePeriods;
 }
 
 public class SchoolPlanFinancesViewModel(School school, Finances finances, int year, FinancialPlan? plan)

--- a/web/src/EducationBenchmarking.Web/Views/SchoolPlanningSteps/TimetableCycle.cshtml
+++ b/web/src/EducationBenchmarking.Web/Views/SchoolPlanningSteps/TimetableCycle.cshtml
@@ -1,0 +1,46 @@
+﻿@using EducationBenchmarking.Web.Extensions
+@model EducationBenchmarking.Web.ViewModels.SchoolPlanViewModel
+
+@{
+    ViewData[ViewDataConstants.Title] = PageTitleConstants.SchoolPlanningTimetableCycle;
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <span class="govuk-caption-l">@Model.Name</span>
+        <h1 class="govuk-heading-l">@ViewData[ViewDataConstants.Title]</h1>
+        <p class="govuk-body">
+            The length of your timetable cycle is the number of periods before it repeats itself.
+        </p>
+        <p class="govuk-body">
+            For example, a timetable that repeats weekly with 5 periods per day would give you a cycle length of 25 periods
+        </p>
+        <p class="govuk-body">
+            Enter an average if your school has a different timetable length for different years
+        </p>
+        @using (Html.BeginForm("TimetableCycle", "SchoolPlanningSteps", new { urn = Model.Urn, year = Model.SelectedYear }, FormMethod.Post, true, new { novalidate = "novalidate" }))
+        {
+            <div class="@(ViewData.ModelState.HasError(nameof(Model.TimetablePeriods)) ? "govuk-form-group govuk-form-group--error" : "govuk-form-group")">
+                <div class="govuk-form-group">
+                    <label class="govuk-label govuk-label--m" for="timetable-periods">
+                        How many periods are there in one timetable cycle?
+                    </label>
+                    @if (ViewData.ModelState.HasError(nameof(Model.TimetablePeriods)))
+                    {
+                        <p id="timetable-error" class="govuk-error-message">
+                            <span class="govuk-visually-hidden">Error:</span> @ViewData.ModelState[nameof(Model.TimetablePeriods)]?.Errors.First().ErrorMessage
+                        </p>
+                    }
+                    <div class="govuk-input__wrapper">
+                        <input class="govuk-input govuk-input--width-10" id="timetable-periods" name="@nameof(Model.TimetablePeriods)" type="number" spellcheck="false" value="@Model.TimetablePeriods">
+                    </div>
+                </div>
+                <div>
+                    <button type="submit" class="govuk-button" data-module="govuk-button">
+                        Continue
+                    </button>
+                </div>
+            </div>
+        }
+    </div>
+</div>

--- a/web/tests/EducationBenchmarking.Web.Integration.Tests/Pages/Schools/FinancialPlanning/WhenViewingPlanningPrePopulateData.cs
+++ b/web/tests/EducationBenchmarking.Web.Integration.Tests/Pages/Schools/FinancialPlanning/WhenViewingPlanningPrePopulateData.cs
@@ -66,7 +66,7 @@ public class WhenViewingPlanningPrePopulateData(BenchmarkingWebAppClient client)
 
         Client.BenchmarkApi.Verify(api => api.UpsertFinancialPlan(It.IsAny<PutFinancialPlanRequest>()), Times.Once);
 
-        DocumentAssert.AssertPageUrl(page, Paths.SchoolFinancialPlanningTimetable(school.Urn, PlanYear).ToAbsolute());
+        DocumentAssert.AssertPageUrl(page, Paths.SchoolFinancialPlanningTimetableCycle(school.Urn, PlanYear).ToAbsolute());
     }
 
     [Theory]

--- a/web/tests/EducationBenchmarking.Web.Integration.Tests/Pages/Schools/FinancialPlanning/WhenViewingPlanningTotalNumberTeachers.cs
+++ b/web/tests/EducationBenchmarking.Web.Integration.Tests/Pages/Schools/FinancialPlanning/WhenViewingPlanningTotalNumberTeachers.cs
@@ -60,8 +60,8 @@ public class WhenViewingPlanningTotalNumberTeachers(BenchmarkingWebAppClient cli
         });
 
         Client.BenchmarkApi.Verify(api => api.UpsertFinancialPlan(It.IsAny<PutFinancialPlanRequest>()), Times.Once);
-
-        DocumentAssert.AssertPageUrl(page, Paths.SchoolFinancialPlanningTotalNumberTeachers(school.Urn, CurrentYear).ToAbsolute());
+        
+        DocumentAssert.AssertPageUrl(page, Paths.SchoolFinancialPlanningTimetableCycle(school.Urn, CurrentYear).ToAbsolute());
     }
 
     [Fact]

--- a/web/tests/EducationBenchmarking.Web.Integration.Tests/Paths.cs
+++ b/web/tests/EducationBenchmarking.Web.Integration.Tests/Paths.cs
@@ -30,8 +30,8 @@ public static class Paths
         $"/school/{urn}/financial-planning/steps/total-income?year={year}";
     public static string SchoolFinancialPlanningPrePopulatedData(string? urn, int year) =>
         $"/school/{urn}/financial-planning/steps/pre-populate-data?year={year}";
-    public static string SchoolFinancialPlanningTimetable(string? urn, int year) =>
-        $"/school/{urn}/financial-planning/steps/timetable?year={year}";
+    public static string SchoolFinancialPlanningTimetableCycle(string? urn, int year) =>
+        $"/school/{urn}/financial-planning/steps/timetable-cycle?year={year}";
     public static string SchoolFinancialPlanningHelp(string? urn) => $"/school/{urn}/financial-planning/steps/help";
     public static string SchoolFinancialPlanningTotalExpenditure(string? urn, int year) =>
         $"/school/{urn}/financial-planning/steps/total-expenditure?year={year}";


### PR DESCRIPTION
### Context
Story - [AB#191586](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/191586) 
Task - [AB#194084](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/194084)

### Change proposed in this pull request
This PR
- Adds view, controllers and updates the model for the icfp timetable page
- logic for backlink directing to either prepopulate-data or total-number-teachers
- validation for inputs 
- display of timetable figure if it exists in the plan.
- updates path on existing integration test for previous page 

### Guidance to review 
N/A

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

