### PR TITLE
Resolved percentage formatting in composed horizontal bar chart

### DIFF
--- a/front-end-components/src/components/charts/utils.test.ts
+++ b/front-end-components/src/components/charts/utils.test.ts
@@ -118,6 +118,23 @@ describe("Chart utils", () => {
         ]);
       });
     });
+
+    describe("with percent option", () => {
+      const options: Partial<ValueFormatterOptions> = { valueUnit: "%" };
+
+      it("formats the values using compact notation as percent", () => {
+        const result = values.map((v) => shortValueFormatter(v, options));
+        expect(result).toEqual([
+          "-987.7%",
+          "0%",
+          "1%",
+          "2.3%",
+          "12,345.7%",
+          "890,123,456%",
+          "not-a-number",
+        ]);
+      });
+    });
   });
 
   describe("statValueFormatter()", () => {

--- a/front-end-components/src/components/charts/utils.ts
+++ b/front-end-components/src/components/charts/utils.ts
@@ -30,13 +30,18 @@ export function shortValueFormatter(
   }
 
   return new Intl.NumberFormat("en-GB", {
-    notation: "compact",
-    compactDisplay: "short",
-    style: options?.valueUnit === "currency" ? "currency" : undefined,
+    notation: options?.valueUnit === "%" ? undefined : "compact",
+    compactDisplay: options?.valueUnit === "%" ? undefined : "short",
+    style:
+      options?.valueUnit === "currency"
+        ? "currency"
+        : options?.valueUnit === "%"
+          ? "percent"
+          : undefined,
     currency: options?.valueUnit === "currency" ? "GBP" : undefined,
     maximumFractionDigits: options?.valueUnit === "currency" ? undefined : 1,
   })
-    .format(value)
+    .format(options?.valueUnit === "%" ? value / 100 : value)
     .toLowerCase();
 }
 

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -95,7 +95,9 @@ export function HorizontalBarChartWrapper<TData extends SchoolChartData>(
                         value: {
                           visible: true,
                           valueFormatter: (v: number) =>
-                            shortValueFormatter(v, { valueUnit }),
+                            shortValueFormatter(v, {
+                              valueUnit: valueUnit ?? dimension.unit,
+                            }),
                         },
                       } as object // todo: fix typing issue
                     }
