### PR TITLE
chore: ensure deployments occur from main

### DIFF
--- a/core-infrastructure/pipelines/build.yaml
+++ b/core-infrastructure/pipelines/build.yaml
@@ -16,6 +16,7 @@ pr: none
 variables:
   TerraformFolder: 'core-infrastructure/terraform'
   TerraformDirectory: '$(System.DefaultWorkingDirectory)/$(TerraformFolder)'
+  ShouldDeploy: and(eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne(variables['Build.Reason'], 'PullRequest'))
 
 stages:
   - stage: Build
@@ -44,6 +45,7 @@ stages:
 
   - stage: DeployDevelopment
     dependsOn: [ Build ]
+    condition: and(succeeded(), $(ShouldDeploy))
     displayName: 'Development'
     jobs:
       - template: jobs-core-deployment.yaml
@@ -55,6 +57,7 @@ stages:
 
   - stage: DeployAutomatedTest
     dependsOn: [ Build ]
+    condition: and(succeeded(), $(ShouldDeploy))
     displayName: 'Automated test'
     jobs:
       - template: jobs-core-deployment.yaml
@@ -66,6 +69,7 @@ stages:
 
   - stage: DeployTest
     dependsOn: [ Build, DeployAutomatedTest ]
+    condition: and(succeeded(), $(ShouldDeploy))
     displayName: 'Test'
     jobs:
       - template: jobs-core-deployment.yaml

--- a/platform/pipelines/build.yaml
+++ b/platform/pipelines/build.yaml
@@ -24,6 +24,7 @@ variables:
   NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS: 30
   TerraformFolder: 'platform/terraform'
   TerraformDirectory: '$(System.DefaultWorkingDirectory)/$(TerraformFolder)'
+  ShouldDeploy: and(eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne(variables['Build.Reason'], 'PullRequest'))
 
 stages:
   - stage: Build
@@ -93,7 +94,7 @@ stages:
   - stage: DeployDevelopment
     dependsOn: [ Build ]
     displayName: 'Development'
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    condition: and(succeeded(), $(ShouldDeploy))
     jobs:
       - template: jobs-platform-deployment.yaml
         parameters:
@@ -105,7 +106,7 @@ stages:
   - stage: DeployAutomatedTest
     dependsOn: [ Build ]
     displayName: 'Automated test'
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    condition: and(succeeded(), $(ShouldDeploy))
     jobs:
       - template: jobs-platform-deployment.yaml
         parameters:
@@ -118,7 +119,7 @@ stages:
   - stage: DeployTest
     dependsOn: [ Build, DeployAutomatedTest ]
     displayName: 'Test'
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    condition: and(succeeded(), $(ShouldDeploy))
     jobs:
       - template: jobs-platform-deployment.yaml
         parameters:

--- a/prototype/pipeline/build.yaml
+++ b/prototype/pipeline/build.yaml
@@ -16,6 +16,7 @@ pr: none
 variables:
   TerraformFolder: 'prototype/terraform'
   TerraformDirectory: '$(System.DefaultWorkingDirectory)/$(TerraformFolder)'
+  ShouldDeploy: and(eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne(variables['Build.Reason'], 'PullRequest'))
 
 stages:
   - stage: Build
@@ -51,6 +52,7 @@ stages:
 
   - stage: DeployDevelopment
     dependsOn: [Build]
+    condition: and(succeeded(), $(ShouldDeploy))
     displayName: 'Deploy to prototype'
     variables:
       - group: 'prototype'

--- a/web/pipelines/build.yaml
+++ b/web/pipelines/build.yaml
@@ -24,6 +24,7 @@ variables:
   NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS: 30
   TerraformFolder: 'web/terraform'
   TerraformDirectory: '$(System.DefaultWorkingDirectory)/$(TerraformFolder)'
+  ShouldDeploy: and(eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne(variables['Build.Reason'], 'PullRequest'))
 
 stages:
   - stage: Build
@@ -92,7 +93,7 @@ stages:
   - stage: DeployDevelopment
     dependsOn: [ Build ]
     displayName: 'Development'
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    condition: and(succeeded(), $(ShouldDeploy))
     variables:
       - group: 'dsi pre-prod'
     jobs:
@@ -106,7 +107,7 @@ stages:
   - stage: DeployAutomatedTest
     dependsOn: [ Build ]
     displayName: 'Automated test'
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    condition: and(succeeded(), $(ShouldDeploy))
     variables:
       - group: 'dsi pre-prod'
     jobs:
@@ -120,7 +121,7 @@ stages:
   - stage: DeployTest
     dependsOn: [ Build, DeployAutomatedTest ]
     displayName: 'Test'
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    condition: and(succeeded(), $(ShouldDeploy))
     variables:
       - group: 'dsi pre-prod'
     jobs:


### PR DESCRIPTION
### Context
Ensure deployments only come from main

### Change proposed in this pull request
Oversight in pipelines meant manual run could use any branch and trigger a deployment - this add condition for main branch

### Guidance to review 
N/A

### Checklist
- [ ] ~~Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)~~
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally

