### PR TITLE
Accessibility improvements to Chart/Table view toggle

### DIFF
--- a/front-end-components/src/components/charts/school-tick/component.tsx
+++ b/front-end-components/src/components/charts/school-tick/component.tsx
@@ -3,33 +3,56 @@ import { SchoolTickProps } from "src/components/charts/school-tick";
 
 export function SchoolTick(props: SchoolTickProps) {
   const {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    className,
     highlightedItemKey,
     linkToSchool,
     onClick,
     payload: { value },
     schoolUrnResolver,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    visibleTicksCount,
+    ...rest
   } = props;
   const urn = linkToSchool && schoolUrnResolver && schoolUrnResolver(value);
   if (!urn) {
     return <Text>{value}</Text>;
   }
 
-  {
-    /* TODO: replace with custom version of https://github.com/recharts/recharts/blob/master/src/component/Text.tsx
-    to avoid CSS hacks to hide multiple <tspan>s */
+  function handleKeyPress(event: React.KeyboardEvent<SVGTextElement>) {
+    if (onClick && urn && event.key === "Enter") {
+      onClick(urn);
+    }
   }
+
   return (
-    <Text
-      {...props}
-      fontWeight={urn === highlightedItemKey ? "bold" : "normal"}
-      cursor={urn ? "pointer" : undefined}
-      className={
-        urn ? "govuk-link govuk-link--no-visited-state school-tick" : undefined
-      }
-      onClick={onClick ? () => onClick(urn) : undefined}
-      lineHeight={0}
-    >
-      {value}
-    </Text>
+    <>
+      {urn && (
+        <line
+          x1={rest.x}
+          y1={rest.y}
+          y2={rest.y}
+          width={rest.width}
+          height={rest.height}
+          className="school-tick-focus"
+        ></line>
+      )}
+      <Text
+        fontWeight={urn === highlightedItemKey ? "bold" : "normal"}
+        cursor={urn ? "pointer" : undefined}
+        className={
+          urn
+            ? "govuk-link govuk-link--no-visited-state school-tick"
+            : undefined
+        }
+        onClick={onClick ? () => onClick(urn) : undefined}
+        onKeyDown={handleKeyPress}
+        lineHeight={0}
+        tabIndex={onClick ? 0 : undefined}
+        {...rest}
+      >
+        {value}
+      </Text>
+    </>
   );
 }

--- a/front-end-components/src/components/charts/school-tick/types.tsx
+++ b/front-end-components/src/components/charts/school-tick/types.tsx
@@ -1,6 +1,9 @@
 import { BaseAxisProps, CartesianTickItem } from "recharts/types/util/types";
+import { TickProps } from "../types";
 
-export interface SchoolTickProps extends Omit<BaseAxisProps, "scale"> {
+export interface SchoolTickProps
+  extends Omit<BaseAxisProps, "scale">,
+    Omit<TickProps, "type" | "onClick" | "ref" | "textAnchor"> {
   highlightedItemKey?: string;
   linkToSchool?: boolean;
   onClick?: (urn: string) => void;

--- a/front-end-components/src/components/charts/table-chart/component.tsx
+++ b/front-end-components/src/components/charts/table-chart/component.tsx
@@ -8,13 +8,14 @@ import { SelectedSchoolContext } from "src/contexts";
 export const TableChart: React.FC<TableChartProps<SchoolChartData>> = (
   props
 ) => {
-  const { tableHeadings, data } = props;
+  const { tableHeadings, data, preventFocus } = props;
   const selectedSchool = useContext(SelectedSchoolContext);
 
   const renderSchoolAnchor = (row: SchoolChartData) => (
     <a
       className="govuk-link govuk-link--no-visited-state"
       href={`/school/${row.urn}`}
+      tabIndex={preventFocus ? -1 : undefined}
     >
       {row.name}
     </a>

--- a/front-end-components/src/components/charts/table-chart/types.tsx
+++ b/front-end-components/src/components/charts/table-chart/types.tsx
@@ -1,6 +1,7 @@
 export type TableChartProps<TData extends SchoolChartData> = {
   tableHeadings: string[];
   data?: TData[];
+  preventFocus?: boolean;
 };
 
 export type SchoolChartData = {

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -122,6 +122,7 @@ export function HorizontalBarChartWrapper<TData extends SchoolChartData>(
                 <TableChart
                   tableHeadings={data.tableHeadings}
                   data={sortedDataPoints}
+                  preventFocus={mode !== ChartModeTable}
                 />
               </div>
             </>

--- a/front-end-components/src/index.css
+++ b/front-end-components/src/index.css
@@ -20,6 +20,7 @@
   --link-colour: #1d70b8;
   --link-hover-colour: #003078;
   --table-grid-colour: #b1b4b6;
+  --focus-colour: #fd0;
 }
 
 .recharts-wrapper .chart-cell,
@@ -129,7 +130,7 @@
   overflow-wrap: break-word;
 }
 
-.chart-stat-wrapper.chart-stat-line-chart .chart-stat-value{
+.chart-stat-wrapper.chart-stat-line-chart .chart-stat-value {
   color: var(--series-highlight-colour);
 }
 
@@ -174,12 +175,25 @@
   fill: var(--link-colour);
 }
 
-.recharts-wrapper .recharts-cartesian-axis .recharts-text.govuk-link:hover {
+.recharts-wrapper .recharts-cartesian-axis .recharts-text.govuk-link:hover,
+.recharts-wrapper .recharts-cartesian-axis .recharts-text.govuk-link:focus {
   fill: var(--link-hover-colour);
+  text-decoration: underline;
 }
 
 .recharts-wrapper .recharts-cartesian-axis .recharts-text.school-tick {
   transform: translate(-0.1em, 0.3em);
+}
+
+.recharts-wrapper .recharts-cartesian-axis line.school-tick-focus:has(~ text) {
+  stroke: transparent;
+  stroke-width: 1.5em;
+}
+
+.recharts-wrapper
+  .recharts-cartesian-axis
+  line.school-tick-focus:has(~ text:focus) {
+  stroke: var(--focus-colour);
 }
 
 .recharts-wrapper


### PR DESCRIPTION
### Context
[AB#202503](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/202503) / [AB#203726](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/203726)
[AB#202520](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/202520) / [AB#203727](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/203727)

### Change proposed in this pull request
Disable tabbing into 'visually hidden' table.
Allow tabbing through school elements within charts.

### Guidance to review 
When table visible, schools should be tabbed between.
When table not visible, tab focus should not enter hidden table.
When chart visible, schools should be tabbed between.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

