### PR TITLE
Workforce data Custom Data form

### DIFF
--- a/web/src/Web.App/Constants/BreadcrumbNodes.cs
+++ b/web/src/Web.App/Constants/BreadcrumbNodes.cs
@@ -4,19 +4,79 @@ namespace Web.App;
 
 public static class BreadcrumbNodes
 {
-    public static MvcBreadcrumbNode SchoolHome(string urn) => new("Index", "School", PageTitles.SchoolHome) { RouteValues = new { urn } };
-    public static MvcBreadcrumbNode SchoolComparison(string urn) => new("Index", "SchoolComparison", PageTitles.Comparison) { RouteValues = new { urn }, Parent = SchoolHome(urn) };
-    public static MvcBreadcrumbNode SchoolSpending(string urn) => new("Index", "SchoolSpending", PageTitles.Spending) { RouteValues = new { urn }, Parent = SchoolHome(urn) };
-    public static MvcBreadcrumbNode SchoolPlanning(string urn) => new("Index", "SchoolPlanning", "Curriculum and financial planning") { RouteValues = new { urn }, Parent = SchoolHome(urn) };
-    public static MvcBreadcrumbNode SchoolCensus(string urn) => new("Index", "SchoolCensus", PageTitles.Census) { RouteValues = new { urn }, Parent = SchoolHome(urn) };
-    public static MvcBreadcrumbNode SchoolCustomData(string urn) => new("Index", "SchoolCustomData", PageTitles.SchoolChangeData) { RouteValues = new { urn }, Parent = SchoolHome(urn) };
+    public static MvcBreadcrumbNode SchoolHome(string urn)
+    {
+        return new MvcBreadcrumbNode("Index", "School", PageTitles.SchoolHome) { RouteValues = new { urn } };
+    }
 
-    public static MvcBreadcrumbNode TrustHome(string companyNumber) => new("Index", "Trust", PageTitles.TrustHome) { RouteValues = new { companyNumber } };
-    public static MvcBreadcrumbNode TrustComparison(string companyNumber) => new("Index", "TrustComparison", PageTitles.Comparison) { RouteValues = new { companyNumber }, Parent = TrustHome(companyNumber) };
-    public static MvcBreadcrumbNode TrustCensus(string companyNumber) => new("Index", "TrustCensus", PageTitles.Census) { RouteValues = new { companyNumber }, Parent = TrustHome(companyNumber) };
-    public static MvcBreadcrumbNode TrustPlanning(string companyNumber) => new("Index", "TrustPlanning", "Curriculum and financial planning") { RouteValues = new { companyNumber }, Parent = TrustHome(companyNumber) };
+    public static MvcBreadcrumbNode SchoolComparison(string urn)
+    {
+        return new MvcBreadcrumbNode("Index", "SchoolComparison", PageTitles.Comparison)
+        { RouteValues = new { urn }, Parent = SchoolHome(urn) };
+    }
 
-    public static MvcBreadcrumbNode LocalAuthorityHome(string code) => new("Index", "LocalAuthority", PageTitles.LocalAuthorityHome) { RouteValues = new { code } };
-    public static MvcBreadcrumbNode LocalAuthorityComparison(string code) => new("Index", "LocalAuthorityComparison", PageTitles.Comparison) { RouteValues = new { code }, Parent = LocalAuthorityHome(code) };
-    public static MvcBreadcrumbNode LocalAuthorityCensus(string code) => new("Index", "LocalAuthorityCensus", PageTitles.Census) { RouteValues = new { code }, Parent = LocalAuthorityHome(code) };
+    public static MvcBreadcrumbNode SchoolSpending(string urn)
+    {
+        return new MvcBreadcrumbNode("Index", "SchoolSpending", PageTitles.Spending)
+        { RouteValues = new { urn }, Parent = SchoolHome(urn) };
+    }
+
+    public static MvcBreadcrumbNode SchoolPlanning(string urn)
+    {
+        return new MvcBreadcrumbNode("Index", "SchoolPlanning", "Curriculum and financial planning")
+        { RouteValues = new { urn }, Parent = SchoolHome(urn) };
+    }
+
+    public static MvcBreadcrumbNode SchoolCensus(string urn)
+    {
+        return new MvcBreadcrumbNode("Index", "SchoolCensus", PageTitles.Census)
+        { RouteValues = new { urn }, Parent = SchoolHome(urn) };
+    }
+
+    public static MvcBreadcrumbNode SchoolCustomData(string urn)
+    {
+        return new MvcBreadcrumbNode("Index", "SchoolCustomData", PageTitles.SchoolChangeData)
+        { RouteValues = new { urn }, Parent = SchoolSpending(urn) };
+    }
+
+    public static MvcBreadcrumbNode TrustHome(string companyNumber)
+    {
+        return new MvcBreadcrumbNode("Index", "Trust", PageTitles.TrustHome) { RouteValues = new { companyNumber } };
+    }
+
+    public static MvcBreadcrumbNode TrustComparison(string companyNumber)
+    {
+        return new MvcBreadcrumbNode("Index", "TrustComparison", PageTitles.Comparison)
+        { RouteValues = new { companyNumber }, Parent = TrustHome(companyNumber) };
+    }
+
+    public static MvcBreadcrumbNode TrustCensus(string companyNumber)
+    {
+        return new MvcBreadcrumbNode("Index", "TrustCensus", PageTitles.Census)
+        { RouteValues = new { companyNumber }, Parent = TrustHome(companyNumber) };
+    }
+
+    public static MvcBreadcrumbNode TrustPlanning(string companyNumber)
+    {
+        return new MvcBreadcrumbNode("Index", "TrustPlanning", "Curriculum and financial planning")
+        { RouteValues = new { companyNumber }, Parent = TrustHome(companyNumber) };
+    }
+
+    public static MvcBreadcrumbNode LocalAuthorityHome(string code)
+    {
+        return new MvcBreadcrumbNode("Index", "LocalAuthority", PageTitles.LocalAuthorityHome)
+        { RouteValues = new { code } };
+    }
+
+    public static MvcBreadcrumbNode LocalAuthorityComparison(string code)
+    {
+        return new MvcBreadcrumbNode("Index", "LocalAuthorityComparison", PageTitles.Comparison)
+        { RouteValues = new { code }, Parent = LocalAuthorityHome(code) };
+    }
+
+    public static MvcBreadcrumbNode LocalAuthorityCensus(string code)
+    {
+        return new MvcBreadcrumbNode("Index", "LocalAuthorityCensus", PageTitles.Census)
+        { RouteValues = new { code }, Parent = LocalAuthorityHome(code) };
+    }
 }

