### PR TITLE
Custom Data 'Totals' calculations and additional validation rules

### DIFF
--- a/web/src/Web.App/Attributes/CompareDecimalValueAttribute.cs
+++ b/web/src/Web.App/Attributes/CompareDecimalValueAttribute.cs
@@ -1,0 +1,114 @@
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace Web.App.Attributes;
+
+public class CompareDecimalValueAttribute(string otherProperty, Operator operatorType) : CompareAttribute(otherProperty)
+{
+    private new string? OtherPropertyDisplayName { get; set; }
+
+    public Operator OperatorType { get; } = operatorType;
+
+    public override string FormatErrorMessage(string name)
+    {
+        var error = OperatorType switch
+        {
+            Operator.EqualTo => "should be equal to",
+            Operator.GreaterThan => "cannot be less than or equal to",
+            Operator.GreaterThanOrEqualTo => "cannot be less than",
+            Operator.LessThan => "cannot be greater than or equal to",
+            Operator.LessThanOrEqualTo => "cannot be greater than",
+            _ => throw new ArgumentOutOfRangeException(nameof(OperatorType))
+        };
+
+        return $"{name} {error} {(OtherPropertyDisplayName ?? OtherProperty).ToLower()}";
+    }
+
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+    {
+        var otherPropertyInfo = validationContext.ObjectType.GetRuntimeProperty(OtherProperty);
+        if (otherPropertyInfo == null)
+        {
+            return new ValidationResult($"Could not find a property named {OtherProperty}.");
+        }
+
+        if (otherPropertyInfo.GetIndexParameters().Length > 0)
+        {
+            throw new ArgumentException(
+                $"The property {validationContext.ObjectType.FullName}.{OtherProperty} could not be found.");
+        }
+
+        var propertyValue = value as decimal?;
+        var otherPropertyValue = otherPropertyInfo.GetValue(validationContext.ObjectInstance, null) as decimal?;
+        switch (OperatorType)
+        {
+            case Operator.EqualTo:
+                if (Equals(value, otherPropertyValue))
+                {
+                    return null;
+                }
+
+                break;
+            case Operator.GreaterThan:
+                if (propertyValue > otherPropertyValue)
+                {
+                    return null;
+                }
+
+                break;
+            case Operator.GreaterThanOrEqualTo:
+                if (propertyValue >= otherPropertyValue)
+                {
+                    return null;
+                }
+
+                break;
+            case Operator.LessThan:
+                if (propertyValue < otherPropertyValue)
+                {
+                    return null;
+                }
+
+                break;
+            case Operator.LessThanOrEqualTo:
+                if (propertyValue <= otherPropertyValue)
+                {
+                    return null;
+                }
+
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(OperatorType));
+        }
+
+        OtherPropertyDisplayName ??= GetDisplayNameForProperty(otherPropertyInfo);
+
+        var memberNames = validationContext.MemberName != null
+            ? new[] { validationContext.MemberName }
+            : null;
+        return new ValidationResult(FormatErrorMessage(validationContext.DisplayName), memberNames);
+    }
+
+    private string? GetDisplayNameForProperty(PropertyInfo property)
+    {
+        var attributes = CustomAttributeExtensions.GetCustomAttributes(property, true);
+        foreach (var attribute in attributes)
+        {
+            if (attribute is DisplayAttribute display)
+            {
+                return display.GetName();
+            }
+        }
+
+        return OtherProperty;
+    }
+}
+
+public enum Operator
+{
+    EqualTo,
+    GreaterThan,
+    GreaterThanOrEqualTo,
+    LessThan,
+    LessThanOrEqualTo
+}

