### PR TITLE
fix: error in deployment plan when zero teaching assistants

### DIFF
--- a/web/src/Web.App/ViewModels/SchoolDeploymentPlanViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolDeploymentPlanViewModel.cs
@@ -128,7 +128,7 @@ public class SchoolDeploymentPlanViewModel(School school, FinancialPlan plan, st
 
     public decimal AverageTeacherCost => TotalTeacherCosts / TotalNumberOfTeachersFte;
 
-    public decimal AverageTeachingAssistantCost => EducationSupportStaffCosts / TotalTeachingAssistants;
+    public decimal AverageTeachingAssistantCost => TotalTeachingAssistants > 0 ? EducationSupportStaffCosts / TotalTeachingAssistants : 0;
 
     public ManagementRole[] ManagementRoles => BuildManagementRoles();
 


### PR DESCRIPTION
### Context
[AB#191678](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/191678) ([AB#200308](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/200308))

### Change proposed in this pull request
Fixes error in deployment plan when zero teaching assistant

### Guidance to review 
Enter zero for all teaching assistances.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

