### PR TITLE
adds other teaching periods confirmation page to cfp journey

### DIFF
--- a/web/src/EducationBenchmarking.Web/Constants/PageTitles.cs
+++ b/web/src/EducationBenchmarking.Web/Constants/PageTitles.cs
@@ -30,6 +30,7 @@ public static class PageTitles
     public const string SchoolPlanningPupilFigures = "What are your pupil figures?";
     public const string SchoolPlanningTeacherPeriodAllocation = "What are your teacher period allocation figures?";
     public const string SchoolPlanningOtherTeacherPeriodsAdd = "Add other teaching periods";
+    public const string SchoolPlanningOtherTeachingPeriodsConfirm = "Proceed without adding other teaching periods?";
     public const string SchoolPlanningTeachingAssistantFigures = "What are your teaching assistant figures?";
     public const string SchoolPlanningManagementRoles = "Management roles with teaching responsibilties";
     public const string SchoolPlanningManagersPerRole = "Number of managers per role";

--- a/web/src/EducationBenchmarking.Web/Domain/FinancialPlanStages/OtherTeachingPeriodsConfirmStage.cs
+++ b/web/src/EducationBenchmarking.Web/Domain/FinancialPlanStages/OtherTeachingPeriodsConfirmStage.cs
@@ -1,0 +1,6 @@
+﻿namespace EducationBenchmarking.Web.Domain.FinancialPlanStages;
+
+public class OtherTeachingPeriodsConfirmStage : Stage
+{
+    public bool? Proceed { get; set; }
+}

--- a/web/src/EducationBenchmarking.Web/Validators/FinancialPlanStageValidator.cs
+++ b/web/src/EducationBenchmarking.Web/Validators/FinancialPlanStageValidator.cs
@@ -21,6 +21,7 @@ public class FinancialPlanStageValidator : IFinancialPlanStageValidator
     private static readonly TeacherPeriodAllocationStageValidator TeacherPeriodAllocation = new();
     private static readonly TeachingAssistantFiguresStageValidator TeachingAssistantFigures = new();
     private static readonly OtherTeachingPeriodsStageValidator OtherTeachingPeriods = new();
+    private static readonly OtherTeachingPeriodsConfirmStageValidator OtherTeachingPeriodsConfirm = new();
     private static readonly ManagementRolesStageValidator ManagementRoles = new();
     private static readonly ManagersPerRoleStageValidator ManagersPerRole = new();
     private static readonly TeachingPeriodsManagerStageValidator TeachingPeriodsManager = new();
@@ -100,6 +101,11 @@ public class FinancialPlanStageValidator : IFinancialPlanStageValidator
         return await OtherTeachingPeriods.ValidateAsync(stage);
     }
 
+    public async Task<ValidationResult> ValidateAsync(OtherTeachingPeriodsConfirmStage stage)
+    {
+        return await OtherTeachingPeriodsConfirm.ValidateAsync(stage);
+    }
+
     public async Task<ValidationResult> ValidateAsync(ManagementRolesStage stage)
     {
         return await ManagementRoles.ValidateAsync(stage);
@@ -133,6 +139,7 @@ public interface IFinancialPlanStageValidator
     Task<ValidationResult> ValidateAsync(TeacherPeriodAllocationStage stage);
     Task<ValidationResult> ValidateAsync(TeachingAssistantFiguresStage stage);
     Task<ValidationResult> ValidateAsync(OtherTeachingPeriodsStage stage);
+    Task<ValidationResult> ValidateAsync(OtherTeachingPeriodsConfirmStage stage);
     Task<ValidationResult> ValidateAsync(ManagementRolesStage stage);
     Task<ValidationResult> ValidateAsync(ManagersPerRoleStage stage);
     Task<ValidationResult> ValidateAsync(TeachingPeriodsManagerStage stage);

--- a/web/src/EducationBenchmarking.Web/Validators/FinancialPlanStages/OtherTeachingPeriodsConfirmStageValidator.cs
+++ b/web/src/EducationBenchmarking.Web/Validators/FinancialPlanStages/OtherTeachingPeriodsConfirmStageValidator.cs
@@ -1,0 +1,16 @@
+﻿using EducationBenchmarking.Web.Domain.FinancialPlanStages;
+using FluentValidation;
+
+namespace EducationBenchmarking.Web.Validators.FinancialPlanStages
+{
+    public class OtherTeachingPeriodsConfirmStageValidator : AbstractValidator<OtherTeachingPeriodsConfirmStage>
+    {
+        public OtherTeachingPeriodsConfirmStageValidator()
+        {
+            RuleFor(p => p.Proceed)
+                .Must(x => x.HasValue)
+                .WithMessage("Please select yes or no")
+                .WithName("Proceed");
+        }
+    }
+}

--- a/web/src/EducationBenchmarking.Web/Validators/FinancialPlanStages/OtherTeachingPeriodsConfirmStageValidator.cs
+++ b/web/src/EducationBenchmarking.Web/Validators/FinancialPlanStages/OtherTeachingPeriodsConfirmStageValidator.cs
@@ -9,8 +9,7 @@ namespace EducationBenchmarking.Web.Validators.FinancialPlanStages
         {
             RuleFor(p => p.Proceed)
                 .Must(x => x.HasValue)
-                .WithMessage("Please select yes or no")
-                .WithName("Proceed");
+                .WithMessage("Select yes if you want to continue without adding other teaching periods");
         }
     }
 }

