### PR TITLE
Download rechart as an image

### DIFF
--- a/front-end-components/package-lock.json
+++ b/front-end-components/package-lock.json
@@ -29,7 +29,7 @@
         "@types/file-saver": "^2.0.7",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.11.19",
-        "@types/react": "^18.2.45",
+        "@types/react": "^18.2.57",
         "@types/react-dom": "^18.2.19",
         "@types/testing-library__react": "^10.2.0",
         "@types/uuid": "^9.0.8",
@@ -3547,9 +3547,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.45",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.45.tgz",
-      "integrity": "sha512-TtAxCNrlrBp8GoeEp1npd5g+d/OejJHFxS3OWmrPBMFaVQMSN0OFySozJio5BHxTuTeug00AVXVAjfDSfk+lUg==",
+      "version": "18.2.57",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.57.tgz",
+      "integrity": "sha512-ZvQsktJgSYrQiMirAN60y4O/LRevIV8hUzSOSNB6gfR3/o3wCBFQx3sPwIYtuDMeiVgsSS3UzCV26tEzgnfvQw==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",

--- a/front-end-components/package-lock.json
+++ b/front-end-components/package-lock.json
@@ -32,7 +32,7 @@
         "@types/react": "^18.2.45",
         "@types/react-dom": "^18.2.19",
         "@types/testing-library__react": "^10.2.0",
-        "@types/uuid": "^9.0.7",
+        "@types/uuid": "^9.0.8",
         "@typescript-eslint/eslint-plugin": "^7.0.2",
         "@typescript-eslint/parser": "^7.0.2",
         "@vitejs/plugin-react": "^4.2.0",
@@ -3601,9 +3601,9 @@
       "dev": true
     },
     "node_modules/@types/uuid": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
-      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true
     },
     "node_modules/@types/yargs": {

--- a/front-end-components/package-lock.json
+++ b/front-end-components/package-lock.json
@@ -25,7 +25,7 @@
         "@babel/preset-react": "^7.23.3",
         "@babel/preset-typescript": "^7.23.3",
         "@testing-library/jest-dom": "^6.4.2",
-        "@testing-library/react": "^14.1.2",
+        "@testing-library/react": "^14.2.1",
         "@types/file-saver": "^2.0.7",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.11.19",
@@ -3338,9 +3338,9 @@
       "dev": true
     },
     "node_modules/@testing-library/react": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.1.2.tgz",
-      "integrity": "sha512-z4p7DVBTPjKM5qDZ0t5ZjzkpSNb+fZy1u6bzO7kk8oeGagpPCAtgh4cx1syrfp7a+QWkM021jGqjJaxJJnXAZg==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.2.1.tgz",
+      "integrity": "sha512-sGdjws32ai5TLerhvzThYFbpnF9XtL65Cjf+gB0Dhr29BGqK+mAeN7SURSdu+eqgET4ANcWoC7FQpkaiGvBr+A==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",

--- a/front-end-components/package-lock.json
+++ b/front-end-components/package-lock.json
@@ -46,7 +46,7 @@
         "prettier": "^3.2.5",
         "prettier-eslint": "^16.3.0",
         "typescript": "^5.2.2",
-        "vite": "^5.1.3"
+        "vite": "^5.1.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -9331,9 +9331,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.3.tgz",
-      "integrity": "sha512-UfmUD36DKkqhi/F75RrxvPpry+9+tTkrXfMNZD+SboZqBCMsxKtO52XeGzzuh7ioz+Eo/SYDBbdb0Z7vgcDJew==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.4.tgz",
+      "integrity": "sha512-n+MPqzq+d9nMVTKyewqw6kSt+R3CkvF9QAKY8obiQn8g1fwTscKxyfaYnC632HtBXAQGc1Yjomphwn1dtwGAHg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",

