### PR TITLE
adds phase filter for trust benchmarking

### DIFF
--- a/web/src/Web.App/Controllers/Api/CensusProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/CensusProxyController.cs
@@ -27,7 +27,7 @@ public class CensusProxyController(
                 var set = type.ToLower() switch
                 {
                     OrganisationTypes.School => await GetSchoolSet(id),
-                    OrganisationTypes.Trust => await GetTrustSet(id),
+                    OrganisationTypes.Trust => await GetTrustSet(id, phase),
                     OrganisationTypes.LocalAuthority => await GetLocalAuthoritySet(id, phase),
                     _ => throw new ArgumentOutOfRangeException(nameof(type))
                 };
@@ -71,9 +71,12 @@ public class CensusProxyController(
         return result.DefaultPupil;
     }
 
-    private async Task<IEnumerable<string>> GetTrustSet(string id)
+    private async Task<IEnumerable<string>> GetTrustSet(string id, string? phase)
     {
-        var query = new ApiQuery().AddIfNotNull("companyNumber", id);
+        var query = new ApiQuery()
+            .AddIfNotNull("companyNumber", id)
+            .AddIfNotNull("phase", phase);
+
         var result = await establishmentApi.QuerySchools(query).GetResultOrThrow<IEnumerable<School>>();
         return result.Select(x => x.Urn).OfType<string>();
     }

--- a/web/src/Web.App/Controllers/Api/ProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/ProxyController.cs
@@ -30,7 +30,7 @@ public class ProxyController(
                     case OrganisationTypes.School:
                         return await SchoolExpenditure(id);
                     case OrganisationTypes.Trust:
-                        return await TrustExpenditure(id);
+                        return await TrustExpenditure(id, phase);
                     case OrganisationTypes.LocalAuthority:
                         return await LocalAuthorityExpenditure(id, phase);
                     default:
@@ -135,9 +135,11 @@ public class ProxyController(
         return new JsonResult(result);
     }
 
-    private async Task<IActionResult> TrustExpenditure(string id)
+    private async Task<IActionResult> TrustExpenditure(string id, string? phase)
     {
-        var query = new ApiQuery().AddIfNotNull("companyNumber", id);
+        var query = new ApiQuery()
+            .AddIfNotNull("companyNumber", id)
+            .AddIfNotNull("phase", phase); ;
         var schools = await establishmentApi.QuerySchools(query).GetResultOrThrow<IEnumerable<School>>();
         var result = await financeService.GetExpenditure(schools.Select(x => x.Urn).OfType<string>());
         return new JsonResult(result);

--- a/web/src/Web.App/Controllers/TrustCensusController.cs
+++ b/web/src/Web.App/Controllers/TrustCensusController.cs
@@ -26,7 +26,13 @@ public class TrustCensusController(
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.TrustCensus(companyNumber);
 
                 var trust = await establishmentApi.GetTrust(companyNumber).GetResultOrThrow<Trust>();
-                var viewModel = new TrustCensusViewModel(trust);
+
+                var query = new ApiQuery().AddIfNotNull("companyNumber", companyNumber);
+                var schools = await establishmentApi.QuerySchools(query).GetResultOrThrow<School[]>();
+
+                var phases = schools.GroupBy(x => x.OverallPhase).OrderByDescending(x => x.Count()).Select(x => x.Key).OfType<string>().ToArray();
+
+                var viewModel = new TrustCensusViewModel(trust, phases);
 
                 return View(viewModel);
             }

--- a/web/src/Web.App/Controllers/TrustComparisonController.cs
+++ b/web/src/Web.App/Controllers/TrustComparisonController.cs
@@ -26,7 +26,14 @@ public class TrustComparisonController(
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.TrustComparison(companyNumber);
 
                 var trust = await establishmentApi.GetTrust(companyNumber).GetResultOrThrow<Trust>();
-                var viewModel = new TrustComparisonViewModel(trust);
+
+                var query = new ApiQuery().AddIfNotNull("companyNumber", companyNumber);
+                var schools = await establishmentApi.QuerySchools(query).GetResultOrThrow<School[]>();
+
+                var phases = schools.GroupBy(x => x.OverallPhase).OrderByDescending(x => x.Count()).Select(x => x.Key).OfType<string>().ToArray();
+
+                var viewModel = new TrustComparisonViewModel(trust, phases);
+
 
                 return View(viewModel);
             }

--- a/web/src/Web.App/ViewModels/TrustCensusViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustCensusViewModel.cs
@@ -2,8 +2,9 @@
 
 namespace Web.App.ViewModels;
 
-public class TrustCensusViewModel(Trust trust)
+public class TrustCensusViewModel(Trust trust, string[] phases)
 {
     public string? CompanyNumber => trust.CompanyNumber;
     public string? Name => trust.Name;
+    public string[] Phases => phases;
 }

--- a/web/src/Web.App/ViewModels/TrustComparisonViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustComparisonViewModel.cs
@@ -2,8 +2,9 @@
 
 namespace Web.App.ViewModels;
 
-public class TrustComparisonViewModel(Trust trust)
+public class TrustComparisonViewModel(Trust trust, string[] phases)
 {
     public string? CompanyNumber => trust.CompanyNumber;
     public string? Name => trust.Name;
+    public string[] Phases => phases;
 }

--- a/web/src/Web.App/Views/TrustCensus/Index.cshtml
+++ b/web/src/Web.App/Views/TrustCensus/Index.cshtml
@@ -1,4 +1,6 @@
-﻿@model Web.App.ViewModels.TrustCensusViewModel
+﻿@using Web.App.Extensions
+@using Newtonsoft.Json
+@model Web.App.ViewModels.TrustCensusViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.Census;
 }
@@ -7,6 +9,10 @@
 
 @await Component.InvokeAsync("DataSource", new { kind = OrganisationTypes.Trust, isPartOfTrust = true, additionText = new [] {"Compare your schools census data."}})
 
-<div id="compare-your-census" data-type="@OrganisationTypes.Trust" data-id="@Model.CompanyNumber"></div>
+<div id="compare-your-census" 
+     data-type="@OrganisationTypes.Trust" 
+     data-id="@Model.CompanyNumber" 
+     data-phases="@Model.Phases.ToJson(Formatting.None)">
+</div>
 
 @await Component.InvokeAsync("TrustFinanceTools", new { identifier = Model.CompanyNumber, tools = new[] { FinanceTools.FinancialPlanning, FinanceTools.CompareYourCosts } })

--- a/web/src/Web.App/Views/TrustComparison/Index.cshtml
+++ b/web/src/Web.App/Views/TrustComparison/Index.cshtml
@@ -1,4 +1,6 @@
-﻿@model Web.App.ViewModels.TrustComparisonViewModel
+﻿@using Web.App.Extensions
+@using Newtonsoft.Json
+@model Web.App.ViewModels.TrustComparisonViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.Comparison;
 }
@@ -7,6 +9,10 @@
 
 @await Component.InvokeAsync("DataSource", new { kind = OrganisationTypes.Trust, isPartOfTrust = true, additionText = new [] {"Compare your schools spending costs."}})
 
-<div id="compare-your-costs" data-type="@OrganisationTypes.Trust" data-id="@Model.CompanyNumber"></div>
+<div id="compare-your-costs" 
+     data-type="@OrganisationTypes.Trust" 
+     data-id="@Model.CompanyNumber" 
+     data-phases="@Model.Phases.ToJson(Formatting.None)">
+</div>
 
 @await Component.InvokeAsync("TrustFinanceTools", new { identifier = Model.CompanyNumber, tools = new[] { FinanceTools.FinancialPlanning, FinanceTools.BenchmarkCensus } })


### PR DESCRIPTION
### Context
[AB#207740](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/207740) - [AB#209254](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/209254) & [AB#207739](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/207739) - [AB#209255](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/209255)

### Change proposed in this pull request
Adds filter by phase to comparison and census benchmarking pages for trusts.

### Guidance to review 
N/A

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

