### PR TITLE
Explicitly set `Teachers with qualified teacher status` to be a percentage value unit dimension

### DIFF
--- a/front-end-components/src/components/charts/utils.test.ts
+++ b/front-end-components/src/components/charts/utils.test.ts
@@ -172,6 +172,23 @@ describe("Chart utils", () => {
       });
     });
 
+    describe("with percent option", () => {
+      const options: Partial<ValueFormatterOptions> = { valueUnit: "%" };
+
+      it("formats the values as percent", () => {
+        const result = values.map((v) => statValueFormatter(v, options));
+        expect(result).toEqual([
+          "-988%",
+          "0%",
+          "1%",
+          "2%",
+          "12,346%",
+          "890,123,456%",
+          "not-a-number",
+        ]);
+      });
+    });
+
     describe("with currency as name option", () => {
       const options: Partial<ValueFormatterOptions> = {
         valueUnit: "currency",

--- a/front-end-components/src/components/charts/utils.ts
+++ b/front-end-components/src/components/charts/utils.ts
@@ -51,11 +51,16 @@ export function statValueFormatter(
   return new Intl.NumberFormat("en-GB", {
     notation: options?.compact ? "compact" : undefined,
     compactDisplay: options?.compact ? "short" : undefined,
-    style: options?.valueUnit === "currency" ? "currency" : undefined,
+    style:
+      options?.valueUnit === "currency"
+        ? "currency"
+        : options?.valueUnit === "%"
+          ? "percent"
+          : undefined,
     currency: options?.valueUnit === "currency" ? "GBP" : undefined,
     currencyDisplay: options?.currencyAsName ? "name" : "symbol",
     maximumFractionDigits: options?.compact ? undefined : 0,
   })
-    .format(value)
+    .format(options?.valueUnit === "%" ? value / 100 : value)
     .toLowerCase();
 }

--- a/front-end-components/src/composed/historic-chart-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/component.tsx
@@ -3,7 +3,10 @@ import { ChartModeChart } from "src/components";
 import { HistoricChartProps } from "src/composed/historic-chart-composed";
 import { ChartModeContext } from "src/contexts";
 import { LineChart } from "src/components/charts/line-chart";
-import { shortValueFormatter } from "src/components/charts/utils.ts";
+import {
+  shortValueFormatter,
+  statValueFormatter,
+} from "src/components/charts/utils.ts";
 import { LineChartTooltip } from "src/components/charts/line-chart-tooltip";
 import { ResolvedStat } from "src/components/charts/resolved-stat";
 import { ChartDataSeries } from "src/components/charts/types";
@@ -15,6 +18,7 @@ export const HistoricChart: React.FC<HistoricChartProps<ChartDataSeries>> = ({
   seriesConfig,
   valueField,
   children,
+  valueUnit,
 }) => {
   const mode = useContext(ChartModeContext);
   const dimension = useContext(ChartDimensionContext);
@@ -37,7 +41,7 @@ export const HistoricChart: React.FC<HistoricChartProps<ChartDataSeries>> = ({
                 seriesLabel={dimension.label}
                 seriesLabelField="term"
                 valueFormatter={shortValueFormatter}
-                valueUnit={dimension.unit}
+                valueUnit={valueUnit ?? dimension.unit}
                 tooltip={(t) => (
                   <LineChartTooltip
                     {...t}
@@ -58,8 +62,12 @@ export const HistoricChart: React.FC<HistoricChartProps<ChartDataSeries>> = ({
               displayIndex={data.length - 1}
               seriesLabelField="term"
               valueField={valueField}
-              valueFormatter={shortValueFormatter}
-              valueUnit={dimension.unit}
+              valueFormatter={(v) =>
+                statValueFormatter(v, {
+                  valueUnit: valueUnit ?? dimension.unit,
+                })
+              }
+              valueUnit={valueUnit ?? dimension.unit}
             />
           </aside>
         </div>

--- a/front-end-components/src/composed/historic-chart-composed/types.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/types.tsx
@@ -1,5 +1,9 @@
 import { ReactNode } from "react";
-import { ChartDataSeries, ChartProps } from "src/components/charts/types";
+import {
+  ChartDataSeries,
+  ChartProps,
+  ChartSeriesValueUnit,
+} from "src/components/charts/types";
 import { ResolvedStatProps } from "src/components/charts/resolved-stat";
 
 export interface HistoricChartProps<T extends ChartDataSeries> {
@@ -8,4 +12,5 @@ export interface HistoricChartProps<T extends ChartDataSeries> {
   seriesConfig: ChartProps<T>["seriesConfig"];
   valueField: ResolvedStatProps<T>["valueField"];
   children?: ReactNode;
+  valueUnit?: ChartSeriesValueUnit;
 }

--- a/front-end-components/src/views/historic-data/partials/census-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/census-section.tsx
@@ -152,9 +152,10 @@ export const CensusSection: React.FC<{ id: string }> = ({ id }) => {
                 },
               }}
               valueField="teachersQualified"
+              valueUnit="%"
             >
               <h2 className="govuk-heading-m">
-                Teachers with qualified teacher status
+                Teachers with qualified teacher status (%)
               </h2>
             </HistoricChart>
 


### PR DESCRIPTION
### Context
[AB#207445](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/207445) [AB#207564](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/207564)

### Change proposed in this pull request
`Teachers with qualified teacher status` chart to include `%` on the y-axis where previously this was missing. Update `statValueFormatter()` to support percentage value units.

### Guidance to review 
To validate locally, browse to `/school/123456/history#census` and find the `Teachers with qualified teacher status (%)` chart. The y-axis and 'stat' should include `%`.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

