### PR TITLE
adds DecileFinder to calculate deciles for rag statuses

### DIFF
--- a/web/src/Web.App/Domain/Deciles.cs
+++ b/web/src/Web.App/Domain/Deciles.cs
@@ -1,17 +1,16 @@
 ﻿namespace Web.App.Domain;
 
-public interface IDecileHandler
+public interface IDecileFinder
 {
-    public int FindDecile();
+    public int Find();
 }
 
-public class DecileHandler : IDecileHandler
+public class FindFromHighest : IDecileFinder
 {
     private readonly decimal _value;
     private readonly IReadOnlyList<decimal> _values;
-    private readonly bool _searchTopDown;
 
-    public DecileHandler(decimal value, IReadOnlyCollection<decimal> values, bool searchTopDown = false)
+    public FindFromHighest(decimal value, IReadOnlyCollection<decimal> values)
     {
         if (values.Count < 10)
         {
@@ -20,20 +19,15 @@ public class DecileHandler : IDecileHandler
 
         _value = value;
         _values = values.Order().ToArray();
-        _searchTopDown = searchTopDown;
     }
 
-    public int FindDecile()
-    {
-        return _searchTopDown ? TopDown() : BottomUp();
-    }
-
-    private int TopDown()
+    public int Find()
     {
         for (var decile = 10; decile > 1; decile--)
         {
+            var nextValueIndex = CountInDecile(decile - 1) - 1;
             var valueIndex = CountInDecile(decile) - 1;
-            if (_value < _values[valueIndex]) continue;
+            if (_value <= _values[nextValueIndex] && _value != _values[valueIndex]) continue;
 
             return decile;
         }
@@ -41,7 +35,30 @@ public class DecileHandler : IDecileHandler
         return 1;
     }
 
-    private int BottomUp()
+    private int CountInDecile(int decile)
+    {
+        var perDecile = _values.Count / 10.0;
+        return (int)Math.Round(perDecile * decile, MidpointRounding.AwayFromZero);
+    }
+}
+
+public class FindFromLowest : IDecileFinder
+{
+    private readonly decimal _value;
+    private readonly IReadOnlyList<decimal> _values;
+
+    public FindFromLowest(decimal value, IReadOnlyCollection<decimal> values)
+    {
+        if (values.Count < 10)
+        {
+            throw new ArgumentException("There must be at least 10 values to calculate deciles.");
+        }
+
+        _value = value;
+        _values = values.Order().ToArray();
+    }
+
+    public int Find()
     {
         for (var decile = 1; decile < 10; decile++)
         {
@@ -60,4 +77,3 @@ public class DecileHandler : IDecileHandler
         return (int)Math.Round(perDecile * decile, MidpointRounding.AwayFromZero);
     }
 }
-

--- a/web/src/Web.App/Domain/Deciles.cs
+++ b/web/src/Web.App/Domain/Deciles.cs
@@ -8,60 +8,77 @@ public interface IDecileHandler
 public class DecileHandler : IDecileHandler
 {
     private readonly decimal _value;
-    private readonly decimal[] _values;
+    private readonly IOrderedEnumerable<decimal> _values;
     private readonly bool _searchTopDown;
 
-    public DecileHandler(decimal value, decimal[] values, bool searchTopDown = false)
+    public DecileHandler(decimal value, IReadOnlyCollection<decimal> values, bool searchTopDown = false)
     {
+        if (values.Count < 10)
+        {
+            throw new ArgumentException("There must be at least 10 values to calculate deciles.");
+        }
+        
         _value = value;
-        _values = values.Length >= 10
-            ? values
-            : throw new ArgumentException("There must be at least 10 values to calculate deciles.");
+        _values = values.Order();
         _searchTopDown = searchTopDown;
     }
 
     public int FindDecile()
     {
-        var upperBounds = GetUpperBoundsForDeciles();
+        var bounds = GetUpperBoundsForDeciles();
 
-        var matchingDeciles = upperBounds.Select((upperBound, index) =>
-        {
-            if (index == 0 && _value <= upperBound)
-                return index + 1;
-            if (index > 0 && _value > upperBounds[index - 1] && _value <= upperBound)
-                return index + 1;
-            if (index > 0 && _value == upperBounds[index])
-                return index + 1;
-            return -1;
-        })
-        .Where(decile => decile != -1);
-
-        return matchingDeciles.Any()
-            ? _searchTopDown
-                ? matchingDeciles.Max()
-                : matchingDeciles.Min()
-            : 10;
+        return _searchTopDown
+            ? TopDown(bounds)
+            : BottomUp(bounds);
     }
 
-    public decimal[] GetUpperBoundsForDeciles()
+    
+    private int TopDown(IReadOnlyList<decimal> bounds)
     {
-        Array.Sort(_values);
-
-        var upperBounds = new decimal[9];
-
-        decimal decileSize = _values.Length / 10;
-
-        int sum = 0;
-        for (int i = 1; i <= 9; i++)
+        for (var i = bounds.Count; i > 0; i--)
         {
-            var currentDecileSize = (int)Math.Round((decileSize * i) / i);
-
-            upperBounds[i - 1] = _values.Skip(sum).Take(currentDecileSize).Max();
-
-            sum += currentDecileSize;
+            var bound = bounds[i];
+            if (_value > bound) continue;
+            
+            return i;
         }
 
-        return upperBounds;
+        return 1;
+    }
+    
+    private int BottomUp(IReadOnlyList<decimal> bounds)
+    {
+        for (var i = 0; i < bounds.Count; i++)
+        {
+            var bound = bounds[i];
+            if (_value > bound) continue;
+            
+            return i + 1;
+        }
+
+        return 10;
+    }
+
+    private decimal[] GetUpperBoundsForDeciles()
+    {
+        var values = _values.ToArray();
+        
+        var bounds = new decimal[9];
+        for (var i = 0; i <= 8; i++)
+        {
+            var decile = i + 1;
+            var valueIndex = CountInDecile(decile) - 1;
+            
+            bounds[i] = values[valueIndex];
+        }
+        
+        return bounds;
+    }
+
+    private int CountInDecile(int decile)
+    {
+        var perDecile = _values.Count() / 10.0;
+        return (int)Math.Round(perDecile * decile);
     }
 }
 

--- a/web/src/Web.App/Domain/Deciles.cs
+++ b/web/src/Web.App/Domain/Deciles.cs
@@ -55,7 +55,7 @@ public class DecileHandler : IDecileHandler
         for (int i = 1; i <= 9; i++)
         {
             var currentDecileSize = (int)Math.Round((decileSize * i) / i);
-            
+
             upperBounds[i - 1] = _values.Skip(sum).Take(currentDecileSize).Max();
 
             sum += currentDecileSize;

--- a/web/src/Web.App/Domain/Deciles.cs
+++ b/web/src/Web.App/Domain/Deciles.cs
@@ -1,0 +1,67 @@
+﻿namespace Web.App.Domain;
+
+public interface IDecileHandler
+{
+    public int FindDecile();
+}
+
+public class DecileHandler : IDecileHandler
+{
+    private readonly decimal _value;
+    private readonly decimal[] _values;
+    private readonly bool _searchTopDown;
+
+    public DecileHandler(decimal value, decimal[] values, bool searchTopDown = false)
+    {
+        _value = value;
+        _values = values.Length >= 10
+            ? values
+            : throw new ArgumentException("There must be at least 10 values to calculate deciles.");
+        _searchTopDown = searchTopDown;
+    }
+
+    public int FindDecile()
+    {
+        var upperBounds = GetUpperBoundsForDeciles();
+
+        var matchingDeciles = upperBounds.Select((upperBound, index) =>
+        {
+            if (index == 0 && _value <= upperBound)
+                return index + 1;
+            if (index > 0 && _value > upperBounds[index - 1] && _value <= upperBound)
+                return index + 1;
+            if (index > 0 && _value == upperBounds[index])
+                return index + 1;
+            return -1;
+        })
+        .Where(decile => decile != -1);
+
+        return matchingDeciles.Any()
+            ? _searchTopDown
+                ? matchingDeciles.Max()
+                : matchingDeciles.Min()
+            : 10;
+    }
+
+    public decimal[] GetUpperBoundsForDeciles()
+    {
+        Array.Sort(_values);
+
+        var upperBounds = new decimal[9];
+
+        decimal decileSize = _values.Length / 10;
+
+        int sum = 0;
+        for (int i = 1; i <= 9; i++)
+        {
+            var currentDecileSize = (int)Math.Round((decileSize * i) / i);
+            
+            upperBounds[i - 1] = _values.Skip(sum).Take(currentDecileSize).Max();
+
+            sum += currentDecileSize;
+        }
+
+        return upperBounds;
+    }
+}
+

--- a/web/src/Web.App/Domain/Deciles.cs
+++ b/web/src/Web.App/Domain/Deciles.cs
@@ -25,60 +25,38 @@ public class DecileHandler : IDecileHandler
 
     public int FindDecile()
     {
-        var bounds = GetUpperBoundsForDeciles();
-
-        return _searchTopDown
-            ? TopDown(bounds)
-            : BottomUp(bounds);
+        return _searchTopDown ? TopDown() : BottomUp();
     }
-
     
-    private int TopDown(IReadOnlyList<decimal> bounds)
+    private int TopDown()
     {
-        for (var i = bounds.Count; i > 0; i--)
+        for (var decile = 10; decile > 1; decile--)
         {
-            var bound = bounds[i];
-            if (_value > bound) continue;
+            var valueIndex = CountInDecile(decile) - 1;
+            if (_value < _values[valueIndex]) continue;
             
-            return i;
+            return decile;
         }
 
         return 1;
     }
     
-    private int BottomUp(IReadOnlyList<decimal> bounds)
+    private int BottomUp()
     {
-        for (var i = 0; i < bounds.Count; i++)
+        for (var decile = 1; decile < 10; decile++)
         {
-            var bound = bounds[i];
-            if (_value > bound) continue;
+            var valueIndex = CountInDecile(decile) - 1;
+            if (_value > _values[valueIndex]) continue;
             
-            return i + 1;
+            return decile;
         }
 
         return 10;
     }
-
-    private decimal[] GetUpperBoundsForDeciles()
+    
+    private int CountInDecile(int decile)
     {
-        var values = _values.ToArray();
-        var count = _values.Count;
-        
-        var bounds = new decimal[9];
-        for (var i = 0; i <= 8; i++)
-        {
-            var decile = i + 1;
-            var valueIndex = CountInDecile(decile, count) - 1;
-            
-            bounds[i] = values[valueIndex];
-        }
-        
-        return bounds;
-    }
-
-    private static int CountInDecile(int decile, int count)
-    {
-        var perDecile = count / 10.0;
+        var perDecile = _values.Count / 10.0;
         return (int)Math.Round(perDecile * decile);
     }
 }

--- a/web/src/Web.App/Domain/Deciles.cs
+++ b/web/src/Web.App/Domain/Deciles.cs
@@ -17,7 +17,7 @@ public class DecileHandler : IDecileHandler
         {
             throw new ArgumentException("There must be at least 10 values to calculate deciles.");
         }
-        
+
         _value = value;
         _values = values.Order().ToArray();
         _searchTopDown = searchTopDown;
@@ -27,37 +27,37 @@ public class DecileHandler : IDecileHandler
     {
         return _searchTopDown ? TopDown() : BottomUp();
     }
-    
+
     private int TopDown()
     {
         for (var decile = 10; decile > 1; decile--)
         {
             var valueIndex = CountInDecile(decile) - 1;
             if (_value < _values[valueIndex]) continue;
-            
+
             return decile;
         }
 
         return 1;
     }
-    
+
     private int BottomUp()
     {
         for (var decile = 1; decile < 10; decile++)
         {
             var valueIndex = CountInDecile(decile) - 1;
             if (_value > _values[valueIndex]) continue;
-            
+
             return decile;
         }
 
         return 10;
     }
-    
+
     private int CountInDecile(int decile)
     {
         var perDecile = _values.Count / 10.0;
-        return (int)Math.Round(perDecile * decile);
+        return (int)Math.Round(perDecile * decile, MidpointRounding.AwayFromZero);
     }
 }
 

--- a/web/src/Web.App/Domain/Deciles.cs
+++ b/web/src/Web.App/Domain/Deciles.cs
@@ -8,7 +8,7 @@ public interface IDecileHandler
 public class DecileHandler : IDecileHandler
 {
     private readonly decimal _value;
-    private readonly IOrderedEnumerable<decimal> _values;
+    private readonly IReadOnlyList<decimal> _values;
     private readonly bool _searchTopDown;
 
     public DecileHandler(decimal value, IReadOnlyCollection<decimal> values, bool searchTopDown = false)
@@ -19,7 +19,7 @@ public class DecileHandler : IDecileHandler
         }
         
         _value = value;
-        _values = values.Order();
+        _values = values.Order().ToArray();
         _searchTopDown = searchTopDown;
     }
 
