### PR TITLE
 Debounced autocomplete API calls for performance reasons

### DIFF
--- a/web/tests/Web.Integration.Tests/packages.lock.json
+++ b/web/tests/Web.Integration.Tests/packages.lock.json
@@ -22,11 +22,11 @@
       },
       "AngleSharp.XPath": {
         "type": "Direct",
-        "requested": "[2.0.3, )",
-        "resolved": "2.0.3",
-        "contentHash": "A1LuEgTfRoAmesx2JOLTOmcoWgu/wB03NjDs7cKESUTcwjhIqTy1PQxquMwoV6ZxWguW3H5a+eokEVm73Jy6Fw==",
+        "requested": "[2.0.4, )",
+        "resolved": "2.0.4",
+        "contentHash": "aL/axnwB5PeVBlYw6D9KREt2laJAlHOTO01NbLVmhN/6hFEvG3RAyUFXRyxWYSRHc6mgnh5UoOJ+E5jiJ2nyPQ==",
         "dependencies": {
-          "AngleSharp": "1.0.2"
+          "AngleSharp": "1.1.2"
         }
       },
       "AutoFixture": {


### PR DESCRIPTION
### Context
[AB#197543](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/197543)

### Change proposed in this pull request
Debounce `fetch` calls by 500ms when using auto complete inputs.

### Guidance to review 
Fewer API calls should be made when using the auto complete input fields for School or Trust search. The results displayed should be from the final API call made, rather than a random historical request.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

