### PR TITLE
adds local authority commercial resources page

### DIFF
--- a/web/src/Web.App/Controllers/LocalAuthorityResourcesController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityResourcesController.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Web.App.Infrastructure.Apis;
+
+namespace Web.App.Controllers;
+
+[Controller]
+[Route("local-authority/{code}/find-ways-to-spend-less")]
+public class LocalAuthorityResourcesController(
+    ILogger<LocalAuthorityResourcesController> logger) : Controller
+{
+    [HttpGet]
+    public IActionResult Index(string code)
+    {
+
+        using (logger.BeginScope(new { code }))
+        {
+            try
+            {
+                return View();
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "An error displaying local authority resources: {DisplayUrl}", Request.GetDisplayUrl());
+                return e is StatusCodeException s ? StatusCode((int)s.Status) : StatusCode(500);
+            }
+        }
+    }
+}

--- a/web/src/Web.App/ViewModels/LocalAuthorityResourcesViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityResourcesViewModel.cs
@@ -1,0 +1,9 @@
+﻿using Web.App.Domain;
+
+namespace Web.App.ViewModels;
+
+public class LocalAuthorityResourcesViewModel(LocalAuthority localAuthority)
+{
+    public string? Code => localAuthority.Code;
+    public string? Name => localAuthority.Name;
+}

--- a/web/src/Web.App/Views/LocalAuthorityResources/index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityResources/index.cshtml
@@ -1,0 +1,18 @@
+﻿@using Web.App.TagHelpers
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.Resources;
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        @await Html.PartialAsync("CommercialResource/AllResources")
+    </div>
+</div>
+
+@section scripts
+{
+    <script type="module" add-nonce="true">
+        import { initAll } from '/js/govuk-frontend.min.js'
+        initAll()
+    </script>
+}


### PR DESCRIPTION
### Context
[AB#199506](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/199506) - [AB#203890](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/203890)

### Change proposed in this pull request
Adds model, view and controller for this page.

### Guidance to review 
View model is currently unused. Controller currently just returns the view without any local authority data. Due to this EstablishmentHeading also is missing from the view. Backlink is also missing. I propose if there are no objections that these are all picked up as tech debt when the rest of the local authority journey is built next sprint. I will add a ticket for this after review.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

