### PR TITLE
Setting and Docs tidy up for Web frontend.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -415,3 +415,5 @@ local.settings.json
 
 # OSX
 .DS_Store
+
+**/docker/sql

--- a/web/README.md
+++ b/web/README.md
@@ -15,6 +15,8 @@ In a console window:
 1. Navigate to `Web.App` project root
 2. Run `dotnet user-secrets init` to initialise secrets in the directory
 
+> Note: If there is already a `<UserSecretsId>` setting in the `Web.App` project file then `dotnet user-secrets init` will fail. This is because the dotnet tool thinks the user secrets has already been initialised. To avoid this run `dotnet user-secrets set "PLACEHOLDER" "PLACEHOLDER". This will create a `secrets.json` file in the folder location described [here](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-8.0&tabs=linux#how-the-secret-manager-tool-works). At this point you can update the `secrets.json` by hand with all of the required settings.
+
 #### Platform APIs
 If running the Platform APIs locally then no further configuration required; ensure the API port configuration matches that in `appsettings.Development.json`.
 

--- a/web/README.md
+++ b/web/README.md
@@ -32,7 +32,16 @@ However, if you are using deployed instances of the Platform APIs then having in
 #### DfE Sign-in (DSI) authentication
 Having initialised secret storage, in a console window:
 1. Navigate to `Web.App` project root
-2. Set XXXX user secret: `dotnet user-secrets set "XXXX" "xxxxx"`
+2. Set DSI Sign-out URI user secret: `dotnet user-secrets set "DFESignInSettings:SignOutUri" "[INSERT URL VALUE]"`
+3. Set DSI Signed out callback path user secret: `dotnet user-secrets set "DFESignInSettings:SignedOutCallbackPath" "[INSERT PATH VALUE]"`
+4. Set DSI Metadata address user secret: `dotnet user-secrets set "DFESignInSettings:MetadataAddress" "[INSERT URL VALUE]"`
+5. Set DSI Issuer user secret: `dotnet user-secrets set "DFESignInSettings:Issuer" "[INSERT SECRET VALUE]"`
+6. Set DSI Client Secret user secret: `dotnet user-secrets set "DFESignInSettings:ClientSecret" "[INSERT CLIENT SECRET VALUE]"`
+7. Set DSI Client ID user secret: `dotnet user-secrets set "DFESignInSettings:ClientID" "[INSERT ID VALUE]"`
+8. Set DSI Callback path user secret: `dotnet user-secrets set "DFESignInSettings:CallbackPath" "[INSERT PATH VALUE]"`
+9. Set DSI Audience user secret: `dotnet user-secrets set "DFESignInSettings:Audience" "[INSERT AUDIENCE VALUE]"`
+10. Set DSI API Url user secret: `dotnet user-secrets set "DFESignInSettings:APIUri" "[INSERT AUDIENCE VALUE]"`
+11. Set DSI API Secret user secret: `dotnet user-secrets set "DFESignInSettings:APISecret" "[INSERT API SECRET VALUE]"`
 
 #### Session cache
 Having initialised secret storage, in a console window:

--- a/web/global.json
+++ b/web/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
+  }
+}

--- a/web/src/Web.App/appsettings.Development.json
+++ b/web/src/Web.App/appsettings.Development.json
@@ -21,18 +21,6 @@
     "ContainerName": "sessions",
     "DatabaseName": "session-data"
   },
-  "DFESignInSettings": {
-    "APISecret": "some-secret",
-    "APIUri": "https://pp-api.signin.education.gov.uk",
-    "Audience": "signin.education.gov.uk",
-    "CallbackPath": "/auth/cb",
-    "ClientID": "some-client-id",
-    "ClientSecret": "some-client-id",
-    "Issuer": "some-issuer",
-    "MetadataAddress": "https://pp-oidc.signin.education.gov.uk/.well-known/openid-configuration",
-    "SignedOutCallbackPath": "/signout/complete",
-    "SignOutUri": "https://pp-services.signin.education.gov.uk/signout"
-  },
   "Serilog": {
     "Using": [
       "Serilog.Sinks.Console"


### PR DESCRIPTION
### Context
This is a minor PR that adds the following 

* .gitgnore for local dev SQL scenarios
* An extra note about `dotnet user-secrets init` in README
* global.json added to ensure that the .NET version is contolled by the solution
* removed DfE settings. 


