### PR TITLE
feat: adding acr to core infrastructure

### DIFF
--- a/core-infrastructure/terraform/acr.tf
+++ b/core-infrastructure/terraform/acr.tf
@@ -1,0 +1,20 @@
+resource "azurerm_container_registry" "acr" {
+  name                = "${var.environment-prefix}acr"
+  resource_group_name = azurerm_resource_group.resource-group.name
+  location            = azurerm_resource_group.resource-group.location
+  sku                 = "Basic"
+  # TODO: Need to review as needed for container apps I believe, unless I can allow the SystemAssignedIdentity
+  admin_enabled       = true 
+  public_network_access_enabled = false 
+
+  retention_policy {
+    days = 30
+    enabled = true
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+  
+  tags = local.common-tags
+}


### PR DESCRIPTION
### Context
This is a pre-requiste change to core infrastructure, to create an Azure Container Registry, to store the pipeline images that will be build

### Change proposed in this pull request
Proposes adding an azure contianer registry to the `core-infrastructure`.

### Guidance to review 
Worth noting that I have enabled admin access on this, however I will be looking to turn that off once I can get the Managed Identity working with Azure Container Apps

### Checklist
- [X] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [X] Your code builds clean without any errors or warnings