@@ -62,12 +62,13 @@ public class DecileHandler : IDecileHandler
     private decimal[] GetUpperBoundsForDeciles()
     {
         var values = _values.ToArray();
+        var count = _values.Count;
         
         var bounds = new decimal[9];
         for (var i = 0; i <= 8; i++)
         {
             var decile = i + 1;
-            var valueIndex = CountInDecile(decile) - 1;
+            var valueIndex = CountInDecile(decile, count) - 1;
             
             bounds[i] = values[valueIndex];
         }
@@ -75,9 +76,9 @@ public class DecileHandler : IDecileHandler
         return bounds;
     }
 
-    private int CountInDecile(int decile)
+    private static int CountInDecile(int decile, int count)
     {
-        var perDecile = _values.Count() / 10.0;
+        var perDecile = count / 10.0;
         return (int)Math.Round(perDecile * decile);
     }
 }

--- a/web/tests/Web.Tests/Domain/GivenValuesDecileHandler.cs
+++ b/web/tests/Web.Tests/Domain/GivenValuesDecileHandler.cs
@@ -57,16 +57,25 @@ public class GivenValuesDecileHandler
     [Theory]
     [InlineData(-1500.0, 1)]
     [InlineData(1976.35, 1)]
-    [InlineData(2000, 2)]
-    [InlineData(2035.20, 3)]
-    [InlineData(2077.45, 4)]
-    [InlineData(2078.35, 5)]
-    [InlineData(2090.89, 6)]
-    [InlineData(2154.56, 7)]
-    [InlineData(2187, 8)]
-    [InlineData(2188, 9)]
-    [InlineData(2200.85, 10)]
-    [InlineData(54325.45, 10)]
+    [InlineData(1976.36, 2)]
+    [InlineData(2003.76, 2)]
+    [InlineData(2003.77, 3)]
+    [InlineData(2067.92, 3)]
+    [InlineData(2067.93, 4)]
+    [InlineData(2088.66, 4)]
+    [InlineData(2088.67, 5)]
+    [InlineData(2112.78, 5)]
+    [InlineData(2112.79, 6)]
+    [InlineData(2143.09, 6)]
+    [InlineData(2143.10, 7)]
+    [InlineData(2166.73, 7)]
+    [InlineData(2166.74, 8)]
+    [InlineData(2195.20, 8)]
+    [InlineData(2195.21, 9)]
+    [InlineData(2218.46, 9)]
+    [InlineData(2218.47, 10)]
+    [InlineData(2225.12, 10)]
+    [InlineData(2500, 10)]
     public void FindsDecileCorrectlyWithRealisticValues(decimal value, int expected)
     {
         var values = new decimal[]
@@ -166,56 +175,5 @@ public class GivenValuesDecileHandler
     public void DecileHandlerThrowsWithLessThanTenValues()
     {
         Assert.Throws<ArgumentException>(() => new DecileHandler(1, [1, 1, 1, 1, 1, 1, 1, 1, 1]));
-    }
-
-    public static IEnumerable<object[]> DecilesTestvalues()
-    {
-        yield return new object[]
-        {
-            new decimal[]
-            {
-                2195.20m,
-                2121.21m,
-                2001.67m,
-                2067.92m,
-                2199.34m,
-                2218.46m,
-                2143.09m,
-                2090.88m,
-                2166.73m,
-                1976.35m,
-                2054.23m,
-                2088.66m,
-                2112.78m,
-                2187.91m,
-                2225.12m,
-                2154.56m,
-                1975.43m,
-                2022.89m,
-                2003.76m,
-                2220.37m,
-                2190.45m,
-                2078.34m,
-            },
-            new decimal[] { 1976.35m, 2003.76m, 2054.23m, 2078.34m, 2090.88m, 2121.21m, 2154.56m, 2187.91m, 2195.20m },
-        };
-
-        yield return new object[]
-        {
-            Enumerable.Range(1, 10).Select(x => (decimal)x).ToArray(),
-            new decimal[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 },
-        };
-
-        yield return new object[]
-        {
-            Enumerable.Range(1, 30).Select(x => (decimal)x).ToArray(),
-            new decimal[] { 3, 6, 9, 12, 15, 18, 21, 24, 27 },
-        };
-
-        yield return new object[]
-        {
-            Enumerable.Range(-10, 20).Select(x => (decimal)x).ToArray(),
-            new decimal[] { -9, -7, -5, -3, -1, 1, 3, 5, 7 },
-        };
     }
 }

