### PR TITLE
`Destroy` release pipeline fixes

### DIFF
--- a/pipelines/common/destroy-terraform.yaml
+++ b/pipelines/common/destroy-terraform.yaml
@@ -4,16 +4,10 @@ parameters:
   environment: ''
   cipEnvironment: ''
   module: ''
-  workspaceDir: '$(Pipeline.Workspace)'
   location: 'westeurope'
+  deleteStorageAccount: false
 
 steps:
-  - task: ExtractFiles@1
-    displayName: 'Extract terraform Files'
-    inputs:
-      archiveFilePatterns: '$(Pipeline.Workspace)/${{ parameters.module }}-terraform/terraform.zip'
-      destinationFolder: '${{ parameters.workspaceDir }}/tf'
-
   - task: AzureCLI@1
     displayName: 'Create terraform dependencies'
     inputs:
@@ -32,7 +26,7 @@ steps:
   - task: qetza.replacetokens.replacetokens-task.replacetokens@6
     displayName: 'Replace tokens in terraform file'
     inputs:
-      sources: '${{ parameters.workspaceDir }}/tf/terraform.tfvars'
+      sources: '${{ parameters.workspaceDir }}/terraform.tfvars'
       escape: off
       tokenPattern: doubleunderscores
 
@@ -46,7 +40,7 @@ steps:
     inputs:
       command: init
       backendType: 'azurerm'
-      workingDirectory: '${{ parameters.workspaceDir }}/tf'
+      workingDirectory: ${{ parameters.workspaceDir }}
       environmentServiceName: ${{ parameters.subscription }}
       backendServiceArm: ${{ parameters.subscription }}
       backendAzureRmResourceGroupName: ${{ parameters.environmentPrefix }}-ebis-terraform
@@ -60,7 +54,7 @@ steps:
     inputs:
       command: destroy
       backendType: 'azurerm'
-      workingDirectory: '${{ parameters.workspaceDir }}/tf'
+      workingDirectory: ${{ parameters.workspaceDir }}
       commandOptions: '-input=false'
       environmentServiceName: ${{ parameters.subscription }}
       backendServiceArm: ${{ parameters.subscription }}
@@ -69,3 +63,18 @@ steps:
       backendAzureRmContainerName: 'tfstate'
       backendAzureRmKey: education-benchmarking-${{ parameters.module }}.tfstate
       backendAzureRmResourceGroupLocation: ${{ parameters.location }}
+
+  - task: AzureCLI@1
+    displayName: 'Delete terraform storage account'
+    condition: and(succeeded(), ${{ parameters.deleteStorageAccount }})
+    inputs:
+      azureSubscription: ${{ parameters.subscription }}
+      scriptLocation: inlineScript
+      inlineScript: |
+        # name can only consist of lowercase letters and numbers, and must be between 3 and 24 characters long
+        storageAccountName=$( { var="${{ parameters.environmentPrefix }}"; echo "${var@L}"; } | sed "s/[^[:alnum:]]//g" | { var=$(cat); echo "${var::15}storagetf"; } )
+        az storage account delete --name $storageAccountName --resource-group ${{ parameters.environmentPrefix }}-ebis-terraform --yes
+        echo "Storage account deleted"
+
+        az group delete --resource-group ${{ parameters.environmentPrefix }}-ebis-terraform --yes
+        echo "Resource group deleted"

--- a/pipelines/core-infrastructure/destroy.yaml
+++ b/pipelines/core-infrastructure/destroy.yaml
@@ -8,8 +8,9 @@ parameters:
   dependsOn: []
 
 jobs:
-  - job: ManualValidation
-    displayName: 'Await manual validation'
+  - job: CoreDestroyManualValidation
+    displayName: 'Validate destruction of Core resources'
+    dependsOn: ${{ parameters.dependsOn }}
     pool: server
     steps:
     - task: ManualValidation@0
@@ -19,7 +20,7 @@ jobs:
 
   - deployment: CoreDestroy
     displayName: 'Core : Destroy'
-    dependsOn: ${{ parameters.dependsOn }}
+    dependsOn: [ CoreDestroyManualValidation ]
     pool:
       vmImage: ubuntu-latest
     environment: ${{ parameters.pipelineEnvironment }}
@@ -27,14 +28,14 @@ jobs:
       runOnce:
         deploy:
           steps:
-            - checkout: none
-
-            - download: current
+            - checkout: self
 
             - template: ..\common\destroy-terraform.yaml
               parameters:
+                workspaceDir: '$(System.DefaultWorkingDirectory)/core-infrastructure/terraform'
                 subscription: ${{ parameters.subscription }}
                 environmentPrefix: ${{ parameters.environmentPrefix }}
                 environment: ${{ parameters.environment }}
                 cipEnvironment: ${{ parameters.cipEnvironment }}
-                module: 'web'
+                module: 'core'
+                deleteStorageAccount: true

--- a/pipelines/destroy/release.yaml
+++ b/pipelines/destroy/release.yaml
@@ -7,7 +7,7 @@ pr: none
 
 parameters:
   - name: environment