--- a/front-end-components/package-lock.json
+++ b/front-end-components/package-lock.json
@@ -10,12 +10,14 @@
       "dependencies": {
         "chart.js": "^4.4.1",
         "classnames": "^2.5.1",
+        "file-saver": "^2.0.5",
         "govuk-frontend": "^5.2.0",
         "punycode": "^2.3.1",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",
         "recharts": "^2.12.1",
+        "recharts-to-png": "^2.3.1",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -24,6 +26,7 @@
         "@babel/preset-typescript": "^7.23.3",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^14.1.2",
+        "@types/file-saver": "^2.0.7",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.11.19",
         "@types/react": "^18.2.45",
@@ -3462,6 +3465,12 @@
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
     },
+    "node_modules/@types/file-saver": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.7.tgz",
+      "integrity": "sha512-dNKVfHd/jk0SkR/exKGj2ggkB45MAkzvWCaqLUUgkyjITkGNzH8H+yUwr+BLJUBjZOe9w8X3wgmXhZDRg1ED6A==",
+      "dev": true
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -4296,6 +4305,14 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -4622,6 +4639,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css.escape": {
@@ -5526,6 +5551,11 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -5901,6 +5931,18 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -8369,6 +8411,24 @@
         "decimal.js-light": "^2.4.1"
       }
     },
+    "node_modules/recharts-to-png": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/recharts-to-png/-/recharts-to-png-2.3.1.tgz",
+      "integrity": "sha512-a+OaAi03oFJMa+Burf3vyH060iFTrb35W8bBYUatNjZVrrMKUcFM3VOI1ym078WIH7XfgYQb17K9p2spVA2FzQ==",
+      "dependencies": {
+        "html2canvas": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.3",
+        "react-dom": ">=16.8.3",
+        "recharts": ">=2.9.0"
+      },
+      "peerDependenciesMeta": {
+        "recharts": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -8974,6 +9034,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -9205,6 +9273,14 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/front-end-components/package.json
+++ b/front-end-components/package.json
@@ -37,7 +37,7 @@
     "@types/file-saver": "^2.0.7",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.19",
-    "@types/react": "^18.2.45",
+    "@types/react": "^18.2.57",
     "@types/react-dom": "^18.2.19",
     "@types/testing-library__react": "^10.2.0",
     "@types/uuid": "^9.0.8",

--- a/front-end-components/package.json
+++ b/front-end-components/package.json
@@ -33,7 +33,7 @@
     "@babel/preset-react": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
     "@testing-library/jest-dom": "^6.4.2",
-    "@testing-library/react": "^14.1.2",
+    "@testing-library/react": "^14.2.1",
     "@types/file-saver": "^2.0.7",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.19",

--- a/front-end-components/package.json
+++ b/front-end-components/package.json
@@ -40,7 +40,7 @@
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.19",
     "@types/testing-library__react": "^10.2.0",
-    "@types/uuid": "^9.0.7",
+    "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^7.0.2",
     "@typescript-eslint/parser": "^7.0.2",
     "@vitejs/plugin-react": "^4.2.0",

--- a/front-end-components/package.json
+++ b/front-end-components/package.json
@@ -54,6 +54,6 @@
     "prettier": "^3.2.5",
     "prettier-eslint": "^16.3.0",
     "typescript": "^5.2.2",
-    "vite": "^5.1.3"
+    "vite": "^5.1.4"
   }
 }

--- a/front-end-components/package.json
+++ b/front-end-components/package.json
@@ -18,12 +18,14 @@
   "dependencies": {
     "chart.js": "^4.4.1",
     "classnames": "^2.5.1",
+    "file-saver": "^2.0.5",
     "govuk-frontend": "^5.2.0",
     "punycode": "^2.3.1",
     "react": "^18.2.0",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.2.0",
     "recharts": "^2.12.1",
+    "recharts-to-png": "^2.3.1",
     "uuid": "^9.0.1"
   },
   "devDependencies": {
@@ -32,6 +34,7 @@
     "@babel/preset-typescript": "^7.23.3",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.1.2",
+    "@types/file-saver": "^2.0.7",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.19",
     "@types/react": "^18.2.45",

--- a/front-end-components/src/components/charts/stat/component.tsx
+++ b/front-end-components/src/components/charts/stat/component.tsx
@@ -66,7 +66,6 @@ function valueFormatter(
     return value || "";
   }
 
-  // todo: polyfill old browsers
   return new Intl.NumberFormat("en-GB", {
     notation: compact ? "compact" : undefined,
     compactDisplay: compact ? "short" : undefined,
@@ -74,5 +73,7 @@ function valueFormatter(
     currency: valueUnit === "currency" ? "GBP" : undefined,
     currencyDisplay: currencyAsName ? "name" : "symbol",
     maximumFractionDigits: compact ? undefined : 0,
-  }).format(value);
+  })
+    .format(value)
+    .toLowerCase();
 }