--- a/web/src/Web.App/ViewModels/SchoolCustomDataChangeViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolCustomDataChangeViewModel.cs
@@ -300,7 +300,7 @@ public class SchoolCustomDataChangeViewModel(
             Name = nameof(SchoolCustomDataViewModel.RevenueReserve),
             Current = CurrentValues.RevenueReserve,
             Custom = CustomInput.RevenueReserve,
-            ReadOnly = true
+            Hidden = true
         });
 
     public SchoolCustomDataSectionViewModel NonFinancialDataSection => new(
@@ -387,6 +387,7 @@ public record SchoolCustomDataValueViewModel
     public decimal? Current { get; init; }
     public decimal? Custom { get; init; }
     public bool ReadOnly { get; init; }
+    public bool Hidden { get; init; }
     public SchoolCustomDataValueUnits Units { get; init; } = SchoolCustomDataValueUnits.Currency;
 }
 

--- a/web/src/Web.App/ViewModels/WorkforceDataCustomDataViewModel.cs
+++ b/web/src/Web.App/ViewModels/WorkforceDataCustomDataViewModel.cs
@@ -20,9 +20,11 @@ public record WorkforceDataCustomDataViewModel : IWorkforceDataCustomDataViewMod
 
     [PositiveNumericValue]
     [Display(Name = SchoolCustomDataViewModelTitles.TeachersFte)]
+    [CompareDecimalValue(nameof(WorkforceFte), Operator.LessThan)]
     public decimal? TeachersFte { get; init; }
 
     [PositiveNumericValue]
     [Display(Name = SchoolCustomDataViewModelTitles.SeniorLeadershipFte)]
+    [CompareDecimalValue(nameof(TeachersFte), Operator.LessThan)]
     public decimal? SeniorLeadershipFte { get; init; }
 }

--- a/web/src/Web.App/Views/SchoolCustomDataChange/FinancialData.cshtml
+++ b/web/src/Web.App/Views/SchoolCustomDataChange/FinancialData.cshtml
@@ -6,7 +6,7 @@
 @await Component.InvokeAsync("EstablishmentHeading", new { title = PageTitles.SchoolChangeDataFinancialData, name = Model.School.Name, id = Model.School.Urn, kind = OrganisationTypes.School })
 
 @await Html.PartialAsync("_ErrorSummary")