--- a/web/src/Web.App/Constants/PageTitles.cs
+++ b/web/src/Web.App/Constants/PageTitles.cs
@@ -44,5 +44,6 @@ public static class PageTitles
     public const string SchoolChangeDataLanding = "Change data used to compare this school";
     public const string SchoolChangeDataFinancialData = "Change financial data";
     public const string SchoolChangeDataNonFinancialData = "Change non-financial data";
+    public const string SchoolChangeDataWorkforceData = "Change workforce data";
     public const string LocalAuthorityHome = "Your local authority";
 }

--- a/web/src/Web.App/Controllers/SchoolCustomDataChangeController.cs
+++ b/web/src/Web.App/Controllers/SchoolCustomDataChangeController.cs
@@ -7,6 +7,7 @@ using Web.App.Extensions;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Extensions;
 using Web.App.Services;
+using Web.App.TagHelpers;
 using Web.App.ViewModels;
 
 namespace Web.App.Controllers;
@@ -30,7 +31,8 @@ public class SchoolCustomDataChangeController(
         {
             try
             {
-                ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.SchoolCustomData(urn);
+                ViewData[ViewDataKeys.Backlink] =
+                    new BacklinkInfo(Url.Action("Index", "SchoolCustomData", new { urn }));
                 var viewModel = await BuildViewModel(urn);
                 return View(viewModel);
             }
@@ -79,7 +81,7 @@ public class SchoolCustomDataChangeController(
         {
             try
             {
-                ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.SchoolCustomData(urn);
+                ViewData[ViewDataKeys.Backlink] = new BacklinkInfo(Url.Action(nameof(FinancialData), new { urn }));
                 var viewModel = await BuildViewModel(urn);
                 return View(viewModel);
             }
@@ -128,7 +130,7 @@ public class SchoolCustomDataChangeController(
         {
             try
             {
-                ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.SchoolCustomData(urn);
+                ViewData[ViewDataKeys.Backlink] = new BacklinkInfo(Url.Action(nameof(NonFinancialData), new { urn }));
                 var viewModel = await BuildViewModel(urn);
                 return View(viewModel);
             }
@@ -158,7 +160,12 @@ public class SchoolCustomDataChangeController(
                 }
 
                 customDataService.MergeCustomDataIntoSession(urn, viewModel);
-                return StatusCode(StatusCodes.Status204NoContent);
+
+                // todo: post to orchestrator
+                customDataService.ClearCustomDataFromSession(urn);
+                // todo: persist orchestrator job ID to auth user data
+
+                return RedirectToAction("Index", "SchoolCustomData", new { urn });
             }
             catch (Exception e)
             {

--- a/web/src/Web.App/Domain/CustomData.cs
+++ b/web/src/Web.App/Domain/CustomData.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Web.App.ViewModels;
+// ReSharper disable MemberCanBePrivate.Global
 
 namespace Web.App.Domain;
 
@@ -152,7 +153,23 @@ public record CustomData
     public decimal? TeachersFte { get; set; }
     public decimal? SeniorLeadershipFte { get; set; }
 
-    public void Merge(IFinancialDataCustomDataViewModel viewModel)
+    public void Merge(ICustomDataViewModel viewModel)
+    {
+        switch (viewModel)
+        {
+            case IFinancialDataCustomDataViewModel financialViewModel:
+                Merge(financialViewModel);
+                break;
+            case INonFinancialDataCustomDataViewModel nonFinancialViewModel:
+                Merge(nonFinancialViewModel);
+                break;
+            case IWorkforceDataCustomDataViewModel workforceViewModel:
+                Merge(workforceViewModel);
+                break;
+        }
+    }
+
+    private void Merge(IFinancialDataCustomDataViewModel viewModel)
     {
         // Administrative supplies
         AdministrativeSuppliesCosts = viewModel.AdministrativeSuppliesCosts;
@@ -189,7 +206,7 @@ public record CustomData
         TeachingStaffCosts = viewModel.TeachingStaffCosts;
 
         // Utilities
-        EnergyCosts = EnergyCosts;
+        EnergyCosts = viewModel.EnergyCosts;
         WaterSewerageCosts = viewModel.WaterSewerageCosts;
 
         // Other costs
@@ -211,12 +228,18 @@ public record CustomData
         RevenueReserve = viewModel.RevenueReserve;
     }
 
-    public void Merge(INonFinancialDataCustomDataViewModel viewModel)
+    private void Merge(INonFinancialDataCustomDataViewModel viewModel)
     {
-        // Non-financial data
         NumberOfPupilsFte = viewModel.NumberOfPupilsFte;
         FreeSchoolMealPercent = viewModel.FreeSchoolMealPercent;
         SpecialEducationalNeedsPercent = viewModel.SpecialEducationalNeedsPercent;
         FloorArea = viewModel.FloorArea;
+    }
+
+    private void Merge(IWorkforceDataCustomDataViewModel viewModel)
+    {
+        WorkforceFte = viewModel.WorkforceFte;
+        TeachersFte = viewModel.TeachersFte;
+        SeniorLeadershipFte = viewModel.SeniorLeadershipFte;
     }
 }

--- a/web/src/Web.App/ViewModels/FinancialDataCustomDataViewModel.cs
+++ b/web/src/Web.App/ViewModels/FinancialDataCustomDataViewModel.cs
@@ -1,9 +1,11 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Web.App.Attributes;
 
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+
 namespace Web.App.ViewModels;
 
-public interface IFinancialDataCustomDataViewModel
+public interface IFinancialDataCustomDataViewModel : ICustomDataViewModel
 {
     decimal? AdministrativeSuppliesCosts { get; }
     decimal? CateringStaffCosts { get; }

--- a/web/src/Web.App/ViewModels/ICustomDataViewModel.cs
+++ b/web/src/Web.App/ViewModels/ICustomDataViewModel.cs
@@ -1,0 +1,3 @@
+﻿namespace Web.App.ViewModels;
+
+public interface ICustomDataViewModel;

--- a/web/src/Web.App/ViewModels/NonFinancialDataCustomDataViewModel.cs
+++ b/web/src/Web.App/ViewModels/NonFinancialDataCustomDataViewModel.cs
@@ -1,9 +1,11 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Web.App.Attributes;
 
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+
 namespace Web.App.ViewModels;
 
-public interface INonFinancialDataCustomDataViewModel
+public interface INonFinancialDataCustomDataViewModel : ICustomDataViewModel
 {
     decimal? NumberOfPupilsFte { get; }
     decimal? FreeSchoolMealPercent { get; }

--- a/web/src/Web.App/ViewModels/SchoolCustomDataChangeViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolCustomDataChangeViewModel.cs
@@ -338,6 +338,34 @@ public class SchoolCustomDataChangeViewModel(
             Units = SchoolCustomDataValueUnits.Area
         }
     );
+
+    public SchoolCustomDataSectionViewModel WorkforceDataSection => new(
+        "Workforce figures",
+        new SchoolCustomDataValueViewModel
+        {
+            Title = SchoolCustomDataViewModelTitles.WorkforceFte,
+            Name = nameof(SchoolCustomDataViewModel.WorkforceFte),
+            Current = CurrentValues.WorkforceFte,
+            Custom = CustomInput.WorkforceFte,
+            Units = SchoolCustomDataValueUnits.Actual
+        },
+        new SchoolCustomDataValueViewModel
+        {
+            Title = SchoolCustomDataViewModelTitles.TeachersFte,
+            Name = nameof(SchoolCustomDataViewModel.TeachersFte),
+            Current = CurrentValues.TeachersFte,
+            Custom = CustomInput.TeachersFte,
+            Units = SchoolCustomDataValueUnits.Actual
+        },
+        new SchoolCustomDataValueViewModel
+        {
+            Title = SchoolCustomDataViewModelTitles.SeniorLeadershipFte,
+            Name = nameof(SchoolCustomDataViewModel.SeniorLeadershipFte),
+            Current = CurrentValues.SeniorLeadershipFte,
+            Custom = CustomInput.SeniorLeadershipFte,
+            Units = SchoolCustomDataValueUnits.Actual
+        }
+    );
 }
 
 public record SchoolCustomDataSectionViewModel

--- a/web/src/Web.App/ViewModels/SchoolCustomDataViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolCustomDataViewModel.cs
@@ -188,4 +188,7 @@ public static class SchoolCustomDataViewModelTitles
     public const string FreeSchoolMealPercent = "Pupils eligible for free school meals (FSM)";
     public const string SpecialEducationalNeedsPercent = "Pupils with special educational needs (SEN)";
     public const string FloorArea = "Gross internal floor area";
+    public const string WorkforceFte = "School workforce (full time equivalent)";
+    public const string TeachersFte = "Number of teachers (full time equivalent)";
+    public const string SeniorLeadershipFte = "Senior leadership (full time equivalent)";
 }

--- a/web/src/Web.App/ViewModels/WorkforceDataCustomDataViewModel.cs
+++ b/web/src/Web.App/ViewModels/WorkforceDataCustomDataViewModel.cs
@@ -1,6 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+using Web.App.Attributes;
+
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+
 namespace Web.App.ViewModels;
 
-public interface IWorkforceDataCustomDataViewModel
+public interface IWorkforceDataCustomDataViewModel : ICustomDataViewModel
 {
     decimal? WorkforceFte { get; }
     decimal? TeachersFte { get; }
@@ -9,7 +14,15 @@ public interface IWorkforceDataCustomDataViewModel
 
 public record WorkforceDataCustomDataViewModel : IWorkforceDataCustomDataViewModel
 {
+    [PositiveNumericValue]
+    [Display(Name = SchoolCustomDataViewModelTitles.WorkforceFte)]
     public decimal? WorkforceFte { get; init; }
+
+    [PositiveNumericValue]
+    [Display(Name = SchoolCustomDataViewModelTitles.TeachersFte)]
     public decimal? TeachersFte { get; init; }
+
+    [PositiveNumericValue]
+    [Display(Name = SchoolCustomDataViewModelTitles.SeniorLeadershipFte)]
     public decimal? SeniorLeadershipFte { get; init; }
 }

--- a/web/src/Web.App/Views/SchoolCustomDataChange/WorkforceData.cshtml
+++ b/web/src/Web.App/Views/SchoolCustomDataChange/WorkforceData.cshtml
@@ -1,0 +1,23 @@
+﻿@model Web.App.ViewModels.SchoolCustomDataChangeViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.SchoolChangeData;
+}
+
+@await Component.InvokeAsync("EstablishmentHeading", new { title = PageTitles.SchoolChangeDataWorkforceData, name = Model.School.Name, id = Model.School.Urn, kind = OrganisationTypes.School })
+
+@await Html.PartialAsync("_ErrorSummary")
+@using (Html.BeginForm("WorkforceData", "SchoolCustomDataChange", new { urn = Model.School.Urn }, FormMethod.Post, true, new { novalidate = "novalidate" }))
+{
+    @await Html.PartialAsync("_CustomDataEntryTable", Model.WorkforceDataSection)
+    <button type="submit" class="govuk-button" data-module="govuk-button">
+        Continue
+    </button>
+}
+
+@section scripts
+{
+    <script type="module" add-nonce="true">
+        import { initAll } from '/js/govuk-frontend.min.js'
+        initAll()
+    </script>
+}

--- a/web/src/Web.App/Views/SchoolCustomDataChange/WorkforceData.cshtml
+++ b/web/src/Web.App/Views/SchoolCustomDataChange/WorkforceData.cshtml
@@ -10,7 +10,7 @@
 {
     @await Html.PartialAsync("_CustomDataEntryTable", Model.WorkforceDataSection)
     <button type="submit" class="govuk-button" data-module="govuk-button">
-        Continue
+        Save changes to data
     </button>
 }
 

--- a/web/src/Web.App/Views/Shared/Components/ComparatorSetDetails/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/ComparatorSetDetails/Default.cshtml
@@ -9,26 +9,35 @@
                 </span>
             </summary>
             <div class="govuk-details__text">
-            @switch (Model.Referrer)
-            {
-                case Referrers.SchoolCensus:
-                    @await Html.PartialAsync("Components/ComparatorSetDetails/_CensusDetails", Model)
-                    break;
-                case Referrers.SchoolSpending:
-                case Referrers.SchoolComparison:
-                    @await Html.PartialAsync("Components/ComparatorSetDetails/_CostDetails", Model)
-                    break;
-            }
-            @if (Model.Referrer is Referrers.SchoolComparison or Referrers.SchoolCensus)
-            {
-                <p class="govuk-body">
-                    <a class="govuk-link govuk-link--no-visited-state"
-                       href="@Url.Action("Custom", "SchoolComparators", new { urn = Model.Identifier, referrer = Model.Referrer })">
-                        Choose your own similar schools
-                    </a>
-                </p>
-            }
+                @switch (Model.Referrer)
+                {
+                    case Referrers.SchoolCensus:
+                        @await Html.PartialAsync("Components/ComparatorSetDetails/_CensusDetails", Model)
+                        break;
+                    case Referrers.SchoolSpending:
+                    case Referrers.SchoolComparison:
+                        @await Html.PartialAsync("Components/ComparatorSetDetails/_CostDetails", Model)
+                        break;
+                }
+                @if (Model.Referrer is Referrers.SchoolComparison or Referrers.SchoolCensus)
+                {
+                    <p class="govuk-body">
+                        <a class="govuk-link govuk-link--no-visited-state"
+                           href="@Url.Action("Custom", "SchoolComparators", new { urn = Model.Identifier, referrer = Model.Referrer })">
+                            Choose your own similar schools
+                        </a>
+                    </p>
+                }
             </div>
         </details>
+
+        <feature name="@FeatureFlags.CustomData">
+            <p class="govuk-body">
+                <a class="govuk-link govuk-link--no-visited-state"
+                   href="@Url.Action("Index", "SchoolCustomData", new { urn = Model.Identifier })">
+                    Change data used to compare this school
+                </a>
+            </p>
+        </feature>
     </div>
 </div>

--- a/web/src/Web.App/Views/_ViewImports.cshtml
+++ b/web/src/Web.App/Views/_ViewImports.cshtml
@@ -2,3 +2,4 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, SmartBreadcrumbs
 @addTagHelper *, Web.App
+@addTagHelper *, Microsoft.FeatureManagement.AspNetCore


### PR DESCRIPTION
### Context
[AB#208016](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/208016) [AB#198080](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/198080)

### Change proposed in this pull request
Population of Custom Workforce Data form, including validation and managing of underlying values via state. Added feature-toggled link from Spending and Costs page.

### Guidance to review 
Data capture should be possible from the Spending and Costs page through to the Workforce Custom Data page. This is the scope of this work item - the actual posting of the Custom Data persisted to session storage to the Orchestrator, and the UI around polling for job completion is covered as part of another story. Final value-dependent validations are also covered under a sibling ticket.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