--- a/web/tests/Web.Tests/Domain/GivenValuesDecileHandler.cs
+++ b/web/tests/Web.Tests/Domain/GivenValuesDecileHandler.cs
@@ -76,7 +76,7 @@ public class GivenValuesDecileHandler
     [InlineData(2218.47, 10)]
     [InlineData(2225.12, 10)]
     [InlineData(2500, 10)]
-    public void FindsDecileCorrectlyWithRealisticValues(decimal value, int expected)
+    public void FindsDecileCorrectlyWithValues(decimal value, int expected)
     {
         var values = new decimal[]
         {
@@ -102,6 +102,65 @@ public class GivenValuesDecileHandler
             2220.37m,
             2190.45m,
             2078.34m,
+        };
+        var decileCalculator = new DecileHandler(value, values);
+
+        var result = decileCalculator.FindDecile();
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(2000, 1)]
+    [InlineData(3131.02, 1)]
+    [InlineData(3132.03, 2)]
+    [InlineData(3169.48, 2)]
+    [InlineData(3169.49, 3)]
+    [InlineData(3299.83, 3)]
+    [InlineData(3299.84, 4)]
+    [InlineData(3367.19, 4)]
+    [InlineData(3367.20, 5)]
+    [InlineData(3488.97, 5)]
+    [InlineData(3488.98, 6)]
+    [InlineData(3571.52, 6)]
+    [InlineData(3571.53, 7)]
+    [InlineData(3701.28, 7)]
+    [InlineData(3701.29, 8)]
+    [InlineData(3812.05, 8)]
+    [InlineData(3812.06, 9)]
+    [InlineData(3951.14, 9)]
+    [InlineData(3951.15, 10)]
+    [InlineData(3974.75, 10)]
+    [InlineData(5000, 10)]
+    public void FindsDecileCorrectlyWithDifferentValues(decimal value, int expected)
+    {
+        var values = new decimal[]
+        {
+            3169.48m,
+            3276.75m,
+            3343.99m,
+            3478.12m,
+            3571.52m,
+            3619.73m,
+            3701.28m,
+            3812.05m,
+            3951.14m,
+            3974.75m,
+            3076.64m,
+            3131.02m,
+            3299.83m,
+            3367.19m,
+            3488.97m,
+            3556.67m,
+            3650.88m,
+            3715.69m,
+            3872.34m,
+            3960.00m,
+            3025.44m,
+            3142.75m,
+            3258.13m,
+            3390.85m,
+            3942.16m,
         };
         var decileCalculator = new DecileHandler(value, values);
 

--- a/web/tests/Web.Tests/Domain/GivenValuesDecileHandler.cs
+++ b/web/tests/Web.Tests/Domain/GivenValuesDecileHandler.cs
@@ -5,18 +5,6 @@ namespace Web.Tests.Domain;
 
 public class GivenValuesDecileHandler
 {
-
-    [Theory]
-    [MemberData(nameof(DecilesTestvalues))]
-    public void GetUpperBoundsForDecilesCorrectly(decimal[] values, decimal[] expected)
-    {
-        var decileCalculator = new DecileHandler(1, values);
-
-        var result = decileCalculator.GetUpperBoundsForDeciles();
-
-        Assert.Equal(expected, result);
-    }
-
     [Theory]
     [InlineData(-100, 1)]
     [InlineData(-1, 1)]

--- a/web/tests/Web.Tests/Domain/GivenValuesDecileHandler.cs
+++ b/web/tests/Web.Tests/Domain/GivenValuesDecileHandler.cs
@@ -1,0 +1,233 @@
+﻿using Web.App.Domain;
+using Xunit;
+
+namespace Web.Tests.Domain;
+
+public class GivenValuesDecileHandler
+{
+
+    [Theory]
+    [MemberData(nameof(DecilesTestvalues))]
+    public void GetUpperBoundsForDecilesCorrectly(decimal[] values, decimal[] expected)
+    {
+        var decileCalculator = new DecileHandler(1, values);
+
+        var result = decileCalculator.GetUpperBoundsForDeciles();
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(-100, 1)]
+    [InlineData(-1, 1)]
+    [InlineData(2, 1)]
+    [InlineData(4, 2)]
+    [InlineData(9, 3)]
+    [InlineData(11, 4)]
+    [InlineData(12.01, 5)]
+    [InlineData(17.99, 6)]
+    [InlineData(20, 7)]
+    [InlineData(23, 8)]
+    [InlineData(27, 9)]
+    [InlineData(27.01, 10)]
+    [InlineData(31, 10)]
+    [InlineData(100, 10)]
+    public void FindsDecileCorrectly(decimal value, int expected)
+    {
+        var values = Enumerable.Range(1, 30).Select(x => (decimal)x).ToArray();
+        var decileCalculator = new DecileHandler(value, values);
+
+        var result = decileCalculator.FindDecile();
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(-100, 1)]
+    [InlineData(-10, 1)]
+    [InlineData(-9, 1)]
+    [InlineData(-7, 2)]
+    [InlineData(-6.99, 3)]
+    [InlineData(-3.01, 4)]
+    [InlineData(-1.5, 5)]
+    [InlineData(0, 6)]
+    [InlineData(1.01, 7)]
+    [InlineData(3.1, 8)]
+    [InlineData(7, 9)]
+    [InlineData(7.01, 10)]
+    [InlineData(100, 10)]
+    public void FindsDecileCorrectlyWithNegativeValues(decimal value, int expected)
+    {
+        var values = Enumerable.Range(-10, 20).Select(x => (decimal)x).ToArray();
+        var decileCalculator = new DecileHandler(value, values);
+
+        var result = decileCalculator.FindDecile();
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(-1500.0, 1)]
+    [InlineData(1976.35, 1)]
+    [InlineData(2000, 2)]
+    [InlineData(2035.20, 3)]
+    [InlineData(2077.45, 4)]
+    [InlineData(2078.35, 5)]
+    [InlineData(2090.89, 6)]
+    [InlineData(2154.56, 7)]
+    [InlineData(2187, 8)]
+    [InlineData(2188, 9)]
+    [InlineData(2200.85, 10)]
+    [InlineData(54325.45, 10)]
+    public void FindsDecileCorrectlyWithRealisticValues(decimal value, int expected)
+    {
+        var values = new decimal[]
+        {
+            2195.20m,
+            2121.21m,
+            2001.67m,
+            2067.92m,
+            2199.34m,
+            2218.46m,
+            2143.09m,
+            2090.88m,
+            2166.73m,
+            1976.35m,
+            2054.23m,
+            2088.66m,
+            2112.78m,
+            2187.91m,
+            2225.12m,
+            2154.56m,
+            1975.43m,
+            2022.89m,
+            2003.76m,
+            2220.37m,
+            2190.45m,
+            2078.34m,
+        };
+        var decileCalculator = new DecileHandler(value, values);
+
+        var result = decileCalculator.FindDecile();
+
+        Assert.Equal(expected, result);
+    }
+
+
+    [Theory]
+    [InlineData(0, true, 1)]
+    [InlineData(0, false, 1)]
+    [InlineData(1, true, 3)]
+    [InlineData(1, false, 1)]
+    [InlineData(2, true, 4)]
+    [InlineData(2, false, 4)]
+    [InlineData(3, true, 5)]
+    [InlineData(3, false, 5)]
+    [InlineData(4, true, 6)]
+    [InlineData(4, false, 6)]
+    [InlineData(5, true, 7)]
+    [InlineData(5, false, 7)]
+    [InlineData(6, true, 8)]
+    [InlineData(6, false, 8)]
+    [InlineData(7, true, 9)]
+    [InlineData(7, false, 9)]
+    [InlineData(8, true, 10)]
+    [InlineData(8, false, 10)]
+    [InlineData(9, true, 10)]
+    [InlineData(9, false, 10)]
+    public void FindsDecileCorrectlyWithSearchParam(int value, bool searchTopDown, int expected)
+    {
+        var decileCalculator = new DecileHandler(value, [1, 1, 1, 2, 3, 4, 5, 6, 7, 8], searchTopDown);
+
+        var result = decileCalculator.FindDecile();
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(0, true, 1)]
+    [InlineData(0, false, 1)]
+    [InlineData(1, true, 1)]
+    [InlineData(1, false, 1)]
+    [InlineData(2, true, 2)]
+    [InlineData(2, false, 2)]
+    [InlineData(3, true, 3)]
+    [InlineData(3, false, 3)]
+    [InlineData(4, true, 6)]
+    [InlineData(4, false, 4)]
+    [InlineData(5, true, 7)]
+    [InlineData(5, false, 7)]
+    [InlineData(6, true, 8)]
+    [InlineData(6, false, 8)]
+    [InlineData(7, true, 9)]
+    [InlineData(7, false, 9)]
+    [InlineData(8, true, 10)]
+    [InlineData(8, false, 10)]
+    [InlineData(9, true, 10)]
+    [InlineData(9, false, 10)]
+    public void FindsDecileCorrectlyWithSearchParamDifferentValues(int value, bool searchTopDown, int expected)
+    {
+        var decileCalculator = new DecileHandler(value, [1, 2, 3, 4, 4, 4, 5, 6, 7, 8], searchTopDown);
+
+        var result = decileCalculator.FindDecile();
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void DecileHandlerThrowsWithLessThanTenValues()
+    {
+        Assert.Throws<ArgumentException>(() => new DecileHandler(1, [1, 1, 1, 1, 1, 1, 1, 1, 1]));
+    }
+
+    public static IEnumerable<object[]> DecilesTestvalues()
+    {
+        yield return new object[]
+        {
+            new decimal[]
+            {
+                2195.20m,
+                2121.21m,
+                2001.67m,
+                2067.92m,
+                2199.34m,
+                2218.46m,
+                2143.09m,
+                2090.88m,
+                2166.73m,
+                1976.35m,
+                2054.23m,
+                2088.66m,
+                2112.78m,
+                2187.91m,
+                2225.12m,
+                2154.56m,
+                1975.43m,
+                2022.89m,
+                2003.76m,
+                2220.37m,
+                2190.45m,
+                2078.34m,
+            },
+            new decimal[] { 1976.35m, 2003.76m, 2054.23m, 2078.34m, 2090.88m, 2121.21m, 2154.56m, 2187.91m, 2195.20m },
+        };
+
+        yield return new object[]
+        {
+            Enumerable.Range(1, 10).Select(x => (decimal)x).ToArray(),
+            new decimal[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+        };
+
+        yield return new object[]
+        {
+            Enumerable.Range(1, 30).Select(x => (decimal)x).ToArray(),
+            new decimal[] { 3, 6, 9, 12, 15, 18, 21, 24, 27 },
+        };
+
+        yield return new object[]
+        {
+            Enumerable.Range(-10, 20).Select(x => (decimal)x).ToArray(),
+            new decimal[] { -9, -7, -5, -3, -1, 1, 3, 5, 7 },
+        };
+    }
+}

--- a/web/tests/Web.Tests/Domain/WhenCalculatingDecilesFindFromHighest.cs
+++ b/web/tests/Web.Tests/Domain/WhenCalculatingDecilesFindFromHighest.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace Web.Tests.Domain;
 
-public class GivenValuesDecileHandler
+public class WhenCalculatingDecilesFindFromHighest
 {
     [Theory]
     [InlineData(-100, 1)]
@@ -23,9 +23,9 @@ public class GivenValuesDecileHandler
     public void FindsDecileCorrectly(decimal value, int expected)
     {
         var values = Enumerable.Range(1, 30).Select(x => (decimal)x).ToArray();
-        var decileCalculator = new DecileHandler(value, values);
+        IDecileFinder decileFinder = new FindFromHighest(value, values);
 
-        var result = decileCalculator.FindDecile();
+        var result = decileFinder.Find();
 
         Assert.Equal(expected, result);
     }
@@ -47,9 +47,9 @@ public class GivenValuesDecileHandler
     public void FindsDecileCorrectlyWithNegativeValues(decimal value, int expected)
     {
         var values = Enumerable.Range(-10, 20).Select(x => (decimal)x).ToArray();
-        var decileCalculator = new DecileHandler(value, values);
+        IDecileFinder decileFinder = new FindFromHighest(value, values);
 
-        var result = decileCalculator.FindDecile();
+        var result = decileFinder.Find();
 
         Assert.Equal(expected, result);
     }
@@ -103,9 +103,9 @@ public class GivenValuesDecileHandler
             2190.45m,
             2078.34m,
         };
-        var decileCalculator = new DecileHandler(value, values);
+        IDecileFinder decileFinder = new FindFromHighest(value, values);
 
-        var result = decileCalculator.FindDecile();
+        var result = decileFinder.Find();
 
         Assert.Equal(expected, result);
     }
@@ -162,70 +162,70 @@ public class GivenValuesDecileHandler
             3390.85m,
             3942.16m,
         };
-        var decileCalculator = new DecileHandler(value, values);
+        IDecileFinder decileFinder = new FindFromHighest(value, values);
 
-        var result = decileCalculator.FindDecile();
+        var result = decileFinder.Find();
 
         Assert.Equal(expected, result);
     }
 
 
     [Theory]
-    [InlineData(0, true, 1)]
-    [InlineData(0, false, 1)]
-    [InlineData(1, true, 3)]
-    [InlineData(1, false, 1)]
-    [InlineData(2, true, 4)]
-    [InlineData(2, false, 4)]
-    [InlineData(3, true, 5)]
-    [InlineData(3, false, 5)]
-    [InlineData(4, true, 6)]
-    [InlineData(4, false, 6)]
-    [InlineData(5, true, 7)]
-    [InlineData(5, false, 7)]
-    [InlineData(6, true, 8)]
-    [InlineData(6, false, 8)]
-    [InlineData(7, true, 9)]
-    [InlineData(7, false, 9)]
-    [InlineData(8, true, 10)]
-    [InlineData(8, false, 10)]
-    [InlineData(9, true, 10)]
-    [InlineData(9, false, 10)]
-    public void FindsDecileCorrectlyWithSearchParam(int value, bool searchTopDown, int expected)
+    [InlineData(0, 1)]
+    [InlineData(1, 3)]
+    [InlineData(2, 4)]
+    [InlineData(3, 5)]
+    [InlineData(4, 6)]
+    [InlineData(5, 7)]
+    [InlineData(6, 8)]
+    [InlineData(7, 9)]
+    [InlineData(8, 10)]
+    [InlineData(9, 10)]
+    public void FindsDecileCorrectlyWithDuplicates(int value, int expected)
     {
-        var decileCalculator = new DecileHandler(value, [1, 1, 1, 2, 3, 4, 5, 6, 7, 8], searchTopDown);
+        IDecileFinder decileFinder = new FindFromHighest(value, [1, 1, 1, 2, 3, 4, 5, 6, 7, 8]);
 
-        var result = decileCalculator.FindDecile();
+        var result = decileFinder.Find();
 
         Assert.Equal(expected, result);
     }
 
     [Theory]
-    [InlineData(0, true, 1)]
-    [InlineData(0, false, 1)]
-    [InlineData(1, true, 1)]
-    [InlineData(1, false, 1)]
-    [InlineData(2, true, 2)]
-    [InlineData(2, false, 2)]
-    [InlineData(3, true, 3)]
-    [InlineData(3, false, 3)]
-    [InlineData(4, true, 6)]
-    [InlineData(4, false, 4)]
-    [InlineData(5, true, 7)]
-    [InlineData(5, false, 7)]
-    [InlineData(6, true, 8)]
-    [InlineData(6, false, 8)]
-    [InlineData(7, true, 9)]
-    [InlineData(7, false, 9)]
-    [InlineData(8, true, 10)]
-    [InlineData(8, false, 10)]
-    [InlineData(9, true, 10)]
-    [InlineData(9, false, 10)]
-    public void FindsDecileCorrectlyWithSearchParamDifferentValues(int value, bool searchTopDown, int expected)
+    [InlineData(0, 1)]
+    [InlineData(1, 1)]
+    [InlineData(2, 2)]
+    [InlineData(3, 3)]
+    [InlineData(4, 6)]
+    [InlineData(5, 7)]
+    [InlineData(6, 8)]
+    [InlineData(7, 9)]
+    [InlineData(8, 10)]
+    [InlineData(9, 10)]
+    public void FindsDecileCorrectlyWithDifferentDuplicates(int value, int expected)
     {
-        var decileCalculator = new DecileHandler(value, [1, 2, 3, 4, 4, 4, 5, 6, 7, 8], searchTopDown);
+        IDecileFinder decileFinder = new FindFromHighest(value, [1, 2, 3, 4, 4, 4, 5, 6, 7, 8]);
 
-        var result = decileCalculator.FindDecile();
+        var result = decileFinder.Find();
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(1, 1)]
+    [InlineData(2, 2)]
+    [InlineData(3, 4)]
+    [InlineData(4, 6)]
+    [InlineData(5, 7)]
+    [InlineData(6, 8)]
+    [InlineData(7, 9)]
+    [InlineData(8, 10)]
+    [InlineData(9, 10)]
+    public void FindsDecileCorrectlyWithOtherDuplicates(int value, int expected)
+    {
+        IDecileFinder decileFinder = new FindFromHighest(value, [1, 2, 3, 3, 4, 4, 5, 6, 7, 8]);
+
+        var result = decileFinder.Find();
 
         Assert.Equal(expected, result);
     }
@@ -233,6 +233,6 @@ public class GivenValuesDecileHandler
     [Fact]
     public void DecileHandlerThrowsWithLessThanTenValues()
     {
-        Assert.Throws<ArgumentException>(() => new DecileHandler(1, [1, 1, 1, 1, 1, 1, 1, 1, 1]));
+        Assert.Throws<ArgumentException>(() => new FindFromHighest(1, [1, 1, 1, 1, 1, 1, 1, 1, 1]));
     }
 }