--- a/web/src/EducationBenchmarking.Web/Views/SchoolPlanningCreate/OtherTeachingPeriodsConfirm.cshtml
+++ b/web/src/EducationBenchmarking.Web/Views/SchoolPlanningCreate/OtherTeachingPeriodsConfirm.cshtml
@@ -1,0 +1,50 @@
+﻿@using EducationBenchmarking.Web.Extensions
+@model EducationBenchmarking.Web.ViewModels.SchoolPlanCreateViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.SchoolPlanningOtherTeachingPeriodsConfirm;
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        @using (Html.BeginForm("OtherTeachingPeriodsConfirm", "SchoolPlanningCreate", new { urn = Model.School.Urn, year = Model.Plan?.Year }, FormMethod.Post, true, new { novalidate = "novalidate" }))
+        {
+            <div class="@(ViewData.ModelState.HasError("Proceed") ? "govuk-form-group govuk-form-group--error" : "govuk-form-group")">
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                        <span class="govuk-caption-l">@Model.School.Name</span>
+                        <h1 class="govuk-fieldset__heading">
+                            @ViewData[ViewDataKeys.Title]
+                        </h1>
+                    </legend>
+                    <div id="proceed-without-other-teaching-periods-hint" class="govuk-hint">
+                        Not adding other teaching periods could make your contact ratio less accurate.
+                    </div>
+                    @if (ViewData.ModelState.HasError("Proceed"))
+                    {
+                        <p id="proceed-error" class="govuk-error-message">
+                            <span class="govuk-visually-hidden">Error:</span> @ViewData.ModelState["Proceed"]?.Errors.First().ErrorMessage
+                        </p>
+                    }
+                    <div class="govuk-radios govuk-radios govuk-radios--inline" data-module="govuk-radios">
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="proceed-Yes" name="proceed" type="radio" value="true">
+                            <label class="govuk-label govuk-radios__label" for="proceed-Yes">
+                                Yes
+                            </label>
+                        </div>
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="proceed-No" name="proceed" type="radio" value="false">
+                            <label class="govuk-label govuk-radios__label" for="proceed-No">
+                                No
+                            </label>
+                        </div>
+                    </div>
+                </fieldset>
+            </div>
+            <button type="submit" class="govuk-button" data-module="govuk-button">
+                Continue
+            </button>
+        }
+    </div>
+</div>
+    


### PR DESCRIPTION
### Context
Story - [AB#191593](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/191593)
Tasks - [AB#198910](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/198910) & [AB#198911](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/198911)

### Change proposed in this pull request
Adds the confirmation page to proceed without adding other teaching periods to the plan for the cfp journey
adds validation if the users does not select yes or no

### Guidance to review 
Hint text used rather than a warning text to match the style used in previous steps of the journey.
Title also changed from the ticket for the same reasons

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