-@using (Html.BeginForm("FinancialData", "SchoolCustomDataChange", new { urn = Model.School.Urn }, FormMethod.Post, true, new { novalidate = "novalidate" }))
+@using (Html.BeginForm("FinancialData", "SchoolCustomDataChange", new { urn = Model.School.Urn }, FormMethod.Post, true, new { novalidate = "novalidate", id = "form-custom-data-financial" }))
 {
     <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-financial-data">
         @await Html.PartialAsync("_AccordionSection", Model.AdministrativeSuppliesSection)
@@ -18,9 +18,13 @@
         @await Html.PartialAsync("_AccordionSection", Model.TeachingAndTeachingSupportSection)
         @await Html.PartialAsync("_AccordionSection", Model.UtilitiesSection)
         @await Html.PartialAsync("_AccordionSection", Model.OtherCostsSection)
-
-        @* TODO: resolve questiond around functionality of 'totals' section *@
-        @await Html.PartialAsync("_AccordionSection", Model.TotalsSection)
+    </div>
+    <div id="custom-data-totals">
+        <h2 class="govuk-heading-m">
+            Totals
+        </h2>
+        @await Html.PartialAsync("_CustomDataEntryTable", Model.TotalsSection)
+        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible"/>
     </div>
     <button type="submit" class="govuk-button" data-module="govuk-button">
         Continue
@@ -29,8 +33,92 @@
 
 @section scripts
 {
+    <!--suppress JSFileReferences -->
     <script type="module" add-nonce="true">
-        import { initAll } from '/js/govuk-frontend.min.js'
-        initAll()
+        import { initAll } from '/js/govuk-frontend.min.js';
+        initAll();
+
+        const currentTotalIncomeElement = document.getElementById("current-TotalIncome");
+        const currentTotalExpenditureElement = document.getElementById("current-TotalExpenditure");
+        const customTotalIncomeElement = document.getElementById("custom-TotalIncome");
+        const customTotalExpenditureElement = document.getElementById("custom-TotalExpenditure");
+        const customTotalIncomeInputElement = document.getElementById("TotalIncome");
+        const customTotalExpenditureInputElement = document.getElementById("TotalExpenditure");
+        const form = document.getElementById("form-custom-data-financial");
+        const inputs = form.getElementsByTagName("input");
+        const currencyFormatter = new Intl.NumberFormat("en-GB", { style: "currency", currency: "GBP" });
+        
+        // get the current totals to help obtain the base figures to use with custom values
+        const currentTotalIncome = parseFloat(currentTotalIncomeElement.dataset.value);
+        const currentTotalExpenditure = parseFloat(currentTotalExpenditureElement.dataset.value);
+        let baseIncome = 0;
+        let baseExpenditure = 0;
+        
+        const recalculateAndSetTotals = function() {
+            let customIncome = 0;
+            let customExpenditure = 0;
+
+            // for every <form>'s <input> that is not `type=hidden`:
+            //   1. parse the corresponding 'current' value
+            //   2. attempt to parse the 'custom' value in the <input>
+            //   3. add 'custom' value, if valid, otherwise 'current' value to 'custom' income/expenditure totals
+            for (let input of inputs) {
+                const currentValueElement = document.getElementById(`current-${input.id}`);
+                if (!currentValueElement || input.type === "hidden") {
+                    continue;
+                }
+                
+                const currentValue = parseFloat(currentValueElement.dataset.value);
+                const value = input.value === "" ? currentValue : parseFloat(input.value);
+                if (isNaN(value)) {
+                    continue;
+                }
+
+                const isIncome = input.id.includes("Income");
+                if (isIncome) {
+                    customIncome += value;
+                } else {
+                    customExpenditure += value;
+                }
+            }
+
+            // then calculate the new totals based on the base values calculated earlier
+            const customTotalIncome = customIncome + baseIncome;
+            const customTotalExpenditure = customExpenditure + baseExpenditure;
+            
+            // and set appropriately in the DOM
+            customTotalIncomeElement.setAttribute("data-value", customTotalIncome.toString());
+            customTotalIncomeElement.innerText = currencyFormatter.format(customTotalIncome);
+            customTotalIncomeInputElement.value = customTotalIncome.toString();
+            customTotalExpenditureElement.setAttribute("data-value", customTotalExpenditure.toString());
+            customTotalExpenditureElement.innerText = currencyFormatter.format(customTotalExpenditure);
+            customTotalExpenditureInputElement.value = customTotalExpenditure.toString();
+        }
+        
+        // for every <form>'s <input> that is not `type=hidden`:
+        //   1. attach an event listener when the field is blurred
+        //   2. add corresponding 'current' value to 'current' income/expenditure totals
+        let currentIncome = 0;
+        let currentExpenditure = 0;
+        for (let input of inputs) {
+            input.addEventListener("blur", recalculateAndSetTotals);
+            
+            const currentValueElement = document.getElementById(`current-${input.id}`);
+            if (!currentValueElement || input.type === "hidden") {
+                continue;
+            }
+            
+            const value = parseFloat(currentValueElement.dataset.value);
+            const isIncome = input.id.includes("Income");
+            if (isIncome) {
+                currentIncome += value;
+            } else {
+                currentExpenditure += value;
+            }
+        }
+
+        // then calculate the base income/expenditure values to use when calculating the 'custom' values 
+        baseIncome = currentTotalIncome - currentIncome;
+        baseExpenditure = currentTotalExpenditure - currentExpenditure;
     </script>
 }

--- a/web/src/Web.App/Views/SchoolCustomDataChange/NonFinancialData.cshtml
+++ b/web/src/Web.App/Views/SchoolCustomDataChange/NonFinancialData.cshtml
@@ -14,7 +14,7 @@
 </div>
 
 @await Html.PartialAsync("_ErrorSummary")
-@using (Html.BeginForm("NonFinancialData", "SchoolCustomDataChange", new { urn = Model.School.Urn }, FormMethod.Post, true, new { novalidate = "novalidate" }))
+@using (Html.BeginForm("NonFinancialData", "SchoolCustomDataChange", new { urn = Model.School.Urn }, FormMethod.Post, true, new { novalidate = "novalidate", id = "form-custom-data-non-financial" }))
 {
     @await Html.PartialAsync("_CustomDataEntryTable", Model.NonFinancialDataSection)
     <button type="submit" class="govuk-button" data-module="govuk-button">

--- a/web/src/Web.App/Views/SchoolCustomDataChange/WorkforceData.cshtml
+++ b/web/src/Web.App/Views/SchoolCustomDataChange/WorkforceData.cshtml
@@ -6,7 +6,7 @@
 @await Component.InvokeAsync("EstablishmentHeading", new { title = PageTitles.SchoolChangeDataWorkforceData, name = Model.School.Name, id = Model.School.Urn, kind = OrganisationTypes.School })
 
 @await Html.PartialAsync("_ErrorSummary")
-@using (Html.BeginForm("WorkforceData", "SchoolCustomDataChange", new { urn = Model.School.Urn }, FormMethod.Post, true, new { novalidate = "novalidate" }))
+@using (Html.BeginForm("WorkforceData", "SchoolCustomDataChange", new { urn = Model.School.Urn }, FormMethod.Post, true, new { novalidate = "novalidate", id = "form-custom-data-workforce" }))
 {
     @await Html.PartialAsync("_CustomDataEntryTable", Model.WorkforceDataSection)
     <button type="submit" class="govuk-button" data-module="govuk-button">

--- a/web/src/Web.App/Views/SchoolCustomDataChange/_CustomDataEntryTableRow.cshtml
+++ b/web/src/Web.App/Views/SchoolCustomDataChange/_CustomDataEntryTableRow.cshtml
@@ -37,13 +37,23 @@
 
 <tr class="govuk-table__row" id="@id">
     <td class="govuk-table__cell">@Model.Title</td>
-    <td class="govuk-table__cell">@currentValueFormatted</td>
+    <td class="govuk-table__cell">
+        <span id="current-@Model.Name" data-value="@currentValue">
+            @currentValueFormatted
+        </span>
+    </td>
     <td class="govuk-table__cell">
         @if (Model.ReadOnly)
         {
-            @Model.Custom.ToCurrency()
+            <span id="custom-@Model.Name" data-value="@Model.Custom">
+                @if (Model.Custom > 0)
+                {
+                    @Model.Custom.ToCurrency()
+                }
+            </span>
+            <input id="@Model.Name" name="@Model.Name" type="hidden" value="@Model.Custom"/>
         }
-        else
+        else if (!Model.Hidden)
         {
             <div class="govuk-form-group govuk-!-margin-bottom-0">
                 <label class="govuk-label govuk-visually-hidden" for="@Model.Name">

--- a/web/tests/Web.Tests/Attributes/GivenACompareDecimalValueAttribute.cs
+++ b/web/tests/Web.Tests/Attributes/GivenACompareDecimalValueAttribute.cs
@@ -1,0 +1,91 @@
+﻿using System.ComponentModel.DataAnnotations;
+using AutoFixture;
+using Web.App.Attributes;
+using Xunit;
+
+namespace Web.Tests.Attributes;
+
+public class GivenCompareDecimalValueAttribute
+{
+    private readonly Fixture _fixture = new();
+
+    [Fact]
+    public void ThrowsValidationExceptionWhenOtherFieldIsInvalid()
+    {
+        var attribute = new CompareDecimalValueAttribute("Other", Operator.EqualTo);
+        var model = new TestModel(100);
+        var context = new ValidationContext(model);
+
+        var exception = Assert.Throws<ValidationException>(() => attribute.Validate(123, context));
+        Assert.Equal("Could not find a property named Other.", exception.Message);
+    }
+
+    [Fact]
+    public void ThrowsValidationExceptionWhenOtherFieldIsIndexer()
+    {
+        var attribute = new CompareDecimalValueAttribute("Item", Operator.EqualTo);
+        var model = new BadTestModel();
+        var context = new ValidationContext(model);
+
+        var exception = Assert.Throws<ArgumentException>(() => attribute.Validate(123, context));
+        Assert.Equal(
+            "The property Web.Tests.Attributes.GivenCompareDecimalValueAttribute+BadTestModel.Item could not be found.",
+            exception.Message);
+    }
+
+    [Theory]
+    [InlineData(50, 100, Operator.EqualTo, "This field should be equal to other field")]
+    [InlineData(50, 100, Operator.GreaterThan, "This field cannot be less than or equal to other field")]
+    [InlineData(100, 100, Operator.GreaterThan, "This field cannot be less than or equal to other field")]
+    [InlineData(50, 100, Operator.GreaterThanOrEqualTo, "This field cannot be less than other field")]
+    [InlineData(100, 50, Operator.LessThan, "This field cannot be greater than or equal to other field")]
+    [InlineData(100, 100, Operator.LessThan, "This field cannot be greater than or equal to other field")]
+    [InlineData(100, 50, Operator.LessThanOrEqualTo, "This field cannot be greater than other field")]
+    public void ReturnsValidationResultWhenComparisonIsNotValid(decimal value, decimal otherValue,
+        Operator operatorType, string expected)
+    {
+        var attribute = new CompareDecimalValueAttribute(nameof(TestModel.OtherField), operatorType);
+        var model = new TestModel(otherValue);
+        var memberName = _fixture.Create<string>();
+        var context = new ValidationContext(model) { DisplayName = "This field", MemberName = memberName };
+
+        var validationResult = attribute.GetValidationResult(value, context);
+        Assert.Equal(expected, validationResult?.ErrorMessage);
+        Assert.Equal([memberName], validationResult?.MemberNames);
+    }
+
+    [Theory]
+    [InlineData(100, 100, Operator.EqualTo)]
+    [InlineData(100, 50, Operator.GreaterThan)]
+    [InlineData(100, 50, Operator.GreaterThanOrEqualTo)]
+    [InlineData(50, 50, Operator.GreaterThanOrEqualTo)]
+    [InlineData(50, 100, Operator.LessThan)]
+    [InlineData(50, 100, Operator.LessThanOrEqualTo)]
+    [InlineData(50, 50, Operator.LessThanOrEqualTo)]
+    public void ReturnsNullWhenComparisonIsValid(decimal value, decimal otherValue, Operator operatorType)
+    {
+        var attribute = new CompareDecimalValueAttribute(nameof(TestModel.OtherField), operatorType);
+        var model = new TestModel(otherValue);
+        var context = new ValidationContext(model);
+
+        var validationResult = attribute.GetValidationResult(value, context);
+        Assert.Null(validationResult);
+    }
+
+    private class TestModel(decimal value)
+    {
+        [Display(Name = "Other field")] public decimal OtherField { get; set; } = value;
+    }
+
+    private class BadTestModel
+    {
+        private readonly string[] _strings = [];
+
+        // ReSharper disable once UnusedMember.Local
+        public string this[int index]
+        {
+            get => _strings[index];
+            set => _strings[index] = value;
+        }
+    }
+}


### PR DESCRIPTION
### Context
[AB#209239](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/209239) [AB#198080](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/198080)

### Change proposed in this pull request
Additional validation rules on Workforce page. Client side calculation of Income/Expenditure totals on Financial Data page.

### Guidance to review 
Vanilla JS is used for the client side calculations here within the Web project, so there is no need to copy over `front-end-components` to test locally. There is a case for refactoring this script into something that could get `gulp`ed from TypeScript in `AssetSrc` into `wwwroot` and then importing by filename in the view rather than polluting the latter with lots of JS. Happy to do so if the reviewer insists!

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