--- a/web/tests/Web.Tests/Domain/WhenCalculatingDecilesFindFromLowest.cs
+++ b/web/tests/Web.Tests/Domain/WhenCalculatingDecilesFindFromLowest.cs
@@ -1,0 +1,238 @@
+﻿using Web.App.Domain;
+using Xunit;
+
+namespace Web.Tests.Domain;
+
+public class WhenCalculatingDecilesFindFromLowest
+{
+    [Theory]
+    [InlineData(-100, 1)]
+    [InlineData(-1, 1)]
+    [InlineData(2, 1)]
+    [InlineData(4, 2)]
+    [InlineData(9, 3)]
+    [InlineData(11, 4)]
+    [InlineData(12.01, 5)]
+    [InlineData(17.99, 6)]
+    [InlineData(20, 7)]
+    [InlineData(23, 8)]
+    [InlineData(27, 9)]
+    [InlineData(27.01, 10)]
+    [InlineData(31, 10)]
+    [InlineData(100, 10)]
+    public void FindsDecileCorrectly(decimal value, int expected)
+    {
+        var values = Enumerable.Range(1, 30).Select(x => (decimal)x).ToArray();
+        IDecileFinder decileFinder = new FindFromLowest(value, values);
+
+        var result = decileFinder.Find();
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(-100, 1)]
+    [InlineData(-10, 1)]
+    [InlineData(-9, 1)]
+    [InlineData(-7, 2)]
+    [InlineData(-6.99, 3)]
+    [InlineData(-3.01, 4)]
+    [InlineData(-1.5, 5)]
+    [InlineData(0, 6)]
+    [InlineData(1.01, 7)]
+    [InlineData(3.1, 8)]
+    [InlineData(7, 9)]
+    [InlineData(7.01, 10)]
+    [InlineData(100, 10)]
+    public void FindsDecileCorrectlyWithNegativeValues(decimal value, int expected)
+    {
+        var values = Enumerable.Range(-10, 20).Select(x => (decimal)x).ToArray();
+        IDecileFinder decileFinder = new FindFromLowest(value, values);
+
+        var result = decileFinder.Find();
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(-1500.0, 1)]
+    [InlineData(1976.35, 1)]
+    [InlineData(1976.36, 2)]
+    [InlineData(2003.76, 2)]
+    [InlineData(2003.77, 3)]
+    [InlineData(2067.92, 3)]
+    [InlineData(2067.93, 4)]
+    [InlineData(2088.66, 4)]
+    [InlineData(2088.67, 5)]
+    [InlineData(2112.78, 5)]
+    [InlineData(2112.79, 6)]
+    [InlineData(2143.09, 6)]
+    [InlineData(2143.10, 7)]
+    [InlineData(2166.73, 7)]
+    [InlineData(2166.74, 8)]
+    [InlineData(2195.20, 8)]
+    [InlineData(2195.21, 9)]
+    [InlineData(2218.46, 9)]
+    [InlineData(2218.47, 10)]
+    [InlineData(2225.12, 10)]
+    [InlineData(2500, 10)]
+    public void FindsDecileCorrectlyWithValues(decimal value, int expected)
+    {
+        var values = new decimal[]
+        {
+            2195.20m,
+            2121.21m,
+            2001.67m,
+            2067.92m,
+            2199.34m,
+            2218.46m,
+            2143.09m,
+            2090.88m,
+            2166.73m,
+            1976.35m,
+            2054.23m,
+            2088.66m,
+            2112.78m,
+            2187.91m,
+            2225.12m,
+            2154.56m,
+            1975.43m,
+            2022.89m,
+            2003.76m,
+            2220.37m,
+            2190.45m,
+            2078.34m,
+        };
+        IDecileFinder decileFinder = new FindFromLowest(value, values);
+
+        var result = decileFinder.Find();
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(2000, 1)]
+    [InlineData(3131.02, 1)]
+    [InlineData(3132.03, 2)]
+    [InlineData(3169.48, 2)]
+    [InlineData(3169.49, 3)]
+    [InlineData(3299.83, 3)]
+    [InlineData(3299.84, 4)]
+    [InlineData(3367.19, 4)]
+    [InlineData(3367.20, 5)]
+    [InlineData(3488.97, 5)]
+    [InlineData(3488.98, 6)]
+    [InlineData(3571.52, 6)]
+    [InlineData(3571.53, 7)]
+    [InlineData(3701.28, 7)]
+    [InlineData(3701.29, 8)]
+    [InlineData(3812.05, 8)]
+    [InlineData(3812.06, 9)]
+    [InlineData(3951.14, 9)]
+    [InlineData(3951.15, 10)]
+    [InlineData(3974.75, 10)]
+    [InlineData(5000, 10)]
+    public void FindsDecileCorrectlyWithDifferentValues(decimal value, int expected)
+    {
+        var values = new decimal[]
+        {
+            3169.48m,
+            3276.75m,
+            3343.99m,
+            3478.12m,
+            3571.52m,
+            3619.73m,
+            3701.28m,
+            3812.05m,
+            3951.14m,
+            3974.75m,
+            3076.64m,
+            3131.02m,
+            3299.83m,
+            3367.19m,
+            3488.97m,
+            3556.67m,
+            3650.88m,
+            3715.69m,
+            3872.34m,
+            3960.00m,
+            3025.44m,
+            3142.75m,
+            3258.13m,
+            3390.85m,
+            3942.16m,
+        };
+        IDecileFinder decileFinder = new FindFromLowest(value, values);
+
+        var result = decileFinder.Find();
+
+        Assert.Equal(expected, result);
+    }
+
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(1, 1)]
+    [InlineData(2, 4)]
+    [InlineData(3, 5)]
+    [InlineData(4, 6)]
+    [InlineData(5, 7)]
+    [InlineData(6, 8)]
+    [InlineData(7, 9)]
+    [InlineData(8, 10)]
+    [InlineData(9, 10)]
+    public void FindsDecileCorrectlyWithDuplicates(int value, int expected)
+    {
+        IDecileFinder decileFinder = new FindFromLowest(value, [1, 1, 1, 2, 3, 4, 5, 6, 7, 8]);
+
+        var result = decileFinder.Find();
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(1, 1)]
+    [InlineData(2, 2)]
+    [InlineData(3, 3)]
+    [InlineData(4, 4)]
+    [InlineData(5, 7)]
+    [InlineData(6, 8)]
+    [InlineData(7, 9)]
+    [InlineData(8, 10)]
+    [InlineData(9, 10)]
+    public void FindsDecileCorrectlyWithDifferentDuplicates(int value, int expected)
+    {
+        IDecileFinder decileFinder = new FindFromLowest(value, [1, 2, 3, 4, 4, 4, 5, 6, 7, 8]);
+
+        var result = decileFinder.Find();
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(1, 1)]
+    [InlineData(2, 2)]
+    [InlineData(3, 3)]
+    [InlineData(4, 5)]
+    [InlineData(5, 7)]
+    [InlineData(6, 8)]
+    [InlineData(7, 9)]
+    [InlineData(8, 10)]
+    [InlineData(9, 10)]
+    public void FindsDecileCorrectlyWithOtherDuplicates(int value, int expected)
+    {
+        IDecileFinder decileFinder = new FindFromLowest(value, [1, 2, 3, 3, 4, 4, 5, 6, 7, 8]);
+
+        var result = decileFinder.Find();
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void DecileHandlerThrowsWithLessThanTenValues()
+    {
+        Assert.Throws<ArgumentException>(() => new FindFromLowest(1, [1, 1, 1, 1, 1, 1, 1, 1, 1]));
+    }
+}

--- a/web/tests/Web.Tests/Web.Tests.csproj
+++ b/web/tests/Web.Tests/Web.Tests.csproj
@@ -15,7 +15,7 @@
         <PackageReference Include="Newtonsoft.Json" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.assert" />
-        <PackageReference Include="xunit.runner.visualstudio"/>
+        <PackageReference Include="xunit.runner.visualstudio" />
         <PackageReference Include="coverlet.collector" />
         <ProjectReference Include="..\..\src\Web.App\Web.App.csproj" />
         <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />


### PR DESCRIPTION
### Context
Story - [AB#199507](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/199507)
Task - [AB#200093](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/200093)

### Change proposed in this pull request
Adds DecileFinder to calculate the deciles of a comparator set and return the decile of a given value that this value falls into the upper and lower bounds of. See story comments for the rules around this. 
Currently we have two implementations of the Find method, "from lowest" and "from highest" which is relevant if duplicate values are split across different deciles. If required we can build on this with other implementations in the future.

### Guidance to review 
Check logic and whether this meets the requirements in this story.
This PR only adds the decile calculation to support the RAG calculation, this task will not be complete on merge, RAG calculation will use this but further business logic will be added in a following PR.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

