### PR TITLE
chore: updates main build pipeline version numbering

### DIFF
--- a/pipelines/core-infrastructure/build.yaml
+++ b/pipelines/core-infrastructure/build.yaml
@@ -10,7 +10,10 @@ trigger:
     include:
       - core-infrastructure
 
-pr: none
+pr:
+  paths:
+    include:
+      - core-infrastructure
 
 variables:
   Version.Revision: $[counter(variables['Build.SourceBranchName'], 0)]
@@ -33,8 +36,15 @@ stages:
               echo "##vso[task.setvariable variable=Version.BuildVersion]$(Version.BuildNumber)"
               echo "##vso[build.updatebuildnumber]$(Version.BuildNumber)"
               echo "##vso[build.addbuildtag]$(Version.BuildNumber)"
-              echo "##vso[build.addbuildtag]Core infrastructure"
             displayName: 'Set release build number'
+            condition: and(succeeded(), eq(variables['ShouldDeploy'],'true'))
+
+          - bash: |
+              if [[ "$(Build.Reason)" == "PullRequest" ]]; then
+                echo "##vso[build.addbuildtag]PR$(System.PullRequest.PullRequestId)"
+              fi
+              echo "##vso[build.addbuildtag]Core infrastructure"
+            displayName: 'Set build tags'
 
       - job: FmtValidateTf
         displayName: "Lint and validate terraform"
@@ -52,6 +62,7 @@ stages:
 
       - job: ZipStaticArtifacts
         displayName: 'Zip static artifacts'
+        condition: eq(variables['ShouldDeploy'],'true')
         steps:
           - template: ..\common\publish-terraform-artifacts.yaml
             parameters:

--- a/pipelines/front-end-components/build.yaml
+++ b/pipelines/front-end-components/build.yaml
@@ -20,35 +20,28 @@ variables:
   Version.BuildNumber: 0.1.$(Version.Revision)
   Version.BuildVersion: $(Version.BuildNumber)
   WorkingDir: 'front-end-components'
+  ShouldDeploy: $[and(eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne(variables['Build.Reason'], 'PullRequest'))]
 
 steps:
   - bash: |
       echo "##vso[build.updatebuildnumber]$(Version.BuildNumber)"
       echo "##vso[build.addbuildtag]$(Version.BuildNumber)"
-      echo "##vso[build.addbuildtag]Front-end components"
+    displayName: 'Set release build number'
+    condition: and(succeeded(), eq(variables['ShouldDeploy'],'true'))
+
+  - bash: |
       if [[ "$(Build.Reason)" == "PullRequest" ]]; then
-        preRelease="pr$(System.PullRequest.PullRequestId)"
         echo "##vso[build.addbuildtag]PR$(System.PullRequest.PullRequestId)"
       fi
-      echo "##vso[task.setvariable variable=Version.PreRelease]$preRelease"
-    displayName: 'Set release build and version number'
+      echo "##vso[build.addbuildtag]Front-end components"
+    displayName: 'Set build tags'
 
   - task: Npm@1
     displayName: 'Update version number'
-    continueOnError: false
+    condition: and(succeeded(), eq(variables['ShouldDeploy'],'true'))
     inputs:
       command: 'custom'
       customCommand: 'version $(Version.BuildNumber)'
-      workingDir: $(WorkingDir)
-      verbose: false
-
-  - task: Npm@1
-    displayName: 'Update pre-release version number'
-    condition: ne(variables['Version.PreRelease'], '')
-    continueOnError: false
-    inputs:
-      command: 'custom'
-      customCommand: 'version prerelease -preid=$(Version.PreRelease)'
       workingDir: $(WorkingDir)
       verbose: false
 

--- a/pipelines/platform/build.yaml
+++ b/pipelines/platform/build.yaml
@@ -39,8 +39,15 @@ stages:
               echo "##vso[task.setvariable variable=Version.BuildVersion]$(Version.BuildNumber)"
               echo "##vso[build.updatebuildnumber]$(Version.BuildNumber)"
               echo "##vso[build.addbuildtag]$(Version.BuildNumber)"
-              echo "##vso[build.addbuildtag]Platform"
             displayName: 'Set release build number'
+            condition: and(succeeded(), eq(variables['ShouldDeploy'],'true'))
+
+          - bash: |
+              if [[ "$(Build.Reason)" == "PullRequest" ]]; then
+                echo "##vso[build.addbuildtag]PR$(System.PullRequest.PullRequestId)"
+              fi
+              echo "##vso[build.addbuildtag]Platform"
+            displayName: 'Set build tags'
 
       - job: FmtValidateTf
         displayName: "Lint and validate terraform"

--- a/pipelines/web/build.yaml
+++ b/pipelines/web/build.yaml
@@ -38,8 +38,15 @@ stages:
               echo "##vso[task.setvariable variable=Version.BuildVersion]$(Version.BuildNumber)"
               echo "##vso[build.updatebuildnumber]$(Version.BuildNumber)"
               echo "##vso[build.addbuildtag]$(Version.BuildNumber)"
-              echo "##vso[build.addbuildtag]Web"
             displayName: 'Set release build number'
+            condition: and(succeeded(), eq(variables['ShouldDeploy'],'true'))
+
+          - bash: |
+              if [[ "$(Build.Reason)" == "PullRequest" ]]; then
+                echo "##vso[build.addbuildtag]PR$(System.PullRequest.PullRequestId)"
+              fi
+              echo "##vso[build.addbuildtag]Web"
+            displayName: 'Set build tags'
 
       - job: FmtValidateTf
         displayName: "Lint and validate terraform"


### PR DESCRIPTION
### Context
Updates main build pipelines to only set version numbering on main builds and skips on PR builds or non-main branches

