### PR TITLE
composed component for Historic data to display either line chart or table

### DIFF
--- a/front-end-components/src/composed/historic-chart-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/component.tsx
@@ -1,0 +1,98 @@
+import { useContext } from "react";
+import { ChartModeChart } from "src/components";
+import { HistoricChartProps } from "src/composed/historic-chart-composed";
+import { ChartModeContext } from "src/contexts";
+import { LineChart } from "src/components/charts/line-chart";
+import { shortValueFormatter } from "src/components/charts/utils.ts";
+import { LineChartTooltip } from "src/components/charts/line-chart-tooltip";
+import { ResolvedStat } from "src/components/charts/resolved-stat";
+import { ChartDataSeries } from "src/components/charts/types";
+import { ChartDimensionContext } from "src/contexts";
+
+export const HistoricChart: React.FC<HistoricChartProps<ChartDataSeries>> = ({
+  chartName,
+  data,
+  seriesConfig,
+  valueField,
+  children,
+}) => {
+  const mode = useContext(ChartModeContext);
+  const dimension = useContext(ChartDimensionContext);
+
+  return (
+    <>
+      {children}
+      {mode == ChartModeChart ? (
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-three-quarters">
+            <div style={{ height: 200 }}>
+              <LineChart
+                chartName={chartName}
+                data={data}
+                grid
+                highlightActive
+                keyField="yearEnd"
+                margin={20}
+                seriesConfig={seriesConfig}
+                seriesLabel={dimension.label}
+                seriesLabelField="yearEnd"
+                valueFormatter={shortValueFormatter}
+                valueUnit={dimension.unit}
+                tooltip={(t) => (
+                  <LineChartTooltip
+                    {...t}
+                    valueFormatter={(v) =>
+                      shortValueFormatter(v, { valueUnit: dimension.unit })
+                    }
+                  />
+                )}
+              />
+            </div>
+          </div>
+          <aside className="govuk-grid-column-one-quarter">
+            <ResolvedStat
+              chartName={`Most recent ${chartName.toLowerCase()}`}
+              className="chart-stat-line-chart"
+              compactValue
+              data={data}
+              displayIndex={data.length - 1}
+              seriesLabelField="yearEnd"
+              valueField={valueField}
+              valueFormatter={shortValueFormatter}
+              valueUnit={dimension.unit}
+            />
+          </aside>
+        </div>
+      ) : (
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-three-quarters">
+            <table className="govuk-table">
+              <thead className="govuk-table__head">
+                <tr className="govuk-table__row">
+                  <th className="govuk-table__header govuk-!-width-one-half">
+                    Year
+                  </th>
+                  <th className="govuk-table__header">{dimension.heading}</th>
+                </tr>
+              </thead>
+              <tbody className="govuk-table__body">
+                {data.map((item) => (
+                  <tr className="govuk-table__row">
+                    <td className="govuk-table__cell">
+                      {Number(item.yearEnd)}
+                    </td>
+                    <td className="govuk-table__cell">
+                      {shortValueFormatter(item[valueField], {
+                        valueUnit: dimension.unit,
+                      })}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};

--- a/front-end-components/src/composed/historic-chart-composed/index.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/composed/historic-chart-composed/types";
+export * from "src/composed/historic-chart-composed/component";

--- a/front-end-components/src/composed/historic-chart-composed/types.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/types.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from "react";
+import { ChartDataSeries, ChartProps } from "src/components/charts/types";
+import { ResolvedStatProps } from "src/components/charts/resolved-stat";
+
+export interface HistoricChartProps<T extends ChartDataSeries> {
+  chartName: string;
+  data: T[];
+  seriesConfig: ChartProps<T>["seriesConfig"];
+  valueField: ResolvedStatProps<T>["valueField"];
+  children?: ReactNode;
+}

--- a/front-end-components/src/views/historic-data/partials/balance-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/balance-section.tsx
@@ -6,12 +6,9 @@ import {
   ChartModeChart,
   CostCategories,
 } from "src/components";
-import { ChartModeContext } from "src/contexts";
+import { ChartModeContext, ChartDimensionContext } from "src/contexts";
 import { Balance, HistoryApi } from "src/services";
-import { LineChart } from "src/components/charts/line-chart";
-import { shortValueFormatter } from "src/components/charts/utils.ts";
-import { LineChartTooltip } from "src/components/charts/line-chart-tooltip";
-import { ResolvedStat } from "src/components/charts/resolved-stat";
+import { HistoricChart } from "src/composed/historic-chart-composed";
 import { Loading } from "src/components/loading";
 
 export const BalanceSection: React.FC<{ type: string; id: string }> = ({
@@ -50,176 +47,114 @@ export const BalanceSection: React.FC<{ type: string; id: string }> = ({
 
   return (
     <ChartModeContext.Provider value={displayMode}>
-      <div className="govuk-grid-row">
-        <div className="govuk-grid-column-two-thirds">
-          <ChartDimensions
-            dimensions={CostCategories}
-            handleChange={handleSelectChange}
-            elementId="balance"
-            defaultValue={dimension.value}
-          />
-        </div>
-        <div className="govuk-grid-column-one-third">
-          <ChartMode
-            displayMode={displayMode}
-            handleChange={handleModeChange}
-            prefix="balance"
-          />
-        </div>
-      </div>
-      <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-0" />
-      {data.length > 0 ? (
-        <>
-          <h2 className="govuk-heading-m">In-year balance</h2>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="In-year balance"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    inYearBalance: {
-                      label: "In-year balance",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent in-year balance"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="inYearBalance"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
+      <ChartDimensionContext.Provider value={dimension}>
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-two-thirds">
+            <ChartDimensions
+              dimensions={CostCategories}
+              handleChange={handleSelectChange}
+              elementId="balance"
+              defaultValue={dimension.value}
+            />
           </div>
-          <h2 className="govuk-heading-m">Revenue reserve</h2>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Revenue reserve<"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    revenueReserve: {
-                      label: "Revenue reserve",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent revenue reserve"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="revenueReserve"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
+          <div className="govuk-grid-column-one-third">
+            <ChartMode
+              displayMode={displayMode}
+              handleChange={handleModeChange}
+              prefix="balance"
+            />
           </div>
-          <details className="govuk-details">
-            <summary className="govuk-details__summary">
-              <span className="govuk-details__summary-text">
-                More about revenue reserve
-              </span>
-            </summary>
-            <div className="govuk-details__text">
-              <p>
-                Local authority maintained schools and single academy trusts
-                <br />
-                Reserves are legally associated with one school and appear in
-                that school’s graphs.
-              </p>
-              <p>
-                Local authority maintained schools
-                <br />
-                Reserves include committed and uncommitted revenue balance. They
-                also include the community-focused extended school revenue
-                balance.
-              </p>
+        </div>
+        <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-0" />
+        {data.length > 0 ? (
+          <>
+            <HistoricChart
+              chartName="In-year balance"
+              data={data}
+              seriesConfig={{
+                inYearBalance: {
+                  label: "In-year balance",
+                  visible: true,
+                },
+              }}
+              valueField="inYearBalance"
+            >
+              <h2 className="govuk-heading-m">In-year balance</h2>
+            </HistoricChart>
 
-              <p>
-                Single academy trusts
-                <br />
-                This is calculated by:
-                <ul className="govuk-list govuk-list--bullet">
-                  <li>
-                    carrying forward the closing balance (restricted and
-                    unrestricted funds) from the previous year
-                  </li>
-                  <li>
-                    adding total income in the current year (revenue, funds
-                    inherited on conversion/transfer and contributions from
-                    academies to trust)
-                  </li>
-                  <li>subtracting total expenditure in the current year</li>
-                </ul>
-              </p>
-              <p>
-                Multi-academy trust
-                <br />
-                The trust is the legal entity and all revenue reserves legally
-                belong to it.
-              </p>
-              <p>
-                Single academies in multi-academy trusts (MATs)
-                <br />
-                We estimated a value per academy by diving up and sharing out
-                the trust’s reserves on a pro-rata basis. For this we used the
-                full-time equivalent (FTE) number of pupils in each academy in
-                that MAT.
-              </p>
-            </div>
-          </details>
-        </>
-      ) : (
-        <Loading />
-      )}
+            <HistoricChart
+              chartName="Revenue reserve"
+              data={data}
+              seriesConfig={{
+                revenueReserve: {
+                  label: "Revenue reserve",
+                  visible: true,
+                },
+              }}
+              valueField="revenueReserve"
+            >
+              <h2 className="govuk-heading-m">Revenue reserve</h2>
+            </HistoricChart>
+
+            <details className="govuk-details">
+              <summary className="govuk-details__summary">
+                <span className="govuk-details__summary-text">
+                  More about revenue reserve
+                </span>
+              </summary>
+              <div className="govuk-details__text">
+                <p>
+                  Local authority maintained schools and single academy trusts
+                  <br />
+                  Reserves are legally associated with one school and appear in
+                  that school’s graphs.
+                </p>
+                <p>
+                  Local authority maintained schools
+                  <br />
+                  Reserves include committed and uncommitted revenue balance.
+                  They also include the community-focused extended school
+                  revenue balance.
+                </p>
+
+                <p>
+                  Single academy trusts
+                  <br />
+                  This is calculated by:
+                  <ul className="govuk-list govuk-list--bullet">
+                    <li>
+                      carrying forward the closing balance (restricted and
+                      unrestricted funds) from the previous year
+                    </li>
+                    <li>
+                      adding total income in the current year (revenue, funds
+                      inherited on conversion/transfer and contributions from
+                      academies to trust)
+                    </li>
+                    <li>subtracting total expenditure in the current year</li>
+                  </ul>
+                </p>
+                <p>
+                  Multi-academy trust
+                  <br />
+                  The trust is the legal entity and all revenue reserves legally
+                  belong to it.
+                </p>
+                <p>
+                  Single academies in multi-academy trusts (MATs)
+                  <br />
+                  We estimated a value per academy by diving up and sharing out
+                  the trust’s reserves on a pro-rata basis. For this we used the
+                  full-time equivalent (FTE) number of pupils in each academy in
+                  that MAT.
+                </p>
+              </div>
+            </details>
+          </>
+        ) : (
+          <Loading />
+        )}
+      </ChartDimensionContext.Provider>
     </ChartModeContext.Provider>
   );
 };

--- a/front-end-components/src/views/historic-data/partials/income-section-direct-revenue.tsx
+++ b/front-end-components/src/views/historic-data/partials/income-section-direct-revenue.tsx
@@ -1,69 +1,29 @@
-import React, { useContext } from "react";
-import { LineChart } from "src/components/charts/line-chart";
-import { shortValueFormatter } from "src/components/charts/utils.ts";
-import { LineChartTooltip } from "src/components/charts/line-chart-tooltip";
-import { ResolvedStat } from "src/components/charts/resolved-stat";
-import { ChartDimensionContext } from "src/contexts";
+import { HistoricChart } from "src/composed/historic-chart-composed";
 import { Income } from "src/services";
 import { Loading } from "src/components/loading";
 
-export const IncomeSectionDirectRevenue: React.FC<{ data: Income[] }> = ({
-  data,
-}) => {
-  const dimension = useContext(ChartDimensionContext);
-
+export const IncomeSectionDirectRevenue: React.FC<{
+  data: Income[];
+}> = ({ data }) => {
   return (
     <>
       {data.length > 0 ? (
         <>
-          <h3 className="govuk-heading-s">
-            Direct revenue financing (capital reserves transfers)
-          </h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Direct revenue financing (capital reserves transfers)"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    directRevenueFinancing: {
-                      label: "Direct revenue financing",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent direct revenue financing"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="directRevenueFinancing"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
+          <HistoricChart
+            chartName="Direct revenue financing (capital reserves transfers)"
+            data={data}
+            seriesConfig={{
+              directRevenueFinancing: {
+                label: "Direct revenue financing",
+                visible: true,
+              },
+            }}
+            valueField="directRevenueFinancing"
+          >
+            <h3 className="govuk-heading-s">
+              Direct revenue financing (capital reserves transfers)
+            </h3>
+          </HistoricChart>
           <details className="govuk-details">
             <summary className="govuk-details__summary">
               <span className="govuk-details__summary-text">

--- a/front-end-components/src/views/historic-data/partials/income-section-grant-funding.tsx
+++ b/front-end-components/src/views/historic-data/partials/income-section-grant-funding.tsx
@@ -1,113 +1,42 @@
-import React, { useContext } from "react";
-import { LineChart } from "src/components/charts/line-chart";
-import { shortValueFormatter } from "src/components/charts/utils.ts";
-import { LineChartTooltip } from "src/components/charts/line-chart-tooltip";
-import { ResolvedStat } from "src/components/charts/resolved-stat";
-import { ChartDimensionContext } from "src/contexts";
+import { HistoricChart } from "src/composed/historic-chart-composed";
 import { Income } from "src/services";
 import { Loading } from "src/components/loading";
 
-export const IncomeSectionGrantFunding: React.FC<{ data: Income[] }> = ({
-  data,
-}) => {
-  const dimension = useContext(ChartDimensionContext);
-
+export const IncomeSectionGrantFunding: React.FC<{
+  data: Income[];
+}> = ({ data }) => {
   return (
     <>
       {data.length > 0 ? (
         <>
-          <h3 className="govuk-heading-s">Grant funding total</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Grant funding total"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    totalGrantFunding: {
-                      label: "total grant funding",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent grant funding total"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="totalGrantFunding"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Direct grants</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Direct grants"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    directGrants: {
-                      label: "Direct grants",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent direct grants"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="directGrants"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
+          <HistoricChart
+            chartName="Grant funding total"
+            data={data}
+            seriesConfig={{
+              totalGrantFunding: {
+                label: "total grant funding",
+                visible: true,
+              },
+            }}
+            valueField="totalGrantFunding"
+          >
+            <h3 className="govuk-heading-s">Grant funding total</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Direct grants"
+            data={data}
+            seriesConfig={{
+              directGrants: {
+                label: "Direct grants",
+                visible: true,
+              },
+            }}
+            valueField="directGrants"
+          >
+            <h3 className="govuk-heading-s">Direct grants</h3>
+          </HistoricChart>
+
           <details className="govuk-details">
             <summary className="govuk-details__summary">
               <span className="govuk-details__summary-text">
@@ -131,285 +60,92 @@ export const IncomeSectionGrantFunding: React.FC<{ data: Income[] }> = ({
               </ul>
             </div>
           </details>
-          <h3 className="govuk-heading-s">Pre-16 and post-16 funding</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Pre-16 and post-16 funding"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    prePost16Funding: {
-                      label: "Pre-16 and post-16 funding",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent pre-16 and post-16 funding"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="prePost16Funding"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Other DfE/EFA revenue grants </h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Other DfE/EFA revenue grants "
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    otherDfeGrants: {
-                      label: "Other DfE/EFA revenue grants ",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent other DfE/EFA revenue grants "
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="otherDfeGrants"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">
-            Other income (local authority and other government grants)
-          </h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Other income (local authority and other government grants)l"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    otherIncomeGrants: {
-                      label:
-                        "Other income (local authority and other government grants)",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent other income (local authority and other government grants)"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="otherIncomeGrants"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Government source (non-grant)</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Government source (non-grant)"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    governmentSource: {
-                      label: "Government source (non-grant)",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent government source (non-grant)"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="governmentSource"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Community grants</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Community grantsl"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    communityGrants: {
-                      label: "Community grants",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent community grants"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="communityGrants"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Academies</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Academies"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    academies: {
-                      label: "Academies",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent academies "
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="academies"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
+          <HistoricChart
+            chartName="Pre-16 and post-16 funding"
+            data={data}
+            seriesConfig={{
+              prePost16Funding: {
+                label: "Pre-16 and post-16 funding",
+                visible: true,
+              },
+            }}
+            valueField="prePost16Funding"
+          >
+            <h3 className="govuk-heading-s">Pre-16 and post-16 funding</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Other DfE/EFA revenue grants"
+            data={data}
+            seriesConfig={{
+              otherDfeGrants: {
+                label: "Other DfE/EFA revenue grants",
+                visible: true,
+              },
+            }}
+            valueField="otherDfeGrants"
+          >
+            <h3 className="govuk-heading-s">Other DfE/EFA revenue grants </h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Other income (local authority and other government grants)"
+            data={data}
+            seriesConfig={{
+              otherIncomeGrants: {
+                label:
+                  "Other income (local authority and other government grants)",
+                visible: true,
+              },
+            }}
+            valueField="otherIncomeGrants"
+          >
+            <h3 className="govuk-heading-s">
+              Other income (local authority and other government grants)
+            </h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Government source (non-grant)"
+            data={data}
+            seriesConfig={{
+              governmentSource: {
+                label: "Government source (non-grant)",
+                visible: true,
+              },
+            }}
+            valueField="governmentSource"
+          >
+            <h3 className="govuk-heading-s">Government source (non-grant)</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Community grants"
+            data={data}
+            seriesConfig={{
+              communityGrants: {
+                label: "Community grants",
+                visible: true,
+              },
+            }}
+            valueField="communityGrants"
+          >
+            <h3 className="govuk-heading-s">Community grants</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Academies"
+            data={data}
+            seriesConfig={{
+              academies: {
+                label: "Academies",
+                visible: true,
+              },
+            }}
+            valueField="academies"
+          >
+            <h3 className="govuk-heading-s">Academies</h3>
+          </HistoricChart>
         </>
       ) : (
         <Loading />

--- a/front-end-components/src/views/historic-data/partials/income-section-self-generated.tsx
+++ b/front-end-components/src/views/historic-data/partials/income-section-self-generated.tsx
@@ -1,115 +1,44 @@
-import React, { useContext } from "react";
-import { LineChart } from "src/components/charts/line-chart";
-import { shortValueFormatter } from "src/components/charts/utils.ts";
-import { LineChartTooltip } from "src/components/charts/line-chart-tooltip";
-import { ResolvedStat } from "src/components/charts/resolved-stat";
-import { ChartDimensionContext } from "src/contexts";
+import { HistoricChart } from "src/composed/historic-chart-composed";
 import { Income } from "src/services";
 import { Loading } from "src/components/loading";
 
-export const IncomeSectionSelfGenerated: React.FC<{ data: Income[] }> = ({
-  data,
-}) => {
-  const dimension = useContext(ChartDimensionContext);
-
+export const IncomeSectionSelfGenerated: React.FC<{
+  data: Income[];
+}> = ({ data }) => {
   return (
     <>
       {data.length > 0 ? (
         <>
-          <h3 className="govuk-heading-s">Self-generated funding total</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Self-generated funding total"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    totalSelfGeneratedFunding: {
-                      label: "Total self-generated funding",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent self-generated funding total"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="totalSelfGeneratedFunding"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">
-            Income from facilities and services
-          </h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Income from facilities and services"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    incomeFacilitiesServices: {
-                      label: "Income from facilities and services",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent income from facilities and services"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="incomeFacilitiesServices"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
+          <HistoricChart
+            chartName="Self-generated funding total"
+            data={data}
+            seriesConfig={{
+              totalSelfGeneratedFunding: {
+                label: "Total self-generated funding",
+                visible: true,
+              },
+            }}
+            valueField="totalSelfGeneratedFunding"
+          >
+            <h3 className="govuk-heading-s">Self-generated funding total</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Income from facilities and services"
+            data={data}
+            seriesConfig={{
+              incomeFacilitiesServices: {
+                label: "Income from facilities and services",
+                visible: true,
+              },
+            }}
+            valueField="incomeFacilitiesServices"
+          >
+            <h3 className="govuk-heading-s">
+              Income from facilities and services
+            </h3>
+          </HistoricChart>
+
           <details className="govuk-details">
             <summary className="govuk-details__summary">
               <span className="govuk-details__summary-text">
@@ -172,52 +101,20 @@ export const IncomeSectionSelfGenerated: React.FC<{ data: Income[] }> = ({
               </ul>
             </div>
           </details>
-          <h3 className="govuk-heading-s">Income from catering</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Income from catering "
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    incomeCatering: {
-                      label: "Income from catering",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent income from catering"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="incomeCatering"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
+          <HistoricChart
+            chartName="Income from catering"
+            data={data}
+            seriesConfig={{
+              incomeCatering: {
+                label: "Income from catering",
+                visible: true,
+              },
+            }}
+            valueField="incomeCatering"
+          >
+            <h3 className="govuk-heading-s">Income from catering</h3>
+          </HistoricChart>
+
           <details className="govuk-details">
             <summary className="govuk-details__summary">
               <span className="govuk-details__summary-text">
@@ -244,52 +141,22 @@ export const IncomeSectionSelfGenerated: React.FC<{ data: Income[] }> = ({
               </ul>
             </div>
           </details>
-          <h3 className="govuk-heading-s">Donations and/or voluntary funds</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Donations and/or voluntary funds"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    donationsVoluntaryFunds: {
-                      label: "Donations and/or voluntary funds",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent donations and/or voluntary funds"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="donationsVoluntaryFunds"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
+          <HistoricChart
+            chartName="Donations and/or voluntary funds"
+            data={data}
+            seriesConfig={{
+              donationsVoluntaryFunds: {
+                label: "Donations and/or voluntary funds",
+                visible: true,
+              },
+            }}
+            valueField="donationsVoluntaryFunds"
+          >
+            <h3 className="govuk-heading-s">
+              Donations and/or voluntary funds
+            </h3>
+          </HistoricChart>
+
           <details className="govuk-details">
             <summary className="govuk-details__summary">
               <span className="govuk-details__summary-text">
@@ -324,54 +191,22 @@ export const IncomeSectionSelfGenerated: React.FC<{ data: Income[] }> = ({
               </ul>
             </div>
           </details>
-          <h3 className="govuk-heading-s">
-            Receipts from supply teacher insurance claims
-          </h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Receipts from supply teacher insurance claims "
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    receiptsSupplyTeacherInsuranceClaims: {
-                      label: "Receipts from supply teacher insurance claims ",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent receipts from supply teacher insurance claims"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="receiptsSupplyTeacherInsuranceClaims"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
+          <HistoricChart
+            chartName="Receipts from supply teacher insurance claims"
+            data={data}
+            seriesConfig={{
+              receiptsSupplyTeacherInsuranceClaims: {
+                label: "Receipts from supply teacher insurance claims",
+                visible: true,
+              },
+            }}
+            valueField="receiptsSupplyTeacherInsuranceClaims"
+          >
+            <h3 className="govuk-heading-s">
+              Receipts from supply teacher insurance claims
+            </h3>
+          </HistoricChart>
+
           <details className="govuk-details">
             <summary className="govuk-details__summary">
               <span className="govuk-details__summary-text">
@@ -398,52 +233,20 @@ export const IncomeSectionSelfGenerated: React.FC<{ data: Income[] }> = ({
               </ul>
             </div>
           </details>
-          <h3 className="govuk-heading-s">Investment income</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Investment income"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    investmentIncome: {
-                      label: "Investment income",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent investment income"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="investmentIncome"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
+          <HistoricChart
+            chartName="Investment income"
+            data={data}
+            seriesConfig={{
+              directRevenueFinancing: {
+                label: "Investment income",
+                visible: true,
+              },
+            }}
+            valueField="investmentIncome"
+          >
+            <h3 className="govuk-heading-s">Investment income</h3>
+          </HistoricChart>
+
           <details className="govuk-details">
             <summary className="govuk-details__summary">
               <span className="govuk-details__summary-text">
@@ -459,52 +262,21 @@ export const IncomeSectionSelfGenerated: React.FC<{ data: Income[] }> = ({
               </ul>
             </div>
           </details>
-          <h3 className="govuk-heading-s">Other self-generated income</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Other self-generated income"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    otherSelfGeneratedIncome: {
-                      label: "Other self-generated income",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent other self-generated income"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="otherSelfGeneratedIncome"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
+
+          <HistoricChart
+            chartName="Other self-generated income"
+            data={data}
+            seriesConfig={{
+              otherSelfGeneratedIncome: {
+                label: "Other self-generated income",
+                visible: true,
+              },
+            }}
+            valueField="otherSelfGeneratedIncome"
+          >
+            <h3 className="govuk-heading-s">Other self-generated income</h3>
+          </HistoricChart>
+
           <details className="govuk-details">
             <summary className="govuk-details__summary">
               <span className="govuk-details__summary-text">

--- a/front-end-components/src/views/historic-data/partials/income-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/income-section.tsx
@@ -8,14 +8,11 @@ import {
 } from "src/components";
 import { HistoryApi, Income } from "src/services";
 import { ChartModeContext, ChartDimensionContext } from "src/contexts";
-import { LineChart } from "src/components/charts/line-chart";
-import { shortValueFormatter } from "src/components/charts/utils.ts";
-import { LineChartTooltip } from "src/components/charts/line-chart-tooltip";
-import { ResolvedStat } from "src/components/charts/resolved-stat";
 import { Loading } from "src/components/loading";
 import { IncomeSectionGrantFunding } from "src/views/historic-data/partials/income-section-grant-funding";
 import { IncomeSectionSelfGenerated } from "src/views/historic-data/partials/income-section-self-generated";
 import { IncomeSectionDirectRevenue } from "src/views/historic-data/partials/income-section-direct-revenue";
+import { HistoricChart } from "src/composed/historic-chart-composed";
 
 export const IncomeSection: React.FC<{ type: string; id: string }> = ({
   type,
@@ -73,54 +70,19 @@ export const IncomeSection: React.FC<{ type: string; id: string }> = ({
         </div>
         <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-0" />
         {data.length > 0 ? (
-          <>
+          <HistoricChart
+            chartName="Total income"
+            data={data}
+            seriesConfig={{
+              totalIncome: {
+                label: "Total income",
+                visible: true,
+              },
+            }}
+            valueField="totalIncome"
+          >
             <h2 className="govuk-heading-m">Total income</h2>
-            <div className="govuk-grid-row">
-              <div className="govuk-grid-column-three-quarters">
-                <div style={{ height: 200 }}>
-                  <LineChart
-                    chartName="Total income"
-                    data={data}
-                    grid
-                    highlightActive
-                    keyField="yearEnd"
-                    margin={20}
-                    seriesConfig={{
-                      totalIncome: {
-                        label: "Total income",
-                        visible: true,
-                      },
-                    }}
-                    seriesLabel={dimension.label}
-                    seriesLabelField="yearEnd"
-                    valueFormatter={shortValueFormatter}
-                    valueUnit={dimension.unit}
-                    tooltip={(t) => (
-                      <LineChartTooltip
-                        {...t}
-                        valueFormatter={(v) =>
-                          shortValueFormatter(v, { valueUnit: dimension.unit })
-                        }
-                      />
-                    )}
-                  />
-                </div>
-              </div>
-              <aside className="govuk-grid-column-one-quarter">
-                <ResolvedStat
-                  chartName="Most recent total income"
-                  className="chart-stat-line-chart"
-                  compactValue
-                  data={data}
-                  displayIndex={data.length - 1}
-                  seriesLabelField="yearEnd"
-                  valueField="totalIncome"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                />
-              </aside>
-            </div>
-          </>
+          </HistoricChart>
         ) : (
           <Loading />
         )}

--- a/front-end-components/src/views/historic-data/partials/spending-section-administrative-supplies.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section-administrative-supplies.tsx
@@ -1,70 +1,28 @@
-import React, { useContext } from "react";
-import { LineChart } from "src/components/charts/line-chart";
-import { shortValueFormatter } from "src/components/charts/utils.ts";
-import { LineChartTooltip } from "src/components/charts/line-chart-tooltip";
-import { ResolvedStat } from "src/components/charts/resolved-stat";
-import { ChartDimensionContext } from "src/contexts";
+import { HistoricChart } from "src/composed/historic-chart-composed";
 import { Expenditure } from "src/services";
 import { Loading } from "src/components/loading";
 
 export const SpendingSectionAdministrativeSupplies: React.FC<{
   data: Expenditure[];
 }> = ({ data }) => {
-  const dimension = useContext(ChartDimensionContext);
-
   return (
     <>
       {data.length > 0 ? (
-        <>
+        <HistoricChart
+          chartName="Administration supplies (non educational) costs"
+          data={data}
+          seriesConfig={{
+            administrativeSuppliesCosts: {
+              label: "Administration supplies (non educational) costs",
+              visible: true,
+            },
+          }}
+          valueField="administrativeSuppliesCosts"
+        >
           <h3 className="govuk-heading-s">
             Administration supplies (non educational) costs
           </h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Administration supplies (non educational) costs "
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    administrativeSuppliesCosts: {
-                      label: "Administration supplies (non educational) costs ",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent administration supplies (non educational) costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="administrativeSuppliesCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-        </>
+        </HistoricChart>
       ) : (
         <Loading />
       )}

--- a/front-end-components/src/views/historic-data/partials/spending-section-catering-services.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section-catering-services.tsx
@@ -1,159 +1,55 @@
-import React, { useContext } from "react";
-import { LineChart } from "src/components/charts/line-chart";
-import { shortValueFormatter } from "src/components/charts/utils.ts";
-import { LineChartTooltip } from "src/components/charts/line-chart-tooltip";
-import { ResolvedStat } from "src/components/charts/resolved-stat";
-import { ChartDimensionContext } from "src/contexts";
+import { HistoricChart } from "src/composed/historic-chart-composed";
 import { Expenditure } from "src/services";
 import { Loading } from "src/components/loading";
 
 export const SpendingSectionCateringServices: React.FC<{
   data: Expenditure[];
 }> = ({ data }) => {
-  const dimension = useContext(ChartDimensionContext);
-
   return (
     <>
       {data.length > 0 ? (
         <>
-          <h3 className="govuk-heading-s">Total gross catering costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Total gross catering costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    totalGrossCateringCosts: {
-                      label: "Total gross catering costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent total gross catering costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="totalGrossCateringCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Catering staff costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Catering staff costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    cateringStaffCosts: {
-                      label: "Catering staff costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent catering staff costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="cateringStaffCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Catering supplies costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Supply teaching staff"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    cateringSuppliesCosts: {
-                      label: "Catering supplies costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent catering supplies costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="cateringSuppliesCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
+          <HistoricChart
+            chartName="Total gross catering costs"
+            data={data}
+            seriesConfig={{
+              totalGrossCateringCosts: {
+                label: "Total gross catering costs",
+                visible: true,
+              },
+            }}
+            valueField="totalGrossCateringCosts"
+          >
+            <h3 className="govuk-heading-s">Total gross catering costs</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Catering staff costs"
+            data={data}
+            seriesConfig={{
+              cateringStaffCosts: {
+                label: "Catering staff costs",
+                visible: true,
+              },
+            }}
+            valueField="cateringStaffCosts"
+          >
+            <h3 className="govuk-heading-s">Catering staff costs</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Catering supplies costs"
+            data={data}
+            seriesConfig={{
+              cateringSuppliesCosts: {
+                label: "Catering supplies costs",
+                visible: true,
+              },
+            }}
+            valueField="cateringSuppliesCosts"
+          >
+            <h3 className="govuk-heading-s">Catering supplies costs</h3>
+          </HistoricChart>
         </>
       ) : (
         <Loading />

--- a/front-end-components/src/views/historic-data/partials/spending-section-educational-ict.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section-educational-ict.tsx
@@ -1,68 +1,26 @@
-import React, { useContext } from "react";
-import { LineChart } from "src/components/charts/line-chart";
-import { shortValueFormatter } from "src/components/charts/utils.ts";
-import { LineChartTooltip } from "src/components/charts/line-chart-tooltip";
-import { ResolvedStat } from "src/components/charts/resolved-stat";
-import { ChartDimensionContext } from "src/contexts";
+import { HistoricChart } from "src/composed/historic-chart-composed";
 import { Expenditure } from "src/services";
 import { Loading } from "src/components/loading";
 
 export const SpendingSectionEducationalIct: React.FC<{
   data: Expenditure[];
 }> = ({ data }) => {
-  const dimension = useContext(ChartDimensionContext);
-
   return (
     <>
       {data.length > 0 ? (
-        <>
+        <HistoricChart
+          chartName="ICT learning resources costs"
+          data={data}
+          seriesConfig={{
+            learningResourcesIctCosts: {
+              label: "ICT learning resources costs",
+              visible: true,
+            },
+          }}
+          valueField="learningResourcesIctCosts"
+        >
           <h3 className="govuk-heading-s">ICT learning resources costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="ICT learning resources costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    learningResourcesIctCosts: {
-                      label: "ICT learning resources costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent ICT learning resources costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="learningResourcesIctCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-        </>
+        </HistoricChart>
       ) : (
         <Loading />
       )}

--- a/front-end-components/src/views/historic-data/partials/spending-section-educational-supplies.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section-educational-supplies.tsx
@@ -1,161 +1,59 @@
-import React, { useContext } from "react";
-import { LineChart } from "src/components/charts/line-chart";
-import { shortValueFormatter } from "src/components/charts/utils.ts";
-import { LineChartTooltip } from "src/components/charts/line-chart-tooltip";
-import { ResolvedStat } from "src/components/charts/resolved-stat";
-import { ChartDimensionContext } from "src/contexts";
+import { HistoricChart } from "src/composed/historic-chart-composed";
 import { Expenditure } from "src/services";
 import { Loading } from "src/components/loading";
 
 export const SpendingSectionEducationalSupplies: React.FC<{
   data: Expenditure[];
 }> = ({ data }) => {
-  const dimension = useContext(ChartDimensionContext);
-
   return (
     <>
       {data.length > 0 ? (
         <>
-          <h3 className="govuk-heading-s">Total educational supplies costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Total educational supplies costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    totalEducationalSuppliesCosts: {
-                      label: "Total educational supplies costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent total educational supplies costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="totalEducationalSuppliesCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Examination fees costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Examination fees costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    examinationFeesCosts: {
-                      label: "Examination fees costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent examination fees costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="examinationFeesCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">
-            Learning resources (non ICT equipment) costs
-          </h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Learning resources (non ICT equipment) costsf"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    learningResourcesNonIctCosts: {
-                      label: "Learning resources (non ICT equipment) costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent learning resources (non ICT equipment) costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="learningResourcesNonIctCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
+          <HistoricChart
+            chartName="Total educational supplies costs"
+            data={data}
+            seriesConfig={{
+              totalEducationalSuppliesCosts: {
+                label: "Total educational supplies costs",
+                visible: true,
+              },
+            }}
+            valueField="totalEducationalSuppliesCosts"
+          >
+            <h3 className="govuk-heading-s">
+              Total educational supplies costs
+            </h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Examination fees costs"
+            data={data}
+            seriesConfig={{
+              examinationFeesCosts: {
+                label: "Examination fees costs",
+                visible: true,
+              },
+            }}
+            valueField="examinationFeesCosts"
+          >
+            <h3 className="govuk-heading-s">Examination fees costs</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Learning resources (non ICT equipment) costs"
+            data={data}
+            seriesConfig={{
+              learningResourcesNonIctCosts: {
+                label: "Learning resources (non ICT equipment) costs",
+                visible: true,
+              },
+            }}
+            valueField="learningResourcesNonIctCosts"
+          >
+            <h3 className="govuk-heading-s">
+              Learning resources (non ICT equipment) costs
+            </h3>
+          </HistoricChart>
         </>
       ) : (
         <Loading />

--- a/front-end-components/src/views/historic-data/partials/spending-section-non-educational-staff-costs.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section-non-educational-staff-costs.tsx
@@ -1,257 +1,89 @@
-import React, { useContext } from "react";
-import { LineChart } from "src/components/charts/line-chart";
-import { shortValueFormatter } from "src/components/charts/utils.ts";
-import { LineChartTooltip } from "src/components/charts/line-chart-tooltip";
-import { ResolvedStat } from "src/components/charts/resolved-stat";
-import { ChartDimensionContext } from "src/contexts";
+import { HistoricChart } from "src/composed/historic-chart-composed";
 import { Expenditure } from "src/services";
 import { Loading } from "src/components/loading";
 
 export const SpendingSectionNonEducationalStaffCosts: React.FC<{
   data: Expenditure[];
 }> = ({ data }) => {
-  const dimension = useContext(ChartDimensionContext);
-
   return (
     <>
       {data.length > 0 ? (
         <>
-          <h3 className="govuk-heading-s">
-            Total non-educational support staff costs
-          </h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Total non-educational support staff costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    totalNonEducationalSupportStaffCosts: {
-                      label: "Total non-educational support staff costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent total non-educational support staff costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="totalNonEducationalSupportStaffCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">
-            Administrative and clerical staff costs
-          </h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Administrative and clerical staff costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    administrativeClericalStaffCosts: {
-                      label: "Administrative and clerical staff costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent administrative and clerical staff costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="administrativeClericalStaffCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Auditor costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Auditor costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    auditorsCosts: {
-                      label: "Auditor costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent auditor costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="auditorsCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Other staff costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Other staff costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    otherStaffCosts: {
-                      label: "Other staff costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent other staff costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="otherStaffCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">
-            Professional services (non-curriculum) cost
-          </h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Professional services (non-curriculum) cost"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    professionalServicesNonCurriculumCosts: {
-                      label: "Professional services (non-curriculum) cost",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent professional services (non-curriculum) cost"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="professionalServicesNonCurriculumCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
+          <HistoricChart
+            chartName="Total non-educational support staff costs"
+            data={data}
+            seriesConfig={{
+              totalNonEducationalSupportStaffCosts: {
+                label: "Total non-educational support staff costs",
+                visible: true,
+              },
+            }}
+            valueField="totalNonEducationalSupportStaffCosts"
+          >
+            <h3 className="govuk-heading-s">
+              Total non-educational support staff costs
+            </h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Administrative and clerical staff costs"
+            data={data}
+            seriesConfig={{
+              administrativeClericalStaffCosts: {
+                label: "Administrative and clerical staff costs",
+                visible: true,
+              },
+            }}
+            valueField="administrativeClericalStaffCosts"
+          >
+            <h3 className="govuk-heading-s">
+              Administrative and clerical staff costs
+            </h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Auditor costs"
+            data={data}
+            seriesConfig={{
+              auditorsCosts: {
+                label: "Auditor costs",
+                visible: true,
+              },
+            }}
+            valueField="auditorsCosts"
+          >
+            <h3 className="govuk-heading-s">Auditor costs</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Other staff costs"
+            data={data}
+            seriesConfig={{
+              otherStaffCosts: {
+                label: "Other staff costs",
+                visible: true,
+              },
+            }}
+            valueField="otherStaffCosts"
+          >
+            <h3 className="govuk-heading-s">Other staff costs</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Professional services (non-curriculum) cost"
+            data={data}
+            seriesConfig={{
+              professionalServicesNonCurriculumCosts: {
+                label: "Professional services (non-curriculum) cost",
+                visible: true,
+              },
+            }}
+            valueField="professionalServicesNonCurriculumCosts"
+          >
+            <h3 className="govuk-heading-s">
+              Professional services (non-curriculum) cost
+            </h3>
+          </HistoricChart>
         </>
       ) : (
         <Loading />

--- a/front-end-components/src/views/historic-data/partials/spending-section-other.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section-other.tsx
@@ -1,675 +1,204 @@
-import React, { useContext } from "react";
-import { LineChart } from "src/components/charts/line-chart";
-import { shortValueFormatter } from "src/components/charts/utils.ts";
-import { LineChartTooltip } from "src/components/charts/line-chart-tooltip";
-import { ResolvedStat } from "src/components/charts/resolved-stat";
-import { ChartDimensionContext } from "src/contexts";
+import { HistoricChart } from "src/composed/historic-chart-composed";
 import { Expenditure } from "src/services";
 import { Loading } from "src/components/loading";
 
 export const SpendingSectionOther: React.FC<{
   data: Expenditure[];
 }> = ({ data }) => {
-  const dimension = useContext(ChartDimensionContext);
-
   return (
     <>
       {data.length > 0 ? (
         <>
-          <h3 className="govuk-heading-s">Total other costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Total other costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    totalOtherCosts: {
-                      label: "Total other costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent total other costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="totalOtherCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Direct revenue financing costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Direct revenue financing costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    directRevenueFinancingCosts: {
-                      label: "Direct revenue financing costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent direct revenue financing costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="directRevenueFinancingCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Grounds maintenance costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Grounds maintenance costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    groundsMaintenanceCosts: {
-                      label: "Grounds maintenance costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent grounds maintenance costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="groundsMaintenanceCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Indirect employee expenses costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Indirect employee expenses costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    indirectEmployeeExpenses: {
-                      label: "Indirect employee expenses costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent indirect employee expenses costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="indirectEmployeeExpenses"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">
-            Interest changes for loan and bank costs
-          </h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Interest changes for loan and bank costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    interestChargesLoanBank: {
-                      label: "Interest changes for loan and bank costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent interest changes for loan and bank costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="interestChargesLoanBank"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Other insurance premiums costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Other insurance premiums costsf"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    otherInsurancePremiumsCosts: {
-                      label: "Other insurance premiums costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent other insurance premiums costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="otherInsurancePremiumsCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">PFI charges costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="PFI charges costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    privateFinanceInitiativeCharges: {
-                      label: "PFI charges costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent PFI charges costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="privateFinanceInitiativeCharges"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Rents and rates costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Rents and rates costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    rentRatesCosts: {
-                      label: "Rents and rates costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent rents and rates costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="rentRatesCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Special facilities costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Special facilities costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    specialFacilitiesCosts: {
-                      label: "Special facilities costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent special facilities costss"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="specialFacilitiesCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">
-            Staff development and training costs
-          </h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Staff development and training costss"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    staffDevelopmentTrainingCosts: {
-                      label: "Staff development and training costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent staff development and training costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="staffDevelopmentTrainingCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Staff-related insurance costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Staff-related insurance costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    staffRelatedInsuranceCosts: {
-                      label: "Staff-related insurance costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent staff-related insurance costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="staffRelatedInsuranceCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Supply teacher insurance costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Supply teacher insurance costss"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    supplyTeacherInsurableCosts: {
-                      label: "Supply teacher insurance costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent supply teacher insurance costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="supplyTeacherInsurableCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">
-            Community focused school staff (maintained schools only)
-          </h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Community focused school staff (maintained schools only)"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    communityFocusedSchoolStaff: {
-                      label:
-                        "Community focused school staff (maintained schools only)",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent community focused school staff (maintained schools only)"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="communityFocusedSchoolStaff"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">
-            Community focused school costs (maintained schools only)
-          </h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Community focused school costs (maintained schools only)"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    communityFocusedSchoolCosts: {
-                      label:
-                        "Community focused school costs (maintained schools only)",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent community focused school costs (maintained schools only)"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="communityFocusedSchoolCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
+          <HistoricChart
+            chartName="Total other costs"
+            data={data}
+            seriesConfig={{
+              totalOtherCosts: {
+                label: "Total other costs",
+                visible: true,
+              },
+            }}
+            valueField="totalOtherCosts"
+          >
+            <h3 className="govuk-heading-s">Total other costs</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Direct revenue financing costs"
+            data={data}
+            seriesConfig={{
+              directRevenueFinancingCosts: {
+                label: "Direct revenue financing costs",
+                visible: true,
+              },
+            }}
+            valueField="directRevenueFinancingCosts"
+          >
+            <h3 className="govuk-heading-s">Direct revenue financing costs</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Grounds maintenance costs"
+            data={data}
+            seriesConfig={{
+              groundsMaintenanceCosts: {
+                label: "Grounds maintenance costs",
+                visible: true,
+              },
+            }}
+            valueField="groundsMaintenanceCosts"
+          >
+            <h3 className="govuk-heading-s">Grounds maintenance costs</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Indirect employee expenses costs"
+            data={data}
+            seriesConfig={{
+              indirectEmployeeExpenses: {
+                label: "Indirect employee expenses costs",
+                visible: true,
+              },
+            }}
+            valueField="indirectEmployeeExpenses"
+          >
+            <h3 className="govuk-heading-s">
+              Indirect employee expenses costs
+            </h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Interest changes for loan and bank costs"
+            data={data}
+            seriesConfig={{
+              interestChargesLoanBank: {
+                label: "Interest changes for loan and bank costs",
+                visible: true,
+              },
+            }}
+            valueField="interestChargesLoanBank"
+          >
+            <h3 className="govuk-heading-s">
+              Interest changes for loan and bank costs
+            </h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Other insurance premiums costs"
+            data={data}
+            seriesConfig={{
+              otherInsurancePremiumsCosts: {
+                label: "Other insurance premiums costs",
+                visible: true,
+              },
+            }}
+            valueField="otherInsurancePremiumsCosts"
+          >
+            <h3 className="govuk-heading-s">Other insurance premiums costs</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="PFI charges costs"
+            data={data}
+            seriesConfig={{
+              privateFinanceInitiativeCharges: {
+                label: "PFI charges costs",
+                visible: true,
+              },
+            }}
+            valueField="privateFinanceInitiativeCharges"
+          >
+            <h3 className="govuk-heading-s">PFI charges costs</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Rents and rates costs"
+            data={data}
+            seriesConfig={{
+              rentRatesCosts: {
+                label: "Rents and rates costs",
+                visible: true,
+              },
+            }}
+            valueField="rentRatesCosts"
+          >
+            <h3 className="govuk-heading-s">Rents and rates costs</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Special facilities costs"
+            data={data}
+            seriesConfig={{
+              specialFacilitiesCosts: {
+                label: "Special facilities costs",
+                visible: true,
+              },
+            }}
+            valueField="specialFacilitiesCosts"
+          >
+            <h3 className="govuk-heading-s">Special facilities costs</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Staff development and training costs"
+            data={data}
+            seriesConfig={{
+              staffDevelopmentTrainingCosts: {
+                label: "Staff development and training costs",
+                visible: true,
+              },
+            }}
+            valueField="staffDevelopmentTrainingCosts"
+          >
+            <h3 className="govuk-heading-s">
+              Staff development and training costs
+            </h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Staff-related insurance costs"
+            data={data}
+            seriesConfig={{
+              staffRelatedInsuranceCosts: {
+                label: "Staff-related insurance costs",
+                visible: true,
+              },
+            }}
+            valueField="staffRelatedInsuranceCosts"
+          >
+            <h3 className="govuk-heading-s">Staff-related insurance costs</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Supply teacher insurance costs"
+            data={data}
+            seriesConfig={{
+              supplyTeacherInsurableCosts: {
+                label: "Supply teacher insurance costs",
+                visible: true,
+              },
+            }}
+            valueField="supplyTeacherInsurableCosts"
+          >
+            <h3 className="govuk-heading-s">Supply teacher insurance costs</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Community focused school staff (maintained schools only)"
+            data={data}
+            seriesConfig={{
+              communityFocusedSchoolStaff: {
+                label:
+                  "Community focused school staff (maintained schools only)",
+                visible: true,
+              },
+            }}
+            valueField="communityFocusedSchoolStaff"
+          >
+            <h3 className="govuk-heading-s">
+              Community focused school staff (maintained schools only)
+            </h3>
+          </HistoricChart>
         </>
       ) : (
         <Loading />

--- a/front-end-components/src/views/historic-data/partials/spending-section-premises-services.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section-premises-services.tsx
@@ -1,253 +1,85 @@
-import React, { useContext } from "react";
-import { LineChart } from "src/components/charts/line-chart";
-import { shortValueFormatter } from "src/components/charts/utils.ts";
-import { LineChartTooltip } from "src/components/charts/line-chart-tooltip";
-import { ResolvedStat } from "src/components/charts/resolved-stat";
-import { ChartDimensionContext } from "src/contexts";
+import { HistoricChart } from "src/composed/historic-chart-composed";
 import { Expenditure } from "src/services";
 import { Loading } from "src/components/loading";
 
 export const SpendingSectionPremisesServices: React.FC<{
   data: Expenditure[];
 }> = ({ data }) => {
-  const dimension = useContext(ChartDimensionContext);
-
   return (
     <>
       {data.length > 0 ? (
         <>
-          <h3 className="govuk-heading-s">
-            Total premises staff and services costs
-          </h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Total premises staff and services costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    totalPremisesStaffServiceCosts: {
-                      label: "Total premises staff and services costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent total premises staff and services costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="totalPremisesStaffServiceCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Cleaning and caretaking costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Cleaning and caretaking costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    cleaningCaretakingCosts: {
-                      label: "Cleaning and caretaking costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent cleaning and caretaking costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="cleaningCaretakingCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Maintenance of premises costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Maintenance of premises costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    maintenancePremisesCosts: {
-                      label: "Maintenance of premises costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent maintenance of premises costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="maintenancePremisesCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Other occupation costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Other occupation costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    otherOccupationCosts: {
-                      label: "Other occupation costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent other occupation costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="otherOccupationCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Premises staff costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Premises staff costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    premisesStaffCosts: {
-                      label: "Premises staff costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent premises staff costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="premisesStaffCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
+          <HistoricChart
+            chartName="Total premises staff and services costs"
+            data={data}
+            seriesConfig={{
+              totalPremisesStaffServiceCosts: {
+                label: "Total premises staff and services costs",
+                visible: true,
+              },
+            }}
+            valueField="totalPremisesStaffServiceCosts"
+          >
+            <h3 className="govuk-heading-s">
+              Total premises staff and services costs
+            </h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Cleaning and caretaking costs"
+            data={data}
+            seriesConfig={{
+              cleaningCaretakingCosts: {
+                label: "Cleaning and caretaking costs",
+                visible: true,
+              },
+            }}
+            valueField="cleaningCaretakingCosts"
+          >
+            <h3 className="govuk-heading-s">Cleaning and caretaking costs</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Maintenance of premises costs"
+            data={data}
+            seriesConfig={{
+              maintenancePremisesCosts: {
+                label: "Maintenance of premises costs",
+                visible: true,
+              },
+            }}
+            valueField="maintenancePremisesCosts"
+          >
+            <h3 className="govuk-heading-s">Maintenance of premises costs</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Other occupation costs"
+            data={data}
+            seriesConfig={{
+              otherOccupationCosts: {
+                label: "Other occupation costs",
+                visible: true,
+              },
+            }}
+            valueField="otherOccupationCosts"
+          >
+            <h3 className="govuk-heading-s">Other occupation costs</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Premises staff costs"
+            data={data}
+            seriesConfig={{
+              premisesStaffCosts: {
+                label: "Premises staff costs",
+                visible: true,
+              },
+            }}
+            valueField="premisesStaffCosts"
+          >
+            <h3 className="govuk-heading-s">Premises staff costs</h3>
+          </HistoricChart>
         </>
       ) : (
         <Loading />

--- a/front-end-components/src/views/historic-data/partials/spending-section-teaching-costs.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section-teaching-costs.tsx
@@ -1,299 +1,99 @@
-import React, { useContext } from "react";
-import { LineChart } from "src/components/charts/line-chart";
-import { shortValueFormatter } from "src/components/charts/utils.ts";
-import { LineChartTooltip } from "src/components/charts/line-chart-tooltip";
-import { ResolvedStat } from "src/components/charts/resolved-stat";
-import { ChartDimensionContext } from "src/contexts";
+import { HistoricChart } from "src/composed/historic-chart-composed";
 import { Expenditure } from "src/services";
 import { Loading } from "src/components/loading";
 
 export const SpendingSectionTeachingCosts: React.FC<{
   data: Expenditure[];
 }> = ({ data }) => {
-  const dimension = useContext(ChartDimensionContext);
-
   return (
     <>
       {data.length > 0 ? (
         <>
-          <h3 className="govuk-heading-s">
-            Total teaching and teaching support staff costs
-          </h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Total teaching and teaching support staff costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    totalTeachingSupportStaffCosts: {
-                      label: "Total teaching and teaching support staff costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent total teaching and teaching support staff costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="totalTeachingSupportStaffCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Teaching staff costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Teaching staff costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    teachingStaffCosts: {
-                      label: "Teaching staff costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent teaching staff costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="teachingStaffCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Supply teaching staff</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Supply teaching staff"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    supplyTeachingStaffCosts: {
-                      label: "Supply teaching staff",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent supply teaching staff"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="supplyTeachingStaffCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Educational consultancy</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Educational consultancy"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    educationalConsultancyCosts: {
-                      label: "Educational consultancy",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent educational consultancy"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="educationalConsultancyCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Education support staff</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Education support staff"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    educationSupportStaffCosts: {
-                      label: "Education support staff",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent education support staff"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="educationSupportStaffCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Agency supply teaching staff</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Agency supply teaching staff"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    agencySupplyTeachingStaffCosts: {
-                      label: "Agency supply teaching staff",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent agency supply teaching staff"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="agencySupplyTeachingStaffCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
+          <HistoricChart
+            chartName="Total teaching and teaching support staff costs"
+            data={data}
+            seriesConfig={{
+              totalTeachingSupportStaffCosts: {
+                label: "Total teaching and teaching support staff costs",
+                visible: true,
+              },
+            }}
+            valueField="totalTeachingSupportStaffCosts"
+          >
+            <h3 className="govuk-heading-s">
+              Total teaching and teaching support staff costs
+            </h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Teaching staff costs"
+            data={data}
+            seriesConfig={{
+              teachingStaffCosts: {
+                label: "Teaching staff costs",
+                visible: true,
+              },
+            }}
+            valueField="teachingStaffCosts"
+          >
+            <h3 className="govuk-heading-s">Teaching staff costs</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Supply teaching staff"
+            data={data}
+            seriesConfig={{
+              supplyTeachingStaffCosts: {
+                label: "Supply teaching staff",
+                visible: true,
+              },
+            }}
+            valueField="supplyTeachingStaffCosts"
+          >
+            <h3 className="govuk-heading-s">Supply teaching staff</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Educational consultancy"
+            data={data}
+            seriesConfig={{
+              educationalConsultancyCosts: {
+                label: "Educational consultancy",
+                visible: true,
+              },
+            }}
+            valueField="educationalConsultancyCosts"
+          >
+            <h3 className="govuk-heading-s">Educational consultancy</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Education support staff"
+            data={data}
+            seriesConfig={{
+              educationSupportStaffCosts: {
+                label: "Education support staff",
+                visible: true,
+              },
+            }}
+            valueField="educationSupportStaffCosts"
+          >
+            <h3 className="govuk-heading-s">Education support staff</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Agency supply teaching staff"
+            data={data}
+            seriesConfig={{
+              agencySupplyTeachingStaffCosts: {
+                label: "Agency supply teaching staff",
+                visible: true,
+              },
+            }}
+            valueField="agencySupplyTeachingStaffCosts"
+          >
+            <h3 className="govuk-heading-s">Agency supply teaching staff</h3>
+          </HistoricChart>
         </>
       ) : (
         <Loading />

--- a/front-end-components/src/views/historic-data/partials/spending-section-utilities.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section-utilities.tsx
@@ -1,159 +1,55 @@
-import React, { useContext } from "react";
-import { LineChart } from "src/components/charts/line-chart";
-import { shortValueFormatter } from "src/components/charts/utils.ts";
-import { LineChartTooltip } from "src/components/charts/line-chart-tooltip";
-import { ResolvedStat } from "src/components/charts/resolved-stat";
-import { ChartDimensionContext } from "src/contexts";
+import { HistoricChart } from "src/composed/historic-chart-composed";
 import { Expenditure } from "src/services";
 import { Loading } from "src/components/loading";
 
 export const SpendingSectionUtilities: React.FC<{
   data: Expenditure[];
 }> = ({ data }) => {
-  const dimension = useContext(ChartDimensionContext);
-
   return (
     <>
       {data.length > 0 ? (
         <>
-          <h3 className="govuk-heading-s">Total utilities costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Total utilities costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    totalUtilitiesCosts: {
-                      label: "Total utilities costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent total utilities costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="totalUtilitiesCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Energy costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Energy costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    energyCosts: {
-                      label: "Energy costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent energy costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="energyCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <h3 className="govuk-heading-s">Water and sewerage costs</h3>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Water and sewerage costs"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    waterSewerageCosts: {
-                      label: "Water and sewerage costs",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: dimension.unit })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent water and sewerage costs"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="waterSewerageCosts"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
+          <HistoricChart
+            chartName="Total utilities costs"
+            data={data}
+            seriesConfig={{
+              totalUtilitiesCosts: {
+                label: "Total utilities costs",
+                visible: true,
+              },
+            }}
+            valueField="totalUtilitiesCosts"
+          >
+            <h3 className="govuk-heading-s">Total utilities costs</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Energy costs"
+            data={data}
+            seriesConfig={{
+              energyCosts: {
+                label: "Energy costs",
+                visible: true,
+              },
+            }}
+            valueField="energyCosts"
+          >
+            <h3 className="govuk-heading-s">Energy costs</h3>
+          </HistoricChart>
+
+          <HistoricChart
+            chartName="Water and sewerage costs"
+            data={data}
+            seriesConfig={{
+              waterSewerageCosts: {
+                label: "Water and sewerage costs",
+                visible: true,
+              },
+            }}
+            valueField="waterSewerageCosts"
+          >
+            <h3 className="govuk-heading-s">Water and sewerage costs</h3>
+          </HistoricChart>
         </>
       ) : (
         <Loading />

--- a/front-end-components/src/views/historic-data/partials/spending-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section.tsx
@@ -8,10 +8,7 @@ import {
 } from "src/components";
 import { Expenditure, HistoryApi } from "src/services";
 import { ChartDimensionContext, ChartModeContext } from "src/contexts";
-import { LineChart } from "src/components/charts/line-chart";
-import { shortValueFormatter } from "src/components/charts/utils.ts";
-import { LineChartTooltip } from "src/components/charts/line-chart-tooltip";
-import { ResolvedStat } from "src/components/charts/resolved-stat";
+import { HistoricChart } from "src/composed/historic-chart-composed";
 import { Loading } from "src/components/loading";
 import { SpendingSectionTeachingCosts } from "src/views/historic-data/partials/spending-section-teaching-costs";
 import { SpendingSectionNonEducationalStaffCosts } from "src/views/historic-data/partials/spending-section-non-educational-staff-costs";
@@ -79,54 +76,19 @@ export const SpendingSection: React.FC<{ type: string; id: string }> = ({
         </div>
         <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-0" />
         {data.length > 0 ? (
-          <>
+          <HistoricChart
+            chartName="Total spending and costs"
+            data={data}
+            seriesConfig={{
+              totalExpenditure: {
+                label: "Total spending and costs",
+                visible: true,
+              },
+            }}
+            valueField="totalExpenditure"
+          >
             <h2 className="govuk-heading-m">Total spending and costs</h2>
-            <div className="govuk-grid-row">
-              <div className="govuk-grid-column-three-quarters">
-                <div style={{ height: 200 }}>
-                  <LineChart
-                    chartName="Total spending and costs"
-                    data={data}
-                    grid
-                    highlightActive
-                    keyField="yearEnd"
-                    margin={20}
-                    seriesConfig={{
-                      totalExpenditure: {
-                        label: "Total expenditure",
-                        visible: true,
-                      },
-                    }}
-                    seriesLabel={dimension.label}
-                    seriesLabelField="yearEnd"
-                    valueFormatter={shortValueFormatter}
-                    valueUnit={dimension.unit}
-                    tooltip={(t) => (
-                      <LineChartTooltip
-                        {...t}
-                        valueFormatter={(v) =>
-                          shortValueFormatter(v, { valueUnit: dimension.unit })
-                        }
-                      />
-                    )}
-                  />
-                </div>
-              </div>
-              <aside className="govuk-grid-column-one-quarter">
-                <ResolvedStat
-                  chartName="Most recent total spending and costs"
-                  className="chart-stat-line-chart"
-                  compactValue
-                  data={data}
-                  displayIndex={data.length - 1}
-                  seriesLabelField="yearEnd"
-                  valueField="totalExpenditure"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                />
-              </aside>
-            </div>
-          </>
+          </HistoricChart>
         ) : (
           <Loading />
         )}

--- a/front-end-components/src/views/historic-data/partials/workforce-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/workforce-section.tsx
@@ -6,12 +6,9 @@ import {
   PupilsPerStaffRole,
   WorkforceCategories,
 } from "src/components";
-import { ChartModeContext } from "src/contexts";
+import { ChartModeContext, ChartDimensionContext } from "src/contexts";
 import { Workforce, WorkforceApi } from "src/services";
-import { LineChart } from "src/components/charts/line-chart";
-import { shortValueFormatter } from "src/components/charts/utils.ts";
-import { LineChartTooltip } from "src/components/charts/line-chart-tooltip";
-import { ResolvedStat } from "src/components/charts/resolved-stat";
+import { HistoricChart } from "src/composed/historic-chart-composed";
 import { Loading } from "src/components/loading";
 
 export const WorkforceSection: React.FC<{ id: string }> = ({ id }) => {
@@ -47,534 +44,295 @@ export const WorkforceSection: React.FC<{ id: string }> = ({ id }) => {
 
   return (
     <ChartModeContext.Provider value={displayMode}>
-      <div className="govuk-grid-row">
-        <div className="govuk-grid-column-two-thirds">
-          <ChartDimensions
-            dimensions={WorkforceCategories}
-            handleChange={handleSelectChange}
-            elementId="workforce"
-            defaultValue={dimension.value}
-          />
+      <ChartDimensionContext.Provider value={dimension}>
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-two-thirds">
+            <ChartDimensions
+              dimensions={WorkforceCategories}
+              handleChange={handleSelectChange}
+              elementId="workforce"
+              defaultValue={dimension.value}
+            />
+          </div>
+          <div className="govuk-grid-column-one-third">
+            <ChartMode
+              displayMode={displayMode}
+              handleChange={handleModeChange}
+              prefix="workforce"
+            />
+          </div>
         </div>
-        <div className="govuk-grid-column-one-third">
-          <ChartMode
-            displayMode={displayMode}
-            handleChange={handleModeChange}
-            prefix="workforce"
-          />
-        </div>
-      </div>
-      <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-0" />
-      {data.length > 0 ? (
-        <>
-          <h2 className="govuk-heading-m">
-            School workforce (full time equivalent)
-          </h2>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="School workforce (full time equivalent)"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    workforceFte: {
-                      label: "School workforce",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) => shortValueFormatter(v, {})}
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent school workforce"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="workforceFte"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <details className="govuk-details">
-            <summary className="govuk-details__summary">
-              <span className="govuk-details__summary-text">
-                More about school workforce
-              </span>
-            </summary>
-            <div className="govuk-details__text">
-              <p>
-                This includes non-classroom based support staff, and full-time
-                equivalent:{" "}
-              </p>
-              <ul className="govuk-list govuk-list--bullet">
-                <li>classroom teachers</li>
-                <li>senior leadership</li>
-                <li>teaching assistants</li>
-              </ul>
-            </div>
-          </details>
-          <h2 className="govuk-heading-m">
-            Total number of teachers (full time equivalent)
-          </h2>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Total number of teachers (full time equivalent)"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    teachersFte: {
-                      label: "Total number of teachers",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) => shortValueFormatter(v, {})}
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent total number of teachers"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="teachersFte"
-                valueUnit={dimension.unit}
-                valueFormatter={shortValueFormatter}
-              />
-            </aside>
-          </div>
-          <details className="govuk-details">
-            <summary className="govuk-details__summary">
-              <span className="govuk-details__summary-text">
-                More about total number of teachers workforce
-              </span>
-            </summary>
-            <div className="govuk-details__text">
-              <p>
-                This is the full-time equivalent of all classroom and leadership
-                teachers.
-              </p>
-            </div>
-          </details>
-          <h2 className="govuk-heading-m">
-            Teachers with qualified teacher status
-          </h2>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Teachers with qualified teacher status (%)"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    teachersQualified: {
-                      label: "Teachers with qualified teacher status (%)",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel="percentage"
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit="%"
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) =>
-                        shortValueFormatter(v, { valueUnit: "%" })
-                      }
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent teachers with qualified teacher status (%)"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="teachersQualified"
-                valueFormatter={shortValueFormatter}
-                valueUnit="%"
-              />
-            </aside>
-          </div>
-          <details className="govuk-details">
-            <summary className="govuk-details__summary">
-              <span className="govuk-details__summary-text">
-                More about teachers with qualified teacher status
-              </span>
-            </summary>
-            <div className="govuk-details__text">
-              <p>
-                We divided the number of teachers with qualified teacher status
-                by the total number of teachers.
-              </p>
-            </div>
-          </details>
-          <h2 className="govuk-heading-m">
-            Senior leadership (full time equivalent)
-          </h2>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Senior leadership (full time equivalent)"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    seniorLeadershipFte: {
-                      label: "Senior leadership",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) => shortValueFormatter(v, {})}
-                    />
-                  )}
-                />
-              </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent senior leadership"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="seniorLeadershipFte"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <details className="govuk-details">
-            <summary className="govuk-details__summary">
-              <span className="govuk-details__summary-text">
-                More about senior leadership
-              </span>
-            </summary>
-            <div className="govuk-details__text">
-              <p>
-                This is the full-time equivalent of senior leadership roles,
-                including:
-              </p>
-              <ul className="govuk-list govuk-list--bullet">
-                <li>headteachers</li>
-                <li>deputy headteachers</li>
-                <li>assistant headteachers</li>
-              </ul>
-            </div>
-          </details>
+        <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-0" />
+        {data.length > 0 ? (
+          <>
+            <HistoricChart
+              chartName="School workforce (full time equivalent)"
+              data={data}
+              seriesConfig={{
+                workforceFte: {
+                  label: "School workforce",
+                  visible: true,
+                },
+              }}
+              valueField="workforceFte"
+            >
+              <h2 className="govuk-heading-m">
+                School workforce (full time equivalent)
+              </h2>
+            </HistoricChart>
 
-          <h2 className="govuk-heading-m">
-            Teaching assistants (full time equivalent)
-          </h2>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Teaching assistants (full time equivalent)"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    teachingAssistantsFte: {
-                      label: "Teaching assistants",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) => shortValueFormatter(v, {})}
-                    />
-                  )}
-                />
+            <details className="govuk-details">
+              <summary className="govuk-details__summary">
+                <span className="govuk-details__summary-text">
+                  More about school workforce
+                </span>
+              </summary>
+              <div className="govuk-details__text">
+                <p>
+                  This includes non-classroom based support staff, and full-time
+                  equivalent:{" "}
+                </p>
+                <ul className="govuk-list govuk-list--bullet">
+                  <li>classroom teachers</li>
+                  <li>senior leadership</li>
+                  <li>teaching assistants</li>
+                </ul>
               </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent teaching assistants"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="teachingAssistantsFte"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <details className="govuk-details">
-            <summary className="govuk-details__summary">
-              <span className="govuk-details__summary-text">
-                More about teaching assistants
-              </span>
-            </summary>
-            <div className="govuk-details__text">
-              <p>
-                This is the full-time equivalent of teaching assistants,
-                including:
-              </p>
-              <ul className="govuk-list govuk-list--bullet">
-                <li>teaching assistants</li>
-                <li>higher level teaching assistants</li>
-                <li>education needs support staff</li>
-              </ul>
-            </div>
-          </details>
-          <h2 className="govuk-heading-m">
-            Non-classroom support staff - excluding auxiliary staff (full time
-            equivalent)
-          </h2>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Non-classroom support staff - excluding auxiliary staff (full time
-        equivalent)"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    nonClassroomSupportStaffFte: {
-                      label: "Non-classroom support staff",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) => shortValueFormatter(v, {})}
-                    />
-                  )}
-                />
+            </details>
+            <HistoricChart
+              chartName="Total number of teachers (full time equivalent)"
+              data={data}
+              seriesConfig={{
+                teachersFte: {
+                  label: "Total number of teachers",
+                  visible: true,
+                },
+              }}
+              valueField="teachersFte"
+            >
+              <h2 className="govuk-heading-m">
+                Total number of teachers (full time equivalent)
+              </h2>
+            </HistoricChart>
+
+            <details className="govuk-details">
+              <summary className="govuk-details__summary">
+                <span className="govuk-details__summary-text">
+                  More about total number of teachers workforce
+                </span>
+              </summary>
+              <div className="govuk-details__text">
+                <p>
+                  This is the full-time equivalent of all classroom and
+                  leadership teachers.
+                </p>
               </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent non-classroom support staff"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="nonClassroomSupportStaffFte"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <details className="govuk-details">
-            <summary className="govuk-details__summary">
-              <span className="govuk-details__summary-text">
-                More about non-classroom support staff
-              </span>
-            </summary>
-            <div className="govuk-details__text">
-              <p>
-                This is the full-time equivalent of non-classroom-based support
-                staff, excluding:
-              </p>
-              <ul className="govuk-list govuk-list--bullet">
-                <li>auxiliary staff</li>
-                <li>third party support staff</li>
-              </ul>
-            </div>
-          </details>
-          <h2 className="govuk-heading-m">
-            Auxiliary staff (full time equivalent)
-          </h2>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="Auxiliary staff (full time equivalent)"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    auxiliaryStaffFte: {
-                      label: "Auxiliary staff (full time equivalent)",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) => shortValueFormatter(v, {})}
-                    />
-                  )}
-                />
+            </details>
+            <HistoricChart
+              chartName="Teachers with qualified teacher status (%)"
+              data={data}
+              seriesConfig={{
+                teachersQualified: {
+                  label: "Teachers with qualified teacher status (%)",
+                  visible: true,
+                },
+              }}
+              valueField="teachersQualified"
+            >
+              <h2 className="govuk-heading-m">
+                Teachers with qualified teacher status
+              </h2>
+            </HistoricChart>
+
+            <details className="govuk-details">
+              <summary className="govuk-details__summary">
+                <span className="govuk-details__summary-text">
+                  More about teachers with qualified teacher status
+                </span>
+              </summary>
+              <div className="govuk-details__text">
+                <p>
+                  We divided the number of teachers with qualified teacher
+                  status by the total number of teachers.
+                </p>
               </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter desktop">
-              <ResolvedStat
-                chartName="Most recent auxiliary staff"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="auxiliaryStaffFte"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <details className="govuk-details">
-            <summary className="govuk-details__summary">
-              <span className="govuk-details__summary-text">
-                More about auxiliary staff
-              </span>
-            </summary>
-            <div className="govuk-details__text">
-              <p>
-                This is the full-time equivalent of auxiliary staff, including;
-              </p>
-              <ul className="govuk-list govuk-list--bullet">
-                <li>catering</li>
-                <li>school maintenance staff</li>
-              </ul>
-            </div>
-          </details>
-          <h2 className="govuk-heading-m">School workforce (headcount)</h2>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-three-quarters">
-              <div style={{ height: 200 }}>
-                <LineChart
-                  chartName="School workforce (headcount)"
-                  data={data}
-                  grid
-                  highlightActive
-                  keyField="yearEnd"
-                  margin={20}
-                  seriesConfig={{
-                    workforceHeadcount: {
-                      label: "School workforce (headcount)",
-                      visible: true,
-                    },
-                  }}
-                  seriesLabel={dimension.label}
-                  seriesLabelField="yearEnd"
-                  valueFormatter={shortValueFormatter}
-                  valueUnit={dimension.unit}
-                  tooltip={(t) => (
-                    <LineChartTooltip
-                      {...t}
-                      valueFormatter={(v) => shortValueFormatter(v, {})}
-                    />
-                  )}
-                />
+            </details>
+            <HistoricChart
+              chartName="Senior leadership (full time equivalent)"
+              data={data}
+              seriesConfig={{
+                seniorLeadershipFte: {
+                  label: "Senior leadership",
+                  visible: true,
+                },
+              }}
+              valueField="seniorLeadershipFte"
+            >
+              <h2 className="govuk-heading-m">
+                Senior leadership (full time equivalent)
+              </h2>
+            </HistoricChart>
+
+            <details className="govuk-details">
+              <summary className="govuk-details__summary">
+                <span className="govuk-details__summary-text">
+                  More about senior leadership
+                </span>
+              </summary>
+              <div className="govuk-details__text">
+                <p>
+                  This is the full-time equivalent of senior leadership roles,
+                  including:
+                </p>
+                <ul className="govuk-list govuk-list--bullet">
+                  <li>headteachers</li>
+                  <li>deputy headteachers</li>
+                  <li>assistant headteachers</li>
+                </ul>
               </div>
-            </div>
-            <aside className="govuk-grid-column-one-quarter">
-              <ResolvedStat
-                chartName="Most recent school workforce (headcount)"
-                className="chart-stat-line-chart"
-                compactValue
-                data={data}
-                displayIndex={data.length - 1}
-                seriesLabelField="yearEnd"
-                valueField="workforceHeadcount"
-                valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
-              />
-            </aside>
-          </div>
-          <details className="govuk-details">
-            <summary className="govuk-details__summary">
-              <span className="govuk-details__summary-text">
-                More about school workforce (headcount)
-              </span>
-            </summary>
-            <div className="govuk-details__text">
-              <p>
-                This is the total headcount of the school workforce, including:
-              </p>
-              <ul className="govuk-list govuk-list--bullet">
-                <li>
-                  full and part-time teachers (including school leadership
-                  teachers)
-                </li>
-                <li>teaching assistant</li>
-                <li>non-classroom based support staff</li>
-              </ul>
-            </div>
-          </details>
-        </>
-      ) : (
-        <Loading />
-      )}
+            </details>
+            <HistoricChart
+              chartName="Teaching assistants (full time equivalent)"
+              data={data}
+              seriesConfig={{
+                teachingAssistantsFte: {
+                  label: "Teaching assistants",
+                  visible: true,
+                },
+              }}
+              valueField="teachingAssistantsFte"
+            >
+              <h2 className="govuk-heading-m">
+                Teaching assistants (full time equivalent)
+              </h2>
+            </HistoricChart>
+
+            <details className="govuk-details">
+              <summary className="govuk-details__summary">
+                <span className="govuk-details__summary-text">
+                  More about teaching assistants
+                </span>
+              </summary>
+              <div className="govuk-details__text">
+                <p>
+                  This is the full-time equivalent of teaching assistants,
+                  including:
+                </p>
+                <ul className="govuk-list govuk-list--bullet">
+                  <li>teaching assistants</li>
+                  <li>higher level teaching assistants</li>
+                  <li>education needs support staff</li>
+                </ul>
+              </div>
+            </details>
+            <HistoricChart
+              chartName="Non-classroom support staff - excluding auxiliary staff (full time
+            equivalent)"
+              data={data}
+              seriesConfig={{
+                nonClassroomSupportStaffFte: {
+                  label: "Non-classroom support staff",
+                  visible: true,
+                },
+              }}
+              valueField="nonClassroomSupportStaffFte"
+            >
+              <h2 className="govuk-heading-m">
+                Non-classroom support staff - excluding auxiliary staff (full
+                time equivalent)
+              </h2>
+            </HistoricChart>
+
+            <details className="govuk-details">
+              <summary className="govuk-details__summary">
+                <span className="govuk-details__summary-text">
+                  More about non-classroom support staff
+                </span>
+              </summary>
+              <div className="govuk-details__text">
+                <p>
+                  This is the full-time equivalent of non-classroom-based
+                  support staff, excluding:
+                </p>
+                <ul className="govuk-list govuk-list--bullet">
+                  <li>auxiliary staff</li>
+                  <li>third party support staff</li>
+                </ul>
+              </div>
+            </details>
+            <HistoricChart
+              chartName="Auxiliary staff (full time equivalent)"
+              data={data}
+              seriesConfig={{
+                auxiliaryStaffFte: {
+                  label: "Auxiliary staff (full time equivalent)",
+                  visible: true,
+                },
+              }}
+              valueField="auxiliaryStaffFte"
+            >
+              <h2 className="govuk-heading-m">
+                Auxiliary staff (full time equivalent)
+              </h2>
+            </HistoricChart>
+
+            <details className="govuk-details">
+              <summary className="govuk-details__summary">
+                <span className="govuk-details__summary-text">
+                  More about auxiliary staff
+                </span>
+              </summary>
+              <div className="govuk-details__text">
+                <p>
+                  This is the full-time equivalent of auxiliary staff,
+                  including;
+                </p>
+                <ul className="govuk-list govuk-list--bullet">
+                  <li>catering</li>
+                  <li>school maintenance staff</li>
+                </ul>
+              </div>
+            </details>
+            <HistoricChart
+              chartName="School workforce (headcount)"
+              data={data}
+              seriesConfig={{
+                workforceHeadcount: {
+                  label: "School workforce",
+                  visible: true,
+                },
+              }}
+              valueField="workforceHeadcount"
+            >
+              <h2 className="govuk-heading-m">School workforce (headcount)</h2>
+            </HistoricChart>
+
+            <details className="govuk-details">
+              <summary className="govuk-details__summary">
+                <span className="govuk-details__summary-text">
+                  More about school workforce (headcount)
+                </span>
+              </summary>
+              <div className="govuk-details__text">
+                <p>
+                  This is the total headcount of the school workforce,
+                  including:
+                </p>
+                <ul className="govuk-list govuk-list--bullet">
+                  <li>
+                    full and part-time teachers (including school leadership
+                    teachers)
+                  </li>
+                  <li>teaching assistant</li>
+                  <li>non-classroom based support staff</li>
+                </ul>
+              </div>
+            </details>
+          </>
+        ) : (
+          <Loading />
+        )}
+      </ChartDimensionContext.Provider>
     </ChartModeContext.Provider>
   );
 };


### PR DESCRIPTION
### Context
[AB#185907](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/185907) - [AB#202606](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/202606)
[AB#185882](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/185882) - [AB#202609](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/202609)
[AB#185900](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/185900) - [AB#202607](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/202607)
[AB#185893](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/185893) - [AB#202608](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/202608)

### Change proposed in this pull request
Adds a component to be used to display either a line chart or table for the data on the Historic data page.

### Guidance to review 
Figures displayed in table view will match the line chart view.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

