### PR TITLE
feat: adds full year display on history charts

### DIFF
--- a/front-end-components/src/composed/historic-chart-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/component.tsx
@@ -31,11 +31,11 @@ export const HistoricChart: React.FC<HistoricChartProps<ChartDataSeries>> = ({
                 data={data}
                 grid
                 highlightActive
-                keyField="yearEnd"
+                keyField="term"
                 margin={20}
                 seriesConfig={seriesConfig}
                 seriesLabel={dimension.label}
-                seriesLabelField="yearEnd"
+                seriesLabelField="term"
                 valueFormatter={shortValueFormatter}
                 valueUnit={dimension.unit}
                 tooltip={(t) => (
@@ -56,7 +56,7 @@ export const HistoricChart: React.FC<HistoricChartProps<ChartDataSeries>> = ({
               compactValue
               data={data}
               displayIndex={data.length - 1}
-              seriesLabelField="yearEnd"
+              seriesLabelField="term"
               valueField={valueField}
               valueFormatter={shortValueFormatter}
               valueUnit={dimension.unit}

--- a/front-end-components/src/services/types.tsx
+++ b/front-end-components/src/services/types.tsx
@@ -54,6 +54,7 @@ export type ExpenditureData = {
 
 export type Balance = {
   yearEnd: string;
+  term: string;
   dimension: string;
   inYearBalance: number;
   revenueReserve: number;
@@ -66,6 +67,7 @@ export type Workforce = {
   localAuthority: string;
   numberOfPupils: bigint;
   yearEnd: string;
+  term: string;
   dimension: string;
   workforceFte: number;
   teachersFte: number;
@@ -80,6 +82,7 @@ export type Workforce = {
 
 export type Income = {
   yearEnd: string;
+  term: string;
   dimension: string;
   totalIncome: number;
   totalGrantFunding: number;
@@ -102,6 +105,7 @@ export type Income = {
 
 export type Expenditure = {
   yearEnd: string;
+  term: string;
   dimension: string;
   totalExpenditure: number;
   totalTeachingSupportStaffCosts: number;

--- a/platform/src/abstractions/Platform.Domain/Responses/BalanceResponseModel.cs
+++ b/platform/src/abstractions/Platform.Domain/Responses/BalanceResponseModel.cs
@@ -7,6 +7,7 @@ namespace Platform.Domain;
 public record BalanceResponseModel
 {
     public int YearEnd { get; private set; }
+    public string Term => $"{YearEnd - 1} to {YearEnd}";
     public Dimension Dimension { get; private set; }
     public decimal? InYearBalance { get; private set; }
     public decimal? RevenueReserve { get; private set; }

--- a/platform/src/abstractions/Platform.Domain/Responses/ExpenditureResponseModel.cs
+++ b/platform/src/abstractions/Platform.Domain/Responses/ExpenditureResponseModel.cs
@@ -7,6 +7,7 @@ namespace Platform.Domain;
 public record ExpenditureResponseModel
 {
     public int YearEnd { get; private set; }
+    public string Term => $"{YearEnd - 1} to {YearEnd}";
     public Dimension Dimension { get; private set; }
     public decimal? TotalExpenditure { get; private set; }
     public decimal? TotalTeachingSupportStaffCosts { get; private set; }

--- a/platform/src/abstractions/Platform.Domain/Responses/IncomeResponseModel.cs
+++ b/platform/src/abstractions/Platform.Domain/Responses/IncomeResponseModel.cs
@@ -5,6 +5,7 @@ namespace Platform.Domain;
 public class IncomeResponseModel
 {
     public int YearEnd { get; private set; }
+    public string Term => $"{YearEnd - 1} to {YearEnd}";
     public Dimension Dimension { get; private set; }
     public decimal? TotalIncome { get; private set; }
     public decimal? TotalGrantFunding { get; private set; }

--- a/platform/src/abstractions/Platform.Domain/Responses/WorkforceResponseModel.cs
+++ b/platform/src/abstractions/Platform.Domain/Responses/WorkforceResponseModel.cs
@@ -12,6 +12,7 @@ public record WorkforceResponseModel
     public string? LocalAuthority { get; private set; }
     public decimal NumberOfPupils { get; private set; }
     public int YearEnd { get; private set; }
+    public string Term => $"{YearEnd - 1} to {YearEnd}";
     public WorkforceDimension Dimension { get; private set; }
     public decimal? WorkforceFte { get; private set; }
     public decimal? TeachersFte { get; private set; }

--- a/web/src/Web.App/Domain/Balance.cs
+++ b/web/src/Web.App/Domain/Balance.cs
@@ -3,6 +3,7 @@
 public record Balance
 {
     public int YearEnd { get; set; }
+    public string? Term { get; set; }
     public string? Dimension { get; set; }
     public decimal? InYearBalance { get; set; }
     public decimal? RevenueReserve { get; set; }

--- a/web/src/Web.App/Domain/Expenditure.cs
+++ b/web/src/Web.App/Domain/Expenditure.cs
@@ -3,6 +3,7 @@
 public record Expenditure
 {
     public int YearEnd { get; set; }
+    public string? Term { get; set; }
     public string? Dimension { get; set; }
     public decimal? TotalExpenditure { get; set; }
     public decimal? TotalTeachingSupportStaffCosts { get; set; }

--- a/web/src/Web.App/Domain/Income.cs
+++ b/web/src/Web.App/Domain/Income.cs
@@ -3,6 +3,7 @@
 public record Income
 {
     public int YearEnd { get; set; }
+    public string? Term { get; set; }
     public string? Dimension { get; set; }
     public decimal? TotalIncome { get; set; }
     public decimal? TotalGrantFunding { get; set; }

--- a/web/src/Web.App/Domain/Workforce.cs
+++ b/web/src/Web.App/Domain/Workforce.cs
@@ -8,6 +8,7 @@ public record Workforce
     public string? LocalAuthority { get; set; }
     public decimal NumberOfPupils { get; set; }
     public int YearEnd { get; set; }
+    public string? Term { get; set; }
     public string? Dimension { get; set; }
     public decimal? WorkforceFte { get; set; }
     public decimal? TeachersFte { get; set; }


### PR DESCRIPTION
### Context
[AB#185882](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/185882) ([AB#204740](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/204740))
[AB#185907](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/185907)
[AB#185900](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/185900)
[AB#185893](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/185893)

### Change proposed in this pull request
Ensures full years are shown both on axis and stat box

### Guidance to review 
N/A

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

