### PR TITLE
Disabled 'Save as image' button on `<HorizontalBarChartWrapper>` during the image download process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -417,3 +417,4 @@ local.settings.json
 .DS_Store
 
 **/docker/sql
+front-end-components/vite.config-dev.js.timestamp-*

--- a/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
@@ -68,8 +68,8 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
   });
 
   useImperativeHandle(ref, () => ({
-    download() {
-      downloadPng();
+    async download() {
+      await downloadPng();
     },
   }));
 

--- a/front-end-components/src/components/charts/line-chart/component.tsx
+++ b/front-end-components/src/components/charts/line-chart/component.tsx
@@ -52,8 +52,8 @@ function LineChartInner<TData extends ChartDataSeries>(
   });
 
   useImperativeHandle(ref, () => ({
-    download() {
-      downloadPng();
+    async download() {
+      await downloadPng();
     },
   }));
 

--- a/front-end-components/src/components/charts/types.tsx
+++ b/front-end-components/src/components/charts/types.tsx
@@ -51,7 +51,7 @@ export type TickProps = SVGProps<SVGGElement> & {
 };
 
 export type ChartHandler = {
-  download: () => void;
+  download: () => Promise<void>;
 };
 
 export type ChartSortDirection = "asc" | "desc";

--- a/front-end-components/src/components/charts/vertical-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/vertical-bar-chart/component.tsx
@@ -58,8 +58,8 @@ function VerticalBarChartInner<TData extends ChartDataSeries>(
   });
 
   useImperativeHandle(ref, () => ({
-    download() {
-      downloadPng();
+    async download() {
+      await downloadPng();
     },
   }));
 

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -1,4 +1,4 @@
-import { createRef, useContext, useMemo } from "react";
+import { createRef, useContext, useMemo, useState } from "react";
 import { HorizontalBarChart } from "src/components/charts/horizontal-bar-chart";
 import { TableChart, SchoolChartData } from "src/components/charts/table-chart";
 import {
@@ -25,6 +25,7 @@ export function HorizontalBarChartWrapper<TData extends SchoolChartData>(
   const dimension = useContext(ChartDimensionContext);
   const selectedSchool = useContext(SelectedSchoolContext);
   const ref = createRef<ChartHandler>();
+  const [imageLoading, setImageLoading] = useState<boolean>();
 
   // if a `sort` is not provided, the default sorting method will be used (value DESC)
   const sortedDataPoints = useMemo(() => {
@@ -53,7 +54,10 @@ export function HorizontalBarChartWrapper<TData extends SchoolChartData>(
             <button
               className="govuk-button govuk-button--secondary"
               data-module="govuk-button"
-              onClick={() => ref.current && ref.current.download()}
+              data-prevent-double-click="true"
+              onClick={() => ref.current?.download()}
+              disabled={imageLoading}
+              aria-disabled={imageLoading}
             >
               Save as image
             </button>
@@ -75,6 +79,7 @@ export function HorizontalBarChartWrapper<TData extends SchoolChartData>(
                       selectedSchool ? [selectedSchool.urn] : undefined
                     }
                     keyField="urn"
+                    onImageLoading={setImageLoading}
                     labels
                     margin={20}
                     ref={ref}

--- a/front-end-components/src/hooks/useDownloadImage.ts
+++ b/front-end-components/src/hooks/useDownloadImage.ts
@@ -18,12 +18,30 @@ export function useDownloadPngImage({
   }, [isLoading, onImageLoading]);
 
   const downloadPng = useCallback(async () => {
-    const png = await getPng();
+    const download = async () => {
+      const png = await getPng();
+      if (png) {
+        saveAs(png, fileName);
+      }
+    };
 
-    if (png) {
-      saveAs(png, fileName);
+    if (onImageLoading) {
+      onImageLoading(true);
+
+      // If loader event is subscribed, allow it to be triggered before the actual generate and download PNG process
+      // due to the latter performing a synchronous XMLHttpRequest on the main thread which is documented as being
+      // detrimental effects to the end user's experience (see `Issues` in browser DevTools for more information).
+      setTimeout(async () => {
+        try {
+          await download();
+        } finally {
+          onImageLoading(false);
+        }
+      }, 100);
+    } else {
+      await download();
     }
-  }, [getPng, fileName]);
+  }, [getPng, fileName, onImageLoading]);
 
   return { downloadPng, ref };
 }


### PR DESCRIPTION
### Context
[AB#201449](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/201449) [AB#201366](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/201366)

### Change proposed in this pull request
Disabled 'Save as image' button when clicked, up until the file is downloaded.

https://github.com/DFE-Digital/education-benchmarking-and-insights/assets/3224486/45d619af-efd2-477f-a11c-25c242433f20

### Guidance to review 
'Save as image' functionality is no quicker than previous implementation, but the user feedback is much improved.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

