### PR TITLE
School and Trust search/suggester refactor

### DIFF
--- a/documentation/developers/features/find-organisation.md
+++ b/documentation/developers/features/find-organisation.md
@@ -100,6 +100,10 @@ Consumption of the feature is managed via the [`<FindOrganisation />` view](/fro
 
 The `<SchoolInput />` and `<TrustInput />` components manage the input field state, key press events and API `fetch` effects. Search results are bound to a list, and when an item is clicked upon, or navigated to with arrow keys and enter pressed, the selected item identifier is set in a hidden `<input />` field. The `<form />` is submitted on the Continue `<button />` press, which `POST`s back to the Controller for model validation and, if all is well, redirection to the appropriate establishment home page.
 
+### Accessible Autocomplete
+
+The [alphagov/accessible-autocomplete](https://github.com/alphagov/accessible-autocomplete) package was chosen for use here due to its (partial) support by the GDS team and the high level of accessibility support. It is also distributed with React integration, has (third party) typings available, and has a high number of downloads/dependents/forks/stars compared. Alternatives were to maintain a custom component to manage the accessibility needs, or other GDS branded options such as `Autocomplete` from [@x-govuk/govuk-prototype-components](https://x-govuk.github.io/govuk-prototype-components/autocomplete/), which is used in the Prototype kit.
+
 ## Configuration
 
 In Establishment API:

--- a/front-end-components/package-lock.json
+++ b/front-end-components/package-lock.json
@@ -8,6 +8,7 @@
       "name": "front-end",
       "version": "0.0.0",
       "dependencies": {
+        "accessible-autocomplete": "^3.0.0",
         "classnames": "^2.5.1",
         "file-saver": "^2.0.5",
         "govuk-frontend": "^5.2.0",
@@ -4410,6 +4411,19 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "deprecated": "Use your platform's native atob() and btoa() methods instead",
       "dev": true
+    },
+    "node_modules/accessible-autocomplete": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-3.0.0.tgz",
+      "integrity": "sha512-Kpm6EX+jjD0AurWfzSP4EVLEKsLUWCazZwidjum+8FCRtSINeaPzVa3ElKVGWvSqVZN9zjeSBF8cirhYEZjW1A==",
+      "peerDependencies": {
+        "preact": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "preact": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.11.3",

--- a/front-end-components/package.json
+++ b/front-end-components/package.json
@@ -16,6 +16,7 @@
     "lint:fix": "eslint . --ext ts,tsx,cjs --fix"
   },
   "dependencies": {
+    "accessible-autocomplete": "^3.0.0",
     "classnames": "^2.5.1",
     "file-saver": "^2.0.5",
     "govuk-frontend": "^5.2.0",

--- a/front-end-components/src/components/auto-complete/component.tsx
+++ b/front-end-components/src/components/auto-complete/component.tsx
@@ -1,6 +1,7 @@
 import AccessibleAutocomplete from "accessible-autocomplete/react";
 import { AutoCompleteProps } from "./types";
 import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
+import { useState } from "react";
 
 export function AutoComplete<T>({
   onSelected,
@@ -9,19 +10,25 @@ export function AutoComplete<T>({
   valueFormatter,
   ...props
 }: AutoCompleteProps<T>) {
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
   const handleSource = (
     query: string,
     populateResults: (values: T[]) => void
   ) => {
+    setIsLoading(true);
+
     onSuggest(query)
       .then(populateResults)
-      .catch(() => populateResults([]));
+      .catch(() => populateResults([]))
+      .finally(() => setIsLoading(false));
   };
 
   return (
     <AccessibleAutocomplete
       {...props}
       onConfirm={(confirmed) => onSelected(confirmed as T)}
+      showNoOptionsFound={false}
       source={(query, syncResults) =>
         handleSource(query, syncResults as (values: T[]) => void)
       }
@@ -31,7 +38,7 @@ export function AutoComplete<T>({
         suggestion: (suggestion: string) =>
           suggestionFormatter(suggestion as T),
       }}
-      tNoResults={() => "No results found"}
+      tNoResults={() => (isLoading ? "Searching..." : "No results found")}
       tStatusQueryTooShort={(minQueryLength: number) =>
         `Type in ${minQueryLength} or more characters for results`
       }
@@ -51,7 +58,7 @@ export function AutoComplete<T>({
             {length} {words.result} {words.is} available.{" "}
             {contentSelectedOption}
           </span>
-        ) as unknown as string;
+        );
       }}
       tAssistiveHint={() =>
         "When autocomplete results are available use up and down arrows to review and enter to select. Touch device users, explore by touch or with swipe gestures."

--- a/front-end-components/src/components/auto-complete/component.tsx
+++ b/front-end-components/src/components/auto-complete/component.tsx
@@ -1,0 +1,61 @@
+import AccessibleAutocomplete from "accessible-autocomplete/react";
+import { AutoCompleteProps } from "./types";
+import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
+
+export function AutoComplete<T>({
+  onSelected,
+  onSuggest,
+  suggestionFormatter,
+  valueFormatter,
+  ...props
+}: AutoCompleteProps<T>) {
+  const handleSource = (
+    query: string,
+    populateResults: (values: T[]) => void
+  ) => {
+    onSuggest(query)
+      .then(populateResults)
+      .catch(() => populateResults([]));
+  };
+
+  return (
+    <AccessibleAutocomplete
+      {...props}
+      onConfirm={(confirmed) => onSelected(confirmed as T)}
+      source={(query, syncResults) =>
+        handleSource(query, syncResults as (values: T[]) => void)
+      }
+      templates={{
+        inputValue: (selectedSuggestion: string) =>
+          valueFormatter(selectedSuggestion as T),
+        suggestion: (suggestion: string) =>
+          suggestionFormatter(suggestion as T),
+      }}
+      tNoResults={() => "No results found"}
+      tStatusQueryTooShort={(minQueryLength: number) =>
+        `Type in ${minQueryLength} or more characters for results`
+      }
+      tStatusNoResults={() => "No search results"}
+      tStatusSelectedOption={(
+        selectedOption: string,
+        length: number,
+        index: number
+      ) => `${selectedOption} ${index + 1} of ${length} is highlighted`}
+      tStatusResults={(length: number, contentSelectedOption: number) => {
+        const words = {
+          result: length === 1 ? "result" : "results",
+          is: length === 1 ? "is" : "are",
+        };
+        return (
+          <span>
+            {length} {words.result} {words.is} available.{" "}
+            {contentSelectedOption}
+          </span>
+        ) as unknown as string;
+      }}
+      tAssistiveHint={() =>
+        "When autocomplete results are available use up and down arrows to review and enter to select. Touch device users, explore by touch or with swipe gestures."
+      }
+    />
+  );
+}

--- a/front-end-components/src/components/auto-complete/component.tsx
+++ b/front-end-components/src/components/auto-complete/component.tsx
@@ -19,8 +19,18 @@ export function AutoComplete<T>({
     setIsLoading(true);
 
     onSuggest(query)
-      .then(populateResults)
-      .catch(() => populateResults([]))
+      .then((results) => {
+        if (results && Array.isArray(results)) {
+          populateResults(results);
+          return;
+        }
+
+        throw new Error("Unexpected results returned from suggester");
+      })
+      .catch(() => {
+        // todo: report failure back to component
+        populateResults([]);
+      })
       .finally(() => setIsLoading(false));
   };
 

--- a/front-end-components/src/components/auto-complete/index.tsx
+++ b/front-end-components/src/components/auto-complete/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/components/auto-complete/types";
+export * from "src/components/auto-complete/component";

--- a/front-end-components/src/components/auto-complete/types.tsx
+++ b/front-end-components/src/components/auto-complete/types.tsx
@@ -1,0 +1,33 @@
+import { AccessibleAutocompleteProps } from "accessible-autocomplete/react";
+
+export type AutoCompleteProps<T> = Pick<
+  AccessibleAutocompleteProps,
+  "defaultValue" | "id" | "name" | "minLength" | "required"
+> & {
+  /**
+   * When the user selects an option.
+   * @param value The option selected by the user
+   */
+  onSelected(value: T): void;
+
+  /**
+   * Executes a suggester using the supplied query
+   * @param query The value entered by the user
+   * @returns The suggested matches based on the query
+   */
+  onSuggest: (query: string) => Promise<T[]>;
+
+  /**
+   * Formatter to use when rendering a suggestion to be displayed
+   * @param value Suggested value
+   * @returns ⚠️ `string` that may contain HTML
+   */
+  suggestionFormatter: (value: T) => string;
+
+  /**
+   * Formatter to use to generate the value to be inserted into the input field
+   * @param value Selected value
+   * @returns Plain `string` that represents the value
+   */
+  valueFormatter: (value: T) => string;
+};

--- a/front-end-components/src/index.css
+++ b/front-end-components/src/index.css
@@ -339,3 +339,7 @@
     display: block;
   }
 }
+
+ul.autocomplete__menu {
+  font-family: "GDS Transport";
+}

--- a/front-end-components/src/types/accessible-autocomplete.d.ts
+++ b/front-end-components/src/types/accessible-autocomplete.d.ts
@@ -1,0 +1,209 @@
+// ref: https://github.com/alphagov/accessible-autocomplete/issues/535#issue-1120049413
+declare module "accessible-autocomplete/react" {
+  import { ReactElement } from "react";
+
+  type SourceFunction = (
+    query: string,
+    populateResults: (values: string[]) => void
+  ) => void;
+
+  /**
+   * This object defines templates (functions) that are used for displaying
+   * parts of the autocomplete. Caution: because this function allows you
+   * to output arbitrary HTML, you should make sure it's trusted, and accessible.
+   */
+  interface AutocompleteTemplates {
+    /**
+     * Receives one argument, the currently selected suggestion, and returns the
+     * string value to be inserted into the input.
+     */
+    inputValue(selectedSuggestion: string): string;
+
+    /**
+     * receives one argument, a suggestion to be displayed. It is used when
+     * rendering suggestions, and should return a string, which can contain HTML.
+     */
+    suggestion(suggestion: string): string;
+  }
+
+  export interface AccessibleAutocompleteProps {
+    /**
+     * The id to assign to the autocomplete input field, to use with a <label for=id>.
+     * Not required if using enhanceSelectElement.
+     */
+    id: string;
+
+    /**
+     * An array of values to search when the user types in the input field, or a function
+     * to take what the user types and call a callback function with the results to be displayed.
+     */
+    source: string[] | SourceFunction;
+
+    /**
+     * Set to true to highlight the first option when the user types in something and
+     * receives results. Pressing enter will select it. Default false.
+     */
+    autoselect?: boolean;
+
+    /**
+     * The autocomplete will confirm the currently selected option when the user clicks
+     * outside of the component. Set to false to disable. Default true.
+     */
+    confirmOnBlur?: boolean;
+
+    /**
+     * Use this property to override the BEM block name that the JavaScript component will use.
+     * You will need to rewrite the CSS class names to use your specified block name.
+     * Default "autocomplete".
+     */
+    cssNamespace?: string;
+
+    /**
+     * Specify a string to prefill the autocomplete with. Default "".
+     */
+    defaultValue?: string;
+
+    /**
+     * You can set this property to specify the way the menu should appear, whether inline or
+     * as an overlay. Default "inline"
+     */
+    displayMenu?: "inline" | "overlay";
+
+    /**
+     * The minimum number of characters that should be entered before the autocomplete will
+     * attempt to suggest options. When the query length is under this, the aria status region
+     * will also provide helpful text to the user informing them they should type in more.
+     * Default 0.
+     */
+    minLength?: number;
+
+    /**
+     * The name for the autocomplete input field, to use with a parent <form>.
+     * Default "input-autocomplete"
+     */
+    name?: string;
+
+    /**
+     * This function will be called when the user confirms an option, with the option they
+     * have confirmed.
+     * Default () => {}
+     */
+    onConfirm?(confirmed: string): void;
+
+    /**
+     * This option will populate the placeholder attribute on the input element.
+     * We think placeholders have usability issues and that there are better alternatives
+     * to input placeholder text, so we do not recommend using this option.
+     */
+    placeholder?: string;
+
+    /**
+     * The input field will be rendered with a required attribute, see W3C required
+     * attribute definition. Default false.
+     */
+    required?: boolean;
+
+    /**
+     * If this is set to true, all values are shown when the user clicks the input.
+     * This is similar to a default dropdown, so the autocomplete is rendered with
+     * a dropdown arrow to convey this behaviour. Default false.
+     */
+    showAllValues?: boolean;
+
+    /**
+     * The autocomplete will display a "No results found" template when there are
+     * no results. Default true.
+     */
+    showNoOptionsFound?: boolean;
+
+    /**
+     * This object defines templates (functions) that are used for displaying parts
+     * of the autocomplete.
+     * Caution: because this function allows you to output arbitrary HTML, you
+     * should make sure it's trusted, and accessible. If your template includes
+     * child elements with defined foreground or background colours, check they
+     * display correctly in forced colors modes. For example, Windows high contrast
+     * mode.
+     */
+    templates?: AutocompleteTemplates;
+
+    /**
+     * A function that gets passed an object with the property className
+     * ({ className: '' }) and should return a string of HTML or a (P)React element.
+     * Caution: because this function allows you to output arbitrary HTML, you
+     * should make sure it's trusted, and accessible.
+     * Default: A triangle pointing down
+     */
+    dropdownArrow?(props: { className: string }): string | ReactElement;
+
+    /**
+     * A function that receives no arguments and should return the text
+     * used in the dropdown to indicate that there are no results.
+     * Default: () => 'No results found'
+     */
+    tNoResults(): string;
+
+    /**
+     * A function that receives one argument that indicates the minimal
+     * amount of characters needed for the dropdown to trigger and should
+     * return the text used in the accessibility hint to indicate that
+     * the query is too short.
+     * Default: (minQueryLength) => `Type in ${minQueryLength} or more characters for results`
+     */
+    tStatusQueryTooShort(minQueryLength: number): string;
+
+    /**
+     * A function that receives no arguments and should return the text
+     * that is used in the accessibility hint to indicate that there are no results.
+     * Default: () => 'No search results'
+     */
+    tStatusNoResults(): string;
+
+    /**
+     * A function that receives two arguments, the selectedOption and the
+     * amount of available options, and it should return the text used in
+     * the accessibility hint to indicate which option is selected.
+     * Default: (selectedOption, length, index) =>
+     * `${selectedOption} ${index + 1} of ${length} is highlighted`
+     */
+    tStatusSelectedOption(
+      selectedOption: string,
+      length: number,
+      index: number
+    ): string;
+
+    /**
+     * A function that receives two arguments, the count of available options
+     * and the return value of tStatusSelectedOption, and should return the
+     * text used in the accessibility hint to indicate which options are
+     * available and which is selected.
+     * Default:
+     * (length, contentSelectedOption) => {
+     *   const words = {
+     *     result: (length === 1) ? 'result' : 'results',
+     *     is: (length === 1) ? 'is' : 'are'
+     *   }
+     *   return <span>{length} {words.result} {words.is} available. {contentSelectedOption}</span>
+     * }
+     */
+    tStatusResults(length: number, contentSelectedOption: number): string;
+
+    /**
+     * A function that receives no arguments and should return the text to
+     * be assigned as the aria description of the html input element, via
+     * the aria-describedby attribute. This text is intended as an initial
+     * instruction to the assistive tech user. The aria-describedby attribute
+     * is automatically removed once user input is detected, in order to
+     * reduce screen reader verbosity.
+     * Default:
+     * () => 'When autocomplete results are available use up and
+     *   down arrows to review and enter to select. Touch device users,
+     *   explore by touch or with swipe gestures.'
+     */
+    tAssistiveHint(): string;
+  }
+
+  export default function AccessibleAutocomplete(
+    props: AccessibleAutocompleteProps
+  ): ReactElement | null;
+}

--- a/front-end-components/src/types/accessible-autocomplete.d.ts
+++ b/front-end-components/src/types/accessible-autocomplete.d.ts
@@ -186,7 +186,10 @@ declare module "accessible-autocomplete/react" {
      *   return <span>{length} {words.result} {words.is} available. {contentSelectedOption}</span>
      * }
      */
-    tStatusResults(length: number, contentSelectedOption: number): string;
+    tStatusResults(
+      length: number,
+      contentSelectedOption: number
+    ): string | ReactElement;
 
     /**
      * A function that receives no arguments and should return the text to

--- a/front-end-components/src/views/find-organisation/partials/school-input.tsx
+++ b/front-end-components/src/views/find-organisation/partials/school-input.tsx
@@ -8,7 +8,7 @@ import {
 import { v4 as uuidv4 } from "uuid";
 
 const SchoolInput: React.FunctionComponent<SchoolInputProps> = (props) => {
-  const { input, urn } = props; // input = defaultValue?
+  const { input, urn } = props;
 
   const [inputValue, setInputValue] = useState<string>(input);
   const [selectedUrn, setSelectedUrn] = useState<string>(urn);
@@ -50,6 +50,11 @@ const SchoolInput: React.FunctionComponent<SchoolInputProps> = (props) => {
   const handleSelected = (value: SuggestResult<SchoolDocument>) => {
     controller.abort();
     controller = new AbortController();
+
+    if (!value) {
+      return;
+    }
+
     setInputValue(value.text.replace(/\*(.*)\*/, "$1"));
     setSelectedUrn(value.document.urn);
   };
@@ -64,10 +69,10 @@ const SchoolInput: React.FunctionComponent<SchoolInputProps> = (props) => {
         onSelected={handleSelected}
         onSuggest={handleSuggest}
         suggestionFormatter={(item) =>
-          item ? item.text.replace(/\*(.*)\*/, "<b>$1</b>") : ""
+          item?.text ? item.text.replace(/\*(.*)\*/, "<b>$1</b>") : ""
         }
         valueFormatter={(item) =>
-          item ? item.text.replace(/\*(.*)\*/, "$1") : ""
+          item?.text ? item.text.replace(/\*(.*)\*/, "$1") : ""
         }
       />
       <input value={selectedUrn} name="urn" type="hidden" />

--- a/front-end-components/src/views/find-organisation/partials/school-input.tsx
+++ b/front-end-components/src/views/find-organisation/partials/school-input.tsx
@@ -9,22 +9,15 @@ import { v4 as uuidv4 } from "uuid";
 
 const SchoolInput: React.FunctionComponent<SchoolInputProps> = (props) => {
   const { input, urn } = props;
-
   const [inputValue, setInputValue] = useState<string>(input);
   const [selectedUrn, setSelectedUrn] = useState<string>(urn);
 
-  let controller = new AbortController();
-
   const handleSuggest = async (query: string) => {
-    controller.abort();
-    controller = new AbortController();
-
     try {
       const res = await fetch(
         "/api/suggest?" +
           new URLSearchParams({ type: "school", search: query }),
         {
-          signal: controller.signal,
           redirect: "manual",
           method: "GET",
           headers: {
@@ -48,9 +41,6 @@ const SchoolInput: React.FunctionComponent<SchoolInputProps> = (props) => {
   };
 
   const handleSelected = (value: SuggestResult<SchoolDocument>) => {
-    controller.abort();
-    controller = new AbortController();
-
     if (!value) {
       return;
     }

--- a/front-end-components/src/views/find-organisation/partials/school-input.tsx
+++ b/front-end-components/src/views/find-organisation/partials/school-input.tsx
@@ -1,170 +1,76 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useState } from "react";
+import { AutoComplete } from "src/components/auto-complete";
 import {
   SchoolDocument,
   SchoolInputProps,
   SuggestResult,
 } from "src/views/find-organisation";
-import { useDebounceCallback } from "usehooks-ts";
 import { v4 as uuidv4 } from "uuid";
 
 const SchoolInput: React.FunctionComponent<SchoolInputProps> = (props) => {
-  const { input, urn } = props;
+  const { input, urn } = props; // input = defaultValue?
 
-  const schoolInput = useRef(null);
-
-  const [index, setIndex] = useState<number>(-1);
-  const [optionsVisible, setOptionsVisible] = useState<boolean>(false);
-  const [optionMode, setOptionMode] = useState<boolean>(false);
-  const [options, setOptions] = useState<SuggestResult<SchoolDocument>[]>([]);
   const [inputValue, setInputValue] = useState<string>(input);
   const [selectedUrn, setSelectedUrn] = useState<string>(urn);
-  const [lastInput, setLastInput] = useState<string>("");
-  const [fetchValue, setFetchValue] = useState<string>();
-  const debounceFetchValue = useDebounceCallback(setFetchValue, 500);
 
   let controller = new AbortController();
 
-  function fillSearch() {
-    if (index < 0) return;
-
-    setInputValue(options[index].text.replace(/(<([^>]+)>)/gi, ""));
-    setSelectedUrn(options[index].document.urn);
-    setOptionsVisible(false);
-  }
-
-  function onKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
-    if (event.key === "Enter" && index > -1 && optionMode) {
-      fillSearch();
-    } else if (event.key === "ArrowDown") {
-      setOptionMode(true);
-      if (index + 1 < options.length) {
-        setIndex(index + 1);
-      }
-      event.preventDefault();
-    } else if (event.key === "ArrowUp") {
-      if (index >= 0) {
-        setOptionMode(true);
-        setIndex(index - 1);
-      }
-      event.preventDefault();
-    }
-  }
-
-  function onKeyPressed() {
+  const handleSuggest = async (query: string) => {
     controller.abort();
     controller = new AbortController();
 
-    if (inputValue === lastInput?.trim()) {
-      setOptionsVisible(true);
-      return;
-    } else if (!optionsVisible) {
-      setOptions([]);
-      setOptionsVisible(true);
-    }
-
-    if (inputValue.length === 0) {
-      setOptions([]);
-      return;
-    }
-
-    setOptionMode(false);
-    setLastInput(inputValue);
-    debounceFetchValue(inputValue);
-  }
-
-  useEffect(() => {
-    if (!fetchValue) {
-      return;
-    }
-
-    fetch(
-      "/api/suggest?" +
-        new URLSearchParams({ type: "school", search: fetchValue }),
-      {
-        signal: controller.signal,
-        redirect: "manual",
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Correlation-ID": uuidv4(),
-        },
-      }
-    )
-      .then((res) => res.json())
-      .then((res) => {
-        if (res.error) {
-          throw res.error;
+    try {
+      const res = await fetch(
+        "/api/suggest?" +
+          new URLSearchParams({ type: "school", search: query }),
+        {
+          signal: controller.signal,
+          redirect: "manual",
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Correlation-ID": uuidv4(),
+          },
         }
+      );
 
-        return res;
-      })
-      .then((response) => {
-        const optsLocal = response;
-        setIndex(-1);
-        optsLocal.forEach((d: SuggestResult<SchoolDocument>) => {
-          d.text = d.text.replace(/\*(.*)\*/, "<b>$1</b>");
-        });
-        setOptions(optsLocal);
-      })
-      .catch(() => {});
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fetchValue]);
+      const response = await res.json();
+      if (response.error) {
+        throw response.error;
+      }
 
-  function hideOptions() {
-    setOptionsVisible(false);
-  }
-  function searchThis(e: React.MouseEvent<HTMLAnchorElement>) {
-    if (e.button !== 0) return;
-
-    fillSearch();
-  }
-
-  function onChange(e: React.ChangeEvent<HTMLInputElement>) {
-    setInputValue(e.target.value);
-  }
-
-  function optionMouseMove(idx: number) {
-    if (idx !== index) {
-      setIndex(idx);
+      return response;
+    } catch {
+      // do something?
     }
-  }
+
+    return [];
+  };
+
+  const handleSelected = (value: SuggestResult<SchoolDocument>) => {
+    controller.abort();
+    controller = new AbortController();
+    setInputValue(value.text.replace(/\*(.*)\*/, "$1"));
+    setSelectedUrn(value.document.urn);
+  };
 
   return (
     <div className="suggest-input">
-      <input
+      <AutoComplete<SuggestResult<SchoolDocument>>
+        defaultValue={inputValue}
         id="school-input"
-        ref={schoolInput}
-        className="govuk-input"
-        aria-label="schoolInput"
         name="schoolInput"
-        type="text"
-        value={inputValue}
-        onKeyDown={onKeyDown}
-        onKeyUp={onKeyPressed}
-        onBlur={hideOptions}
-        onChange={onChange}
-        autoComplete="off"
+        minLength={3}
+        onSelected={handleSelected}
+        onSuggest={handleSuggest}
+        suggestionFormatter={(item) =>
+          item ? item.text.replace(/\*(.*)\*/, "<b>$1</b>") : ""
+        }
+        valueFormatter={(item) =>
+          item ? item.text.replace(/\*(.*)\*/, "$1") : ""
+        }
       />
       <input value={selectedUrn} name="urn" type="hidden" />
-      {options.length > 0 && optionsVisible && (
-        <ul className="govuk-input" id="school-suggestions">
-          {options.map((item, idx) => {
-            return (
-              <li key={item.id}>
-                <a
-                  onMouseMove={() => {
-                    optionMouseMove(idx);
-                  }}
-                  className={index === idx ? "active" : ""}
-                  onMouseDown={searchThis}
-                  href="#"
-                  dangerouslySetInnerHTML={{ __html: item.text }}
-                />
-              </li>
-            );
-          })}
-        </ul>
-      )}
     </div>
   );
 };

--- a/front-end-components/src/views/find-organisation/partials/trust-input.tsx
+++ b/front-end-components/src/views/find-organisation/partials/trust-input.tsx
@@ -1,171 +1,81 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useState } from "react";
+import { AutoComplete } from "src/components/auto-complete";
 import {
   SuggestResult,
   TrustDocument,
   TrustInputProps,
-} from "src/views/find-organisation/types";
-import { useDebounceCallback } from "usehooks-ts";
+} from "src/views/find-organisation";
 import { v4 as uuidv4 } from "uuid";
 
-const TrustInput: React.FC<TrustInputProps> = (props) => {
+const TrustInput: React.FunctionComponent<TrustInputProps> = (props) => {
   const { input, companyNumber } = props;
 
-  const trustInput = useRef(null);
-
-  const [index, setIndex] = useState<number>(-1);
-  const [optionsVisible, setOptionsVisible] = useState<boolean>(false);
-  const [optionMode, setOptionMode] = useState<boolean>(false);
-  const [options, setOptions] = useState<SuggestResult<TrustDocument>[]>([]);
   const [inputValue, setInputValue] = useState<string>(input);
   const [selectedCompanyNumber, setSelectedCompanyNumber] =
     useState<string>(companyNumber);
-  const [lastInput, setLastInput] = useState<string>("");
-  const [fetchValue, setFetchValue] = useState<string>();
-  const debounceFetchValue = useDebounceCallback(setFetchValue, 500);
 
   let controller = new AbortController();
 
-  function fillSearch() {
-    if (index < 0) return;
-
-    setInputValue(options[index].text.replace(/(<([^>]+)>)/gi, ""));
-    setSelectedCompanyNumber(options[index].document.companyNumber);
-    setOptionsVisible(false);
-  }
-
-  function onKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
-    if (event.key === "Enter" && index > -1 && optionMode) {
-      fillSearch();
-    } else if (event.key === "ArrowDown") {
-      setOptionMode(true);
-      if (index + 1 < options.length) {
-        setIndex(index + 1);
-      }
-      event.preventDefault();
-    } else if (event.key === "ArrowUp") {
-      if (index >= 0) {
-        setOptionMode(true);
-        setIndex(index - 1);
-      }
-      event.preventDefault();
-    }
-  }
-
-  function onKeyPressed() {
+  const handleSuggest = async (query: string) => {
     controller.abort();
     controller = new AbortController();
 
-    if (inputValue === lastInput?.trim()) {
-      setOptionsVisible(true);
-      return;
-    } else if (!optionsVisible) {
-      setOptions([]);
-      setOptionsVisible(true);
-    }
-
-    if (inputValue.length === 0) {
-      setOptions([]);
-      return;
-    }
-
-    setOptionMode(false);
-    setLastInput(inputValue);
-    debounceFetchValue(inputValue);
-  }
-
-  useEffect(() => {
-    if (!fetchValue) {
-      return;
-    }
-
-    fetch(
-      "/api/suggest?" +
-        new URLSearchParams({ type: "trust", search: fetchValue }),
-      {
-        signal: controller.signal,
-        redirect: "manual",
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Correlation-ID": uuidv4(),
-        },
-      }
-    )
-      .then((res) => res.json())
-      .then((res) => {
-        if (res.error) {
-          throw res.error;
+    try {
+      const res = await fetch(
+        "/api/suggest?" + new URLSearchParams({ type: "trust", search: query }),
+        {
+          signal: controller.signal,
+          redirect: "manual",
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Correlation-ID": uuidv4(),
+          },
         }
+      );
 
-        return res;
-      })
-      .then((response) => {
-        const optsLocal = response;
-        setIndex(-1);
-        optsLocal.forEach((d: SuggestResult<TrustDocument>) => {
-          d.text = d.text.replace(/\*(.*)\*/, "<b>$1</b>");
-        });
-        setOptions(optsLocal);
-      })
-      .catch(() => {});
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fetchValue]);
+      const response = await res.json();
+      if (response.error) {
+        throw response.error;
+      }
 
-  function hideOptions() {
-    setOptionsVisible(false);
-  }
-  function searchThis(e: React.MouseEvent<HTMLAnchorElement>) {
-    if (e.button !== 0) return;
-
-    fillSearch();
-  }
-
-  function onChange(e: React.ChangeEvent<HTMLInputElement>) {
-    setInputValue(e.target.value);
-  }
-
-  function optionMouseMove(idx: number) {
-    if (idx !== index) {
-      setIndex(idx);
+      return response;
+    } catch {
+      // do something?
     }
-  }
+
+    return [];
+  };
+
+  const handleSelected = (value: SuggestResult<TrustDocument>) => {
+    controller.abort();
+    controller = new AbortController();
+
+    if (!value) {
+      return;
+    }
+
+    setInputValue(value.text.replace(/\*(.*)\*/, "$1"));
+    setSelectedCompanyNumber(value.document.companyNumber);
+  };
 
   return (
     <div className="suggest-input">
-      <input
+      <AutoComplete<SuggestResult<TrustDocument>>
+        defaultValue={inputValue}
         id="trust-input"
-        ref={trustInput}
-        className="govuk-input"
-        aria-label="trustInput"
         name="trustInput"
-        type="text"
-        value={inputValue}
-        onKeyDown={onKeyDown}
-        onKeyUp={onKeyPressed}
-        onBlur={hideOptions}
-        onChange={onChange}
-        autoComplete="off"
+        minLength={3}
+        onSelected={handleSelected}
+        onSuggest={handleSuggest}
+        suggestionFormatter={(item) =>
+          item?.text ? item.text.replace(/\*(.*)\*/, "<b>$1</b>") : ""
+        }
+        valueFormatter={(item) =>
+          item?.text ? item.text.replace(/\*(.*)\*/, "$1") : ""
+        }
       />
       <input value={selectedCompanyNumber} name="companyNumber" type="hidden" />
-      {options.length > 0 && optionsVisible && (
-        <ul className="govuk-input" id="trust-suggestions">
-          {options.map((item, idx) => {
-            return (
-              <li key={item.id}>
-                <a
-                  onMouseMove={() => {
-                    optionMouseMove(idx);
-                  }}
-                  className={index === idx ? "active" : ""}
-                  onMouseDown={searchThis}
-                  href="#"
-                  dangerouslySetInnerHTML={{ __html: item.text }}
-                />
-              </li>
-            );
-          })}
-        </ul>
-      )}
     </div>
   );
 };

--- a/front-end-components/src/views/find-organisation/partials/trust-input.tsx
+++ b/front-end-components/src/views/find-organisation/partials/trust-input.tsx
@@ -9,22 +9,15 @@ import { v4 as uuidv4 } from "uuid";
 
 const TrustInput: React.FunctionComponent<TrustInputProps> = (props) => {
   const { input, companyNumber } = props;
-
   const [inputValue, setInputValue] = useState<string>(input);
   const [selectedCompanyNumber, setSelectedCompanyNumber] =
     useState<string>(companyNumber);
 
-  let controller = new AbortController();
-
   const handleSuggest = async (query: string) => {
-    controller.abort();
-    controller = new AbortController();
-
     try {
       const res = await fetch(
         "/api/suggest?" + new URLSearchParams({ type: "trust", search: query }),
         {
-          signal: controller.signal,
           redirect: "manual",
           method: "GET",
           headers: {
@@ -48,9 +41,6 @@ const TrustInput: React.FunctionComponent<TrustInputProps> = (props) => {
   };
 
   const handleSelected = (value: SuggestResult<TrustDocument>) => {
-    controller.abort();
-    controller = new AbortController();
-
     if (!value) {
       return;
     }

--- a/web/src/Web.App/Views/Shared/_Layout.cshtml
+++ b/web/src/Web.App/Views/Shared/_Layout.cshtml
@@ -128,8 +128,7 @@
                         class="govuk-footer__link"
                         href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
                         rel="license">
-                        Open Government Licence v3.0
-                    </a>, except where otherwise stated
+                        Open Government Licence v3.0</a>, except where otherwise stated
                 </span>
             </div>
             <div class="govuk-footer__meta-item">

--- a/web/tests/Web.A11yTests/Pages/WhenViewingFindOrganisation.cs
+++ b/web/tests/Web.A11yTests/Pages/WhenViewingFindOrganisation.cs
@@ -10,9 +10,19 @@ public class WhenViewingFindOrganisation(
     WebDriver webDriver)
     : PageBase(testOutputHelper, webDriver)
 {
-    //known issues conditionally reveal https://design-system.service.gov.uk/components/radios/
     private readonly AxeRunContext _context = new()
-    { Exclude = [new AxeSelector("#school"), new AxeSelector("#trust")] };
+    {
+        // known issues
+        Exclude =
+        [
+            // conditionally reveal https://design-system.service.gov.uk/components/radios/
+            new AxeSelector("#school"),
+            new AxeSelector("#trust"),
+            // accessible-autocomplete component uses `aria-describedby` rather than an explicit label
+            new AxeSelector("#school-input"),
+            new AxeSelector("#trust-input")
+        ]
+    };
 
     protected override string PageUrl => "/find-organisation";
 

--- a/web/tests/Web.E2ETests/Features/FindOrganisation.feature
+++ b/web/tests/Web.E2ETests/Features/FindOrganisation.feature
@@ -4,4 +4,5 @@
         Given I am on find organisation page
         And 'school' organisation type is selected
         When I select the school with urn '118167' from suggester
+        When I click Continue
         Then the school homepage is displayed

--- a/web/tests/Web.E2ETests/Pages/FindOrganisationPage.cs
+++ b/web/tests/Web.E2ETests/Pages/FindOrganisationPage.cs
@@ -32,11 +32,17 @@ public class FindOrganisationPage(IPage page)
         await ContinueButton.ShouldBeVisible().ShouldBeEnabled();
     }
 
-    public async Task<HomePage> SelectSchoolFromSuggester(string text)
+    public async Task SelectSchoolFromSuggester(string text)
     {
         await SchoolSearchInputField.PressSequentially(text);
         await SchoolSuggestionsDropdown.ShouldBeVisible();
-        await SchoolSearchInputField.Press(ArrowDownKey).Press(EnterKey);
+        await SchoolSearchInputField.PressAsync(ArrowDownKey);
+        await page.Keyboard.PressAsync(EnterKey);
+    }
+    
+    public async Task<HomePage> ClickContinue()
+    {
+        await ContinueButton.ClickAsync();
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
         return new HomePage(page);
     }

--- a/web/tests/Web.E2ETests/Pages/FindOrganisationPage.cs
+++ b/web/tests/Web.E2ETests/Pages/FindOrganisationPage.cs
@@ -39,7 +39,7 @@ public class FindOrganisationPage(IPage page)
         await SchoolSearchInputField.PressAsync(ArrowDownKey);
         await page.Keyboard.PressAsync(EnterKey);
     }
-    
+
     public async Task<HomePage> ClickContinue()
     {
         await ContinueButton.ClickAsync();
@@ -56,5 +56,4 @@ public class FindOrganisationPage(IPage page)
         };
         await radioButton.Check();
     }
-
 }

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -82,7 +82,7 @@ public static class Selectors
     public const string SchoolNamesLinksInCharts = "text.recharts-text.govuk-link";
     public const string ChartBars = ".recharts-surface path.recharts-rectangle.chart-cell";
 
-    public const string SchoolSuggestDropdown = "#school-suggestions";
+    public const string SchoolSuggestDropdown = "#school-input__listbox";
     public const string MainContent = "#main-content";
     public const string GovukTag = ".govuk-tag";
 

--- a/web/tests/Web.E2ETests/Steps/FindOrganisationSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/FindOrganisationSteps.cs
@@ -29,7 +29,7 @@ public class FindOrganisationSteps(PageDriver driver)
         Assert.NotNull(_findOrganisationPage);
         await _findOrganisationPage.SelectSchoolFromSuggester(urn);
     }
-    
+
     [When("I click Continue")]
     public async Task WhenIClickContinue()
     {
@@ -53,5 +53,4 @@ public class FindOrganisationSteps(PageDriver driver)
     }
 
     private static string FindOrganisationUrl() => $"{TestConfiguration.ServiceUrl}/find-organisation";
-
 }

--- a/web/tests/Web.E2ETests/Steps/FindOrganisationSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/FindOrganisationSteps.cs
@@ -27,7 +27,14 @@ public class FindOrganisationSteps(PageDriver driver)
     public async Task WhenISelectTheSchoolWithUrnFromSuggester(string urn)
     {
         Assert.NotNull(_findOrganisationPage);
-        _schoolHomePage = await _findOrganisationPage.SelectSchoolFromSuggester(urn);
+        await _findOrganisationPage.SelectSchoolFromSuggester(urn);
+    }
+    
+    [When("I click Continue")]
+    public async Task WhenIClickContinue()
+    {
+        Assert.NotNull(_findOrganisationPage);
+        _schoolHomePage = await _findOrganisationPage.ClickContinue();
     }
 
     [Then("the school homepage is displayed")]


### PR DESCRIPTION
### Context
[AB#207281](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/207281) [AB#206189](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/206189)

### Change proposed in this pull request
Replace School and Trust search suggesters with `<AccessibleAutocomplete>` component from `alphagov`.

### Guidance to review 
Functionally, this component should work exactly the same as the previous iteration. This includes the accessibility support.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

