### PR TITLE
feat: add filters to local authority benchmarking pages

### DIFF
--- a/front-end-components/src/contexts/contexts.tsx
+++ b/front-end-components/src/contexts/contexts.tsx
@@ -18,3 +18,5 @@ export const ChartDimensionContext = createContext<Dimension>({
 export const SelectedSchoolContext = createContext(School.empty());
 
 export const HasIncompleteDataContext = createContext(false);
+
+export const PhaseContext = createContext<string | undefined>(undefined);

--- a/front-end-components/src/index.css
+++ b/front-end-components/src/index.css
@@ -326,15 +326,14 @@
   background: lightgray;
 }
 
-.view-as-toggle {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
+.chart-options {
+  display: grid;
+  grid-template-columns: 75% 25%;
   width: 100%;
 }
 
 @media (max-width: 640px) {
-  .view-as-toggle {
+  .chart-options {
     width: 100%;
     display: block;
   }

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -80,13 +80,13 @@ if (findOrganisationElement) {
 const compareCostsElement = document.getElementById(CompareCostsElementId);
 
 if (compareCostsElement) {
-  const { type, id } = compareCostsElement.dataset;
+  const { type, id, phases } = compareCostsElement.dataset;
   if (type && id) {
     const root = ReactDOM.createRoot(compareCostsElement);
-
+    const phasesParsed = phases ? (JSON.parse(phases) as string[]) : null;
     root.render(
       <React.StrictMode>
-        <CompareYourCosts type={type} id={id} />
+        <CompareYourCosts type={type} id={id} phases={phasesParsed} />
       </React.StrictMode>
     );
   }
@@ -95,13 +95,13 @@ if (compareCostsElement) {
 const compareCensusElement = document.getElementById(CompareCensusElementId);
 
 if (compareCensusElement) {
-  const { type, id } = compareCensusElement.dataset;
+  const { type, id, phases } = compareCensusElement.dataset;
   if (type && id) {
     const root = ReactDOM.createRoot(compareCensusElement);
-
+    const phasesParsed = phases ? (JSON.parse(phases) as string[]) : null;
     root.render(
       <React.StrictMode>
-        <CompareYourCensus type={type} id={id} />
+        <CompareYourCensus type={type} id={id} phases={phasesParsed} />
       </React.StrictMode>
     );
   }

--- a/front-end-components/src/services/census-api.tsx
+++ b/front-end-components/src/services/census-api.tsx
@@ -29,25 +29,28 @@ export class CensusApi {
     type: string,
     id: string,
     dimension: string,
-    category: string
+    category: string,
+    phase?: string
   ): Promise<Census[]> {
-    return fetch(
-      "/api/census?" +
-        new URLSearchParams({
-          type: type,
-          id: id,
-          dimension: dimension,
-          category: category,
-        }),
-      {
-        redirect: "manual",
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Correlation-ID": uuidv4(),
-        },
-      }
-    )
+    const params = new URLSearchParams({
+      type: type,
+      id: id,
+      dimension: dimension,
+      category: category,
+    });
+
+    if (phase) {
+      params.append("phase", phase);
+    }
+
+    return fetch("/api/census?" + params, {
+      redirect: "manual",
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Correlation-ID": uuidv4(),
+      },
+    })
       .then((res) => res.json())
       .then((res) => {
         if (res.error) {

--- a/front-end-components/src/services/establishment-api.tsx
+++ b/front-end-components/src/services/establishment-api.tsx
@@ -4,20 +4,26 @@ import { ExpenditureData } from "src/services";
 export class EstablishmentsApi {
   static async getExpenditure(
     type: string,
-    id: string
+    id: string,
+    phase?: string
   ): Promise<ExpenditureData[]> {
-    return fetch(
-      "/api/establishments/expenditure?" +
-        new URLSearchParams({ type: type, id: id }),
-      {
-        redirect: "manual",
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Correlation-ID": uuidv4(),
-        },
-      }
-    )
+    const params = new URLSearchParams({
+      type: type,
+      id: id,
+    });
+
+    if (phase) {
+      params.append("phase", phase);
+    }
+
+    return fetch("/api/establishments/expenditure?" + params, {
+      redirect: "manual",
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Correlation-ID": uuidv4(),
+      },
+    })
       .then((res) => res.json())
       .then((res) => {
         if (res.error) {

--- a/front-end-components/src/views/compare-your-census/partials/auxiliary-staff.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/auxiliary-staff.tsx
@@ -1,10 +1,20 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import {
   ChartDimensions,
   PupilsPerStaffRole,
   CensusCategories,
 } from "src/components";
-import { ChartDimensionContext, HasIncompleteDataContext } from "src/contexts";
+import {
+  ChartDimensionContext,
+  HasIncompleteDataContext,
+  PhaseContext,
+} from "src/contexts";
 import { AuxiliaryStaffData } from "src/views/compare-your-census/partials";
 import {
   HorizontalBarChartWrapper,
@@ -16,6 +26,7 @@ export const AuxiliaryStaff: React.FC<{ type: string; id: string }> = ({
   type,
   id,
 }) => {
+  const phase = useContext(PhaseContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
   const [data, setData] = useState(new Array<Census>());
   const getData = useCallback(async () => {
@@ -24,9 +35,10 @@ export const AuxiliaryStaff: React.FC<{ type: string; id: string }> = ({
       type,
       id,
       dimension.value,
-      "AuxiliaryStaffFte"
+      "AuxiliaryStaffFte",
+      phase
     );
-  }, [id, dimension, type]);
+  }, [id, dimension, type, phase]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-census/partials/headcount.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/headcount.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import {
   ChartDimensions,
   HeadcountPerFTE,
@@ -6,7 +12,11 @@ import {
   PupilsPerStaffRole,
   CensusCategories,
 } from "src/components";
-import { ChartDimensionContext, HasIncompleteDataContext } from "src/contexts";
+import {
+  ChartDimensionContext,
+  HasIncompleteDataContext,
+  PhaseContext,
+} from "src/contexts";
 import { HeadcountData } from "src/views/compare-your-census/partials";
 import {
   HorizontalBarChartWrapper,
@@ -18,6 +28,7 @@ export const Headcount: React.FC<{ type: string; id: string }> = ({
   type,
   id,
 }) => {
+  const phase = useContext(PhaseContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
   const [data, setData] = useState(new Array<Census>());
   const getData = useCallback(async () => {
@@ -26,9 +37,10 @@ export const Headcount: React.FC<{ type: string; id: string }> = ({
       type,
       id,
       dimension.value,
-      "WorkforceHeadcount"
+      "WorkforceHeadcount",
+      phase
     );
-  }, [id, dimension, type]);
+  }, [id, dimension, type, phase]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-census/partials/non-classroom-support.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/non-classroom-support.tsx
@@ -1,10 +1,20 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import {
   ChartDimensions,
   PupilsPerStaffRole,
   CensusCategories,
 } from "src/components";
-import { ChartDimensionContext, HasIncompleteDataContext } from "src/contexts";
+import {
+  ChartDimensionContext,
+  HasIncompleteDataContext,
+  PhaseContext,
+} from "src/contexts";
 import { NonClassroomSupportData } from "src/views/compare-your-census/partials";
 import {
   HorizontalBarChartWrapper,
@@ -16,6 +26,7 @@ export const NonClassroomSupport: React.FC<{ type: string; id: string }> = ({
   type,
   id,
 }) => {
+  const phase = useContext(PhaseContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
   const [data, setData] = useState(new Array<Census>());
   const getData = useCallback(async () => {
@@ -24,9 +35,10 @@ export const NonClassroomSupport: React.FC<{ type: string; id: string }> = ({
       type,
       id,
       dimension.value,
-      "NonClassroomSupportStaffFte"
+      "NonClassroomSupportStaffFte",
+      phase
     );
-  }, [id, dimension, type]);
+  }, [id, dimension, type, phase]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-census/partials/school-workforce.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/school-workforce.tsx
@@ -1,11 +1,21 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import {
   ChartDimensions,
   PercentageOfWorkforce,
   PupilsPerStaffRole,
   CensusCategories,
 } from "src/components";
-import { ChartDimensionContext, HasIncompleteDataContext } from "src/contexts";
+import {
+  ChartDimensionContext,
+  HasIncompleteDataContext,
+  PhaseContext,
+} from "src/contexts";
 import { SchoolCensusData } from "src/views/compare-your-census/partials";
 import {
   HorizontalBarChartWrapper,
@@ -17,12 +27,19 @@ export const SchoolWorkforce: React.FC<{ type: string; id: string }> = ({
   type,
   id,
 }) => {
+  const phase = useContext(PhaseContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
   const [data, setData] = useState(new Array<Census>());
   const getData = useCallback(async () => {
     setData(new Array<Census>());
-    return await CensusApi.query(type, id, dimension.value, "WorkforceFte");
-  }, [id, dimension, type]);
+    return await CensusApi.query(
+      type,
+      id,
+      dimension.value,
+      "WorkforceFte",
+      phase
+    );
+  }, [id, dimension, type, phase]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-census/partials/senior-leadership.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/senior-leadership.tsx
@@ -1,10 +1,20 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import {
   ChartDimensions,
   PupilsPerStaffRole,
   CensusCategories,
 } from "src/components";
-import { ChartDimensionContext, HasIncompleteDataContext } from "src/contexts";
+import {
+  ChartDimensionContext,
+  HasIncompleteDataContext,
+  PhaseContext,
+} from "src/contexts";
 import { SeniorLeadershipData } from "src/views/compare-your-census/partials";
 import {
   HorizontalBarChartWrapper,
@@ -16,6 +26,7 @@ export const SeniorLeadership: React.FC<{ type: string; id: string }> = ({
   type,
   id,
 }) => {
+  const phase = useContext(PhaseContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
   const [data, setData] = useState(new Array<Census>());
   const getData = useCallback(async () => {
@@ -24,9 +35,10 @@ export const SeniorLeadership: React.FC<{ type: string; id: string }> = ({
       type,
       id,
       dimension.value,
-      "SeniorLeadershipFte"
+      "SeniorLeadershipFte",
+      phase
     );
-  }, [id, dimension, type]);
+  }, [id, dimension, type, phase]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-census/partials/teaching-assistants.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/teaching-assistants.tsx
@@ -1,10 +1,20 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import {
   ChartDimensions,
   PupilsPerStaffRole,
   CensusCategories,
 } from "src/components";
-import { ChartDimensionContext, HasIncompleteDataContext } from "src/contexts";
+import {
+  ChartDimensionContext,
+  HasIncompleteDataContext,
+  PhaseContext,
+} from "src/contexts";
 import { TeachingAssistantsData } from "src/views/compare-your-census/partials";
 import {
   HorizontalBarChartWrapper,
@@ -16,6 +26,7 @@ export const TeachingAssistants: React.FC<{ type: string; id: string }> = ({
   type,
   id,
 }) => {
+  const phase = useContext(PhaseContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
   const [data, setData] = useState(new Array<Census>());
   const getData = useCallback(async () => {
@@ -24,9 +35,10 @@ export const TeachingAssistants: React.FC<{ type: string; id: string }> = ({
       type,
       id,
       dimension.value,
-      "TeachingAssistantsFte"
+      "TeachingAssistantsFte",
+      phase
     );
-  }, [id, dimension, type]);
+  }, [id, dimension, type, phase]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-census/partials/total-teachers-qualified.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/total-teachers-qualified.tsx
@@ -1,9 +1,19 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
-import { ChartDimensionContext, HasIncompleteDataContext } from "src/contexts";
+import {
+  ChartDimensionContext,
+  HasIncompleteDataContext,
+  PhaseContext,
+} from "src/contexts";
 import { TotalTeachersQualifiedData } from "src/views/compare-your-census/partials";
 import { Percent } from "src/components";
 import { Census, CensusApi } from "src/services";
@@ -12,11 +22,12 @@ export const TotalTeachersQualified: React.FC<{ type: string; id: string }> = ({
   type,
   id,
 }) => {
+  const phase = useContext(PhaseContext);
   const [data, setData] = useState(new Array<Census>());
   const getData = useCallback(async () => {
     setData(new Array<Census>());
-    return await CensusApi.query(type, id, "Total", "TeachersQualified");
-  }, [id, type]);
+    return await CensusApi.query(type, id, "Total", "TeachersQualified", phase);
+  }, [id, type, phase]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-census/partials/total-teachers.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/total-teachers.tsx
@@ -1,10 +1,20 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import {
   ChartDimensions,
   PupilsPerStaffRole,
   CensusCategories,
 } from "src/components";
-import { ChartDimensionContext, HasIncompleteDataContext } from "src/contexts";
+import {
+  ChartDimensionContext,
+  HasIncompleteDataContext,
+  PhaseContext,
+} from "src/contexts";
 import { TotalTeachersData } from "src/views/compare-your-census/partials";
 import {
   HorizontalBarChartWrapper,
@@ -16,12 +26,19 @@ export const TotalTeachers: React.FC<{ type: string; id: string }> = ({
   type,
   id,
 }) => {
+  const phase = useContext(PhaseContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
   const [data, setData] = useState(new Array<Census>());
   const getData = useCallback(async () => {
     setData(new Array<Census>());
-    return await CensusApi.query(type, id, dimension.value, "TeachersFte");
-  }, [id, dimension, type]);
+    return await CensusApi.query(
+      type,
+      id,
+      dimension.value,
+      "TeachersFte",
+      phase
+    );
+  }, [id, dimension, type, phase]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-census/types.tsx
+++ b/front-end-components/src/views/compare-your-census/types.tsx
@@ -1,4 +1,5 @@
 export type CompareYourCensusViewProps = {
   type: string;
   id: string;
+  phases: string[] | null;
 };

--- a/front-end-components/src/views/compare-your-census/view.tsx
+++ b/front-end-components/src/views/compare-your-census/view.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from "react";
 import { CompareYourCensusViewProps } from "src/views";
 import { ChartMode, ChartModeChart } from "src/components";
-import { SelectedSchoolContext, ChartModeContext } from "src/contexts";
+import {
+  SelectedSchoolContext,
+  ChartModeContext,
+  PhaseContext,
+} from "src/contexts";
 import {
   AuxiliaryStaff,
   Headcount,
@@ -16,28 +20,66 @@ import {
 export const CompareYourCensus: React.FC<CompareYourCensusViewProps> = (
   props
 ) => {
-  const { type, id } = props;
+  const { type, id, phases } = props;
   const [displayMode, setDisplayMode] = useState<string>(ChartModeChart);
+  const [phase, setPhase] = useState<string | undefined>(
+    phases ? phases[0] : undefined
+  );
 
   const toggleChartMode = (e: React.ChangeEvent<HTMLInputElement>) => {
     setDisplayMode(e.target.value);
   };
 
+  const handlePhaseChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    console.log(e.target.value);
+    setPhase(e.target.value);
+  };
+
   return (
     <SelectedSchoolContext.Provider value={{ urn: id, name: "" }}>
-      <div className="view-as-toggle">
-        <ChartMode displayMode={displayMode} handleChange={toggleChartMode} />
-      </div>
-      <ChartModeContext.Provider value={displayMode}>
-        <SchoolWorkforce id={id} type={type} />
-        <TotalTeachers id={id} type={type} />
-        <TotalTeachersQualified id={id} type={type} />
-        <SeniorLeadership id={id} type={type} />
-        <TeachingAssistants id={id} type={type} />
-        <NonClassroomSupport id={id} type={type} />
-        <AuxiliaryStaff id={id} type={type} />
-        <Headcount id={id} type={type} />
-      </ChartModeContext.Provider>
+      <PhaseContext.Provider value={phase}>
+        <div className="chart-options">
+          <div>
+            {phases && (
+              <div className="govuk-form-group">
+                <label className="govuk-label govuk-label--s" htmlFor="phase">
+                  Phase
+                </label>
+                <select
+                  className="govuk-select"
+                  name="phase"
+                  id="phase"
+                  onChange={handlePhaseChange}
+                >
+                  {phases.map((phase) => {
+                    return (
+                      <option key={phase} value={phase}>
+                        {phase}
+                      </option>
+                    );
+                  })}
+                </select>
+              </div>
+            )}
+          </div>
+          <div>
+            <ChartMode
+              displayMode={displayMode}
+              handleChange={toggleChartMode}
+            />
+          </div>
+        </div>
+        <ChartModeContext.Provider value={displayMode}>
+          <SchoolWorkforce id={id} type={type} />
+          <TotalTeachers id={id} type={type} />
+          <TotalTeachersQualified id={id} type={type} />
+          <SeniorLeadership id={id} type={type} />
+          <TeachingAssistants id={id} type={type} />
+          <NonClassroomSupport id={id} type={type} />
+          <AuxiliaryStaff id={id} type={type} />
+          <Headcount id={id} type={type} />
+        </ChartModeContext.Provider>
+      </PhaseContext.Provider>
     </SelectedSchoolContext.Provider>
   );
 };

--- a/front-end-components/src/views/compare-your-census/view.tsx
+++ b/front-end-components/src/views/compare-your-census/view.tsx
@@ -31,7 +31,6 @@ export const CompareYourCensus: React.FC<CompareYourCensusViewProps> = (
   };
 
   const handlePhaseChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    console.log(e.target.value);
     setPhase(e.target.value);
   };
 

--- a/front-end-components/src/views/compare-your-costs/types.tsx
+++ b/front-end-components/src/views/compare-your-costs/types.tsx
@@ -1,4 +1,5 @@
 export type CompareYourCostsViewProps = {
   type: string;
   id: string;
+  phases: string[] | null;
 };

--- a/front-end-components/src/views/compare-your-costs/view.tsx
+++ b/front-end-components/src/views/compare-your-costs/view.tsx
@@ -19,18 +19,21 @@ import { useGovUk } from "src/hooks/useGovUk";
 export const CompareYourCosts: React.FC<CompareYourCostsViewProps> = (
   props
 ) => {
-  const { type, id } = props;
+  const { type, id, phases } = props;
   const [expenditureData, setExpenditureData] = useState<ExpenditureData[]>();
   const [displayMode, setDisplayMode] = useState<string>(ChartModeChart);
   const [selectedSchool, setSelectedSchool] = useState<SelectedSchool>(
     School.empty
   );
+  const [phase, setPhase] = useState<string | undefined>(
+    phases ? phases[0] : undefined
+  );
 
   useGovUk();
 
   const getExpenditure = useCallback(async () => {
-    return await EstablishmentsApi.getExpenditure(type, id);
-  }, [type, id]);
+    return await EstablishmentsApi.getExpenditure(type, id, phase);
+  }, [type, id, phase]);
 
   useEffect(
     () => {
@@ -56,13 +59,43 @@ export const CompareYourCosts: React.FC<CompareYourCostsViewProps> = (
     setDisplayMode(e.target.value);
   };
 
+  const handlePhaseChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    console.log(e.target.value);
+    setPhase(e.target.value);
+  };
+
   const hasIncompleteData =
     expenditureData?.some((x) => x.hasIncompleteData) ?? false;
 
   return (
     <SelectedSchoolContext.Provider value={selectedSchool}>
-      <div className="view-as-toggle">
-        <ChartMode displayMode={displayMode} handleChange={toggleChartMode} />
+      <div className="chart-options">
+        <div>
+          {phases && (
+            <div className="govuk-form-group">
+              <label className="govuk-label govuk-label--s" htmlFor="phase">
+                Phase
+              </label>
+              <select
+                className="govuk-select"
+                name="phase"
+                id="phase"
+                onChange={handlePhaseChange}
+              >
+                {phases.map((phase) => {
+                  return (
+                    <option key={phase} value={phase}>
+                      {phase}
+                    </option>
+                  );
+                })}
+              </select>
+            </div>
+          )}
+        </div>
+        <div>
+          <ChartMode displayMode={displayMode} handleChange={toggleChartMode} />
+        </div>
       </div>
       <HasIncompleteDataContext.Provider value={hasIncompleteData}>
         <ChartModeContext.Provider value={displayMode}>

--- a/front-end-components/src/views/compare-your-costs/view.tsx
+++ b/front-end-components/src/views/compare-your-costs/view.tsx
@@ -60,7 +60,6 @@ export const CompareYourCosts: React.FC<CompareYourCostsViewProps> = (
   };
 
   const handlePhaseChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    console.log(e.target.value);
     setPhase(e.target.value);
   };
 

--- a/platform/src/apis/Platform.Api.Establishment/Db/SchoolDb.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Db/SchoolDb.cs
@@ -13,7 +13,7 @@ namespace Platform.Api.Establishment.Db;
 public interface ISchoolDb
 {
     Task<SchoolResponseModel?> Get(string urn);
-    Task<IEnumerable<SchoolResponseModel>> Query(string? companyNumber, string? laCode);
+    Task<IEnumerable<SchoolResponseModel>> Query(string? companyNumber, string? laCode, string? phase);
 }
 
 [ExcludeFromCodeCoverage]
@@ -49,7 +49,7 @@ public class SchoolDb : CosmosDatabase, ISchoolDb
         return school == null ? null : SchoolResponseModel.Create(school);
     }
 
-    public async Task<IEnumerable<SchoolResponseModel>> Query(string? companyNumber, string? laCode)
+    public async Task<IEnumerable<SchoolResponseModel>> Query(string? companyNumber, string? laCode, string? phase)
     {
         var schools = await ItemEnumerableAsync<EdubaseDataObject>(
                 _collectionName,
@@ -57,12 +57,17 @@ public class SchoolDb : CosmosDatabase, ISchoolDb
                 {
                     if (!string.IsNullOrEmpty(companyNumber) && int.TryParse(companyNumber, out var companyParsed))
                     {
-                        q = q.Where(x => x.CompanyNumber == companyParsed);
+                        q = q.Where(x => x.CompanyNumber == companyParsed && x.FinanceType == EstablishmentTypes.Academies);
                     }
 
                     if (!string.IsNullOrEmpty(laCode) && int.TryParse(laCode, out var laparsed))
                     {
-                        q = q.Where(x => x.LaCode == laparsed);
+                        q = q.Where(x => x.LaCode == laparsed && x.FinanceType == EstablishmentTypes.Maintained);
+                    }
+
+                    if (!string.IsNullOrEmpty(phase))
+                    {
+                        q = q.Where(x => x.OverallPhase == phase);
                     }
 
                     return q;

--- a/platform/src/apis/Platform.Api.Establishment/SchoolsFunctions.cs
+++ b/platform/src/apis/Platform.Api.Establishment/SchoolsFunctions.cs
@@ -75,6 +75,7 @@ public class SchoolsFunctions
     [ProducesResponseType((int)HttpStatusCode.InternalServerError)]
     [QueryStringParameter("companyNumber", "Company number", DataType = typeof(int), Required = false)]
     [QueryStringParameter("laCode", "Local authority code", DataType = typeof(int), Required = false)]
+    [QueryStringParameter("phase", "Phase", DataType = typeof(string), Required = false)]
     public async Task<IActionResult> QuerySchoolsAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "get", Route = "schools")]
         HttpRequest req)
@@ -92,7 +93,8 @@ public class SchoolsFunctions
             {
                 var companyNumber = req.Query["companyNumber"].ToString();
                 var laCode = req.Query["laCode"].ToString();
-                var schools = await _db.Query(companyNumber, laCode);
+                var phase = req.Query["phase"].ToString();
+                var schools = await _db.Query(companyNumber, laCode, phase);
                 return new JsonContentResult(schools);
             }
             catch (Exception e)

--- a/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesQuerySchoolsRequest.cs
+++ b/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesQuerySchoolsRequest.cs
@@ -12,7 +12,7 @@ public class WhenFunctionReceivesQuerySchoolsRequest : SchoolsFunctionsTestBase
     public async Task ShouldReturn200OnValidRequest()
     {
         Db
-            .Setup(d => d.Query(It.IsAny<string?>(), It.IsAny<string?>()))
+            .Setup(d => d.Query(It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .ReturnsAsync(Array.Empty<SchoolResponseModel>());
 
         var result = await Functions.QuerySchoolsAsync(CreateRequest()) as JsonContentResult;
@@ -25,7 +25,7 @@ public class WhenFunctionReceivesQuerySchoolsRequest : SchoolsFunctionsTestBase
     public async Task ShouldReturn500OnError()
     {
         Db
-            .Setup(d => d.Query(It.IsAny<string?>(), It.IsAny<string?>()))
+            .Setup(d => d.Query(It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .Throws(new Exception());
 
         var result = await Functions.QuerySchoolsAsync(CreateRequest()) as StatusCodeResult;

--- a/web/src/Web.App/Controllers/Api/CensusProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/CensusProxyController.cs
@@ -18,7 +18,7 @@ public class CensusProxyController(
 {
     [HttpGet]
     [Produces("application/json")]
-    public async Task<IActionResult> Query([FromQuery] string type, [FromQuery] string id, [FromQuery] string category, [FromQuery] string dimension)
+    public async Task<IActionResult> Query([FromQuery] string type, [FromQuery] string id, [FromQuery] string category, [FromQuery] string dimension, [FromQuery] string? phase)
     {
         using (logger.BeginScope(new { type, id }))
         {
@@ -28,7 +28,7 @@ public class CensusProxyController(
                 {
                     OrganisationTypes.School => await GetSchoolSet(id),
                     OrganisationTypes.Trust => await GetTrustSet(id),
-                    OrganisationTypes.LocalAuthority => await GetLocalAuthoritySet(id),
+                    OrganisationTypes.LocalAuthority => await GetLocalAuthoritySet(id, phase),
                     _ => throw new ArgumentOutOfRangeException(nameof(type))
                 };
 
@@ -78,9 +78,12 @@ public class CensusProxyController(
         return result.Select(x => x.Urn).OfType<string>();
     }
 
-    private async Task<IEnumerable<string>> GetLocalAuthoritySet(string id)
+    private async Task<IEnumerable<string>> GetLocalAuthoritySet(string id, string? phase)
     {
-        var query = new ApiQuery().AddIfNotNull("laCode", id);
+        var query = new ApiQuery()
+            .AddIfNotNull("laCode", id)
+            .AddIfNotNull("phase", phase);
+
         var result = await establishmentApi.QuerySchools(query).GetResultOrThrow<IEnumerable<School>>();
         return result.Select(x => x.Urn).OfType<string>();
     }

--- a/web/src/Web.App/Controllers/Api/ProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/ProxyController.cs
@@ -19,7 +19,7 @@ public class ProxyController(
     [HttpGet]
     [Produces("application/json")]
     [Route("establishments/expenditure")]
-    public async Task<IActionResult> EstablishmentExpenditure([FromQuery] string type, [FromQuery] string id)
+    public async Task<IActionResult> EstablishmentExpenditure([FromQuery] string type, [FromQuery] string id, [FromQuery] string? phase)
     {
         using (logger.BeginScope(new { type, id }))
         {
@@ -32,7 +32,7 @@ public class ProxyController(
                     case OrganisationTypes.Trust:
                         return await TrustExpenditure(id);
                     case OrganisationTypes.LocalAuthority:
-                        return await LocalAuthorityExpenditure(id);
+                        return await LocalAuthorityExpenditure(id, phase);
                     default:
                         throw new ArgumentOutOfRangeException(nameof(type));
                 }
@@ -124,9 +124,12 @@ public class ProxyController(
     }
 
 
-    private async Task<IActionResult> LocalAuthorityExpenditure(string id)
+    private async Task<IActionResult> LocalAuthorityExpenditure(string id, string? phase)
     {
-        var query = new ApiQuery().AddIfNotNull("laCode", id);
+        var query = new ApiQuery()
+            .AddIfNotNull("laCode", id)
+            .AddIfNotNull("phase", phase);
+
         var schools = await establishmentApi.QuerySchools(query).GetResultOrThrow<IEnumerable<School>>();
         var result = await financeService.GetExpenditure(schools.Select(x => x.Urn).OfType<string>());
         return new JsonResult(result);

--- a/web/src/Web.App/Controllers/LocalAuthorityCensusController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityCensusController.cs
@@ -26,7 +26,13 @@ public class LocalAuthorityCensusController(
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.LocalAuthorityCensus(code);
 
                 var localAuthority = await establishmentApi.GetLocalAuthority(code).GetResultOrThrow<LocalAuthority>();
-                var viewModel = new LocalAuthorityCensusViewModel(localAuthority);
+
+                var query = new ApiQuery().AddIfNotNull("laCode", code);
+                var schools = await establishmentApi.QuerySchools(query).GetResultOrThrow<School[]>();
+
+                var phases = schools.GroupBy(x => x.OverallPhase).OrderByDescending(x => x.Count()).Select(x => x.Key).OfType<string>().ToArray();
+
+                var viewModel = new LocalAuthorityCensusViewModel(localAuthority, phases);
 
                 return View(viewModel);
             }

--- a/web/src/Web.App/Controllers/LocalAuthorityComparisonController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityComparisonController.cs
@@ -26,7 +26,13 @@ public class LocalAuthorityComparisonController(
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.LocalAuthorityComparison(code);
 
                 var localAuthority = await establishmentApi.GetLocalAuthority(code).GetResultOrThrow<LocalAuthority>();
-                var viewModel = new LocalAuthorityComparisonViewModel(localAuthority);
+
+                var query = new ApiQuery().AddIfNotNull("laCode", code);
+                var schools = await establishmentApi.QuerySchools(query).GetResultOrThrow<School[]>();
+
+                var phases = schools.GroupBy(x => x.OverallPhase).OrderByDescending(x => x.Count()).Select(x => x.Key).OfType<string>().ToArray();
+
+                var viewModel = new LocalAuthorityComparisonViewModel(localAuthority, phases);
 
                 return View(viewModel);
             }

--- a/web/src/Web.App/ViewModels/LocalAuthorityCensusViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityCensusViewModel.cs
@@ -2,8 +2,9 @@
 
 namespace Web.App.ViewModels;
 
-public class LocalAuthorityCensusViewModel(LocalAuthority localAuthority)
+public class LocalAuthorityCensusViewModel(LocalAuthority localAuthority, string[] phases)
 {
     public string? Code => localAuthority.Code;
     public string? Name => localAuthority.Name;
+    public string[] Phases => phases;
 }

--- a/web/src/Web.App/ViewModels/LocalAuthorityComparisonViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityComparisonViewModel.cs
@@ -2,8 +2,9 @@
 
 namespace Web.App.ViewModels;
 
-public class LocalAuthorityComparisonViewModel(LocalAuthority localAuthority)
+public class LocalAuthorityComparisonViewModel(LocalAuthority localAuthority, string[] phases)
 {
     public string? Code => localAuthority.Code;
     public string? Name => localAuthority.Name;
+    public string[] Phases => phases;
 }

--- a/web/src/Web.App/Views/LocalAuthorityCensus/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityCensus/Index.cshtml
@@ -1,4 +1,6 @@
-﻿@model Web.App.ViewModels.LocalAuthorityCensusViewModel
+﻿@using Newtonsoft.Json
+@using Web.App.Extensions
+@model Web.App.ViewModels.LocalAuthorityCensusViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.Census;
 }
@@ -7,6 +9,10 @@
 
 @await Component.InvokeAsync("DataSource", new { kind = OrganisationTypes.LocalAuthority, additionText = new [] {"Compare your schools census data."}})
 
-<div id="compare-your-census" data-type="@OrganisationTypes.LocalAuthority" data-id="@Model.Code"></div>
+<div id="compare-your-census"
+     data-type="@OrganisationTypes.LocalAuthority"
+     data-id="@Model.Code"
+     data-phases="@Model.Phases.ToJson(Formatting.None)">
+</div>
 
 @await Component.InvokeAsync("LocalAuthorityFinanceTools", new { identifier = Model.Code, tools = new[] { FinanceTools.CompareYourCosts } })

--- a/web/src/Web.App/Views/LocalAuthorityComparison/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityComparison/Index.cshtml
@@ -1,4 +1,6 @@
-﻿@model Web.App.ViewModels.LocalAuthorityComparisonViewModel
+﻿@using Newtonsoft.Json
+@using Web.App.Extensions
+@model Web.App.ViewModels.LocalAuthorityComparisonViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.Comparison;
 }
@@ -7,6 +9,10 @@
 
 @await Component.InvokeAsync("DataSource", new { kind = OrganisationTypes.LocalAuthority, additionText = new [] {"Compare your schools spending costs."}})
 
-<div id="compare-your-costs" data-type="@OrganisationTypes.LocalAuthority" data-id="@Model.Code"></div>
+<div id="compare-your-costs"
+     data-type="@OrganisationTypes.LocalAuthority"
+     data-id="@Model.Code"
+     data-phases="@Model.Phases.ToJson(Formatting.None)">
+</div>
 
 @await Component.InvokeAsync("LocalAuthorityFinanceTools", new { identifier = Model.Code, tools = new[] { FinanceTools.BenchmarkCensus } })


### PR DESCRIPTION
### Context
[AB#200888](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/200888) ([AB#209181](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/209181))

### Change proposed in this pull request
Adds phase filters to cost comparison and census benchmarking pages for local authority

### Guidance to review 
Front-end version will require bumping post PR merge

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

