### PR TITLE
Apply latest Terraform changes to infrastructure before destroying them, to ensure state remains consistent

### DIFF
--- a/pipelines/common/sync-terraform.yaml
+++ b/pipelines/common/sync-terraform.yaml
@@ -1,0 +1,90 @@
+parameters:
+  subscription: ''
+  environmentPrefix: ''
+  environment: ''
+  cipEnvironment: ''
+  module: ''
+  location: 'westeurope'
+
+steps:
+  - task: AzureCLI@1
+    displayName: 'Create terraform dependencies'
+    inputs:
+      azureSubscription: ${{ parameters.subscription }}
+      scriptLocation: inlineScript
+      inlineScript: |
+        storageAccountName=${{ parameters.environmentPrefix }}storagetf
+        echo "##vso[task.setvariable variable=environmentPrefix]${{ parameters.environmentPrefix }}"
+        echo "##vso[task.setvariable variable=environment]${{ parameters.environment }}"
+        echo "##vso[task.setvariable variable=cipEnvironment]${{ parameters.cipEnvironment }}"
+        echo "##vso[task.setvariable variable=location]${{ parameters.location }}"
+        echo "##vso[task.setvariable variable=azureRmStorageAccountName]$storageAccountName"
+
+        skipSync=false
+        resourceGroup=$(az group show --name ${{ parameters.environmentPrefix }}-ebis-${{ parameters.module }} -o tsv 2>nul)
+        if [[ $resourceGroup == "" ]]; then
+          skipSync=true
+        fi
+        echo "##vso[task.setvariable variable=SkipSync]$skipSync"
+
+  - task: qetza.replacetokens.replacetokens-task.replacetokens@6
+    condition: and(succeeded(), ne(variables['SkipSync'], 'true'))
+    displayName: 'Replace tokens in terraform file'
+    inputs:
+      sources: '${{ parameters.workspaceDir }}/terraform.tfvars'
+      escape: off
+      tokenPattern: doubleunderscores
+
+  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-installer.TerraformInstaller@0
+    condition: and(succeeded(), ne(variables['SkipSync'], 'true'))
+    displayName: 'Terraform : install'
+    inputs:
+      terraformVersion: 1.8.2
+
+  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+    condition: and(succeeded(), ne(variables['SkipSync'], 'true'))
+    displayName: 'Terraform : init'
+    inputs:
+      command: init
+      backendType: 'azurerm'
+      workingDirectory: ${{ parameters.workspaceDir }}
+      environmentServiceName: ${{ parameters.subscription }}
+      backendServiceArm: ${{ parameters.subscription }}
+      backendAzureRmResourceGroupName: ${{ parameters.environmentPrefix }}-ebis-terraform
+      backendAzureRmStorageAccountName: $(azureRmStorageAccountName)
+      backendAzureRmContainerName: 'tfstate'
+      backendAzureRmKey: education-benchmarking-${{ parameters.module }}.tfstate
+      backendAzureRmResourceGroupLocation: ${{ parameters.location }}
+
+  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+    condition: and(succeeded(), ne(variables['SkipSync'], 'true'))
+    displayName: 'Terraform : plan'
+    inputs:
+      command: plan
+      backendType: 'azurerm'
+      commandOptions: '-input=false -out=${{ parameters.workspaceDir }}\education-benchmarking-${{ parameters.module }}.plan'
+      workingDirectory: ${{ parameters.workspaceDir }}
+      environmentServiceName: ${{ parameters.subscription }}
+      backendServiceArm: ${{ parameters.subscription }}
+      backendAzureRmResourceGroupName: ${{ parameters.environmentPrefix }}-ebis-terraform
+      backendAzureRmStorageAccountName: $(azureRmStorageAccountName)
+      backendAzureRmContainerName: 'tfstate'
+      backendAzureRmKey: education-benchmarking-${{ parameters.module }}.tfstate
+      publishPlanResults: '${{ parameters.environmentPrefix }}-${{ parameters.module }}-plan'
+      backendAzureRmResourceGroupLocation: ${{ parameters.location }}
+
+  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+    condition: and(succeeded(), ne(variables['SkipSync'], 'true'))
+    displayName: 'Terraform : apply'
+    inputs:
+      command: apply
+      backendType: 'azurerm'
+      workingDirectory: ${{ parameters.workspaceDir }}
+      commandOptions: '-auto-approve -input=false ${{ parameters.workspaceDir }}\education-benchmarking-${{ parameters.module }}.plan'
+      environmentServiceName: ${{ parameters.subscription }}
+      backendServiceArm: ${{ parameters.subscription }}
+      backendAzureRmResourceGroupName: ${{ parameters.environmentPrefix }}-ebis-terraform
+      backendAzureRmStorageAccountName: $(azureRmStorageAccountName)
+      backendAzureRmContainerName: 'tfstate'
+      backendAzureRmKey: education-benchmarking-${{ parameters.module }}.tfstate
+      backendAzureRmResourceGroupLocation: ${{ parameters.location }}

