### PR TITLE
added a11y tests for when viewing commercial resources

### DIFF
--- a/web/tests/Web.A11yTests/Pages/Schools/WhenViewingCommercialResources.cs
+++ b/web/tests/Web.A11yTests/Pages/Schools/WhenViewingCommercialResources.cs
@@ -1,0 +1,23 @@
+using Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Web.A11yTests.Pages.Schools;
+
+public class WhenViewingCommercialResources(
+        ITestOutputHelper testOutputHelper,
+        WebDriver webDriver)
+    : PageBase(testOutputHelper, webDriver)
+{
+    protected override string PageUrl => $"/school/{TestConfiguration.School}/find-ways-to-spend-less";
+
+    [Theory]
+    [InlineData("all")]
+    [InlineData("recommended")]
+    public async Task ThenThereAreNoAccessibilityIssues(string resource)
+    {
+        await GoToPage();
+        await Page.Locator($"#tab_{resource}").ClickAsync();
+        await EvaluatePage();
+    }
+}


### PR DESCRIPTION
### Context
[AB#185942](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/185942)([AB#201985](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/201985))

### Change proposed in this pull request
a11y tests for the page

### Guidance to review 
N/A
### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