-    displayName: 'Source environment'
+    displayName: 'Environment associated with original deployment'
     type: string
     default: feature
     values:
@@ -17,9 +17,9 @@ parameters:
       - pre-production
       - test
   - name: environmentPrefix
-    displayName: 'Environment prefix to destroy'
+    displayName: 'Environment prefix to destroy (e.g. s198d01-feature-name)'
     type: string
-    default: ' '
+    default: ''
   - name: areYouSure
     displayName: 'Are you sure you wish to destroy this environment?'
     type: string
@@ -31,14 +31,12 @@ parameters:
 variables:
   Environment: ${{ parameters.environment }}
   EnvironmentPrefix: ${{ parameters.environmentPrefix }}
-  ShouldDestroy: $[and(eq('${{ parameters.areYouSure }}', 'Yes'), ne('${{ parameters.environmentPrefix }}', ' '))]
+  ShouldDestroy: $[and(eq('${{ parameters.areYouSure }}', 'Yes'), ne('${{ parameters.environmentPrefix }}', ''))]
 
 stages:
   - stage: Destroy
     condition: eq(variables['ShouldDestroy'], 'true')
     displayName: 'Destroy Environment'
-    variables:
-      - group: 'dsi pre-prod'
     jobs:
       - template: destroy.yaml
         parameters:

--- a/pipelines/platform/destroy.yaml
+++ b/pipelines/platform/destroy.yaml
@@ -8,8 +8,9 @@ parameters:
   dependsOn: []
 
 jobs:
-  - job: ManualValidation
-    displayName: 'Await manual validation'
+  - job: PlatformDestroyManualValidation
+    displayName: 'Validate destruction of Platform resources'
+    dependsOn: ${{ parameters.dependsOn }}
     pool: server
     steps:
     - task: ManualValidation@0
@@ -19,7 +20,7 @@ jobs:
 
   - deployment: PlatformDestroy
     displayName: 'Platform : Destroy'
-    dependsOn: ${{ parameters.dependsOn }}
+    dependsOn: [ PlatformDestroyManualValidation ]
     pool:
       vmImage: ubuntu-latest
     environment: ${{ parameters.pipelineEnvironment }}
@@ -27,14 +28,13 @@ jobs:
       runOnce:
         deploy:
           steps:
-            - checkout: none
-
-            - download: current
+            - checkout: self
 
             - template: ..\common\destroy-terraform.yaml
               parameters:
+                workspaceDir: '$(System.DefaultWorkingDirectory)/platform/terraform'
                 subscription: ${{ parameters.subscription }}
                 environmentPrefix: ${{ parameters.environmentPrefix }}
                 environment: ${{ parameters.environment }}
                 cipEnvironment: ${{ parameters.cipEnvironment }}
-                module: 'web'
+                module: 'platform'

--- a/pipelines/web/destroy.yaml
+++ b/pipelines/web/destroy.yaml
@@ -5,11 +5,11 @@ parameters:
   pipelineEnvironment: ''
   cipEnvironment: ''
   workspaceDir: '$(Pipeline.Workspace)'
-  dependsOn: []
 
 jobs:
-  - job: ManualValidation
-    displayName: 'Await manual validation'
+  - job: WebDestroyManualValidation
+    displayName: 'Validate destruction of Web resources'
+    dependsOn: ${{ parameters.dependsOn }}
     pool: server
     steps:
     - task: ManualValidation@0
@@ -19,7 +19,7 @@ jobs:
 
   - deployment: WebDestroy
     displayName: 'Web : Destroy'
-    dependsOn: ${{ parameters.dependsOn }}
+    dependsOn: [ WebDestroyManualValidation ]
     pool:
       vmImage: ubuntu-latest
     environment: ${{ parameters.pipelineEnvironment }}
@@ -27,12 +27,11 @@ jobs:
       runOnce:
         deploy:
           steps:
-            - checkout: none
-
-            - download: current
+            - checkout: self
 
             - template: ..\common\destroy-terraform.yaml
               parameters:
+                workspaceDir: '$(System.DefaultWorkingDirectory)/web/terraform'
                 subscription: ${{ parameters.subscription }}
                 environmentPrefix: ${{ parameters.environmentPrefix }}
                 environment: ${{ parameters.environment }}


### PR DESCRIPTION
### Context
It was not possible to test the `Destroy` pipeline until it was merged to `main`. Herein are the related bug fixes.

### Change proposed in this pull request
Fixed dependency tree between pipeline jobs. Made job names unique. Fixed Terraform working directory. Destroyed Terraform state as the very last task.

### Guidance to review 
Deploy a new feature branch, then run the Destroy pipeline to remove it again.

### Checklist
- [ ] ~Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)~
- [ ] ~Your code builds clean without any errors or warnings~
- [ ] ~You have run all unit/integration tests and they pass~
- [x] Your branch has been rebased onto main
- [ ] ~You have tested by running locally~

