### PR TITLE
Added Local Authority search to Find Organisation page

### DIFF
--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -57,7 +57,7 @@ const findOrganisationElement = document.getElementById(
 );
 
 if (findOrganisationElement) {
-  const { findMethod, schoolInput, schoolError, trustError, urn } =
+  const { findMethod, laError, schoolInput, schoolError, trustError, urn } =
     findOrganisationElement.dataset;
   if (findMethod) {
     const root = ReactDOM.createRoot(findOrganisationElement);
@@ -66,6 +66,7 @@ if (findOrganisationElement) {
       <React.StrictMode>
         <FindOrganisation
           findMethod={findMethod}
+          laError={laError}
           schoolInput={schoolInput}
           schoolError={schoolError}
           trustError={trustError}

--- a/front-end-components/src/views/find-organisation/partials/la-input.tsx
+++ b/front-end-components/src/views/find-organisation/partials/la-input.tsx
@@ -1,22 +1,22 @@
 import React, { useState } from "react";
 import { AutoComplete } from "src/components/auto-complete";
 import {
-  SchoolDocument,
-  SchoolInputProps,
+  LaDocument,
+  LaInputProps,
   SuggestResult,
 } from "src/views/find-organisation";
 import { v4 as uuidv4 } from "uuid";
 
-const SchoolInput: React.FunctionComponent<SchoolInputProps> = (props) => {
-  const { input, urn } = props;
+const LaInput: React.FunctionComponent<LaInputProps> = (props) => {
+  const { input, code } = props;
   const [inputValue, setInputValue] = useState<string>(input);
-  const [selectedUrn, setSelectedUrn] = useState<string>(urn);
+  const [selectedCode, setSelectedCode] = useState<string>(code);
 
   const handleSuggest = async (query: string) => {
     try {
       const res = await fetch(
         "/api/suggest?" +
-          new URLSearchParams({ type: "school", search: query }),
+          new URLSearchParams({ type: "local-authority", search: query }),
         {
           redirect: "manual",
           method: "GET",
@@ -40,21 +40,21 @@ const SchoolInput: React.FunctionComponent<SchoolInputProps> = (props) => {
     return [];
   };
 
-  const handleSelected = (value: SuggestResult<SchoolDocument>) => {
+  const handleSelected = (value: SuggestResult<LaDocument>) => {
     if (!value) {
       return;
     }
 
     setInputValue(value.document.name);
-    setSelectedUrn(value.document.urn);
+    setSelectedCode(value.document.code);
   };
 
   return (
     <div className="suggest-input">
-      <AutoComplete<SuggestResult<SchoolDocument>>
+      <AutoComplete<SuggestResult<LaDocument>>
         defaultValue={inputValue}
-        id="school-input"
-        name="schoolInput"
+        id="la-input"
+        name="laInput"
         minLength={3}
         onSelected={handleSelected}
         onSuggest={handleSuggest}
@@ -63,9 +63,9 @@ const SchoolInput: React.FunctionComponent<SchoolInputProps> = (props) => {
         }
         valueFormatter={(item) => item?.document?.name ?? ""}
       />
-      <input value={selectedUrn} name="urn" type="hidden" />
+      <input value={selectedCode} name="code" type="hidden" />
     </div>
   );
 };
 
-export default SchoolInput;
+export default LaInput;

--- a/front-end-components/src/views/find-organisation/partials/trust-input.tsx
+++ b/front-end-components/src/views/find-organisation/partials/trust-input.tsx
@@ -45,7 +45,7 @@ const TrustInput: React.FunctionComponent<TrustInputProps> = (props) => {
       return;
     }
 
-    setInputValue(value.text.replace(/\*(.*)\*/, "$1"));
+    setInputValue(value.document.name);
     setSelectedCompanyNumber(value.document.companyNumber);
   };
 
@@ -61,9 +61,7 @@ const TrustInput: React.FunctionComponent<TrustInputProps> = (props) => {
         suggestionFormatter={(item) =>
           item?.text ? item.text.replace(/\*(.*)\*/, "<b>$1</b>") : ""
         }
-        valueFormatter={(item) =>
-          item?.text ? item.text.replace(/\*(.*)\*/, "$1") : ""
-        }
+        valueFormatter={(item) => item?.document?.name ?? ""}
       />
       <input value={selectedCompanyNumber} name="companyNumber" type="hidden" />
     </div>

--- a/front-end-components/src/views/find-organisation/types.tsx
+++ b/front-end-components/src/views/find-organisation/types.tsx
@@ -4,13 +4,16 @@ export type TrustInputProps = {
 };
 
 export type FindOrganisationProps = {
-  findMethod: string;
-  schoolInput?: string;
-  schoolError?: string;
-  trustInput?: string;
-  trustError?: string;
-  urn?: string;
+  code?: string;
   companyNumber?: string;
+  findMethod: string;
+  laError?: string;
+  laInput?: string;
+  schoolError?: string;
+  schoolInput?: string;
+  trustError?: string;
+  trustInput?: string;
+  urn?: string;
 };
 
 export type SchoolInputProps = {
@@ -24,10 +27,57 @@ export type SuggestResult<T> = {
   document: T;
 };
 
+export type LaInputProps = {
+  input: string;
+  code: string;
+};
+
+/**
+ * @example 
+    {
+      "text": "*Harrow* Way Community School",
+      "document": {
+        "urn": "116431",
+        "name": "Harrow Way Community School",
+        "town": "Andover",
+        "postcode": "SP10 3RH",
+        "hasSixthForm": false
+      }
+    }
+ */
 export type SchoolDocument = {
+  hasSixthForm: boolean;
+  name: string;
+  postcode: string;
+  town: string;
   urn: string;
 };
 
+/**
+ * @example
+    {
+      "text": "*Advantage* Multi Academy Trust",
+      "document": {
+        "companyNumber": "10969334",
+        "name": "Advantage Multi Academy Trust"
+      }
+    }
+ */
 export type TrustDocument = {
   companyNumber: string;
+  name: string;
+};
+
+/**
+ * @example {
+      "text": "Redcar *and* Cleveland",
+      "document": {
+        "code": "807",
+        "name": "Redcar and Cleveland"
+      }
+    }
+ */
+export type LaDocument = {
+  code: string;
+  name: string;
 };

--- a/front-end-components/src/views/find-organisation/view.tsx
+++ b/front-end-components/src/views/find-organisation/view.tsx
@@ -3,16 +3,20 @@ import SchoolInput from "src/views/find-organisation/partials/school-input";
 import { FindOrganisationProps } from "src/views/find-organisation";
 import TrustInput from "src/views/find-organisation/partials/trust-input";
 import { useGovUk } from "src/hooks/useGovUk";
+import LaInput from "src/views/find-organisation/partials/la-input";
 
 export const FindOrganisation: React.FC<FindOrganisationProps> = (props) => {
   const {
+    code,
+    companyNumber,
     findMethod,
-    schoolInput,
+    laError,
+    laInput,
     schoolError,
+    schoolInput,
+    trustInput,
     trustError,
     urn,
-    trustInput,
-    companyNumber,
   } = props;
 
   const formElem = useRef(null);
@@ -64,6 +68,7 @@ export const FindOrganisation: React.FC<FindOrganisationProps> = (props) => {
                 <SchoolInput input={schoolInput ?? ""} urn={urn ?? ""} />
               </div>
             </div>
+
             <div className="govuk-radios__item">
               <input
                 className="govuk-radios__input"
@@ -102,6 +107,44 @@ export const FindOrganisation: React.FC<FindOrganisationProps> = (props) => {
                   input={trustInput ?? ""}
                   companyNumber={companyNumber ?? ""}
                 />
+              </div>
+            </div>
+
+            <div className="govuk-radios__item">
+              <input
+                className="govuk-radios__input"
+                id="local-authority"
+                name="findMethod"
+                type="radio"
+                value="local-authority"
+                defaultChecked={findMethod === "local-authority"}
+                data-aria-controls="conditional-local-authority"
+              />
+              <label
+                className="govuk-label govuk-radios__label"
+                htmlFor="local-authority"
+              >
+                Local authority
+              </label>
+            </div>
+            <div
+              className="govuk-radios__conditional govuk-radios__conditional--hidden"
+              id="conditional-local-authority"
+            >
+              <div
+                className={
+                  laError
+                    ? "govuk-form-group suggest-form-group govuk-form-group--error"
+                    : "govuk-form-group suggest-form-group"
+                }
+              >
+                <div id="local-authority-hint" className="govuk-hint">
+                  Name or 3 digit code
+                </div>
+                <p id="local-authority-error" className="govuk-error-message">
+                  {laError}
+                </p>
+                <LaInput input={laInput ?? ""} code={code ?? ""} />
               </div>
             </div>
           </div>

--- a/web/src/Web.App/Controllers/FindOrganisationController.cs
+++ b/web/src/Web.App/Controllers/FindOrganisationController.cs
@@ -51,6 +51,20 @@ public class FindOrganisationController(ILogger<FindOrganisationController> logg
 
                             return RedirectToAction("Index", "Trust", new { companyNumber = viewModel.CompanyNumber });
                         }
+                    case OrganisationTypes.LocalAuthority:
+                        {
+                            if (string.IsNullOrWhiteSpace(viewModel.Code) || string.IsNullOrEmpty(viewModel.LaInput))
+                            {
+                                var message = string.IsNullOrEmpty(viewModel.LaInput)
+                                    ? "Enter a name or 3 digit code"
+                                    : "Please select a local authority from the suggester";
+                                ModelState.AddModelError("la-input", message);
+                                return View(viewModel);
+                            }
+
+                            // todo: create and link to LA target route
+                            return RedirectToAction("Index", "Home", new { code = viewModel.Code });
+                        }
                     default:
                         throw new ArgumentOutOfRangeException(nameof(viewModel.FindMethod));
                 }
@@ -58,7 +72,7 @@ public class FindOrganisationController(ILogger<FindOrganisationController> logg
             catch (Exception e)
             {
                 logger.LogError(e, "An error occurred finding an organisation: {DisplayUrl}", Request.GetDisplayUrl());
-                return StatusCode(500);
+                return StatusCode(StatusCodes.Status400BadRequest);
             }
         }
     }

--- a/web/src/Web.App/ViewModels/FindOrganisationViewModel.cs
+++ b/web/src/Web.App/ViewModels/FindOrganisationViewModel.cs
@@ -2,9 +2,11 @@ namespace Web.App.ViewModels;
 
 public class FindOrganisationViewModel
 {
-    public string FindMethod { get; set; } = OrganisationTypes.School;
-    public string? SchoolInput { get; set; }
-    public string? Urn { get; set; }
-    public string? TrustInput { get; set; }
+    public string? Code { get; set; }
     public string? CompanyNumber { get; set; }
+    public string FindMethod { get; set; } = OrganisationTypes.School;
+    public string? LaInput { get; set; }
+    public string? SchoolInput { get; set; }
+    public string? TrustInput { get; set; }
+    public string? Urn { get; set; }
 }

--- a/web/src/Web.App/Views/FindOrganisation/Index.cshtml
+++ b/web/src/Web.App/Views/FindOrganisation/Index.cshtml
@@ -28,13 +28,16 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <div id="find-organisation"
-             data-find-method="@Model.FindMethod"
-             data-urn="@Model.Urn"
              data-company-number="@Model.CompanyNumber"
-             data-school-input="@Model.SchoolInput"
+             data-find-method="@Model.FindMethod"
+             data-la-error="@ViewData.ModelState["la-input"]?.Errors.FirstOrDefault()?.ErrorMessage"
+             data-la-input="@Model.LaInput"
              data-school-error="@ViewData.ModelState["school-input"]?.Errors.FirstOrDefault()?.ErrorMessage"
+             data-school-input="@Model.SchoolInput"
+             data-trust-error="@ViewData.ModelState["trust-input"]?.Errors.FirstOrDefault()?.ErrorMessage"
              data-trust-input="@Model.TrustInput"
-             data-trust-error="@ViewData.ModelState["trust-input"]?.Errors.FirstOrDefault()?.ErrorMessage">
+             data-urn="@Model.Urn"
+        >
         </div>
     </div>
 </div>

--- a/web/tests/Web.A11yTests/Pages/WhenViewingFindOrganisation.cs
+++ b/web/tests/Web.A11yTests/Pages/WhenViewingFindOrganisation.cs
@@ -16,9 +16,11 @@ public class WhenViewingFindOrganisation(
         Exclude =
         [
             // conditionally reveal https://design-system.service.gov.uk/components/radios/
+            new AxeSelector("#local-authority"),
             new AxeSelector("#school"),
             new AxeSelector("#trust"),
             // accessible-autocomplete component uses `aria-describedby` rather than an explicit label
+            new AxeSelector("#la-input"),
             new AxeSelector("#school-input"),
             new AxeSelector("#trust-input")
         ]
@@ -27,6 +29,7 @@ public class WhenViewingFindOrganisation(
     protected override string PageUrl => "/find-organisation";
 
     [Theory]
+    [InlineData("local-authority")]
     [InlineData("school")]
     [InlineData("trust")]
     public async Task ThenThereAreNoAccessibilityIssues(string organisationType)
@@ -37,6 +40,7 @@ public class WhenViewingFindOrganisation(
     }
 
     [Theory]
+    [InlineData("local-authority")]
     [InlineData("school")]
     [InlineData("trust")]
     public async Task ValidationErrorThenThereAreNoAccessibilityIssues(string organisationType)


### PR DESCRIPTION
### Context
[AB#207649](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/207649) [AB#206189](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/206189)

### Change proposed in this pull request
Added the ability to search by Local Authority on the Find Organisation page.

### Guidance to review 
LA search should function in a similar way to the School and Trust search. The suggestions on matching name or code should appear for the user to select from. Validation errors should be displayed in the same way. Once the form is successfully submitted, it is currently intentional that the home page is redirected to in lieu of the Local Authority landing page (see the `todo`).

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

