### PR TITLE
Allow navigation by element ID between Spending and Costs page and corresponding Expenditure accordion section

### DIFF
--- a/front-end-components/package-lock.json
+++ b/front-end-components/package-lock.json
@@ -17,6 +17,7 @@
         "recharts": "^2.12.1",
         "recharts-to-png": "^2.3.1",
         "stats-lite": "^2.2.0",
+        "usehooks-ts": "^3.1.0",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -7571,8 +7572,7 @@
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-      "dev": true
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -9549,6 +9549,20 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/usehooks-ts": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.1.0.tgz",
+      "integrity": "sha512-bBIa7yUyPhE1BCc0GmR96VU/15l/9gP1Ch5mYdLcFBaFGQsdmXkvjV0TtOqW1yUd6VjIwDunm+flSciCQXujiw==",
+      "dependencies": {
+        "lodash.debounce": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=16.15.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0  || ^17 || ^18"
       }
     },
     "node_modules/utrie": {

--- a/front-end-components/package.json
+++ b/front-end-components/package.json
@@ -25,6 +25,7 @@
     "recharts": "^2.12.1",
     "recharts-to-png": "^2.3.1",
     "stats-lite": "^2.2.0",
+    "usehooks-ts": "^3.1.0",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/front-end-components/src/hooks/useGovUk.ts
+++ b/front-end-components/src/hooks/useGovUk.ts
@@ -1,0 +1,30 @@
+import { useLayoutEffect, useState } from "react";
+import { initAll } from "govuk-frontend";
+
+// https://frontend.design-system.service.gov.uk/javascript-api-reference/
+export function useGovUk() {
+  const [isLoaded, setIsLoaded] = useState<boolean>();
+
+  useLayoutEffect(() => {
+    if (!isLoaded) {
+      initAll();
+    }
+
+    setIsLoaded(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  /**
+   * See https://frontend.design-system.service.gov.uk/configure-components/#initialise-only-part-of-a-page
+   */
+  const reInit = (scope: Element) => {
+    if (scope) {
+      initAll({ scope });
+    }
+  };
+
+  return {
+    isLoaded,
+    reInit,
+  };
+}

--- a/front-end-components/src/hooks/useHash.ts
+++ b/front-end-components/src/hooks/useHash.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from "react";
+import { useEventListener } from "usehooks-ts";
+
+// get and set the 'hash' value from the browser URL
+export function useHash() {
+  const [hash, setHash] = useState(() => window.location.hash);
+
+  const hashChangeHandler = useCallback(() => {
+    setHash(window.location.hash);
+  }, []);
+
+  useEventListener("hashchange", hashChangeHandler);
+
+  const updateHash = useCallback(
+    (newHash: string) => {
+      if (newHash !== hash) {
+        window.location.hash = newHash;
+      }
+    },
+    [hash]
+  );
+
+  return [hash, updateHash];
+}

--- a/front-end-components/src/types/govuk-frontend.d.ts
+++ b/front-end-components/src/types/govuk-frontend.d.ts
@@ -1,0 +1,64 @@
+declare module "govuk-frontend" {
+  /**
+   * Accordion translations
+   *
+   * Messages used by the component for the labels of its buttons. This includes
+   * the visible text shown on screen, and text to help assistive technology users
+   * for the buttons toggling each section.
+   * @property {string} [hideAllSections] - The text content for the 'Hide all
+   *   sections' button, used when at least one section is expanded.
+   * @property {string} [hideSection] - The text content for the 'Hide'
+   *   button, used when a section is expanded.
+   * @property {string} [hideSectionAriaLabel] - The text content appended to the
+   *   'Hide' button's accessible name when a section is expanded.
+   * @property {string} [showAllSections] - The text content for the 'Show all
+   *   sections' button, used when all sections are collapsed.
+   * @property {string} [showSection] - The text content for the 'Show'
+   *   button, used when a section is collapsed.
+   * @property {string} [showSectionAriaLabel] - The text content appended to the
+   *   'Show' button's accessible name when a section is expanded.
+   */
+  interface AccordionTranslations {
+    hideAllSections: string;
+    hideSection: string;
+    hideSectionAriaLabel: string;
+    showAllSections: string;
+    showSection: string;
+    showSectionAriaLabel: string;
+  }
+
+  /**
+   * Accordion config
+   *
+   * @property {AccordionTranslations} [i18n=Accordion.defaults.i18n] - Accordion translations
+   * @property {boolean} [rememberExpanded] - Whether the expanded and collapsed
+   *   state of each section is remembered and restored when navigating.
+   */
+  interface AccordionConfig {
+    i18n: AccordionTranslations;
+    rememberExpanded: boolean;
+  }
+
+  /**
+   * Config for all components via `initAll()`
+   *
+   * @property {AccordionConfig} [accordion] - Accordion config
+   * @property {ButtonConfig} [button] - Button config
+   * @property {CharacterCountConfig} [characterCount] - Character Count config
+   * @property {ErrorSummaryConfig} [errorSummary] - Error Summary config
+   * @property {ExitThisPageConfig} [exitThisPage] - Exit This Page config
+   * @property {NotificationBannerConfig} [notificationBanner] - Notification Banner config
+   * @property {PasswordInputConfig} [passwordInput] - Password input config
+   */
+  interface Config {
+    accordion: Partial<AccordionConfig>;
+  }
+
+  /**
+   * Initialise all components
+   *
+   * Use the `data-module` attributes to find, instantiate and init all of the
+   * components provided as part of GOV.UK Frontend.
+   */
+  export function initAll(config?: Partial<Config> & { scope?: Element }): void;
+}

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/administrative-supplies.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/administrative-supplies.tsx
@@ -14,6 +14,8 @@ import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
+import { useHash } from "src/hooks/useHash";
+import classNames from "classnames";
 
 export const AdministrativeSupplies: React.FC<AdministrativeSuppliesProps> = ({
   schools,
@@ -54,9 +56,17 @@ export const AdministrativeSupplies: React.FC<AdministrativeSuppliesProps> = ({
       };
     }, [dimension, schools]);
 
+  const id = "administrative-supplies";
+  const [hash] = useHash();
+
   return (
     <ChartDimensionContext.Provider value={dimension}>
-      <div className="govuk-accordion__section">
+      <div
+        className={classNames("govuk-accordion__section", {
+          "govuk-accordion__section--expanded": hash === `#${id}`,
+        })}
+        id={id}
+      >
         <div className="govuk-accordion__section-header">
           <h2 className="govuk-accordion__section-heading">
             <span

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
@@ -14,6 +14,8 @@ import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
+import { useHash } from "src/hooks/useHash";
+import classNames from "classnames";
 
 export const CateringStaffServices: React.FC<CateringStaffServicesProps> = ({
   schools,
@@ -107,9 +109,17 @@ export const CateringStaffServices: React.FC<CateringStaffServicesProps> = ({
       };
     }, [dimension, schools, tableHeadings]);
 
+  const id = "catering-staff-and-services";
+  const [hash] = useHash();
+
   return (
     <ChartDimensionContext.Provider value={dimension}>
-      <div className="govuk-accordion__section">
+      <div
+        className={classNames("govuk-accordion__section", {
+          "govuk-accordion__section--expanded": hash === `#${id}`,
+        })}
+        id={id}
+      >
         <div className="govuk-accordion__section-header">
           <h2 className="govuk-accordion__section-heading">
             <span

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-ict.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-ict.tsx
@@ -14,6 +14,8 @@ import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
+import { useHash } from "src/hooks/useHash";
+import classNames from "classnames";
 
 export const EducationalIct: React.FC<EducationalIctProps> = ({ schools }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
@@ -52,9 +54,17 @@ export const EducationalIct: React.FC<EducationalIctProps> = ({ schools }) => {
       };
     }, [dimension, schools]);
 
+  const id = "educational-ict";
+  const [hash] = useHash();
+
   return (
     <ChartDimensionContext.Provider value={dimension}>
-      <div className="govuk-accordion__section">
+      <div
+        className={classNames("govuk-accordion__section", {
+          "govuk-accordion__section--expanded": hash === `#${id}`,
+        })}
+        id={id}
+      >
         <div className="govuk-accordion__section-header">
           <h2 className="govuk-accordion__section-heading">
             <span

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-supplies.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-supplies.tsx
@@ -14,6 +14,8 @@ import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
+import { useHash } from "src/hooks/useHash";
+import classNames from "classnames";
 
 export const EducationalSupplies: React.FC<EducationalSuppliesProps> = ({
   schools,
@@ -107,9 +109,17 @@ export const EducationalSupplies: React.FC<EducationalSuppliesProps> = ({
       };
     }, [dimension, schools, tableHeadings]);
 
+  const id = "educational-supplies";
+  const [hash] = useHash();
+
   return (
     <ChartDimensionContext.Provider value={dimension}>
-      <div className="govuk-accordion__section">
+      <div
+        className={classNames("govuk-accordion__section", {
+          "govuk-accordion__section--expanded": hash === `#${id}`,
+        })}
+        id={id}
+      >
         <div className="govuk-accordion__section-header">
           <h2 className="govuk-accordion__section-heading">
             <span

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/non-educational-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/non-educational-support-staff.tsx
@@ -14,6 +14,8 @@ import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
+import classNames from "classnames";
+import { useHash } from "src/hooks/useHash";
 
 export const NonEducationalSupportStaff: React.FC<
   NonEducationalSupportStaffProps
@@ -124,9 +126,17 @@ export const NonEducationalSupportStaff: React.FC<
       };
     }, [dimension, schools, tableHeadings]);
 
+  const id = "non-educational-support-staff";
+  const [hash] = useHash();
+
   return (
     <ChartDimensionContext.Provider value={dimension}>
-      <div className="govuk-accordion__section">
+      <div
+        className={classNames("govuk-accordion__section", {
+          "govuk-accordion__section--expanded": hash === `#${id}`,
+        })}
+        id={id}
+      >
         <div className="govuk-accordion__section-header">
           <h2 className="govuk-accordion__section-heading">
             <span

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/other-costs.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/other-costs.tsx
@@ -14,6 +14,8 @@ import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
+import { useHash } from "src/hooks/useHash";
+import classNames from "classnames";
 
 export const OtherCosts: React.FC<OtherCostsProps> = ({ schools }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
@@ -275,9 +277,17 @@ export const OtherCosts: React.FC<OtherCostsProps> = ({ schools }) => {
       };
     }, [dimension, schools, tableHeadings]);
 
+  const id = "other";
+  const [hash] = useHash();
+
   return (
     <ChartDimensionContext.Provider value={dimension}>
-      <div className="govuk-accordion__section">
+      <div
+        className={classNames("govuk-accordion__section", {
+          "govuk-accordion__section--expanded": hash === `#${id}`,
+        })}
+        id={id}
+      >
         <div className="govuk-accordion__section-header">
           <h2 className="govuk-accordion__section-heading">
             <span

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
@@ -14,6 +14,8 @@ import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
+import { useHash } from "src/hooks/useHash";
+import classNames from "classnames";
 
 export const PremisesStaffServices: React.FC<PremisesStaffServicesProps> = ({
   schools,
@@ -124,9 +126,17 @@ export const PremisesStaffServices: React.FC<PremisesStaffServicesProps> = ({
       };
     }, [dimension, schools, tableHeadings]);
 
+  const id = "premises-and-services";
+  const [hash] = useHash();
+
   return (
     <ChartDimensionContext.Provider value={dimension}>
-      <div className="govuk-accordion__section">
+      <div
+        className={classNames("govuk-accordion__section", {
+          "govuk-accordion__section--expanded": hash === `#${id}`,
+        })}
+        id={id}
+      >
         <div className="govuk-accordion__section-header">
           <h2 className="govuk-accordion__section-heading">
             <span

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/teaching-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/teaching-support-staff.tsx
@@ -14,6 +14,8 @@ import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
+import { useHash } from "src/hooks/useHash";
+import classNames from "classnames";
 
 export const TeachingSupportStaff: React.FC<TeachingSupportStaffProps> = ({
   schools,
@@ -141,9 +143,17 @@ export const TeachingSupportStaff: React.FC<TeachingSupportStaffProps> = ({
       };
     }, [dimension, schools, tableHeadings]);
 
+  const id = "teaching-and-teaching-support-staff";
+  const [hash] = useHash();
+
   return (
     <ChartDimensionContext.Provider value={dimension}>
-      <div className="govuk-accordion__section">
+      <div
+        className={classNames("govuk-accordion__section", {
+          "govuk-accordion__section--expanded": hash === `#${id}`,
+        })}
+        id={id}
+      >
         <div className="govuk-accordion__section-header">
           <h2 className="govuk-accordion__section-heading">
             <span

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/utilities.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/utilities.tsx
@@ -14,6 +14,8 @@ import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
+import { useHash } from "src/hooks/useHash";
+import classNames from "classnames";
 
 export const Utilities: React.FC<UtilitiesProps> = ({ schools }) => {
   const [dimension, setDimension] = useState(PoundsPerMetreSq);
@@ -88,9 +90,17 @@ export const Utilities: React.FC<UtilitiesProps> = ({ schools }) => {
       };
     }, [dimension, schools, tableHeadings]);
 
+  const id = "utilities";
+  const [hash] = useHash();
+
   return (
     <ChartDimensionContext.Provider value={dimension}>
-      <div className="govuk-accordion__section">
+      <div
+        className={classNames("govuk-accordion__section", {
+          "govuk-accordion__section--expanded": hash === `#${id}`,
+        })}
+        id={id}
+      >
         <div className="govuk-accordion__section-header">
           <h2 className="govuk-accordion__section-heading">
             <span

--- a/front-end-components/src/views/compare-your-costs/partials/expenditure-accordion.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/expenditure-accordion.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useLayoutEffect } from "react";
+import { useHash } from "src/hooks/useHash";
 import { ExpenditureAccordionProps } from "src/views/compare-your-costs/partials";
 import {
   AdministrativeSupplies,
@@ -15,12 +16,26 @@ import {
 export const ExpenditureAccordion: React.FC<ExpenditureAccordionProps> = ({
   schools,
 }) => {
+  const [hash] = useHash();
+
+  useLayoutEffect(() => {
+    if (!hash) {
+      return;
+    }
+
+    // scroll section into view if expanded accordion contents have been rendered out of position
+    document
+      .querySelector(`.govuk-accordion__section${hash}`)
+      ?.scrollIntoView();
+  }, [hash]);
+
   return (
     <div className="govuk-grid-row">
       <div className="govuk-grid-column-full">
         <div
           className="govuk-accordion"
           data-module="govuk-accordion"
+          data-remember-expanded="false"
           id="accordion"
         >
           <TeachingSupportStaff schools={schools} />

--- a/front-end-components/src/views/compare-your-costs/view.tsx
+++ b/front-end-components/src/views/compare-your-costs/view.tsx
@@ -1,12 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useState,
-} from "react";
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-//@ts-expect-error
-import { initAll } from "govuk-frontend";
+import React, { useCallback, useEffect, useState } from "react";
 import {
   TotalExpenditure,
   ExpenditureAccordion,
@@ -21,6 +13,7 @@ import {
   ChartModeContext,
 } from "src/contexts";
 import { SchoolEstablishment } from "src/constants.tsx";
+import { useGovUk } from "src/hooks/useGovUk";
 
 export const CompareYourCosts: React.FC<CompareYourCostsViewProps> = (
   props
@@ -32,9 +25,7 @@ export const CompareYourCosts: React.FC<CompareYourCostsViewProps> = (
     School.empty
   );
 
-  useLayoutEffect(() => {
-    initAll();
-  }, []);
+  useGovUk();
 
   const getExpenditure = useCallback(async () => {
     return await EstablishmentsApi.getExpenditure(type, id);

--- a/front-end-components/src/views/find-organisation/view.tsx
+++ b/front-end-components/src/views/find-organisation/view.tsx
@@ -1,10 +1,8 @@
-import React, { useLayoutEffect, useRef } from "react";
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-//@ts-expect-error
-import { initAll } from "govuk-frontend";
+import { useRef } from "react";
 import SchoolInput from "src/views/find-organisation/partials/school-input";
 import { FindOrganisationProps } from "src/views/find-organisation";
 import TrustInput from "src/views/find-organisation/partials/trust-input";
+import { useGovUk } from "src/hooks/useGovUk";
 
 export const FindOrganisation: React.FC<FindOrganisationProps> = (props) => {
   const {
@@ -19,9 +17,7 @@ export const FindOrganisation: React.FC<FindOrganisationProps> = (props) => {
 
   const formElem = useRef(null);
 
-  useLayoutEffect(() => {
-    initAll();
-  }, []);
+  useGovUk();
 
   return (
     <form action="" method="POST" role="search" ref={formElem}>

--- a/front-end-components/src/views/historic-data/view.tsx
+++ b/front-end-components/src/views/historic-data/view.tsx
@@ -1,7 +1,3 @@
-import React, { useLayoutEffect } from "react";
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-//@ts-expect-error
-import { initAll } from "govuk-frontend";
 import {
   BalanceSection,
   IncomeSection,
@@ -10,12 +6,11 @@ import {
 } from "src/views/historic-data/partials";
 import { HistoricDataViewProps } from "src/views/historic-data/types";
 import { SchoolEstablishment } from "src/constants.tsx";
+import { useGovUk } from "src/hooks/useGovUk";
 
 export const HistoricData: React.FC<HistoricDataViewProps> = (props) => {
   const { type, id } = props;
-  useLayoutEffect(() => {
-    initAll();
-  }, []);
+  useGovUk();
 
   return (
     <div className="govuk-tabs" data-module="govuk-tabs">

--- a/web/src/Web.App/Domain/RagRating.cs
+++ b/web/src/Web.App/Domain/RagRating.cs
@@ -10,6 +10,7 @@ public record RagRating
     public string? Urn { get; set; }
     public int CostCategoryId { get; set; }
     public string? CostCategory { get; set; }
+    public string CostCategoryAnchorId => string.IsNullOrWhiteSpace(CostCategory) ? string.Empty : CostCategory.ToLower().Replace(" ", "-");
     public string? CostGroup { get; private set; }
     public decimal Value { get; set; }
     public decimal Median { get; set; }

--- a/web/src/Web.App/Views/SchoolSpending/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/Index.cshtml
@@ -34,7 +34,7 @@
                  data-sort-direction="asc">
             </div>
             <p class="govuk-body">
-                <a href="#" class="govuk-link govuk-link--no-visited-state">View all @category.Rating.CostCategory?.ToLower() costs</a>
+                <a href="comparison#@category.Rating.CostCategoryAnchorId" class="govuk-link govuk-link--no-visited-state">View all @category.Rating.CostCategory?.ToLower() costs</a>
             </p>
         </div>
     </div>
@@ -64,7 +64,7 @@
                  data-sort-direction="asc">
             </div>
             <p class="govuk-body">
-                <a href="#" class="govuk-link govuk-link--no-visited-state">View all @category.Rating.CostCategory?.ToLower() costs</a>
+                <a href="comparison#@category.Rating.CostCategoryAnchorId" class="govuk-link govuk-link--no-visited-state">View all @category.Rating.CostCategory?.ToLower() costs</a>
             </p>
         </div>
     </div>


### PR DESCRIPTION
### Context
AB#202122 AB#199553

### Change proposed in this pull request
Disabled 'remember expanded section' config on Expenditure accordion.
Allowed navigation via URL hash from Spending and Costs to respective accordion section in Expenditure accordion.

### Guidance to review 
Search for a school and view Spending and Costs. Click the 'view all XXX' link under any of the summary sections to be navigated to an opened section in the Expenditure accordion.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

