### PR TITLE
bugfix: explicitly set column header

### DIFF
--- a/front-end-components/src/composed/historic-chart-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/component.tsx
@@ -19,7 +19,8 @@ export const HistoricChart: React.FC<HistoricChartProps<ChartDataSeries>> = ({
   valueField,
   children,
   valueUnit,
-  label,
+  axisLabel,
+  columnHeading,
 }) => {
   const mode = useContext(ChartModeContext);
   const dimension = useContext(ChartDimensionContext);
@@ -39,7 +40,7 @@ export const HistoricChart: React.FC<HistoricChartProps<ChartDataSeries>> = ({
                 keyField="term"
                 margin={20}
                 seriesConfig={seriesConfig}
-                seriesLabel={label ?? dimension.label}
+                seriesLabel={axisLabel ?? dimension.label}
                 seriesLabelField="term"
                 valueFormatter={shortValueFormatter}
                 valueUnit={valueUnit ?? dimension.unit}
@@ -79,7 +80,9 @@ export const HistoricChart: React.FC<HistoricChartProps<ChartDataSeries>> = ({
                   <th className="govuk-table__header govuk-!-width-one-half">
                     Year
                   </th>
-                  <th className="govuk-table__header">{dimension.heading}</th>
+                  <th className="govuk-table__header">
+                    {columnHeading ?? dimension.heading}
+                  </th>
                 </tr>
               </thead>
               <tbody className="govuk-table__body">

--- a/front-end-components/src/composed/historic-chart-composed/types.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/types.tsx
@@ -13,5 +13,6 @@ export interface HistoricChartProps<T extends ChartDataSeries> {
   valueField: ResolvedStatProps<T>["valueField"];
   children?: ReactNode;
   valueUnit?: ChartSeriesValueUnit;
-  label?: string;
+  axisLabel?: string;
+  columnHeading?: string;
 }

--- a/front-end-components/src/views/historic-data/partials/census-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/census-section.tsx
@@ -76,7 +76,8 @@ export const CensusSection: React.FC<{ id: string }> = ({ id }) => {
               }}
               valueField="numberOfPupils"
               valueUnit="amount"
-              label="total"
+              axisLabel="total"
+              columnHeading="Total"
             >
               <h2 className="govuk-heading-m">Pupils on roll</h2>
             </HistoricChart>
@@ -155,7 +156,8 @@ export const CensusSection: React.FC<{ id: string }> = ({ id }) => {
               }}
               valueField="teachersQualified"
               valueUnit="%"
-              label="percentage"
+              axisLabel="percentage"
+              columnHeading="Percent"
             >
               <h2 className="govuk-heading-m">
                 Teachers with qualified teacher status (%)


### PR DESCRIPTION
### Context
Fixes incorrect column headers show on historic data - explicitly sets column header for qualified status and pupils on roll