@@ -117,7 +119,7 @@ export function HorizontalBarChartWrapper<TData extends SchoolChartData>(
                     tooltip={(t) => <SchoolCensusTooltip {...t} />}
                     valueFormatter={shortValueFormatter}
                     valueLabel={dimension.label}
-                    valueUnit={valueUnit}
+                    valueUnit={valueUnit ?? dimension.unit}
                   />
                 </div>
               )}

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/administrative-supplies.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/administrative-supplies.tsx
@@ -86,7 +86,6 @@ export const AdministrativeSupplies: React.FC<AdministrativeSuppliesProps> = ({
           <HorizontalBarChartWrapper
             data={administrativeSuppliesBarData}
             chartName="administrative supplies (non-eductional)"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">
               Administrative supplies (Non-educational)

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
@@ -139,7 +139,6 @@ export const CateringStaffServices: React.FC<CateringStaffServicesProps> = ({
           <HorizontalBarChartWrapper
             data={netCateringBarData}
             chartName="net catering costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Net catering costs</h3>
             <ChartDimensions
@@ -152,21 +151,18 @@ export const CateringStaffServices: React.FC<CateringStaffServicesProps> = ({
           <HorizontalBarChartWrapper
             data={cateringStaffBarData}
             chartName="catering staff costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Catering staff costs</h3>
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper
             data={cateringSuppliesBarData}
             chartName="catering supplies costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Catering supplies costs</h3>
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper
             data={incomeCateringBarData}
             chartName="income from catering"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Income from catering</h3>
           </HorizontalBarChartWrapper>

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-ict.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-ict.tsx
@@ -84,7 +84,6 @@ export const EducationalIct: React.FC<EducationalIctProps> = ({ schools }) => {
           <HorizontalBarChartWrapper
             data={learningResourcesBarData}
             chartName="eductional learning resources costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">
               Educational learning resources costs

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-supplies.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-supplies.tsx
@@ -139,7 +139,6 @@ export const EducationalSupplies: React.FC<EducationalSuppliesProps> = ({
           <HorizontalBarChartWrapper
             data={totalEducationalSuppliesBarData}
             chartName="total educational supplies costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">
               Total educational supplies costs
@@ -154,14 +153,12 @@ export const EducationalSupplies: React.FC<EducationalSuppliesProps> = ({
           <HorizontalBarChartWrapper
             data={examinationFeesBarData}
             chartName="examination fees costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Examination fees costs</h3>
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper
             data={breakdownEducationalBarData}
             chartName="breakdown of eductional supplies costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">
               Breakdown of educational supplies costs
@@ -170,7 +167,6 @@ export const EducationalSupplies: React.FC<EducationalSuppliesProps> = ({
           <HorizontalBarChartWrapper
             data={learningResourcesBarData}
             chartName="learning resource (not ICT equipment) costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">
               Learning resources (not ICT equipment) costs

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/non-educational-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/non-educational-support-staff.tsx
@@ -156,7 +156,6 @@ export const NonEducationalSupportStaff: React.FC<
           <HorizontalBarChartWrapper
             data={totalNonEducationalBarData}
             chartName="total non-educational support staff costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">
               Total non-educational support staff costs
@@ -171,7 +170,6 @@ export const NonEducationalSupportStaff: React.FC<
           <HorizontalBarChartWrapper
             data={administrativeClericalBarData}
             chartName="administrative and clerical staff costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">
               Administrative and clerical staff costs
@@ -180,21 +178,18 @@ export const NonEducationalSupportStaff: React.FC<
           <HorizontalBarChartWrapper
             data={auditorsCostsBarData}
             chartName="auditors costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Auditors costs</h3>
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper
             data={otherStaffCostsBarData}
             chartName="other staff costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Other staff costs</h3>
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper
             data={professionalServicesBarData}
             chartName="profession services (non-curriculum) costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">
               Professional services (non-curriculum) costs

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/other-costs.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/other-costs.tsx
@@ -307,7 +307,6 @@ export const OtherCosts: React.FC<OtherCostsProps> = ({ schools }) => {
           <HorizontalBarChartWrapper
             data={totalOtherCostsBarData}
             chartName="total other costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Total other costs</h3>
             <ChartDimensions
@@ -320,35 +319,30 @@ export const OtherCosts: React.FC<OtherCostsProps> = ({ schools }) => {
           <HorizontalBarChartWrapper
             data={otherInsurancePremiumsCostsBarData}
             chartName="other insurance premiums costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Other insurance premiums costs</h3>
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper
             data={directRevenueFinancingCostsBarData}
             chartName="direct revenue financing costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Direct revenue financing costs</h3>
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper
             data={groundsMaintenanceCostsBarData}
             chartName="ground maintenance costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Ground maintenance costs</h3>
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper
             data={indirectEmployeeExpensesBarData}
             chartName="indirect employee expenses"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Indirect employee expenses</h3>
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper
             data={interestChargesLoanBankBarData}
             chartName="interest charges for loan and bank"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">
               Interest charges for loan and bank
@@ -357,28 +351,24 @@ export const OtherCosts: React.FC<OtherCostsProps> = ({ schools }) => {
           <HorizontalBarChartWrapper
             data={privateFinanceInitiativeChargesBarData}
             chartName="PFI charges"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">PFI charges</h3>
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper
             data={rentRatesCostsBarData}
             chartName="rent and rates costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Rent and rates costs</h3>
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper
             data={specialFacilitiesCostsBarData}
             chartName="special facilities costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Special facilities costs</h3>
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper
             data={staffDevelopmentTrainingCostsBarData}
             chartName="staff development and training costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">
               Staff development and training costs
@@ -387,21 +377,18 @@ export const OtherCosts: React.FC<OtherCostsProps> = ({ schools }) => {
           <HorizontalBarChartWrapper
             data={staffRelatedInsuranceCostsBarData}
             chartName="staff-related insurance costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Staff-related insurance costs</h3>
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper
             data={supplyTeacherInsurableCostsBarData}
             chartName="supply teacher insurance costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Supply teacher insurance costs</h3>
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper
             data={communityFocusedSchoolStaffBarData}
             chartName="community focused school staff (maintained schools only)"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">
               Community focused school staff (maintained schools only)
@@ -410,7 +397,6 @@ export const OtherCosts: React.FC<OtherCostsProps> = ({ schools }) => {
           <HorizontalBarChartWrapper
             data={communityFocusedSchoolCostsBarData}
             chartName="community focused school costs (maintained schools only)"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">
               Community focused school costs (maintained schools only)

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
@@ -156,7 +156,6 @@ export const PremisesStaffServices: React.FC<PremisesStaffServicesProps> = ({
           <HorizontalBarChartWrapper
             data={totalPremisesStaffServiceCostsBarData}
             chartName="total premises staff and service costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">
               Total premises staff and service costs
@@ -171,28 +170,24 @@ export const PremisesStaffServices: React.FC<PremisesStaffServicesProps> = ({
           <HorizontalBarChartWrapper
             data={cleaningCaretakingBarData}
             chartName="cleaning and caretaking costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Cleaning and caretaking costs</h3>
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper
             data={maintenanceBarData}
             chartName="maintenance of premises costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Maintenance of premises costs</h3>
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper
             data={otherOccupationBarData}
             chartName="other occupation costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Other occupation costs</h3>
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper
             data={premisesStaffBarData}
             chartName="premises staff costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Premises staff costs</h3>
           </HorizontalBarChartWrapper>

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/teaching-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/teaching-support-staff.tsx
@@ -173,7 +173,6 @@ export const TeachingSupportStaff: React.FC<TeachingSupportStaffProps> = ({
           <HorizontalBarChartWrapper
             data={totalTeachingBarData}
             chartName="total teaching and support staff cost"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">
               Total teaching and teaching support staff costs
@@ -188,35 +187,30 @@ export const TeachingSupportStaff: React.FC<TeachingSupportStaffProps> = ({
           <HorizontalBarChartWrapper
             data={teachingStaffBarData}
             chartName="teaching staff costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Teaching staff costs</h3>
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper
             data={supplyTeachingBarData}
             chartName="supply teaching staff costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Supply teaching staff costs</h3>
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper
             data={educationalConsultancyBarData}
             chartName="educational consultancy costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Educational consultancy costs</h3>
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper
             data={educationSupportStaffBarData}
             chartName="educational support staff costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">Educational support staff costs</h3>
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper
             data={agencySupplyBarData}
             chartName="agency supply teaching staff costs"
-            valueUnit="currency"
           >
             <h3 className="govuk-heading-s">
               Agency supply teaching staff costs

--- a/front-end-components/src/views/compare-your-costs/partials/total-expenditure.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/total-expenditure.tsx
@@ -57,11 +57,7 @@ export const TotalExpenditure: React.FC<TotalExpenditureProps> = ({
 
   return (
     <ChartDimensionContext.Provider value={dimension}>
-      <HorizontalBarChartWrapper
-        data={chartData}
-        chartName="total expenditure"
-        valueUnit="currency"
-      >
+      <HorizontalBarChartWrapper data={chartData} chartName="total expenditure">
         <h2 className="govuk-heading-m">Total Expenditure</h2>
         <ChartDimensions
           dimensions={CostCategories.filter(function (category) {


### PR DESCRIPTION
### Context
[AB#207861](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/207861) [AB#207893](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/207893)

### Change proposed in this pull request
Added support for `%` `valueUnit` to the `shortValueFormatter()` and ensured `valueUnit` from `dimension` used instead of an overridden value at chart definition level.

### Guidance to review 
Use the drop down on the Compare your costs page to change the dimension, and therefore the associated units for each chart to ensure the correct labels are shown.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

