### PR TITLE
added a11y tests for total educational support staff page

### DIFF
--- a/web/tests/EducationBenchmarking.Web.A11yTests/Pages/Schools/FinancialPlanning/WhenViewingFinancialPlanningTotalEducationSupportStaffCosts.cs
+++ b/web/tests/EducationBenchmarking.Web.A11yTests/Pages/Schools/FinancialPlanning/WhenViewingFinancialPlanningTotalEducationSupportStaffCosts.cs
@@ -1,0 +1,31 @@
+﻿using EducationBenchmarking.Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace EducationBenchmarking.Web.A11yTests.Pages.Schools.FinancialPlanning;
+
+[Collection(nameof(FinancialPlanCollection))]
+public class WhenViewingFinancialPlanningTotalEducationSupportStaffCosts(
+        ITestOutputHelper outputHelper,
+        WebDriver webDriver,
+        FinancialPlanFixture plan)
+    : PageBase(outputHelper, webDriver)
+{
+    protected override string PageUrl =>
+        $"/school/{plan.Urn}/financial-planning/steps/total-education-support?year={plan.Year}";
+
+    [Fact]
+    public async Task ThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await EvaluatePage();
+    }
+
+    [Fact]
+    public async Task ValidationErrorThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await Page.Locator(":text('Continue')").ClickAsync();
+        await EvaluatePage();
+    }
+}


### PR DESCRIPTION
### Context
[AB#192517](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/192517) ([AB#195882](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/195882))


### Change proposed in this pull request
added a11y tests for total education support staff costs page

### Guidance to review 
none

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