--- a/front-end-components/src/components/charts/types.tsx
+++ b/front-end-components/src/components/charts/types.tsx
@@ -32,6 +32,7 @@ export interface ChartProps<TData extends ChartDataSeries> {
   keyField: keyof TData;
   margin?: number;
   multiLineAxisLabel?: boolean;
+  onImageLoading?: (loading: boolean) => void;
   seriesConfig?: ChartSeriesConfig<TData>;
   seriesLabel?: string;
   seriesLabelField: keyof TData;

--- a/front-end-components/src/components/charts/types.tsx
+++ b/front-end-components/src/components/charts/types.tsx
@@ -1,4 +1,4 @@
-import React, { SVGProps } from "react";
+import React, { Ref, SVGProps } from "react";
 import { CartesianTickItem } from "recharts/types/util/types";
 
 export type HorizontalBarChartWrapperProps = {
@@ -33,6 +33,7 @@ export interface ChartProps<TData extends ChartDataSeries> {
   margin?: number;
   multiLineAxisLabel?: boolean;
   onImageLoading?: (loading: boolean) => void;
+  ref?: Ref<ChartHandler>;
   seriesConfig?: ChartSeriesConfig<TData>;
   seriesLabel?: string;
   seriesLabelField: keyof TData;
@@ -61,4 +62,8 @@ export type TickProps = SVGProps<SVGGElement> & {
   index: number;
   payload: CartesianTickItem;
   visibleTicksCount: number;
+};
+
+export type ChartHandler = {
+  download: () => void;
 };

--- a/front-end-components/src/components/charts/vertical-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/vertical-bar-chart/component.tsx
@@ -3,16 +3,11 @@ import {
   ReactElement,
   Ref,
   forwardRef,
-  useCallback,
-  useEffect,
   useImperativeHandle,
   useMemo,
   useState,
 } from "react";
-import {
-  VerticalBarChartHandler,
-  VerticalBarChartProps,
-} from "src/components/charts/vertical-bar-chart";
+import { VerticalBarChartProps } from "src/components/charts/vertical-bar-chart";
 import {
   Bar,
   BarChart,
@@ -27,13 +22,12 @@ import {
 } from "recharts";
 import { CategoricalChartState } from "recharts/types/chart/types";
 import classNames from "classnames";
-import { ChartDataSeries, TickProps } from "src/components";
-import { useCurrentPng } from "recharts-to-png";
-import { saveAs } from "file-saver";
+import { ChartDataSeries, ChartHandler, TickProps } from "src/components";
+import { useDownloadPngImage } from "src/hooks/useDownloadImage";
 
 function VerticalBarChartInner<TData extends ChartDataSeries>(
   props: VerticalBarChartProps<TData>,
-  ref: ForwardedRef<VerticalBarChartHandler>
+  ref: ForwardedRef<ChartHandler>
 ) {
   const {
     chartName,
@@ -52,9 +46,14 @@ function VerticalBarChartInner<TData extends ChartDataSeries>(
     valueUnit,
   } = props;
 
+  const { downloadPng, ref: rechartsRef } = useDownloadPngImage({
+    fileName: `${chartName}.png`,
+    onImageLoading,
+  });
+
   useImperativeHandle(ref, () => ({
     download() {
-      handleDownload();
+      downloadPng();
     },
   }));
 
@@ -74,22 +73,6 @@ function VerticalBarChartInner<TData extends ChartDataSeries>(
   };
 
   const margin = _margin || 5;
-
-  const [getPng, { ref: rechartsRef, isLoading }] = useCurrentPng({
-    backgroundColor: "#fff",
-  });
-
-  useEffect(() => {
-    onImageLoading && onImageLoading(isLoading);
-  }, [isLoading, onImageLoading]);
-
-  const handleDownload = useCallback(async () => {
-    const png = await getPng();
-
-    if (png) {
-      saveAs(png, `${chartName}.png`);
-    }
-  }, [getPng, chartName]);
 
   // https://stackoverflow.com/a/61373602/504477
   const renderCell = (
@@ -236,5 +219,5 @@ const MultiLineAxisTick = ({
 export const VerticalBarChart = forwardRef(VerticalBarChartInner) as <
   TData extends ChartDataSeries,
 >(
-  p: VerticalBarChartProps<TData> & { ref?: Ref<VerticalBarChartHandler> }
+  p: VerticalBarChartProps<TData> & { ref?: Ref<ChartHandler> }
 ) => ReactElement;

--- a/front-end-components/src/components/charts/vertical-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/vertical-bar-chart/component.tsx
@@ -3,6 +3,8 @@ import {
   ReactElement,
   Ref,
   forwardRef,
+  useCallback,
+  useEffect,
   useImperativeHandle,
   useMemo,
   useState,
@@ -26,6 +28,8 @@ import {
 import { CategoricalChartState } from "recharts/types/chart/types";
 import classNames from "classnames";
 import { ChartDataSeries, TickProps } from "src/components";
+import { useCurrentPng } from "recharts-to-png";
+import { saveAs } from "file-saver";
 
 function VerticalBarChartInner<TData extends ChartDataSeries>(
   props: VerticalBarChartProps<TData>,
@@ -40,6 +44,7 @@ function VerticalBarChartInner<TData extends ChartDataSeries>(
     legend,
     margin: _margin,
     multiLineAxisLabel,
+    onImageLoading,
     seriesConfig,
     seriesLabel,
     seriesLabelField,
@@ -49,7 +54,7 @@ function VerticalBarChartInner<TData extends ChartDataSeries>(
 
   useImperativeHandle(ref, () => ({
     download() {
-      alert("todo");
+      handleDownload();
     },
   }));
 
@@ -69,6 +74,22 @@ function VerticalBarChartInner<TData extends ChartDataSeries>(
   };
 
   const margin = _margin || 5;
+
+  const [getPng, { ref: rechartsRef, isLoading }] = useCurrentPng({
+    backgroundColor: "#fff",
+  });
+
+  useEffect(() => {
+    onImageLoading && onImageLoading(isLoading);
+  }, [isLoading, onImageLoading]);
+
+  const handleDownload = useCallback(async () => {
+    const png = await getPng();
+
+    if (png) {
+      saveAs(png, `${chartName}.png`);
+    }
+  }, [getPng, chartName]);
 
   // https://stackoverflow.com/a/61373602/504477
   const renderCell = (
@@ -119,6 +140,7 @@ function VerticalBarChartInner<TData extends ChartDataSeries>(
             left: margin,
           }}
           onMouseMove={handleBarChartMouseMove}
+          ref={rechartsRef}
         >
           {grid && (
             <CartesianGrid

--- a/front-end-components/src/components/charts/vertical-bar-chart/types.tsx
+++ b/front-end-components/src/components/charts/vertical-bar-chart/types.tsx
@@ -1,10 +1,11 @@
+import { Ref } from "react";
 import { ChartDataSeries, ChartProps, ChartSeriesValue } from "src/components";
 
 export interface VerticalBarChartProps<TData extends ChartDataSeries>
   extends ChartProps<TData> {
   highlightedItemKeys?: ChartSeriesValue[];
   legend?: boolean;
-  ref?: VerticalBarChartHandler;
+  ref?: Ref<VerticalBarChartHandler>;
 }
 
 export type VerticalBarChartHandler = {

--- a/front-end-components/src/components/charts/vertical-bar-chart/types.tsx
+++ b/front-end-components/src/components/charts/vertical-bar-chart/types.tsx
@@ -1,13 +1,7 @@
-import { Ref } from "react";
 import { ChartDataSeries, ChartProps, ChartSeriesValue } from "src/components";
 
 export interface VerticalBarChartProps<TData extends ChartDataSeries>
   extends ChartProps<TData> {
   highlightedItemKeys?: ChartSeriesValue[];
   legend?: boolean;
-  ref?: Ref<VerticalBarChartHandler>;
 }
-
-export type VerticalBarChartHandler = {
-  download: () => void;
-};

--- a/front-end-components/src/hooks/useDownloadImage.ts
+++ b/front-end-components/src/hooks/useDownloadImage.ts
@@ -1,0 +1,29 @@
+import saveAs from "file-saver";
+import { useEffect, useCallback } from "react";
+import { useCurrentPng } from "recharts-to-png";
+
+export function useDownloadPngImage({
+  fileName,
+  onImageLoading,
+}: {
+  fileName: string;
+  onImageLoading?: (loading: boolean) => void;
+}) {
+  const [getPng, { ref, isLoading }] = useCurrentPng({
+    backgroundColor: "#fff",
+  });
+
+  useEffect(() => {
+    onImageLoading && onImageLoading(isLoading);
+  }, [isLoading, onImageLoading]);
+
+  const downloadPng = useCallback(async () => {
+    const png = await getPng();
+
+    if (png) {
+      saveAs(png, fileName);
+    }
+  }, [getPng, fileName]);
+
+  return { downloadPng, ref };
+}

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -9,12 +9,10 @@ import {
   VerticalBarChart2SeriesElementId,
   VerticalBarChart3SeriesElementId,
 } from "src/constants";
-import {
-  VerticalBarChart,
-  VerticalBarChartHandler,
-} from "./components/charts/vertical-bar-chart";
+import { VerticalBarChart } from "./components/charts/vertical-bar-chart";
 import { LineChart } from "./components/charts/line-chart";
 import { Stat } from "./components/charts/stat";
+import { ChartHandler } from "./components";
 
 const compareYourSchoolElement = document.getElementById(
   CompareYourSchoolElementId
@@ -69,11 +67,11 @@ const VerticalChart2Series = ({
     id: number;
   }[];
 }) => {
-  const verticalChart2SeriesRef = useRef<VerticalBarChartHandler>(null);
+  const verticalChart2SeriesRef = useRef<ChartHandler>(null);
   const [imageLoading, setImageLoading] = useState<boolean>();
 
   return (
-    <div>
+    <div className="govuk-grid-row">
       <button
         className="govuk-button govuk-button--secondary"
         data-module="govuk-button"
@@ -153,37 +151,102 @@ if (verticalChart3SeriesElement) {
 
     root.render(
       <React.StrictMode>
-        <div className="govuk-grid-column-two-thirds" style={{ height: 400 }}>
-          <VerticalBarChart
-            chartName="Percentage of pupils on roll and teacher cost"
-            data={data}
-            grid
-            keyField="id"
-            legend
-            margin={20}
-            multiLineAxisLabel
-            seriesConfig={{
-              pupilsOnRoll: {
-                label: "Pupils on roll",
-                visible: true,
-              },
-              teacherCost: {
-                label: "Teacher cost",
-                visible: true,
-              },
-              teachingAssistantCost: {
-                label: "Teaching assistant cost",
-                visible: true,
-              },
-            }}
-            seriesLabelField="group"
-            valueUnit="%"
-          />
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-two-thirds" style={{ height: 400 }}>
+            <VerticalBarChart
+              chartName="Percentage of pupils on roll and teacher cost"
+              data={data}
+              grid
+              keyField="id"
+              legend
+              margin={20}
+              multiLineAxisLabel
+              seriesConfig={{
+                pupilsOnRoll: {
+                  label: "Pupils on roll",
+                  visible: true,
+                },
+                teacherCost: {
+                  label: "Teacher cost",
+                  visible: true,
+                },
+                teachingAssistantCost: {
+                  label: "Teaching assistant cost",
+                  visible: true,
+                },
+              }}
+              seriesLabelField="group"
+              valueUnit="%"
+            />
+          </div>
         </div>
       </React.StrictMode>
     );
   }
 }
+
+// eslint-disable-next-line react-refresh/only-export-components
+const LineChart1Series = ({
+  data,
+}: {
+  data: {
+    term: string;
+    inYearBalance: number;
+  }[];
+}) => {
+  const lineChart1SeriesRef = useRef<ChartHandler>(null);
+  const [imageLoading, setImageLoading] = useState<boolean>();
+
+  return (
+    <div className="govuk-grid-row">
+      <button
+        className="govuk-button govuk-button--secondary"
+        data-module="govuk-button"
+        disabled={imageLoading}
+        aria-disabled={imageLoading}
+        onClick={() => lineChart1SeriesRef?.current?.download()}
+      >
+        Download as image
+      </button>
+      <div className="govuk-grid-column-two-thirds">
+        <div
+          className="govuk-grid-column-three-quarters"
+          style={{ height: 400 }}
+        >
+          <LineChart
+            chartName="In-year balance"
+            data={data}
+            keyField="term"
+            margin={20}
+            onImageLoading={setImageLoading}
+            ref={lineChart1SeriesRef}
+            seriesConfig={{
+              inYearBalance: {
+                label: "Pupils on roll",
+                visible: true,
+              },
+            }}
+            seriesLabel="Absolute total"
+            seriesLabelField="term"
+            valueUnit="currency"
+            tooltip
+          />
+        </div>
+        <aside className="govuk-grid-column-one-quarter desktop">
+          <Stat
+            chartName="Most recent in-year balance"
+            className="chart-stat-line-chart"
+            data={data}
+            displayIndex={data.length - 1}
+            seriesLabelField="term"
+            valueField="inYearBalance"
+            valueUnit="currency"
+          />
+        </aside>
+      </div>
+    </div>
+  );
+};
 
 const lineChart1SeriesElement = document.getElementById(
   LineChart1SeriesElementId
@@ -200,40 +263,7 @@ if (lineChart1SeriesElement) {
 
     root.render(
       <React.StrictMode>
-        <div className="govuk-grid-column-two-thirds">
-          <div
-            className="govuk-grid-column-three-quarters"
-            style={{ height: 400 }}
-          >
-            <LineChart
-              chartName="In-year balance"
-              data={data}
-              keyField="term"
-              margin={20}
-              seriesConfig={{
-                inYearBalance: {
-                  label: "Pupils on roll",
-                  visible: true,
-                },
-              }}
-              seriesLabel="Absolute total"
-              seriesLabelField="term"
-              valueUnit="currency"
-              tooltip
-            />
-          </div>
-          <aside className="govuk-grid-column-one-quarter desktop">
-            <Stat
-              chartName="Most recent in-year balance"
-              className="chart-stat-line-chart"
-              data={data}
-              displayIndex={data.length - 1}
-              seriesLabelField="term"
-              valueField="inYearBalance"
-              valueUnit="currency"
-            />
-          </aside>
-        </div>
+        <LineChart1Series data={data} />
       </React.StrictMode>
     );
   }

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef, useState } from "react";
 import ReactDOM from "react-dom/client";
 import "src/index.css";
 import { CompareYourSchool, CompareYourWorkforce } from "src/views";
@@ -9,7 +9,10 @@ import {
   VerticalBarChart2SeriesElementId,
   VerticalBarChart3SeriesElementId,
 } from "src/constants";
-import { VerticalBarChart } from "./components/charts/vertical-bar-chart";
+import {
+  VerticalBarChart,
+  VerticalBarChartHandler,
+} from "./components/charts/vertical-bar-chart";
 import { LineChart } from "./components/charts/line-chart";
 import { Stat } from "./components/charts/stat";
 
@@ -55,14 +58,68 @@ if (compareWorkforceElement) {
   }
 }
 
-const verticalChart1SeriesElement = document.getElementById(
+// eslint-disable-next-line react-refresh/only-export-components
+const VerticalChart2Series = ({
+  data,
+}: {
+  data: {
+    group: string;
+    pupilsOnRoll: number;
+    teacherCost: number;
+    id: number;
+  }[];
+}) => {
+  const verticalChart2SeriesRef = useRef<VerticalBarChartHandler>(null);
+  const [imageLoading, setImageLoading] = useState<boolean>();
+
+  return (
+    <div>
+      <button
+        className="govuk-button govuk-button--secondary"
+        data-module="govuk-button"
+        disabled={imageLoading}
+        aria-disabled={imageLoading}
+        onClick={() => verticalChart2SeriesRef?.current?.download()}
+      >
+        Download as image
+      </button>
+      <div className="govuk-grid-column-two-thirds" style={{ height: 400 }}>
+        <VerticalBarChart
+          chartName="Percentage of pupils on roll and teacher cost"
+          data={data}
+          grid
+          keyField="id"
+          legend
+          margin={20}
+          multiLineAxisLabel
+          onImageLoading={setImageLoading}
+          ref={verticalChart2SeriesRef}
+          seriesConfig={{
+            pupilsOnRoll: {
+              label: "Pupils on roll",
+              visible: true,
+            },
+            teacherCost: {
+              label: "Teacher cost",
+              visible: true,
+            },
+          }}
+          seriesLabelField="group"
+          valueUnit="%"
+        />
+      </div>
+    </div>
+  );
+};
+
+const verticalChart2SeriesElement = document.getElementById(
   VerticalBarChart2SeriesElementId
 );
 
-if (verticalChart1SeriesElement) {
-  const { json } = verticalChart1SeriesElement.dataset;
+if (verticalChart2SeriesElement) {
+  const { json } = verticalChart2SeriesElement.dataset;
   if (json) {
-    const root = ReactDOM.createRoot(verticalChart1SeriesElement);
+    const root = ReactDOM.createRoot(verticalChart2SeriesElement);
     const data = JSON.parse(json) as {
       group: string;
       pupilsOnRoll: number;
@@ -72,42 +129,20 @@ if (verticalChart1SeriesElement) {
 
     root.render(
       <React.StrictMode>
-        <div className="govuk-grid-column-two-thirds" style={{ height: 400 }}>
-          <VerticalBarChart
-            chartName="Percentage of pupils on roll and teacher cost"
-            data={data}
-            grid
-            keyField="id"
-            legend
-            margin={20}
-            multiLineAxisLabel
-            seriesConfig={{
-              pupilsOnRoll: {
-                label: "Pupils on roll",
-                visible: true,
-              },
-              teacherCost: {
-                label: "Teacher cost",
-                visible: true,
-              },
-            }}
-            seriesLabelField="group"
-            valueUnit="%"
-          />
-        </div>
+        <VerticalChart2Series data={data} />
       </React.StrictMode>
     );
   }
 }
 
-const verticalChart2SeriesElement = document.getElementById(
+const verticalChart3SeriesElement = document.getElementById(
   VerticalBarChart3SeriesElementId
 );
 
-if (verticalChart2SeriesElement) {
-  const { json } = verticalChart2SeriesElement.dataset;
+if (verticalChart3SeriesElement) {
+  const { json } = verticalChart3SeriesElement.dataset;
   if (json) {
-    const root = ReactDOM.createRoot(verticalChart2SeriesElement);
+    const root = ReactDOM.createRoot(verticalChart3SeriesElement);
     const data = JSON.parse(json) as {
       group: string;
       pupilsOnRoll: number;


### PR DESCRIPTION
### Context
[AB#197110](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/197110)

### Change proposed in this pull request
Added ability to download chart (or any element, in fact) as an image. 

### Guidance to review 
Sample usage in the `front-end-components` local dev server.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

