### PR TITLE
adds rating banner for spending and costs page WiP

### DIFF
--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -39,11 +39,15 @@
 }
 
 .priority.high, .priority.high .govuk-tag--red {
-  border: 1px solid #942514;
+    padding-top: 1px;
+    padding-bottom: 2px;
+    border: 1px solid #942514;
 }
 
 .priority.medium, .priority.medium .govuk-tag--yellow {
-  border: 1px solid #594D00;
+    padding-top: 1px;
+    padding-bottom: 2px;
+    border: 1px solid #594D00;
 }
 
 .priority.low, .priority.low .govuk-tag--grey {

--- a/web/src/Web.App/Domain/CostCategories.cs
+++ b/web/src/Web.App/Domain/CostCategories.cs
@@ -197,17 +197,17 @@ public static class CategoryBuilder
         var premisesStaffServicesRating = new PremisesStaffServicesRating(premisesStaffServices, baseUrn);
         var utilitiesRating = new UtilitiesRating(utilities, baseUrn);
 
-        return new List<(CostCategory CostCategory, CostRating CostRating)>
+        return new List<(CostCategory, CostRating)>
         {
-            (CostCategory: teachingStaff, CostRating: teachingStaffRating),
-            (CostCategory: administrativeSupplies, CostRating: administrativeSuppliesRating),
-            (CostCategory: cateringStaffServices, CostRating: cateringStaffServicesRating),
-            (CostCategory: educationalIct, CostRating: educationalIctRating),
-            (CostCategory: educationalSupplies, CostRating: educationalSuppliesRating),
-            (CostCategory: nonEducationalSupportStaff, CostRating: nonEducationalSupportStaffRating),
-            (CostCategory: other, CostRating: otherRating),
-            (CostCategory: premisesStaffServices, CostRating: premisesStaffServicesRating),
-            (CostCategory: utilities, CostRating: utilitiesRating),
+            (teachingStaff, teachingStaffRating),
+            (administrativeSupplies, administrativeSuppliesRating),
+            (cateringStaffServices, cateringStaffServicesRating),
+            (educationalIct, educationalIctRating),
+            (educationalSupplies, educationalSuppliesRating),
+            (nonEducationalSupportStaff, nonEducationalSupportStaffRating),
+            (other, otherRating),
+            (premisesStaffServices, premisesStaffServicesRating),
+            (utilities, utilitiesRating),
         };
     }
 

--- a/web/src/Web.App/Domain/CostCategories.cs
+++ b/web/src/Web.App/Domain/CostCategories.cs
@@ -160,7 +160,7 @@ public class EducationalIct : CostCategory
         {
             IsGoodOrOutstanding = true;
         }
-        
+
         UsingCloseComparators = usingCloseComparators;
     }
 

--- a/web/src/Web.App/ViewModels/SchoolSpendingViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolSpendingViewModel.cs
@@ -10,5 +10,5 @@ public class SchoolSpendingViewModel(
     public string? Name => school.Name;
     public string? Urn => school.Urn;
 
-    public IEnumerable<CostCategory> Categories => CategoryBuilder.Build(pupilExpenditure, areaExpenditure, school.Urn, school.OfstedRating, false);
+    public IEnumerable<(CostCategory, CostRating)> Categories => CategoryBuilder.Build(pupilExpenditure, areaExpenditure, school.Urn, school.OfstedRating, false);
 }

--- a/web/src/Web.App/ViewModels/SchoolSpendingViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolSpendingViewModel.cs
@@ -10,5 +10,5 @@ public class SchoolSpendingViewModel(
     public string? Name => school.Name;
     public string? Urn => school.Urn;
 
-    public IEnumerable<CostCategory> Categories => CategoryBuilder.Build(pupilExpenditure, areaExpenditure);
+    public IEnumerable<CostCategory> Categories => CategoryBuilder.Build(pupilExpenditure, areaExpenditure, school.Urn, school.OfstedRating, false);
 }

--- a/web/src/Web.App/ViewModels/SchoolViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolViewModel.cs
@@ -18,5 +18,5 @@ public class SchoolViewModel(
     public decimal InYearBalance => finances.TotalIncome - finances.TotalExpenditure;
     public decimal RevenueReserve => finances.RevenueReserve;
 
-    public IEnumerable<CostCategory> Categories => CategoryBuilder.Build(pupilExpenditure, areaExpenditure, school.Urn, school.OfstedRating, false);
+    public IEnumerable<(CostCategory, CostRating)> Categories => CategoryBuilder.Build(pupilExpenditure, areaExpenditure, school.Urn, school.OfstedRating, false);
 }

