### PR TITLE
chore: disables access key on threat, audit and vulnerability storage

### DIFF
--- a/core-infrastructure/terraform/storage.tf
+++ b/core-infrastructure/terraform/storage.tf
@@ -50,4 +50,5 @@ resource "azurerm_key_vault_secret" "data-storage-connection-string" {
   value        = azurerm_storage_account.data.primary_connection_string
   key_vault_id = azurerm_key_vault.key-vault.id
   content_type = "connection-string"
+  depends_on   = [azurerm_key_vault_access_policy.terraform_sp_access]
 }

--- a/pipelines/feature/release.yaml
+++ b/pipelines/feature/release.yaml
@@ -97,7 +97,7 @@ stages:
   - stage: BuildDataPipeline
     dependsOn: [ BuildNumber, DeployCore ]
     displayName: 'Data Pipeline : Build and Deploy'
-    variables: 
+    variables:
       environmentPrefix: $[ stageDependencies.BuildNumber.SetBuildNumber.outputs['outputVars.Environment_Prefix'] ]
     jobs:
       - job: ZipStaticDataPipelineArtifacts

--- a/platform/terraform/README.md
+++ b/platform/terraform/README.md
@@ -44,6 +44,10 @@
 | [azurerm_mssql_server_vulnerability_assessment.sql-server-vulnerability](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_server_vulnerability_assessment) | resource |
 | [azurerm_mssql_virtual_network_rule.sql-server-vnet-rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_virtual_network_rule) | resource |
 | [azurerm_resource_group.resource-group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_role_assignment.sp-vulnerability-storage-role-blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.sql-audit-storage-role-blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.sql-threat-storage-role-blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.sql-vulnerability-storage-role-blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_search_service.search](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/search_service) | resource |
 | [azurerm_storage_account.audit-storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
 | [azurerm_storage_account.orchestrator-storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |

--- a/platform/terraform/storage.tf
+++ b/platform/terraform/storage.tf
@@ -1,17 +1,3 @@
-/*resource "azurerm_role_assignment" "sp-platform-storage-role-blob" {
-  scope                = azurerm_storage_account.platform-storage.id
-  role_definition_name = "Storage Blob Data Contributor"
-  principal_id         = data.azurerm_client_config.client.object_id
-  principal_type       = "ServicePrincipal"
-}
-
-resource "azurerm_role_assignment" "sp-platform-storage-role-file" {
-  scope                = azurerm_storage_account.platform-storage.id
-  role_definition_name = "Storage File Data SMB Share Contributor"
-  principal_id         = data.azurerm_client_config.client.object_id
-  principal_type       = "ServicePrincipal"
-}*/
-
 resource "azurerm_storage_account" "platform-storage" {
   #checkov:skip=CKV_AZURE_43:False positive on storage account adhering to the naming rules
   #checkov:skip=CKV_AZURE_33:See ADO backlog AB#206389
@@ -47,8 +33,6 @@ resource "azurerm_storage_account" "audit-storage" {
   #checkov:skip=CKV_AZURE_43:False positive on storage account adhering to the naming rules
   #checkov:skip=CKV_AZURE_33:See ADO backlog AB#206389
   #checkov:skip=CKV2_AZURE_1:See ADO backlog AB#206389
-  #checkov:skip=CKV2_AZURE_40:See ADO backlog AB#206389
-  #checkov:skip=CKV2_AZURE_41:See ADO backlog AB#206389
   #checkov:skip=CKV2_AZURE_33:See ADO backlog AB#206389
   #checkov:skip=CKV_AZURE_59:See ADO backlog AB#206389
   name                            = "${var.environment-prefix}audit"
@@ -59,7 +43,7 @@ resource "azurerm_storage_account" "audit-storage" {
   allow_nested_items_to_be_public = false
   tags                            = local.common-tags
   min_tls_version                 = "TLS1_2"
-  public_network_access_enabled   = true
+  shared_access_key_enabled       = false
 
   blob_properties {
     delete_retention_policy {
@@ -70,14 +54,19 @@ resource "azurerm_storage_account" "audit-storage" {
     expiration_action = "Log"
     expiration_period = "90.00:00:00"
   }
+
+  network_rules {
+    default_action = "Deny"
+    bypass = [
+      "AzureServices"
+    ]
+  }
 }
 
 resource "azurerm_storage_account" "threat-storage" {
   #checkov:skip=CKV_AZURE_43:False positive on storage account adhering to the naming rules
   #checkov:skip=CKV_AZURE_33:See ADO backlog AB#206389
   #checkov:skip=CKV2_AZURE_1:See ADO backlog AB#206389
-  #checkov:skip=CKV2_AZURE_40:See ADO backlog AB#206389
-  #checkov:skip=CKV2_AZURE_41:See ADO backlog AB#206389
   #checkov:skip=CKV2_AZURE_33:See ADO backlog AB#206389
   #checkov:skip=CKV_AZURE_59:See ADO backlog AB#206389
   name                            = "${var.environment-prefix}threat"
@@ -88,7 +77,7 @@ resource "azurerm_storage_account" "threat-storage" {
   allow_nested_items_to_be_public = false
   tags                            = local.common-tags
   min_tls_version                 = "TLS1_2"
-  public_network_access_enabled   = true
+  shared_access_key_enabled       = false
 
   blob_properties {
     delete_retention_policy {
@@ -100,15 +89,26 @@ resource "azurerm_storage_account" "threat-storage" {
     expiration_action = "Log"
     expiration_period = "90.00:00:00"
   }
+
+  network_rules {
+    default_action = "Deny"
+    bypass = [
+      "AzureServices"
+    ]
+  }
 }
 
+resource "azurerm_role_assignment" "sp-vulnerability-storage-role-blob" {
+  scope                = azurerm_storage_account.platform-storage.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = data.azurerm_client_config.client.object_id
+  principal_type       = "ServicePrincipal"
+}
 
 resource "azurerm_storage_account" "vulnerability-storage" {
   #checkov:skip=CKV_AZURE_43:False positive on storage account adhering to the naming rules
   #checkov:skip=CKV_AZURE_33:See ADO backlog AB#206389
   #checkov:skip=CKV2_AZURE_1:See ADO backlog AB#206389
-  #checkov:skip=CKV2_AZURE_40:See ADO backlog AB#206389
-  #checkov:skip=CKV2_AZURE_41:See ADO backlog AB#206389
   #checkov:skip=CKV2_AZURE_33:See ADO backlog AB#206389
   #checkov:skip=CKV_AZURE_59:See ADO backlog AB#206389
   name                            = "${var.environment-prefix}vulnerability"
@@ -119,7 +119,7 @@ resource "azurerm_storage_account" "vulnerability-storage" {
   allow_nested_items_to_be_public = false
   tags                            = local.common-tags
   min_tls_version                 = "TLS1_2"
-  public_network_access_enabled   = true
+  shared_access_key_enabled       = false
 
   blob_properties {
     delete_retention_policy {
@@ -139,20 +139,6 @@ resource "azurerm_storage_container" "vulnerability-container" {
   storage_account_name  = azurerm_storage_account.vulnerability-storage.name
   container_access_type = "private"
 }
-
-/*resource "azurerm_role_assignment" "sp-orchestrator-storage-role-blob" {
-  scope                = azurerm_storage_account.orchestrator-storage.id
-  role_definition_name = "Storage Blob Data Contributor"
-  principal_id         = data.azurerm_client_config.client.object_id
-  principal_type       = "ServicePrincipal"
-}
-
-resource "azurerm_role_assignment" "sp-orchestrator-storage-role-file" {
-  scope                = azurerm_storage_account.platform-storage.id
-  role_definition_name = "Storage File Data SMB Share Contributor"
-  principal_id         = data.azurerm_client_config.client.object_id
-  principal_type       = "ServicePrincipal"
-}*/
 
 resource "azurerm_storage_account" "orchestrator-storage" {
   #checkov:skip=CKV_AZURE_43:False positive on storage account adhering to the naming rules


### PR DESCRIPTION
### Context
[AB#209017](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/209017) ([AB#209018](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/209018))

### Change proposed in this pull request
Disables shared access on threat, audit and vulnerability storage accounts. Also applies network ACL to threat and audit - public access still required for vulnerability to allow ADO pipeline to create the storage container.

### Guidance to review 
N/A

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