--- a/pipelines/core-infrastructure/sync.yaml
+++ b/pipelines/core-infrastructure/sync.yaml
@@ -1,0 +1,30 @@
+parameters:
+  subscription: ''
+  environmentPrefix: ''
+  environment: ''
+  pipelineEnvironment: ''
+  cipEnvironment: ''
+  workspaceDir: '$(Pipeline.Workspace)'
+  dependsOn: []
+
+jobs:
+  - deployment: CoreSync
+    displayName: 'Core : Sync'
+    dependsOn: ${{ parameters.dependsOn }}
+    pool:
+      vmImage: ubuntu-latest
+    environment: ${{ parameters.pipelineEnvironment }}
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+            - checkout: self
+
+            - template: ..\common\sync-terraform.yaml
+              parameters:
+                workspaceDir: '$(System.DefaultWorkingDirectory)/core-infrastructure/terraform'
+                subscription: ${{ parameters.subscription }}
+                environmentPrefix: ${{ parameters.environmentPrefix }}
+                environment: ${{ parameters.environment }}
+                cipEnvironment: ${{ parameters.cipEnvironment }}
+                module: 'core'

--- a/pipelines/destroy/destroy.yaml
+++ b/pipelines/destroy/destroy.yaml
@@ -7,9 +7,36 @@ parameters:
   dependsOn: []
 
 jobs:
-  - template: ../web/destroy.yaml
+  - template: ../core-infrastructure/sync.yaml
     parameters:
       dependsOn: ${{ parameters.dependsOn }}
+      subscription: ${{ parameters.subscription }}
+      environmentPrefix: ${{ parameters.environmentPrefix }}
+      environment: ${{ parameters.environment }}
+      pipelineEnvironment: ${{ parameters.pipelineEnvironment }}
+      cipEnvironment: ${{ parameters.cipEnvironment }}
+
+  - template: ../platform/sync.yaml
+    parameters:
+      dependsOn: [ CoreSync ]
+      subscription: ${{ parameters.subscription }}
+      environmentPrefix: ${{ parameters.environmentPrefix }}
+      environment: ${{ parameters.environment }}
+      pipelineEnvironment: ${{ parameters.pipelineEnvironment }}
+      cipEnvironment: ${{ parameters.cipEnvironment }}
+
+  - template: ../web/sync.yaml
+    parameters:
+      dependsOn: [ PlatformSync ]
+      subscription: ${{ parameters.subscription }}
+      environmentPrefix: ${{ parameters.environmentPrefix }}
+      environment: ${{ parameters.environment }}
+      pipelineEnvironment: ${{ parameters.pipelineEnvironment }}
+      cipEnvironment: ${{ parameters.cipEnvironment }}
+
+  - template: ../web/destroy.yaml
+    parameters:
+      dependsOn: [ WebSync ]
       subscription: ${{ parameters.subscription }}
       environmentPrefix: ${{ parameters.environmentPrefix }}
       environment: ${{ parameters.environment }}

--- a/pipelines/platform/sync.yaml
+++ b/pipelines/platform/sync.yaml
@@ -1,0 +1,30 @@
+parameters:
+  subscription: ''
+  environmentPrefix: ''
+  environment: ''
+  pipelineEnvironment: ''
+  cipEnvironment: ''
+  workspaceDir: '$(Pipeline.Workspace)'
+  dependsOn: []
+
+jobs:
+  - deployment: PlatformSync
+    displayName: 'Platform : Sync'
+    dependsOn: ${{ parameters.dependsOn }}
+    pool:
+      vmImage: ubuntu-latest
+    environment: ${{ parameters.pipelineEnvironment }}
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+            - checkout: self
+
+            - template: ..\common\sync-terraform.yaml
+              parameters:
+                workspaceDir: '$(System.DefaultWorkingDirectory)/platform/terraform'
+                subscription: ${{ parameters.subscription }}
+                environmentPrefix: ${{ parameters.environmentPrefix }}
+                environment: ${{ parameters.environment }}
+                cipEnvironment: ${{ parameters.cipEnvironment }}
+                module: 'platform'

--- a/pipelines/web/sync.yaml
+++ b/pipelines/web/sync.yaml
@@ -1,0 +1,29 @@
+parameters:
+  subscription: ''
+  environmentPrefix: ''
+  environment: ''
+  pipelineEnvironment: ''
+  cipEnvironment: ''
+  workspaceDir: '$(Pipeline.Workspace)'
+
+jobs:
+  - deployment: WebSync
+    displayName: 'Web : Sync'
+    dependsOn: ${{ parameters.dependsOn }}
+    pool:
+      vmImage: ubuntu-latest
+    environment: ${{ parameters.pipelineEnvironment }}
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+            - checkout: self
+
+            - template: ..\common\sync-terraform.yaml
+              parameters:
+                workspaceDir: '$(System.DefaultWorkingDirectory)/web/terraform'
+                subscription: ${{ parameters.subscription }}
+                environmentPrefix: ${{ parameters.environmentPrefix }}
+                environment: ${{ parameters.environment }}
+                cipEnvironment: ${{ parameters.cipEnvironment }}
+                module: 'web'


### PR DESCRIPTION
### Context
[AB#208908](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/208908) [AB#208907](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/208907)

### Change proposed in this pull request
Add steps to the Destroy pipeline to 'sync' Terraform (i.e. re-`apply` in the correct order) before attempting the `destroy`, if the target resource group has yet to be destroyed. This will ensure that the target environment is in the expected state before destruction, particularly when it comes to `data` imports between modules, which was the original source of this problem.

### Guidance to review 
This has been validated by successfully destroying the `d12` infrastructure using this branch as the source when running the pipeline. Previously this was failing due to missing `data` dependencies which were resolved using the 'sync' addition.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~~Your code builds clean without any errors or warnings~~
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

