### PR TITLE
Remove dependency on cosmos for session data for local dev.

### DIFF
--- a/documentation/developers/session-data.md
+++ b/documentation/developers/session-data.md
@@ -16,7 +16,7 @@ Two configuration have been implemented;
 This is the default option when no configuration has been set.
 
 ### Cosmos
-This follow settings will enable Cosmos Db to be used as the backing data store. 
+The follow settings will enable Cosmos Db to be used as the backing data store. 
 
 ```
 "SessionData" : {

--- a/documentation/developers/session-data.md
+++ b/documentation/developers/session-data.md
@@ -1,0 +1,30 @@
+# Session state 
+
+The web app needs to maintain/store user data across requests - specifically modifications to comparator sets. 
+Given these actions can be performed by any user (authenticated and non-authenticated) options for storing this data were limited.
+
+Cookies store was considered, however their size should be kept to a minimum with most browsers restrict cookie size to 4096 bytes. 
+Whilst there are options to work around this, it would introduce dependencies on client side scripting.
+
+Session state is being used for storage of user data while the user browses a web app, more information can be found [here](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/app-state?view=aspnetcore-8.0#session-state).
+
+Two configuration have been implemented;
+1. In-memory
+2. Cosmos
+
+### In-memory
+This is the default option when no configuration has been set.
+
+### Cosmos
+This follow settings will enable Cosmos Db to be used as the backing data store. 
+
+```
+"SessionData" : {
+    "Using" : "Cosmos",
+    "Settings" : {
+        "ConnectionString" : "[INSERT CONNECTION STRING VALUE]",
+        "ContainerName": "[INSERT CONTAINER NAME VALUE]",
+        "DatabaseName": "[INSERT DATABASE NAME VALUE]"
+    }
+}
+```

--- a/web/README.md
+++ b/web/README.md
@@ -43,11 +43,6 @@ Having initialised secret storage, in a console window:
 10. Set DSI API Url user secret: `dotnet user-secrets set "DFESignInSettings:APIUri" "[INSERT AUDIENCE VALUE]"`
 11. Set DSI API Secret user secret: `dotnet user-secrets set "DFESignInSettings:APISecret" "[INSERT API SECRET VALUE]"`
 
-#### Session cache
-Having initialised secret storage, in a console window:
-1. Navigate to `Web.App` project root
-2. Set session cache connection string user secret: `dotnet user-secrets set "CosmosCacheSettings:ConnectionString" "[INSERT CONNECTION STRING VALUE]"`
-3. Optional, direct mode is preferred however if you have issues run the follow to set the mode to gateway: `dotnet user-secrets set "CosmosCacheSettings:IsDirect" false`
 
 ### Running tests
 

--- a/web/src/Web.App/Extensions/WebApplicationBuilderExtensions.cs
+++ b/web/src/Web.App/Extensions/WebApplicationBuilderExtensions.cs
@@ -8,7 +8,7 @@ public static class WebApplicationBuilderExtensions
     {
         var section = builder.Configuration.GetSection("SessionData");
         var storeType = section.GetValue<string>("Using");
-        
+
         switch (storeType?.ToLower())
         {
             case "cosmos":
@@ -27,7 +27,7 @@ public static class WebApplicationBuilderExtensions
                 builder.Services.AddDistributedMemoryCache();
                 break;
         }
-        
+
         return builder;
     }
 }

--- a/web/src/Web.App/Extensions/WebApplicationBuilderExtensions.cs
+++ b/web/src/Web.App/Extensions/WebApplicationBuilderExtensions.cs
@@ -15,10 +15,13 @@ public static class WebApplicationBuilderExtensions
                 builder.Services.AddCosmosCache(opts =>
                 {
                     var settings = section.GetSection("Settings").Get<CosmosCacheSettings>();
+                    
                     ArgumentNullException.ThrowIfNull(settings);
-
-                    opts.ContainerName = settings.ContainerName ?? throw new ArgumentNullException(nameof(settings.ContainerName));
-                    opts.DatabaseName = settings.DatabaseName ?? throw new ArgumentNullException(nameof(settings.DatabaseName));
+                    ArgumentNullException.ThrowIfNull(settings.ContainerName);
+                    ArgumentNullException.ThrowIfNull(settings.DatabaseName);
+                    
+                    opts.ContainerName = settings.ContainerName;
+                    opts.DatabaseName = settings.DatabaseName;
                     opts.CosmosClient = CosmosClientFactory.Create(settings);
                     opts.CreateIfNotExists = false;
                 });

--- a/web/src/Web.App/Extensions/WebApplicationBuilderExtensions.cs
+++ b/web/src/Web.App/Extensions/WebApplicationBuilderExtensions.cs
@@ -1,0 +1,33 @@
+﻿using Web.App.Infrastructure.Session;
+
+namespace Web.App.Extensions;
+
+public static class WebApplicationBuilderExtensions
+{
+    public static WebApplicationBuilder AddCacheService(this WebApplicationBuilder builder)
+    {
+        var section = builder.Configuration.GetSection("SessionData");
+        var storeType = section.GetValue<string>("Using");
+        
+        switch (storeType?.ToLower())
+        {
+            case "cosmos":
+                builder.Services.AddCosmosCache(opts =>
+                {
+                    var settings = section.GetSection("Settings").Get<CosmosCacheSettings>();
+                    ArgumentNullException.ThrowIfNull(settings);
+
+                    opts.ContainerName = settings.ContainerName ?? throw new ArgumentNullException(nameof(settings.ContainerName));
+                    opts.DatabaseName = settings.DatabaseName ?? throw new ArgumentNullException(nameof(settings.DatabaseName));
+                    opts.CosmosClient = CosmosClientFactory.Create(settings);
+                    opts.CreateIfNotExists = false;
+                });
+                break;
+            default:
+                builder.Services.AddDistributedMemoryCache();
+                break;
+        }
+        
+        return builder;
+    }
+}

--- a/web/src/Web.App/Extensions/WebApplicationBuilderExtensions.cs
+++ b/web/src/Web.App/Extensions/WebApplicationBuilderExtensions.cs
@@ -15,11 +15,11 @@ public static class WebApplicationBuilderExtensions
                 builder.Services.AddCosmosCache(opts =>
                 {
                     var settings = section.GetSection("Settings").Get<CosmosCacheSettings>();
-                    
+
                     ArgumentNullException.ThrowIfNull(settings);
                     ArgumentNullException.ThrowIfNull(settings.ContainerName);
                     ArgumentNullException.ThrowIfNull(settings.DatabaseName);
-                    
+
                     opts.ContainerName = settings.ContainerName;
                     opts.DatabaseName = settings.DatabaseName;
                     opts.CosmosClient = CosmosClientFactory.Create(settings);

--- a/web/src/Web.App/Infrastructure/Session/CosmosCacheSettings.cs
+++ b/web/src/Web.App/Infrastructure/Session/CosmosCacheSettings.cs
@@ -5,7 +5,6 @@ namespace Web.App.Infrastructure.Session;
 [ExcludeFromCodeCoverage]
 public class CosmosCacheSettings
 {
-    public const string Section = nameof(CosmosCacheSettings);
     public string? ConnectionString { get; set; }
     public bool IsDirect { get; set; } = true;
     public string? ContainerName { get; set; }

--- a/web/src/Web.App/Program.cs
+++ b/web/src/Web.App/Program.cs
@@ -9,7 +9,6 @@ using Web.App;
 using Web.App.Extensions;
 using Web.App.Handlers;
 using Web.App.Infrastructure.Apis;
-using Web.App.Infrastructure.Session;
 using Web.App.Services;
 using Web.App.Validators;
 using Web.Identity.Extensions;
@@ -49,6 +48,8 @@ builder.Services.AddSession(options =>
     options.Cookie.IsEssential = true;
 });
 
+builder.AddCacheService();
+
 if (!builder.Environment.IsIntegration())
 {
     builder.Services.AddDfeSignIn(options =>
@@ -81,17 +82,6 @@ if (!builder.Environment.IsIntegration())
 
     builder.Services.AddHttpClient<IBenchmarkApi, BenchmarkApi>()
         .ConfigureHttpClientForApi(Constants.BenchmarkApi);
-
-    builder.Services.AddCosmosCache(opts =>
-    {
-        var settings = builder.Configuration.GetSection(CosmosCacheSettings.Section).Get<CosmosCacheSettings>();
-        ArgumentNullException.ThrowIfNull(settings);
-
-        opts.ContainerName = settings.ContainerName ?? throw new ArgumentNullException(nameof(settings.ContainerName));
-        opts.DatabaseName = settings.DatabaseName ?? throw new ArgumentNullException(nameof(settings.DatabaseName));
-        opts.CosmosClient = CosmosClientFactory.Create(settings);
-        opts.CreateIfNotExists = false;
-    });
 }
 
 var app = builder.Build();
@@ -114,7 +104,6 @@ app.MapControllerRoute(
     pattern: "{controller=Home}/{action=Index}/{id?}");
 
 app.Run();
-
 
 
 [ExcludeFromCodeCoverage]

--- a/web/terraform/main.tf
+++ b/web/terraform/main.tf
@@ -123,9 +123,10 @@ resource "azurerm_linux_web_app" "education-benchmarking-as" {
     "DFESignInSettings__MetadataAddress"             = var.dfe-signin.metadata-address
     "DFESignInSettings__SignedOutCallbackPath"       = var.dfe-signin.signed-out-callback-path
     "DFESignInSettings__SignOutUri"                  = var.dfe-signin.sign-out-uri
-    "CosmosCacheSettings__ConnectionString"          = azurerm_cosmosdb_account.session-cache-account.primary_sql_connection_string
-    "CosmosCacheSettings__ContainerName"             = azurerm_cosmosdb_sql_container.session-cache-container.name
-    "CosmosCacheSettings__DatabaseName"              = azurerm_cosmosdb_sql_database.session-cache-database.name
+    "SessionData__Using"                             = "Cosmos"
+    "SessionData__Settings__ConnectionString"        = azurerm_cosmosdb_account.session-cache-account.primary_sql_connection_string
+    "SessionData__Settings__ContainerName"           = azurerm_cosmosdb_sql_container.session-cache-container.name
+    "SessionData__Settings__DatabaseName"            = azurerm_cosmosdb_sql_database.session-cache-database.name
   }
   tags = local.common-tags
 }


### PR DESCRIPTION
### Context
Remove local dev dependency on Azure resource - for local development memory cache can be used, instead of cosmos.

Always gives flexibility to use other provides per environment (i.e. in memory for non-production to reduce costs).

### Checklist
- [x] ~~Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)~~
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

