### PR TITLE
Added `<noscript>` block to Find Organisation page

### DIFF
--- a/web/src/Web.App/Views/FindOrganisation/Index.cshtml
+++ b/web/src/Web.App/Views/FindOrganisation/Index.cshtml
@@ -9,6 +9,22 @@
         <h1 class="govuk-heading-l">@ViewData[ViewDataKeys.Title]</h1>
     </div>
 </div>
+
+<noscript>
+    <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+            <span class="govuk-visually-hidden">Warning</span>
+            Your browser does not meet the minimum requirements to use this service.
+        </strong>
+    </div>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>
+            Please ensure that JavaScript is enabled.
+        </li>
+    </ul>
+</noscript>
+
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <div id="find-organisation"


### PR DESCRIPTION
### Context
[AB#207282](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/207282) [AB#206189](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/206189)

### Change proposed in this pull request
Warning message displayed to user on the above page if JavaScript is disabled, rather than showing a blank page.

### Guidance to review 
Validate with/without JavaScript enabled.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