--- a/web/src/Web.App/ViewModels/SchoolViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolViewModel.cs
@@ -18,5 +18,5 @@ public class SchoolViewModel(
     public decimal InYearBalance => finances.TotalIncome - finances.TotalExpenditure;
     public decimal RevenueReserve => finances.RevenueReserve;
 
-    public IEnumerable<CostCategory> Categories => CategoryBuilder.Build(pupilExpenditure, areaExpenditure);
+    public IEnumerable<CostCategory> Categories => CategoryBuilder.Build(pupilExpenditure, areaExpenditure, school.Urn, school.OfstedRating, false);
 }

--- a/web/src/Web.App/Views/SchoolSpending/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/Index.cshtml
@@ -18,23 +18,24 @@
 {
     <div class="govuk-grid-row govuk-!-margin-bottom-4">
         <div class="govuk-grid-column-two-thirds">
-            <h3 class="govuk-heading-s govuk-!-font-size-27">@category.Name</h3>
+            <h3 class="govuk-heading-s govuk-!-font-size-27">@category.Item1.Name</h3>
 
-            <p class="@category.Priority govuk-body">
-                <strong class="govuk-tag govuk-tag--@category.Colour.ToString().ToLower()">
-                    @category.DisplayText
+            @* TODO : Add RAG calculations *@
+            <p class="@category.Item2.Priority govuk-body">
+                <strong class="govuk-tag govuk-tag--@category.Item2.Colour.ToString().ToLower()">
+                    @category.Item2.DisplayText
                 </strong>
-                Spends more than <strong>@category.Percentage%</strong> of similar schools.
+                Spends more than <strong>@category.Item2.Percentage%</strong> of similar schools.
             </p>
             <div class="govuk-!-margin-bottom-2"
                  data-spending-and-costs-composed
-                 data-json="@category.Values.Select(x => new { urn = x.Key, amount = x.Value.Value }).ToArray().ToJson(Formatting.None)"
+                 data-json="@category.Item1.Values.Select(x => new { urn = x.Key, amount = x.Value.Value }).ToArray().ToJson(Formatting.None)"
                  data-highlight="@Model.Urn"
-                 data-suffix="@category.Label"
+                 data-suffix="@category.Item1.Label"
                  data-sort-direction="asc">
             </div>
             <p class="govuk-body">
-                <a href="#" class="govuk-link govuk-link--no-visited-state">View all @category.Name.ToLower() costs</a>
+                <a href="#" class="govuk-link govuk-link--no-visited-state">View all @category.Item1.Name.ToLower() costs</a>
             </p>
         </div>
     </div>

--- a/web/src/Web.App/Views/SchoolSpending/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/Index.cshtml
@@ -20,13 +20,12 @@
         <div class="govuk-grid-column-two-thirds">
             <h3 class="govuk-heading-s govuk-!-font-size-27">@category.Name</h3>
 
-            @*TODO : Add RAG calculations
-            <p class="priority high govuk-body">
-                <strong class="govuk-tag govuk-tag--red">
-                    High priority
+            <p class="@category.Priority govuk-body">
+                <strong class="govuk-tag govuk-tag--@category.Colour.ToString().ToLower()">
+                    @category.DisplayText
                 </strong>
-                Spends <strong>£4,747</strong> per pupil - more than <strong>92%</strong> of similar schools.
-            </p>*@
+                Spends more than <strong>@category.Percentage%</strong> of similar schools.
+            </p>
             <div class="govuk-!-margin-bottom-2"
                  data-spending-and-costs-composed
                  data-json="@category.Values.Select(x => new { urn = x.Key, amount = x.Value.Value }).ToArray().ToJson(Formatting.None)"


### PR DESCRIPTION
### Context
[AB#199553](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/199553) - story
[AB#201299](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/201299) - task

### Change proposed in this pull request
Adds rating banner for each section with charts for the spending and costs page.
Adds properties to base CostRating class required for values needed.
Adds an abstract method SetRatingValues that can be overriden.
Takes baseUrn as a parameter for the constructor to identify the base school for the set
Takes ofstedRating as a string? parameter for the constructors where required to set IsGoodOrOutstanding.
Takes usingCloseComparators as a bool parameter to set UsingCloseComparators where required currently just passing in false in the view model as changes required to ComparatorSet to use this.
Alters CSS to align borders of the rating banner.

### Guidance to review 
work in progress - adding further commits

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

