### PR TITLE
adds a11y tests for timetable cycle page

### DIFF
--- a/web/tests/EducationBenchmarking.Web.A11yTests/Pages/Schools/FinancialPlanning/WhenViewingFinancialPlanningTimetableCycle.cs
+++ b/web/tests/EducationBenchmarking.Web.A11yTests/Pages/Schools/FinancialPlanning/WhenViewingFinancialPlanningTimetableCycle.cs
@@ -1,0 +1,30 @@
+﻿using EducationBenchmarking.Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace EducationBenchmarking.Web.A11yTests.Pages.Schools.FinancialPlanning;
+
+[Collection(nameof(FinancialPlanMinimalDataCollection))]
+public class WhenViewingFinancialPlanningTotalTimetableCycle(
+    ITestOutputHelper outputHelper,
+    WebDriver webDriver,
+    FinancialPlanMinimalDataFixture plan)
+    : PageBase(outputHelper, webDriver)
+{
+    protected override string PageUrl => $"/school/{plan.Urn}/financial-planning/steps/timetable-cycle?year={plan.Year}";
+
+    [Fact]
+    public async Task ThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await EvaluatePage();
+    }
+
+    [Fact]
+    public async Task ValidationErrorThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await Page.Locator(":text('Continue')").ClickAsync();
+        await EvaluatePage();
+    }
+}


### PR DESCRIPTION
### Context
Story - [AB#191586](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/191586)
Task - [AB#195880](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/195880)

### Change proposed in this pull request
Adds a11y tests for this CFP Timecycle page

### Guidance to review 
N/A

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

