### PR TITLE
Fixed ResolvedStat formatting in historical chart composed

### DIFF
--- a/front-end-components/src/composed/historic-chart-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/component.tsx
@@ -65,11 +65,7 @@ export const HistoricChart: React.FC<HistoricChartProps<ChartDataSeries>> = ({
               displayIndex={data.length - 1}
               seriesLabelField="term"
               valueField={valueField}
-              valueFormatter={(v) =>
-                statValueFormatter(v, {
-                  valueUnit: valueUnit ?? dimension.unit,
-                })
-              }
+              valueFormatter={statValueFormatter}
               valueUnit={valueUnit ?? dimension.unit}
             />
           </aside>


### PR DESCRIPTION
### Context
[AB#207445](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/207445) [AB#207564](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/207564)

### Change proposed in this pull request
Bug fix for Stat formatting after earlier formatting fix to historical charts. Ensures options correctly passed to formatter.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

