### PR TITLE
incomplete data warning UI

### DIFF
--- a/documentation/developers/features/incomplete-data.md
+++ b/documentation/developers/features/incomplete-data.md
@@ -8,13 +8,11 @@ This document provides detailed information for developers about the implementat
 
 The intention of this feature is to provide a warning for users of the service flagging when the data they are viewing contains incomplete data for the year. This will be used in school to school comparisons on the Spending and Costs, Workforce and Compare your Costs pages.
 
-In Cosmos DB the record for a school has a field "Periods covered by return". This has an int value representing the number of months the school has submitted data for.
+In Cosmos DB the record for a school has a field "Periods covered by return". This has a value representing the number of months the school has submitted data for.
 
 This is used to create a HasIncompleteData prop which is used to flag when financial data is incomplete. See the Usage section for a list of where this is used relating to this feature [here](#usage).
 
-For the Spending and costs page this is used to conditionally render a warning text banner in the Razor view.
-
-For the Compare your costs and Benchmark workforce data this is again conditionally rendered but in the React components.
+Warning text is rendered for the Spending and costs page, Compare your costs and Benchmark workforce data when any of the schools in the comparison are flagged as having incomplete data.
 
 ## Goals
 
@@ -43,25 +41,9 @@ In front-end-components
 
 - [Workforce and ExpenditureData](../../../front-end-components/src/services/types.tsx)
 
-### Views
-
-A warning banner is rendered in the Razor view for the Spending and costs page here
-
-- [SchoolSpending view](../../../web/src/Web.App/Views/SchoolSpending/Index.cshtml)
-
-A warning banner is rendered within the React component for the Workforce benchmark data page here
-
-- [SchoolWorkforce view](../../../web/src/Web.App/Views/SchoolWorkforce/Index.cshtml)
-- [compare-your-workforce front-end-components](../../../front-end-components/src/views/compare-your-workforce)
-
-A warning banner is rendered within the React component for the Compare your costs page here
-
-- [SchoolComparison view](../../../web/src/Web.App/Views/SchoolComparison/Index.cshtml)
-- [compare-your-costs front-end-components](../../../front-end-components/src/views/compare-your-costs)
-
 ### WarningBanner
 
-A React component is used in front-end-components which is used to display the warning if the HasIncompleteData is true. This is styled as per GDS guidelines.
+A React component is used in front-end-components which is used to display the warning if the HasIncompleteData is true. This is styled as per GDS guidelines as inset text.
 
 [warning-banner](../../../front-end-components/src/components/warning-banner)
 
@@ -71,17 +53,9 @@ A React component is used in front-end-components which is used to display the w
   - *Type:* Boolean
   - *Description:* This controls whether this component returns the warning banner or null.
 
-- **icon**
-  - *Type:* String
-  - *Description:* This is used for the warning icon
-
-- **visuallyHiddenText**
-  - *Type:* String
-  - *Description:* This is for screen readers
-
 - **message**
   - *Type:* String
-  - *Description:* The warning text that will be displayed
+  - *Description:* The warning text that will be displayed.
 
 #### WarningBanner Example
 
@@ -89,21 +63,30 @@ The below JSX
 
 ```jsx
 <WarningBanner
-    isRendered={true}
-    icon="!"
-    visuallyHiddenText="Warning"
-    message="Some schools don't have a complete set of financial data for this period"
+  isRendered={true}
+  message="Warning message"
 />
 ```
 
 is rendered as the below HTML
 
 ```html
-<div class="govuk-warning-text">
-    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-    <strong class="govuk-warning-text__text">
-        <span class="govuk-visually-hidden">Warning</span>
-        Some schools don't have a complete set of financial data for this period
-    </strong>
+<div class="govuk-inset-text">
+  Warning message
 </div>
 ```
+
+#### Composed components
+
+This component is used as part of the composed components below to render the warning along with the chart or table data.
+
+- [comparison-chart-summary](../../../front-end-components/src/composed/comparison-chart-summary/composed.tsx)
+- [horizontal-bar-chart-wrapper](../../../front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx)
+
+#### Usage in MVC web app
+
+The React component is used in the following views in the MVC web app
+
+- [SchoolSpending view](../../../web/src/Web.App/Views/SchoolSpending/Index.cshtml)
+- [SchoolWorkforce view](../../../web/src/Web.App/Views/SchoolWorkforce/Index.cshtml)
+- [SchoolComparison view](../../../web/src/Web.App/Views/SchoolComparison/Index.cshtml)

--- a/documentation/developers/features/incomplete-data.md
+++ b/documentation/developers/features/incomplete-data.md
@@ -1,43 +1,104 @@
-# Developer Feature Documentation: Incomplete Data - WiP
+# Developer Feature Documentation: Incomplete Data
 
 ## Introduction
+
 This document provides detailed information for developers about the implementation, usage, and integration of the Incomplete Data feature within the system.
 
 ## Overview
-The intention of this feature is to provide warning text for users of the service flagging when the data they are viewing contains incomplete data for the year. This will be used in school to school comparisons on the Spending and Costs, Workforce and Compare your Costs pages.
 
-In Cosmos DB the record for a school has a field "Periods covered by return". This has a value as an int representing the number of months the school has submitted data for.
+The intention of this feature is to provide a warning for users of the service flagging when the data they are viewing contains incomplete data for the year. This will be used in school to school comparisons on the Spending and Costs, Workforce and Compare your Costs pages.
 
-In the platform api response models [here for expenditure](../../../platform/src/abstractions/Platform.Domain/Responses/SchoolExpenditureResponseModel.cs) and [here for workforce](../../../platform/src/abstractions/Platform.Domain/Responses/WorkforceResponseModel.cs) this is used to create HasIncompleteData prop for use in the web app or front end components.  
+In Cosmos DB the record for a school has a field "Periods covered by return". This has an int value representing the number of months the school has submitted data for.
 
-[add more as feature is built]
+This is used to create a HasIncompleteData prop which is used to flag when financial data is incomplete. See the Usage section for a list of where this is used relating to this feature [here](#usage).
+
+For the Spending and costs page this is used to conditionally render a warning text banner in the Razor view.
+
+For the Compare your costs and Benchmark workforce data this is again conditionally rendered but in the React components.
 
 ## Goals
-### Primary Goal
-When data submitted for the school is incomplete it is important this is flagged to the user when they are viewing comparisons so they can make informed decisions with how they proceed with the information we provide
-### Secondary Goals
-[List any additional objectives or improvements that this feature may achieve.]
 
-## Prerequisites/Dependencies
-[List any prerequisites or dependencies that developers need to install or configure before working with the feature.]
-### External Dependencies
-[Identify any external dependencies, third-party services, or components that the feature relies on.]
-### Internal Dependencies
-[Specify any internal dependencies or dependencies on other features within the system.]
+### Primary Goal
+
+When data submitted for the school is incomplete it is important this is flagged to the user when they are viewing comparisons so they can make informed decisions with how they proceed with the information we provide
 
 ## Usage
-[Explain how developers can use the feature, including any APIs, libraries, or components that they need to interact with.]
 
-[Identify the key components or modules that comprise the feature and describe their responsibilities.]
+### HasIncompleteData prop
 
-## API Reference
-[If applicable, provide a detailed API reference for the feature, including endpoints, request/response formats, and authentication mechanisms.]
+This feature currently makes a HasIncompleteData prop available in the following:
 
-## Configuration
-[Document any configuration settings or parameters that developers can customize to tailor the behavior of the feature.]
+In platform
 
-## Deployment
-[Describe the deployment process for releasing the feature to production or staging environments.]
+- [Expenditure](../../../platform/src/abstractions/Platform.Domain/Responses/SchoolExpenditureResponseModel.cs)
+- [Workforce](../../../platform/src/abstractions/Platform.Domain/Responses/WorkforceResponseModel.cs)
 
-## Known Issues
-[List any known issues or limitations of the feature, along with any workarounds or plans for resolution.]
+In web app
+
+- [SchoolExpenditure](../../../web/src/Web.App/Domain/SchoolExpenditure.cs)
+- [Workforce](../../../web/src/Web.App/Domain/Workforce.cs)
+- [SchoolSpendingViewModel](../../../web/src/Web.App/ViewModels/SchoolSpendingViewModel.cs)
+
+In front-end-components
+
+- [Workforce and ExpenditureData](../../../front-end-components/src/services/types.tsx)
+
+### Views
+
+A warning banner is rendered in the Razor view for the Spending and costs page here
+
+- [SchoolSpending view](../../../web/src/Web.App/Views/SchoolSpending/Index.cshtml)
+
+A warning banner is rendered within the React component for the Workforce benchmark data page here
+
+- [SchoolWorkforce view](../../../web/src/Web.App/Views/SchoolWorkforce/Index.cshtml)
+- [compare-your-workforce front-end-components](../../../front-end-components/src/views/compare-your-workforce)
+
+A warning banner is rendered within the React component for the Compare your costs page here
+
+- [SchoolComparion view](../../../web/src/Web.App/Views/SchoolComparion/Index.cshtml)
+- [compare-your-costs front-end-components](../../../front-end-components/src/views/compare-your-costs)
+
+### WarningBanner
+
+A React component is used in front-end-components which is used to display the warning if the HasIncompleteData is true. This is styled as per GDS guidelines.
+
+[warning-banner](../../../front-end-components/src/components/warning-banner)
+
+#### WarningBanner Props
+
+- **icon**
+  - *Type:* String
+  - *Description:* This is used for the warning icon
+
+- **visuallyHiddenText**
+  - *Type:* String
+  - *Description:* This is for screen readers
+
+- **message**
+  - *Type:* String
+  - *Description:* The warning text that will be displayed
+
+#### WarningBanner Example
+
+The below JSX
+
+```jsx
+<WarningBanner
+    icon="!"
+    visuallyHiddenText="Warning"
+    message="Some schools don't have a complete set of financial data for this period"
+/>
+```
+
+is rendered as the below HTML
+
+```html
+<div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+        <span class="govuk-visually-hidden">Warning</span>
+        Some schools don't have a complete set of financial data for this period
+    </strong>
+</div>
+```

--- a/documentation/developers/features/incomplete-data.md
+++ b/documentation/developers/features/incomplete-data.md
@@ -67,6 +67,10 @@ A React component is used in front-end-components which is used to display the w
 
 #### WarningBanner Props
 
+- **isRendered**
+  - *Type:* Boolean
+  - *Description:* This controls whether this component returns the warning banner or null.
+
 - **icon**
   - *Type:* String
   - *Description:* This is used for the warning icon
@@ -85,6 +89,7 @@ The below JSX
 
 ```jsx
 <WarningBanner
+    isRendered={true}
     icon="!"
     visuallyHiddenText="Warning"
     message="Some schools don't have a complete set of financial data for this period"

--- a/documentation/developers/features/incomplete-data.md
+++ b/documentation/developers/features/incomplete-data.md
@@ -56,7 +56,7 @@ A warning banner is rendered within the React component for the Workforce benchm
 
 A warning banner is rendered within the React component for the Compare your costs page here
 
-- [SchoolComparion view](../../../web/src/Web.App/Views/SchoolComparion/Index.cshtml)
+- [SchoolComparison view](../../../web/src/Web.App/Views/SchoolComparison/Index.cshtml)
 - [compare-your-costs front-end-components](../../../front-end-components/src/views/compare-your-costs)
 
 ### WarningBanner

--- a/front-end-components/src/components/charts/types.tsx
+++ b/front-end-components/src/components/charts/types.tsx
@@ -40,7 +40,7 @@ type ChartSeriesConfig<TData extends ChartDataSeries> = Partial<
 >;
 
 type ChartSeriesName = string;
-export type ChartSeriesValue = string | number | bigint;
+export type ChartSeriesValue = string | number | bigint | boolean;
 export type ChartSeriesValueUnit = "%" | "currency";
 export type ChartDataSeries = { [name: ChartSeriesName]: ChartSeriesValue };
 

--- a/front-end-components/src/components/warning-banner/component.tsx
+++ b/front-end-components/src/components/warning-banner/component.tsx
@@ -1,0 +1,17 @@
+import { WarningBannerProps } from "src/components/warning-banner";
+
+export const WarningBanner: React.FC<WarningBannerProps> = (props) => {
+  const { icon, visuallyHiddenText, message } = props;
+
+  return (
+    <div className="govuk-warning-text">
+      <span className="govuk-warning-text__icon" aria-hidden="true">
+        {icon}
+      </span>
+      <strong className="govuk-warning-text__text">
+        <span className="govuk-visually-hidden">{visuallyHiddenText}</span>
+        {message}
+      </strong>
+    </div>
+  );
+};

--- a/front-end-components/src/components/warning-banner/component.tsx
+++ b/front-end-components/src/components/warning-banner/component.tsx
@@ -1,17 +1,7 @@
 import { WarningBannerProps } from "src/components/warning-banner";
 
 export const WarningBanner: React.FC<WarningBannerProps> = (props) => {
-  const { isRendered, icon, visuallyHiddenText, message } = props;
+  const { isRendered, message } = props;
 
-  return isRendered ? (
-    <div className="govuk-warning-text">
-      <span className="govuk-warning-text__icon" aria-hidden="true">
-        {icon}
-      </span>
-      <strong className="govuk-warning-text__text">
-        <span className="govuk-visually-hidden">{visuallyHiddenText}</span>
-        {message}
-      </strong>
-    </div>
-  ) : null;
+  return isRendered ? <div className="govuk-inset-text">{message}</div> : null;
 };

--- a/front-end-components/src/components/warning-banner/component.tsx
+++ b/front-end-components/src/components/warning-banner/component.tsx
@@ -1,9 +1,9 @@
 import { WarningBannerProps } from "src/components/warning-banner";
 
 export const WarningBanner: React.FC<WarningBannerProps> = (props) => {
-  const { icon, visuallyHiddenText, message } = props;
+  const { isRendered, icon, visuallyHiddenText, message } = props;
 
-  return (
+  return isRendered ? (
     <div className="govuk-warning-text">
       <span className="govuk-warning-text__icon" aria-hidden="true">
         {icon}
@@ -13,5 +13,5 @@ export const WarningBanner: React.FC<WarningBannerProps> = (props) => {
         {message}
       </strong>
     </div>
-  );
+  ) : null;
 };

--- a/front-end-components/src/components/warning-banner/index.tsx
+++ b/front-end-components/src/components/warning-banner/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/components/warning-banner/types";
+export * from "src/components/warning-banner/component";

--- a/front-end-components/src/components/warning-banner/types.tsx
+++ b/front-end-components/src/components/warning-banner/types.tsx
@@ -1,4 +1,5 @@
 export type WarningBannerProps = {
+  isRendered: boolean;
   icon: string;
   visuallyHiddenText: string;
   message: string;

--- a/front-end-components/src/components/warning-banner/types.tsx
+++ b/front-end-components/src/components/warning-banner/types.tsx
@@ -1,0 +1,5 @@
+export type WarningBannerProps = {
+  icon: string;
+  visuallyHiddenText: string;
+  message: string;
+};

--- a/front-end-components/src/components/warning-banner/types.tsx
+++ b/front-end-components/src/components/warning-banner/types.tsx
@@ -1,6 +1,4 @@
 export type WarningBannerProps = {
   isRendered: boolean;
-  icon: string;
-  visuallyHiddenText: string;
   message: string;
 };

--- a/front-end-components/src/composed/comparison-chart-summary/composed.tsx
+++ b/front-end-components/src/composed/comparison-chart-summary/composed.tsx
@@ -9,6 +9,7 @@ import {
 import { Stat } from "src/components/charts/stat";
 import { ResolvedStat } from "src/components/charts/resolved-stat";
 import stats from "stats-lite";
+import { WarningBanner } from "src/components/warning-banner";
 
 export function ComparisonChartSummary<TData extends ChartDataSeries>(
   props: ComparisonChartSummaryComposedProps<TData>
@@ -21,6 +22,7 @@ export function ComparisonChartSummary<TData extends ChartDataSeries>(
     sortDirection,
     valueField,
     suffix,
+    hasIncompleteData,
     ...rest
   } = props;
 
@@ -67,63 +69,69 @@ export function ComparisonChartSummary<TData extends ChartDataSeries>(
   const averageDiffPercent = (averageDiff / average) * 100;
 
   return (
-    <div className="composed-chart-wrapper">
-      <div className="composed-chart">
-        <VerticalBarChart
-          barCategoryGap={3}
-          data={sortedData}
-          hideXAxis
-          hideYAxis
-          highlightedItemKeys={
-            highlightedItemKey ? [highlightedItemKey] : undefined
-          }
-          keyField={keyField}
-          seriesConfig={seriesConfig}
-          seriesLabelField={keyField}
-          {...rest}
-        />
-      </div>
-      <div className="chart-stat-summary">
-        <ResolvedStat
-          chartName="This school spends"
-          className="chart-stat-highlight"
-          data={data}
-          displayIndex={highlightedItemIndex}
-          seriesLabel="This school spends"
-          seriesLabelField="urn"
-          suffix={suffix}
-          valueField={valueField}
-          valueFormatter={statValueFormatter}
-          valueUnit="currency"
-        />
-        <Stat
-          chartName="Similar schools spend"
-          label="Similar schools spend"
-          suffix={suffix && `${suffix}, on average`}
-          value={average}
-          valueFormatter={statValueFormatter}
-          valueUnit="currency"
-        />
-        {!isNaN(averageDiff) && (
-          <Stat
+    <>
+      <WarningBanner
+        isRendered={hasIncompleteData}
+        message="Some schools are missing data for this financial year"
+      />
+      <div className="composed-chart-wrapper">
+        <div className="composed-chart">
+          <VerticalBarChart
+            barCategoryGap={3}
+            data={sortedData}
+            hideXAxis
+            hideYAxis
+            highlightedItemKeys={
+              highlightedItemKey ? [highlightedItemKey] : undefined
+            }
+            keyField={keyField}
+            seriesConfig={seriesConfig}
+            seriesLabelField={keyField}
+            {...rest}
+          />
+        </div>
+        <div className="chart-stat-summary">
+          <ResolvedStat
             chartName="This school spends"
-            label="This school spends"
-            suffix={
-              <span>
-                <strong>{averageDiff < 0 ? "less" : "more"}</strong> {suffix}
-              </span>
-            }
-            value={Math.abs(averageDiff)}
+            className="chart-stat-highlight"
+            data={data}
+            displayIndex={highlightedItemIndex}
+            seriesLabel="This school spends"
+            seriesLabelField="urn"
+            suffix={suffix}
+            valueField={valueField}
             valueFormatter={statValueFormatter}
-            valueSuffix={
-              isNaN(averageDiffPercent) || !isFinite(averageDiffPercent)
-                ? undefined
-                : `(${Math.abs(averageDiffPercent).toFixed(1)}%)`
-            }
             valueUnit="currency"
           />
-        )}
+          <Stat
+            chartName="Similar schools spend"
+            label="Similar schools spend"
+            suffix={suffix && `${suffix}, on average`}
+            value={average}
+            valueFormatter={statValueFormatter}
+            valueUnit="currency"
+          />
+          {!isNaN(averageDiff) && (
+            <Stat
+              chartName="This school spends"
+              label="This school spends"
+              suffix={
+                <span>
+                  <strong>{averageDiff < 0 ? "less" : "more"}</strong> {suffix}
+                </span>
+              }
+              value={Math.abs(averageDiff)}
+              valueFormatter={statValueFormatter}
+              valueSuffix={
+                isNaN(averageDiffPercent) || !isFinite(averageDiffPercent)
+                  ? undefined
+                  : `(${Math.abs(averageDiffPercent).toFixed(1)}%)`
+              }
+              valueUnit="currency"
+            />
+          )}
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/front-end-components/src/composed/comparison-chart-summary/types.tsx
+++ b/front-end-components/src/composed/comparison-chart-summary/types.tsx
@@ -14,4 +14,5 @@ export type ComparisonChartSummaryComposedProps<TData extends ChartDataSeries> =
     highlightedItemKey?: string;
     sortDirection: ChartSortDirection;
     valueField: keyof TData;
+    hasIncompleteData: boolean;
   };

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -5,6 +5,7 @@ import {
   ChartDimensionContext,
   ChartModeContext,
   SelectedSchoolContext,
+  HasIncompleteDataContext,
 } from "src/contexts";
 import { Loading } from "src/components/loading";
 import { ChartHandler } from "src/components/charts";
@@ -16,6 +17,7 @@ import {
 } from "src/components/charts/utils";
 import { SchoolTick } from "src/components/charts/school-tick";
 import { SchoolWorkforceTooltip } from "src/components/charts/school-workforce-tooltip";
+import { WarningBanner } from "src/components/warning-banner";
 
 export function HorizontalBarChartWrapper<TData extends SchoolChartData>(
   props: HorizontalBarChartWrapperProps<TData>
@@ -24,6 +26,7 @@ export function HorizontalBarChartWrapper<TData extends SchoolChartData>(
   const mode = useContext(ChartModeContext);
   const dimension = useContext(ChartDimensionContext);
   const selectedSchool = useContext(SelectedSchoolContext);
+  const hasIncompleteData = useContext(HasIncompleteDataContext);
   const ref = createRef<ChartHandler>();
   const [imageLoading, setImageLoading] = useState<boolean>();
 
@@ -64,6 +67,10 @@ export function HorizontalBarChartWrapper<TData extends SchoolChartData>(
           </div>
         )}
       </div>
+      <WarningBanner
+        isRendered={hasIncompleteData}
+        message="Some schools are missing data for this financial year"
+      />
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-full">
           {sortedDataPoints.length > 0 ? (

--- a/front-end-components/src/contexts/contexts.tsx
+++ b/front-end-components/src/contexts/contexts.tsx
@@ -16,3 +16,5 @@ export const ChartDimensionContext = createContext<Dimension>({
   heading: "",
 });
 export const SelectedSchoolContext = createContext(School.empty());
+
+export const HasIncompleteDataContext = createContext(false);

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -470,7 +470,8 @@ const spendingAndCostsComposedElements = document.querySelectorAll<HTMLElement>(
 
 if (spendingAndCostsComposedElements) {
   spendingAndCostsComposedElements.forEach((element) => {
-    const { highlight, json, sortDirection, suffix } = element.dataset;
+    const { highlight, json, sortDirection, suffix, hasIncompleteData } =
+      element.dataset;
     if (json) {
       const root = ReactDOM.createRoot(element);
       const data = JSON.parse(json) as {
@@ -490,6 +491,7 @@ if (spendingAndCostsComposedElements) {
             sortDirection={(sortDirection as ChartSortDirection) || "asc"}
             valueField="amount"
             valueUnit="currency"
+            hasIncompleteData={Boolean(hasIncompleteData)}
           />
         </React.StrictMode>
       );

--- a/front-end-components/src/services/types.tsx
+++ b/front-end-components/src/services/types.tsx
@@ -49,6 +49,7 @@ export type ExpenditureData = {
   totalUtilitiesCosts: number;
   energyCosts: number;
   waterSewerageCosts: number;
+  hasIncompleteData: boolean;
 };
 
 export type Balance = {
@@ -74,6 +75,7 @@ export type Workforce = {
   auxiliaryStaffFte: number;
   workforceHeadcount: number;
   teachersQualified: number;
+  hasIncompleteData: boolean;
 };
 
 export type Income = {

--- a/front-end-components/src/views/compare-your-costs/view.tsx
+++ b/front-end-components/src/views/compare-your-costs/view.tsx
@@ -6,6 +6,7 @@ import {
 import { CompareYourCostsViewProps } from "src/views/compare-your-costs";
 import { EstablishmentsApi, ExpenditureData } from "src/services";
 import { ChartMode, ChartModeChart } from "src/components";
+import { WarningBanner } from "src/components/warning-banner";
 import {
   School,
   SelectedSchool,
@@ -55,8 +56,17 @@ export const CompareYourCosts: React.FC<CompareYourCostsViewProps> = (
     setDisplayMode(e.target.value);
   };
 
+  const hasIncompleteData = expenditureData?.some((x) => x.hasIncompleteData);
+
   return (
     <SelectedSchoolContext.Provider value={selectedSchool}>
+      {hasIncompleteData ? (
+        <WarningBanner
+          icon="!"
+          visuallyHiddenText="Warning"
+          message="Some schools don't have a complete set of financial data for this period"
+        />
+      ) : null}
       <div className="view-as-toggle">
         <ChartMode displayMode={displayMode} handleChange={toggleChartMode} />
       </div>

--- a/front-end-components/src/views/compare-your-costs/view.tsx
+++ b/front-end-components/src/views/compare-your-costs/view.tsx
@@ -6,12 +6,12 @@ import {
 import { CompareYourCostsViewProps } from "src/views/compare-your-costs";
 import { EstablishmentsApi, ExpenditureData } from "src/services";
 import { ChartMode, ChartModeChart } from "src/components";
-import { WarningBanner } from "src/components/warning-banner";
 import {
   School,
   SelectedSchool,
   SelectedSchoolContext,
   ChartModeContext,
+  HasIncompleteDataContext,
 } from "src/contexts";
 import { SchoolEstablishment } from "src/constants.tsx";
 import { useGovUk } from "src/hooks/useGovUk";
@@ -61,27 +61,23 @@ export const CompareYourCosts: React.FC<CompareYourCostsViewProps> = (
 
   return (
     <SelectedSchoolContext.Provider value={selectedSchool}>
-      <WarningBanner
-        isRendered={hasIncompleteData}
-        icon="!"
-        visuallyHiddenText="Warning"
-        message="Some schools don't have a complete set of financial data for this period"
-      />
       <div className="view-as-toggle">
         <ChartMode displayMode={displayMode} handleChange={toggleChartMode} />
       </div>
-      <ChartModeContext.Provider value={displayMode}>
-        <TotalExpenditure
-          schools={
-            expenditureData ? expenditureData : new Array<ExpenditureData>()
-          }
-        />
-        <ExpenditureAccordion
-          schools={
-            expenditureData ? expenditureData : new Array<ExpenditureData>()
-          }
-        />
-      </ChartModeContext.Provider>
+      <HasIncompleteDataContext.Provider value={hasIncompleteData}>
+        <ChartModeContext.Provider value={displayMode}>
+          <TotalExpenditure
+            schools={
+              expenditureData ? expenditureData : new Array<ExpenditureData>()
+            }
+          />
+          <ExpenditureAccordion
+            schools={
+              expenditureData ? expenditureData : new Array<ExpenditureData>()
+            }
+          />
+        </ChartModeContext.Provider>
+      </HasIncompleteDataContext.Provider>
     </SelectedSchoolContext.Provider>
   );
 };

--- a/front-end-components/src/views/compare-your-costs/view.tsx
+++ b/front-end-components/src/views/compare-your-costs/view.tsx
@@ -56,17 +56,17 @@ export const CompareYourCosts: React.FC<CompareYourCostsViewProps> = (
     setDisplayMode(e.target.value);
   };
 
-  const hasIncompleteData = expenditureData?.some((x) => x.hasIncompleteData);
+  const hasIncompleteData =
+    expenditureData?.some((x) => x.hasIncompleteData) ?? false;
 
   return (
     <SelectedSchoolContext.Provider value={selectedSchool}>
-      {hasIncompleteData ? (
-        <WarningBanner
-          icon="!"
-          visuallyHiddenText="Warning"
-          message="Some schools don't have a complete set of financial data for this period"
-        />
-      ) : null}
+      <WarningBanner
+        isRendered={hasIncompleteData}
+        icon="!"
+        visuallyHiddenText="Warning"
+        message="Some schools don't have a complete set of financial data for this period"
+      />
       <div className="view-as-toggle">
         <ChartMode displayMode={displayMode} handleChange={toggleChartMode} />
       </div>

--- a/front-end-components/src/views/compare-your-workforce/partials/auxiliary-staff.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/auxiliary-staff.tsx
@@ -4,13 +4,12 @@ import {
   PupilsPerStaffRole,
   WorkforceCategories,
 } from "src/components";
-import { ChartDimensionContext } from "src/contexts";
+import { ChartDimensionContext, HasIncompleteDataContext } from "src/contexts";
 import { AuxiliaryStaffData } from "src/views/compare-your-workforce/partials";
 import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
-import { WarningBanner } from "src/components/warning-banner";
 import { Workforce, WorkforceApi } from "src/services";
 
 export const AuxiliaryStaff: React.FC<{ type: string; id: string }> = ({
@@ -68,27 +67,23 @@ export const AuxiliaryStaff: React.FC<{ type: string; id: string }> = ({
   const hasIncompleteData = data.some((x) => x.hasIncompleteData);
 
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <HorizontalBarChartWrapper
-        data={chartData}
-        chartName="auxiliary staff (full time equivalent)"
-      >
-        <h2 className="govuk-heading-m">
-          Auxiliary staff (Full Time Equivalent)
-        </h2>
-        <WarningBanner
-          isRendered={hasIncompleteData}
-          icon="!"
-          visuallyHiddenText="Warning"
-          message="Some schools don't have a complete set of financial data for this period"
-        />
-        <ChartDimensions
-          dimensions={WorkforceCategories}
-          handleChange={handleSelectChange}
-          elementId="auxiliary-staff"
-          defaultValue={dimension.value}
-        />
-      </HorizontalBarChartWrapper>
-    </ChartDimensionContext.Provider>
+    <HasIncompleteDataContext.Provider value={hasIncompleteData}>
+      <ChartDimensionContext.Provider value={dimension}>
+        <HorizontalBarChartWrapper
+          data={chartData}
+          chartName="auxiliary staff (full time equivalent)"
+        >
+          <h2 className="govuk-heading-m">
+            Auxiliary staff (Full Time Equivalent)
+          </h2>
+          <ChartDimensions
+            dimensions={WorkforceCategories}
+            handleChange={handleSelectChange}
+            elementId="auxiliary-staff"
+            defaultValue={dimension.value}
+          />
+        </HorizontalBarChartWrapper>
+      </ChartDimensionContext.Provider>
+    </HasIncompleteDataContext.Provider>
   );
 };

--- a/front-end-components/src/views/compare-your-workforce/partials/auxiliary-staff.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/auxiliary-staff.tsx
@@ -10,6 +10,7 @@ import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
+import { WarningBanner } from "src/components/warning-banner";
 import { Workforce, WorkforceApi } from "src/services";
 
 export const AuxiliaryStaff: React.FC<{ type: string; id: string }> = ({
@@ -64,6 +65,8 @@ export const AuxiliaryStaff: React.FC<{ type: string; id: string }> = ({
     setDimension(dimension);
   };
 
+  const hasIncompleteData = data.some((x) => x.hasIncompleteData);
+
   return (
     <ChartDimensionContext.Provider value={dimension}>
       <HorizontalBarChartWrapper
@@ -73,6 +76,13 @@ export const AuxiliaryStaff: React.FC<{ type: string; id: string }> = ({
         <h2 className="govuk-heading-m">
           Auxiliary staff (Full Time Equivalent)
         </h2>
+        {hasIncompleteData ? (
+          <WarningBanner
+            icon="!"
+            visuallyHiddenText="Warning"
+            message="Some schools don't have a complete set of financial data for this period"
+          />
+        ) : null}
         <ChartDimensions
           dimensions={WorkforceCategories}
           handleChange={handleSelectChange}

--- a/front-end-components/src/views/compare-your-workforce/partials/auxiliary-staff.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/auxiliary-staff.tsx
@@ -76,13 +76,12 @@ export const AuxiliaryStaff: React.FC<{ type: string; id: string }> = ({
         <h2 className="govuk-heading-m">
           Auxiliary staff (Full Time Equivalent)
         </h2>
-        {hasIncompleteData ? (
-          <WarningBanner
-            icon="!"
-            visuallyHiddenText="Warning"
-            message="Some schools don't have a complete set of financial data for this period"
-          />
-        ) : null}
+        <WarningBanner
+          isRendered={hasIncompleteData}
+          icon="!"
+          visuallyHiddenText="Warning"
+          message="Some schools don't have a complete set of financial data for this period"
+        />
         <ChartDimensions
           dimensions={WorkforceCategories}
           handleChange={handleSelectChange}

--- a/front-end-components/src/views/compare-your-workforce/partials/headcount.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/headcount.tsx
@@ -76,13 +76,12 @@ export const Headcount: React.FC<{ type: string; id: string }> = ({
         chartName="school workforce (headcount)"
       >
         <h2 className="govuk-heading-m">School workforce (Headcount)</h2>
-        {hasIncompleteData ? (
-          <WarningBanner
-            icon="!"
-            visuallyHiddenText="Warning"
-            message="Some schools don't have a complete set of financial data for this period"
-          />
-        ) : null}
+        <WarningBanner
+          isRendered={hasIncompleteData}
+          icon="!"
+          visuallyHiddenText="Warning"
+          message="Some schools don't have a complete set of financial data for this period"
+        />
         <ChartDimensions
           dimensions={WorkforceCategories.filter(
             (category) =>

--- a/front-end-components/src/views/compare-your-workforce/partials/headcount.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/headcount.tsx
@@ -6,13 +6,12 @@ import {
   PupilsPerStaffRole,
   WorkforceCategories,
 } from "src/components";
-import { ChartDimensionContext } from "src/contexts";
+import { ChartDimensionContext, HasIncompleteDataContext } from "src/contexts";
 import { HeadcountData } from "src/views/compare-your-workforce/partials";
 import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
-import { WarningBanner } from "src/components/warning-banner";
 import { Workforce, WorkforceApi } from "src/services";
 
 export const Headcount: React.FC<{ type: string; id: string }> = ({
@@ -70,28 +69,25 @@ export const Headcount: React.FC<{ type: string; id: string }> = ({
   const hasIncompleteData = data.some((x) => x.hasIncompleteData);
 
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <HorizontalBarChartWrapper
-        data={chartData}
-        chartName="school workforce (headcount)"
-      >
-        <h2 className="govuk-heading-m">School workforce (Headcount)</h2>
-        <WarningBanner
-          isRendered={hasIncompleteData}
-          icon="!"
-          visuallyHiddenText="Warning"
-          message="Some schools don't have a complete set of financial data for this period"
-        />
-        <ChartDimensions
-          dimensions={WorkforceCategories.filter(
-            (category) =>
-              category !== HeadcountPerFTE && category !== PercentageOfWorkforce
-          )}
-          handleChange={handleSelectChange}
-          elementId="headcount"
-          defaultValue={dimension.value}
-        />
-      </HorizontalBarChartWrapper>
-    </ChartDimensionContext.Provider>
+    <HasIncompleteDataContext.Provider value={hasIncompleteData}>
+      <ChartDimensionContext.Provider value={dimension}>
+        <HorizontalBarChartWrapper
+          data={chartData}
+          chartName="school workforce (headcount)"
+        >
+          <h2 className="govuk-heading-m">School workforce (Headcount)</h2>
+          <ChartDimensions
+            dimensions={WorkforceCategories.filter(
+              (category) =>
+                category !== HeadcountPerFTE &&
+                category !== PercentageOfWorkforce
+            )}
+            handleChange={handleSelectChange}
+            elementId="headcount"
+            defaultValue={dimension.value}
+          />
+        </HorizontalBarChartWrapper>
+      </ChartDimensionContext.Provider>
+    </HasIncompleteDataContext.Provider>
   );
 };

--- a/front-end-components/src/views/compare-your-workforce/partials/headcount.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/headcount.tsx
@@ -12,6 +12,7 @@ import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
+import { WarningBanner } from "src/components/warning-banner";
 import { Workforce, WorkforceApi } from "src/services";
 
 export const Headcount: React.FC<{ type: string; id: string }> = ({
@@ -66,6 +67,8 @@ export const Headcount: React.FC<{ type: string; id: string }> = ({
     setDimension(dimension);
   };
 
+  const hasIncompleteData = data.some((x) => x.hasIncompleteData);
+
   return (
     <ChartDimensionContext.Provider value={dimension}>
       <HorizontalBarChartWrapper
@@ -73,6 +76,13 @@ export const Headcount: React.FC<{ type: string; id: string }> = ({
         chartName="school workforce (headcount)"
       >
         <h2 className="govuk-heading-m">School workforce (Headcount)</h2>
+        {hasIncompleteData ? (
+          <WarningBanner
+            icon="!"
+            visuallyHiddenText="Warning"
+            message="Some schools don't have a complete set of financial data for this period"
+          />
+        ) : null}
         <ChartDimensions
           dimensions={WorkforceCategories.filter(
             (category) =>

--- a/front-end-components/src/views/compare-your-workforce/partials/non-classroom-support.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/non-classroom-support.tsx
@@ -4,13 +4,12 @@ import {
   PupilsPerStaffRole,
   WorkforceCategories,
 } from "src/components";
-import { ChartDimensionContext } from "src/contexts";
+import { ChartDimensionContext, HasIncompleteDataContext } from "src/contexts";
 import { NonClassroomSupportData } from "src/views/compare-your-workforce/partials";
 import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
-import { WarningBanner } from "src/components/warning-banner";
 import { Workforce, WorkforceApi } from "src/services";
 
 export const NonClassroomSupport: React.FC<{ type: string; id: string }> = ({
@@ -68,28 +67,24 @@ export const NonClassroomSupport: React.FC<{ type: string; id: string }> = ({
   const hasIncompleteData = data.some((x) => x.hasIncompleteData);
 
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <HorizontalBarChartWrapper
-        data={chartData}
-        chartName="non-classroom support staff - excluding auxiliary staff (full time equivalent)"
-      >
-        <h2 className="govuk-heading-m">
-          Non-classroom support staff - excluding auxiliary staff (Full Time
-          Equivalent)
-        </h2>
-        <WarningBanner
-          isRendered={hasIncompleteData}
-          icon="!"
-          visuallyHiddenText="Warning"
-          message="Some schools don't have a complete set of financial data for this period"
-        />
-        <ChartDimensions
-          dimensions={WorkforceCategories}
-          handleChange={handleSelectChange}
-          elementId="nonclassroom-support"
-          defaultValue={dimension.value}
-        />
-      </HorizontalBarChartWrapper>
-    </ChartDimensionContext.Provider>
+    <HasIncompleteDataContext.Provider value={hasIncompleteData}>
+      <ChartDimensionContext.Provider value={dimension}>
+        <HorizontalBarChartWrapper
+          data={chartData}
+          chartName="non-classroom support staff - excluding auxiliary staff (full time equivalent)"
+        >
+          <h2 className="govuk-heading-m">
+            Non-classroom support staff - excluding auxiliary staff (Full Time
+            Equivalent)
+          </h2>
+          <ChartDimensions
+            dimensions={WorkforceCategories}
+            handleChange={handleSelectChange}
+            elementId="nonclassroom-support"
+            defaultValue={dimension.value}
+          />
+        </HorizontalBarChartWrapper>
+      </ChartDimensionContext.Provider>
+    </HasIncompleteDataContext.Provider>
   );
 };

--- a/front-end-components/src/views/compare-your-workforce/partials/non-classroom-support.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/non-classroom-support.tsx
@@ -10,6 +10,7 @@ import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
+import { WarningBanner } from "src/components/warning-banner";
 import { Workforce, WorkforceApi } from "src/services";
 
 export const NonClassroomSupport: React.FC<{ type: string; id: string }> = ({
@@ -64,6 +65,8 @@ export const NonClassroomSupport: React.FC<{ type: string; id: string }> = ({
     setDimension(dimension);
   };
 
+  const hasIncompleteData = data.some((x) => x.hasIncompleteData);
+
   return (
     <ChartDimensionContext.Provider value={dimension}>
       <HorizontalBarChartWrapper
@@ -74,6 +77,13 @@ export const NonClassroomSupport: React.FC<{ type: string; id: string }> = ({
           Non-classroom support staff - excluding auxiliary staff (Full Time
           Equivalent)
         </h2>
+        {hasIncompleteData ? (
+          <WarningBanner
+            icon="!"
+            visuallyHiddenText="Warning"
+            message="Some schools don't have a complete set of financial data for this period"
+          />
+        ) : null}
         <ChartDimensions
           dimensions={WorkforceCategories}
           handleChange={handleSelectChange}

--- a/front-end-components/src/views/compare-your-workforce/partials/non-classroom-support.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/non-classroom-support.tsx
@@ -77,13 +77,12 @@ export const NonClassroomSupport: React.FC<{ type: string; id: string }> = ({
           Non-classroom support staff - excluding auxiliary staff (Full Time
           Equivalent)
         </h2>
-        {hasIncompleteData ? (
-          <WarningBanner
-            icon="!"
-            visuallyHiddenText="Warning"
-            message="Some schools don't have a complete set of financial data for this period"
-          />
-        ) : null}
+        <WarningBanner
+          isRendered={hasIncompleteData}
+          icon="!"
+          visuallyHiddenText="Warning"
+          message="Some schools don't have a complete set of financial data for this period"
+        />
         <ChartDimensions
           dimensions={WorkforceCategories}
           handleChange={handleSelectChange}

--- a/front-end-components/src/views/compare-your-workforce/partials/school-workforce.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/school-workforce.tsx
@@ -11,6 +11,7 @@ import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
+import { WarningBanner } from "src/components/warning-banner";
 import { Workforce, WorkforceApi } from "src/services";
 
 export const SchoolWorkforce: React.FC<{ type: string; id: string }> = ({
@@ -60,6 +61,8 @@ export const SchoolWorkforce: React.FC<{ type: string; id: string }> = ({
     setDimension(dimension);
   };
 
+  const hasIncompleteData = data.some((x) => x.hasIncompleteData);
+
   return (
     <ChartDimensionContext.Provider value={dimension}>
       <HorizontalBarChartWrapper
@@ -69,6 +72,13 @@ export const SchoolWorkforce: React.FC<{ type: string; id: string }> = ({
         <h2 className="govuk-heading-m">
           School workforce (Full Time Equivalent)
         </h2>
+        {hasIncompleteData ? (
+          <WarningBanner
+            icon="!"
+            visuallyHiddenText="Warning"
+            message="Some schools don't have a complete set of financial data for this period"
+          />
+        ) : null}
         <ChartDimensions
           dimensions={WorkforceCategories.filter(
             (category) => category !== PercentageOfWorkforce

--- a/front-end-components/src/views/compare-your-workforce/partials/school-workforce.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/school-workforce.tsx
@@ -72,13 +72,12 @@ export const SchoolWorkforce: React.FC<{ type: string; id: string }> = ({
         <h2 className="govuk-heading-m">
           School workforce (Full Time Equivalent)
         </h2>
-        {hasIncompleteData ? (
-          <WarningBanner
-            icon="!"
-            visuallyHiddenText="Warning"
-            message="Some schools don't have a complete set of financial data for this period"
-          />
-        ) : null}
+        <WarningBanner
+          isRendered={hasIncompleteData}
+          icon="!"
+          visuallyHiddenText="Warning"
+          message="Some schools don't have a complete set of financial data for this period"
+        />
         <ChartDimensions
           dimensions={WorkforceCategories.filter(
             (category) => category !== PercentageOfWorkforce

--- a/front-end-components/src/views/compare-your-workforce/partials/school-workforce.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/school-workforce.tsx
@@ -5,13 +5,12 @@ import {
   PupilsPerStaffRole,
   WorkforceCategories,
 } from "src/components";
-import { ChartDimensionContext } from "src/contexts";
+import { ChartDimensionContext, HasIncompleteDataContext } from "src/contexts";
 import { SchoolWorkforceData } from "src/views/compare-your-workforce/partials";
 import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
-import { WarningBanner } from "src/components/warning-banner";
 import { Workforce, WorkforceApi } from "src/services";
 
 export const SchoolWorkforce: React.FC<{ type: string; id: string }> = ({
@@ -64,29 +63,25 @@ export const SchoolWorkforce: React.FC<{ type: string; id: string }> = ({
   const hasIncompleteData = data.some((x) => x.hasIncompleteData);
 
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <HorizontalBarChartWrapper
-        data={chartData}
-        chartName="school workforce (full time equivalent)"
-      >
-        <h2 className="govuk-heading-m">
-          School workforce (Full Time Equivalent)
-        </h2>
-        <WarningBanner
-          isRendered={hasIncompleteData}
-          icon="!"
-          visuallyHiddenText="Warning"
-          message="Some schools don't have a complete set of financial data for this period"
-        />
-        <ChartDimensions
-          dimensions={WorkforceCategories.filter(
-            (category) => category !== PercentageOfWorkforce
-          )}
-          handleChange={handleSelectChange}
-          elementId="school-workforce"
-          defaultValue={dimension.value}
-        />
-      </HorizontalBarChartWrapper>
-    </ChartDimensionContext.Provider>
+    <HasIncompleteDataContext.Provider value={hasIncompleteData}>
+      <ChartDimensionContext.Provider value={dimension}>
+        <HorizontalBarChartWrapper
+          data={chartData}
+          chartName="school workforce (full time equivalent)"
+        >
+          <h2 className="govuk-heading-m">
+            School workforce (Full Time Equivalent)
+          </h2>
+          <ChartDimensions
+            dimensions={WorkforceCategories.filter(
+              (category) => category !== PercentageOfWorkforce
+            )}
+            handleChange={handleSelectChange}
+            elementId="school-workforce"
+            defaultValue={dimension.value}
+          />
+        </HorizontalBarChartWrapper>
+      </ChartDimensionContext.Provider>
+    </HasIncompleteDataContext.Provider>
   );
 };

--- a/front-end-components/src/views/compare-your-workforce/partials/senior-leadership.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/senior-leadership.tsx
@@ -4,13 +4,12 @@ import {
   PupilsPerStaffRole,
   WorkforceCategories,
 } from "src/components";
-import { ChartDimensionContext } from "src/contexts";
+import { ChartDimensionContext, HasIncompleteDataContext } from "src/contexts";
 import { SeniorLeadershipData } from "src/views/compare-your-workforce/partials";
 import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
-import { WarningBanner } from "src/components/warning-banner";
 import { Workforce, WorkforceApi } from "src/services";
 
 export const SeniorLeadership: React.FC<{ type: string; id: string }> = ({
@@ -68,27 +67,23 @@ export const SeniorLeadership: React.FC<{ type: string; id: string }> = ({
   const hasIncompleteData = data.some((x) => x.hasIncompleteData);
 
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <HorizontalBarChartWrapper
-        data={chartData}
-        chartName="senior leadership (full time equivalent)"
-      >
-        <h2 className="govuk-heading-m">
-          Senior Leadership (Full Time Equivalent)
-        </h2>
-        <WarningBanner
-          isRendered={hasIncompleteData}
-          icon="!"
-          visuallyHiddenText="Warning"
-          message="Some schools don't have a complete set of financial data for this period"
-        />
-        <ChartDimensions
-          dimensions={WorkforceCategories}
-          handleChange={handleSelectChange}
-          elementId="senior-leadership"
-          defaultValue={dimension.value}
-        />
-      </HorizontalBarChartWrapper>
-    </ChartDimensionContext.Provider>
+    <HasIncompleteDataContext.Provider value={hasIncompleteData}>
+      <ChartDimensionContext.Provider value={dimension}>
+        <HorizontalBarChartWrapper
+          data={chartData}
+          chartName="senior leadership (full time equivalent)"
+        >
+          <h2 className="govuk-heading-m">
+            Senior Leadership (Full Time Equivalent)
+          </h2>
+          <ChartDimensions
+            dimensions={WorkforceCategories}
+            handleChange={handleSelectChange}
+            elementId="senior-leadership"
+            defaultValue={dimension.value}
+          />
+        </HorizontalBarChartWrapper>
+      </ChartDimensionContext.Provider>
+    </HasIncompleteDataContext.Provider>
   );
 };

--- a/front-end-components/src/views/compare-your-workforce/partials/senior-leadership.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/senior-leadership.tsx
@@ -76,13 +76,12 @@ export const SeniorLeadership: React.FC<{ type: string; id: string }> = ({
         <h2 className="govuk-heading-m">
           Senior Leadership (Full Time Equivalent)
         </h2>
-        {hasIncompleteData ? (
-          <WarningBanner
-            icon="!"
-            visuallyHiddenText="Warning"
-            message="Some schools don't have a complete set of financial data for this period"
-          />
-        ) : null}
+        <WarningBanner
+          isRendered={hasIncompleteData}
+          icon="!"
+          visuallyHiddenText="Warning"
+          message="Some schools don't have a complete set of financial data for this period"
+        />
         <ChartDimensions
           dimensions={WorkforceCategories}
           handleChange={handleSelectChange}

--- a/front-end-components/src/views/compare-your-workforce/partials/senior-leadership.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/senior-leadership.tsx
@@ -10,6 +10,7 @@ import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
+import { WarningBanner } from "src/components/warning-banner";
 import { Workforce, WorkforceApi } from "src/services";
 
 export const SeniorLeadership: React.FC<{ type: string; id: string }> = ({
@@ -64,6 +65,8 @@ export const SeniorLeadership: React.FC<{ type: string; id: string }> = ({
     setDimension(dimension);
   };
 
+  const hasIncompleteData = data.some((x) => x.hasIncompleteData);
+
   return (
     <ChartDimensionContext.Provider value={dimension}>
       <HorizontalBarChartWrapper
@@ -73,6 +76,13 @@ export const SeniorLeadership: React.FC<{ type: string; id: string }> = ({
         <h2 className="govuk-heading-m">
           Senior Leadership (Full Time Equivalent)
         </h2>
+        {hasIncompleteData ? (
+          <WarningBanner
+            icon="!"
+            visuallyHiddenText="Warning"
+            message="Some schools don't have a complete set of financial data for this period"
+          />
+        ) : null}
         <ChartDimensions
           dimensions={WorkforceCategories}
           handleChange={handleSelectChange}

--- a/front-end-components/src/views/compare-your-workforce/partials/teaching-assistants.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/teaching-assistants.tsx
@@ -4,13 +4,12 @@ import {
   PupilsPerStaffRole,
   WorkforceCategories,
 } from "src/components";
-import { ChartDimensionContext } from "src/contexts";
+import { ChartDimensionContext, HasIncompleteDataContext } from "src/contexts";
 import { TeachingAssistantsData } from "src/views/compare-your-workforce/partials";
 import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
-import { WarningBanner } from "src/components/warning-banner";
 import { Workforce, WorkforceApi } from "src/services";
 
 export const TeachingAssistants: React.FC<{ type: string; id: string }> = ({
@@ -68,27 +67,23 @@ export const TeachingAssistants: React.FC<{ type: string; id: string }> = ({
   const hasIncompleteData = data.some((x) => x.hasIncompleteData);
 
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <HorizontalBarChartWrapper
-        data={chartData}
-        chartName="teaching assistants (full time equivalent)"
-      >
-        <h2 className="govuk-heading-m">
-          Teaching Assistants (Full Time Equivalent)
-        </h2>
-        <WarningBanner
-          isRendered={hasIncompleteData}
-          icon="!"
-          visuallyHiddenText="Warning"
-          message="Some schools don't have a complete set of financial data for this period"
-        />
-        <ChartDimensions
-          dimensions={WorkforceCategories}
-          handleChange={handleSelectChange}
-          elementId="teaching-assistants"
-          defaultValue={dimension.value}
-        />
-      </HorizontalBarChartWrapper>
-    </ChartDimensionContext.Provider>
+    <HasIncompleteDataContext.Provider value={hasIncompleteData}>
+      <ChartDimensionContext.Provider value={dimension}>
+        <HorizontalBarChartWrapper
+          data={chartData}
+          chartName="teaching assistants (full time equivalent)"
+        >
+          <h2 className="govuk-heading-m">
+            Teaching Assistants (Full Time Equivalent)
+          </h2>
+          <ChartDimensions
+            dimensions={WorkforceCategories}
+            handleChange={handleSelectChange}
+            elementId="teaching-assistants"
+            defaultValue={dimension.value}
+          />
+        </HorizontalBarChartWrapper>
+      </ChartDimensionContext.Provider>
+    </HasIncompleteDataContext.Provider>
   );
 };

--- a/front-end-components/src/views/compare-your-workforce/partials/teaching-assistants.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/teaching-assistants.tsx
@@ -10,6 +10,7 @@ import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
+import { WarningBanner } from "src/components/warning-banner";
 import { Workforce, WorkforceApi } from "src/services";
 
 export const TeachingAssistants: React.FC<{ type: string; id: string }> = ({
@@ -64,6 +65,8 @@ export const TeachingAssistants: React.FC<{ type: string; id: string }> = ({
     setDimension(dimension);
   };
 
+  const hasIncompleteData = data.some((x) => x.hasIncompleteData);
+
   return (
     <ChartDimensionContext.Provider value={dimension}>
       <HorizontalBarChartWrapper
@@ -73,6 +76,13 @@ export const TeachingAssistants: React.FC<{ type: string; id: string }> = ({
         <h2 className="govuk-heading-m">
           Teaching Assistants (Full Time Equivalent)
         </h2>
+        {hasIncompleteData ? (
+          <WarningBanner
+            icon="!"
+            visuallyHiddenText="Warning"
+            message="Some schools don't have a complete set of financial data for this period"
+          />
+        ) : null}
         <ChartDimensions
           dimensions={WorkforceCategories}
           handleChange={handleSelectChange}

--- a/front-end-components/src/views/compare-your-workforce/partials/teaching-assistants.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/teaching-assistants.tsx
@@ -76,13 +76,12 @@ export const TeachingAssistants: React.FC<{ type: string; id: string }> = ({
         <h2 className="govuk-heading-m">
           Teaching Assistants (Full Time Equivalent)
         </h2>
-        {hasIncompleteData ? (
-          <WarningBanner
-            icon="!"
-            visuallyHiddenText="Warning"
-            message="Some schools don't have a complete set of financial data for this period"
-          />
-        ) : null}
+        <WarningBanner
+          isRendered={hasIncompleteData}
+          icon="!"
+          visuallyHiddenText="Warning"
+          message="Some schools don't have a complete set of financial data for this period"
+        />
         <ChartDimensions
           dimensions={WorkforceCategories}
           handleChange={handleSelectChange}

--- a/front-end-components/src/views/compare-your-workforce/partials/total-teachers-qualified.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/total-teachers-qualified.tsx
@@ -3,6 +3,7 @@ import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
+import { WarningBanner } from "src/components/warning-banner";
 import { ChartDimensionContext } from "src/contexts";
 import { TotalTeachersQualifiedData } from "src/views/compare-your-workforce/partials";
 import { Percent } from "src/components";
@@ -45,6 +46,8 @@ export const TotalTeachersQualified: React.FC<{ type: string; id: string }> = ({
       };
     }, [data]);
 
+  const hasIncompleteData = data.some((x) => x.hasIncompleteData);
+
   return (
     <ChartDimensionContext.Provider value={Percent}>
       <HorizontalBarChartWrapper
@@ -54,6 +57,13 @@ export const TotalTeachersQualified: React.FC<{ type: string; id: string }> = ({
         <h2 className="govuk-heading-m">
           Teachers with qualified teacher status (%)
         </h2>
+        {hasIncompleteData ? (
+          <WarningBanner
+            icon="!"
+            visuallyHiddenText="Warning"
+            message="Some schools don't have a complete set of financial data for this period"
+          />
+        ) : null}
       </HorizontalBarChartWrapper>
     </ChartDimensionContext.Provider>
   );

--- a/front-end-components/src/views/compare-your-workforce/partials/total-teachers-qualified.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/total-teachers-qualified.tsx
@@ -57,13 +57,12 @@ export const TotalTeachersQualified: React.FC<{ type: string; id: string }> = ({
         <h2 className="govuk-heading-m">
           Teachers with qualified teacher status (%)
         </h2>
-        {hasIncompleteData ? (
-          <WarningBanner
-            icon="!"
-            visuallyHiddenText="Warning"
-            message="Some schools don't have a complete set of financial data for this period"
-          />
-        ) : null}
+        <WarningBanner
+          isRendered={hasIncompleteData}
+          icon="!"
+          visuallyHiddenText="Warning"
+          message="Some schools don't have a complete set of financial data for this period"
+        />
       </HorizontalBarChartWrapper>
     </ChartDimensionContext.Provider>
   );

--- a/front-end-components/src/views/compare-your-workforce/partials/total-teachers-qualified.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/total-teachers-qualified.tsx
@@ -3,8 +3,7 @@ import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
-import { WarningBanner } from "src/components/warning-banner";
-import { ChartDimensionContext } from "src/contexts";
+import { ChartDimensionContext, HasIncompleteDataContext } from "src/contexts";
 import { TotalTeachersQualifiedData } from "src/views/compare-your-workforce/partials";
 import { Percent } from "src/components";
 import { Workforce, WorkforceApi } from "src/services";
@@ -49,21 +48,17 @@ export const TotalTeachersQualified: React.FC<{ type: string; id: string }> = ({
   const hasIncompleteData = data.some((x) => x.hasIncompleteData);
 
   return (
-    <ChartDimensionContext.Provider value={Percent}>
-      <HorizontalBarChartWrapper
-        data={chartData}
-        chartName="teachers with qualified teacher status (%)"
-      >
-        <h2 className="govuk-heading-m">
-          Teachers with qualified teacher status (%)
-        </h2>
-        <WarningBanner
-          isRendered={hasIncompleteData}
-          icon="!"
-          visuallyHiddenText="Warning"
-          message="Some schools don't have a complete set of financial data for this period"
-        />
-      </HorizontalBarChartWrapper>
-    </ChartDimensionContext.Provider>
+    <HasIncompleteDataContext.Provider value={hasIncompleteData}>
+      <ChartDimensionContext.Provider value={Percent}>
+        <HorizontalBarChartWrapper
+          data={chartData}
+          chartName="teachers with qualified teacher status (%)"
+        >
+          <h2 className="govuk-heading-m">
+            Teachers with qualified teacher status (%)
+          </h2>
+        </HorizontalBarChartWrapper>
+      </ChartDimensionContext.Provider>
+    </HasIncompleteDataContext.Provider>
   );
 };

--- a/front-end-components/src/views/compare-your-workforce/partials/total-teachers.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/total-teachers.tsx
@@ -71,13 +71,12 @@ export const TotalTeachers: React.FC<{ type: string; id: string }> = ({
         <h2 className="govuk-heading-m">
           Total number of teachers (Full Time Equivalent)
         </h2>
-        {hasIncompleteData ? (
-          <WarningBanner
-            icon="!"
-            visuallyHiddenText="Warning"
-            message="Some schools don't have a complete set of financial data for this period"
-          />
-        ) : null}
+        <WarningBanner
+          isRendered={hasIncompleteData}
+          icon="!"
+          visuallyHiddenText="Warning"
+          message="Some schools don't have a complete set of financial data for this period"
+        />
         <ChartDimensions
           dimensions={WorkforceCategories}
           handleChange={handleSelectChange}

--- a/front-end-components/src/views/compare-your-workforce/partials/total-teachers.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/total-teachers.tsx
@@ -4,13 +4,12 @@ import {
   PupilsPerStaffRole,
   WorkforceCategories,
 } from "src/components";
-import { ChartDimensionContext } from "src/contexts";
+import { ChartDimensionContext, HasIncompleteDataContext } from "src/contexts";
 import { TotalTeachersData } from "src/views/compare-your-workforce/partials";
 import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
-import { WarningBanner } from "src/components/warning-banner";
 import { Workforce, WorkforceApi } from "src/services";
 
 export const TotalTeachers: React.FC<{ type: string; id: string }> = ({
@@ -63,27 +62,23 @@ export const TotalTeachers: React.FC<{ type: string; id: string }> = ({
   const hasIncompleteData = data.some((x) => x.hasIncompleteData);
 
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <HorizontalBarChartWrapper
-        data={chartData}
-        chartName="total number of teachers (full time equivalent)"
-      >
-        <h2 className="govuk-heading-m">
-          Total number of teachers (Full Time Equivalent)
-        </h2>
-        <WarningBanner
-          isRendered={hasIncompleteData}
-          icon="!"
-          visuallyHiddenText="Warning"
-          message="Some schools don't have a complete set of financial data for this period"
-        />
-        <ChartDimensions
-          dimensions={WorkforceCategories}
-          handleChange={handleSelectChange}
-          elementId="total-teachers"
-          defaultValue={dimension.value}
-        />
-      </HorizontalBarChartWrapper>
-    </ChartDimensionContext.Provider>
+    <HasIncompleteDataContext.Provider value={hasIncompleteData}>
+      <ChartDimensionContext.Provider value={dimension}>
+        <HorizontalBarChartWrapper
+          data={chartData}
+          chartName="total number of teachers (full time equivalent)"
+        >
+          <h2 className="govuk-heading-m">
+            Total number of teachers (Full Time Equivalent)
+          </h2>
+          <ChartDimensions
+            dimensions={WorkforceCategories}
+            handleChange={handleSelectChange}
+            elementId="total-teachers"
+            defaultValue={dimension.value}
+          />
+        </HorizontalBarChartWrapper>
+      </ChartDimensionContext.Provider>
+    </HasIncompleteDataContext.Provider>
   );
 };

--- a/front-end-components/src/views/compare-your-workforce/partials/total-teachers.tsx
+++ b/front-end-components/src/views/compare-your-workforce/partials/total-teachers.tsx
@@ -10,6 +10,7 @@ import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
+import { WarningBanner } from "src/components/warning-banner";
 import { Workforce, WorkforceApi } from "src/services";
 
 export const TotalTeachers: React.FC<{ type: string; id: string }> = ({
@@ -59,6 +60,8 @@ export const TotalTeachers: React.FC<{ type: string; id: string }> = ({
     setDimension(dimension);
   };
 
+  const hasIncompleteData = data.some((x) => x.hasIncompleteData);
+
   return (
     <ChartDimensionContext.Provider value={dimension}>
       <HorizontalBarChartWrapper
@@ -68,6 +71,13 @@ export const TotalTeachers: React.FC<{ type: string; id: string }> = ({
         <h2 className="govuk-heading-m">
           Total number of teachers (Full Time Equivalent)
         </h2>
+        {hasIncompleteData ? (
+          <WarningBanner
+            icon="!"
+            visuallyHiddenText="Warning"
+            message="Some schools don't have a complete set of financial data for this period"
+          />
+        ) : null}
         <ChartDimensions
           dimensions={WorkforceCategories}
           handleChange={handleSelectChange}

--- a/web/src/Web.App/Domain/SchoolExpenditure.cs
+++ b/web/src/Web.App/Domain/SchoolExpenditure.cs
@@ -65,6 +65,6 @@ public record SchoolExpenditure
     public decimal TotalUtilitiesCosts { get; set; }
     public decimal EnergyCosts { get; set; }
     public decimal WaterSewerageCosts { get; set; }
-
+    public bool HasIncompleteData { get; set; }
     public int FloorArea { get; set; }
 }

--- a/web/src/Web.App/Domain/Workforce.cs
+++ b/web/src/Web.App/Domain/Workforce.cs
@@ -17,4 +17,5 @@ public record Workforce
     public decimal? AuxiliaryStaffFte { get; set; }
     public decimal? WorkforceHeadcount { get; set; }
     public decimal? TeachersQualified { get; set; }
+    public bool HasIncompleteData { get; set; }
 }

--- a/web/src/Web.App/ViewModels/SchoolSpendingViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolSpendingViewModel.cs
@@ -25,4 +25,6 @@ public class SchoolSpendingViewModel(
         .OrderBy(x => x.Rating.StatusOrder)
         .ThenByDescending(x => x.Rating.Decile)
         .ThenByDescending(x => x.Rating.Value);
+
+    public bool HasIncompleteData => pupilExpenditure.Concat(areaExpenditure).Any(x => x.HasIncompleteData);
 }

--- a/web/src/Web.App/Views/SchoolSpending/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/Index.cshtml
@@ -11,17 +11,6 @@
 
 @await Component.InvokeAsync("ComparatorSetDetails", new { identifier = Model.Urn, referrer = Referrers.SchoolSpending })
 
-@if (Model.HasIncompleteData)
-{
-    <div class="govuk-warning-text">
-        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-        <strong class="govuk-warning-text__text">
-            <span class="govuk-visually-hidden">Warning</span>
-            Some schools don't have a complete set of financial data for this period
-        </strong>
-    </div>
-}
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-heading-m govuk-!-font-size-36">Priority costs</h2>
@@ -43,7 +32,8 @@
                  data-json="@category.Values.Select(x => new { urn = x.Key, amount = x.Value.Value }).ToArray().ToJson(Formatting.None)"
                  data-highlight="@Model.Urn"
                  data-suffix="@category.Rating.Unit"
-                 data-sort-direction="asc">
+                 data-sort-direction="asc"
+                 data-has-incomplete-data="@Model.HasIncompleteData">
             </div>
             <p class="govuk-body">
                 <a href="comparison#@category.Rating.CostCategoryAnchorId" class="govuk-link govuk-link--no-visited-state">View all @category.Rating.CostCategory?.ToLower() costs</a>
@@ -73,7 +63,8 @@
                  data-json="@category.Values.Select(x => new { urn = x.Key, amount = x.Value.Value }).ToArray().ToJson(Formatting.None)"
                  data-highlight="@Model.Urn"
                  data-suffix="@category.Rating.Unit"
-                 data-sort-direction="asc">
+                 data-sort-direction="asc"
+                data-has-incomplete-data="@Model.HasIncompleteData">
             </div>
             <p class="govuk-body">
                 <a href="comparison#@category.Rating.CostCategoryAnchorId" class="govuk-link govuk-link--no-visited-state">View all @category.Rating.CostCategory?.ToLower() costs</a>

--- a/web/src/Web.App/Views/SchoolSpending/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/Index.cshtml
@@ -11,12 +11,24 @@
 
 @await Component.InvokeAsync("ComparatorSetDetails", new { identifier = Model.Urn, referrer = Referrers.SchoolSpending })
 
+@if (Model.HasIncompleteData)
+{
+    <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+            <span class="govuk-visually-hidden">Warning</span>
+            Some schools don't have a complete set of financial data for this period
+        </strong>
+    </div>
+}
+
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-heading-m govuk-!-font-size-36">Priority costs</h2>
         <p class="govuk-body">This shows where spending is different to similar schools.</p>
     </div>
 </div>
+
 @foreach (var category in Model.PriorityCosts)
 {
     <div class="govuk-grid-row govuk-!-margin-bottom-4">


### PR DESCRIPTION
### Context

[AB#201938](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/201938) - [AB#203886](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/203886)

[AB#205583](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/205583)

### Change proposed in this pull request

Adds a warning banner conditionally rendered on the presence of incomplete financial data in any of the schools being used as part of a comparison. For pages Spending and costs, Compare your costs and Workforce benchmark data.

Creates a React component to be used for a warning banner which is used in the composed components to render this warning for each chart/table.

Also updates the documentation for this feature.

### Guidance to review 

This now fulfills the AC of [AB#205583](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/205583) which supersedes the previous story.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

