### PR TITLE
adds integration tests for trust comparison and census

### DIFF
--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -120,6 +120,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         InsightApi.Reset();
         InsightApi.Setup(api => api.GetSchoolFinances(It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok());
         InsightApi.Setup(api => api.GetRatings(It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(Array.Empty<RagRating>()));
+        InsightApi.Setup(api => api.GetCurrentReturnYears()).ReturnsAsync(ApiResult.Ok(new FinanceYears { Aar = 2022, Cfr = 2021 }));
         return this;
     }
 

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingCensus.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingCensus.cs
@@ -1,0 +1,123 @@
+﻿using System.Net;
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using AngleSharp.XPath;
+using AutoFixture;
+using Web.App.Domain;
+using Xunit;
+using Web.App;
+using Web.App.Extensions;
+using Newtonsoft.Json;
+
+namespace Web.Integration.Tests.Pages.Trusts;
+
+public class WhenViewingCensus(SchoolBenchmarkingWebAppClient client) : PageBase<SchoolBenchmarkingWebAppClient>(client)
+{
+    [Fact]
+    public async Task CanDisplay()
+    {
+        var (page, trust) = await SetupNavigateInitPage();
+
+        AssertPageLayout(page, trust);
+    }
+
+    [Fact]
+    public async Task CanNavigateToCompareCosts()
+    {
+        var (page, trust) = await SetupNavigateInitPage();
+
+        var liElements = page.QuerySelectorAll("ul.app-links > li");
+        var anchor = liElements[1].QuerySelector("h3 > a");
+        Assert.NotNull(anchor);
+
+        var newPage = await Client.Follow(anchor);
+
+        DocumentAssert.AssertPageUrl(newPage, Paths.TrustComparison(trust.CompanyNumber).ToAbsolute());
+    }
+
+    [Fact]
+    public async Task CanDisplayNotFound()
+    {
+        const string companyNumber = "12345678";
+        var page = await Client.SetupEstablishmentWithNotFound()
+            .Navigate(Paths.TrustCensus(companyNumber));
+
+        PageAssert.IsNotFoundPage(page);
+        DocumentAssert.AssertPageUrl(page, Paths.TrustCensus(companyNumber).ToAbsolute(), HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task CanDisplayProblemWithService()
+    {
+        const string companyNumber = "12345678";
+        var page = await Client.SetupEstablishmentWithException()
+            .Navigate(Paths.TrustCensus(companyNumber));
+
+        PageAssert.IsProblemPage(page);
+        DocumentAssert.AssertPageUrl(page, Paths.TrustCensus(companyNumber).ToAbsolute(), HttpStatusCode.InternalServerError);
+    }
+
+    private async Task<(IHtmlDocument page, Trust trust)> SetupNavigateInitPage()
+    {
+        var trust = Fixture.Build<Trust>()
+            .Create();
+
+        var primarySchools = Fixture.Build<School>()
+            .With(x => x.CompanyNumber, trust.CompanyNumber)
+            .With(x => x.OverallPhase, OverallPhaseTypes.Primary)
+            .CreateMany(9);
+
+        var secondarySchools = Fixture.Build<School>()
+            .With(x => x.CompanyNumber, trust.CompanyNumber)
+            .With(x => x.OverallPhase, OverallPhaseTypes.Secondary)
+            .CreateMany(11);
+
+        var schools = primarySchools.Concat(secondarySchools).ToArray();
+      
+        var page = await Client.SetupEstablishment(trust, schools)
+            .SetupInsights()
+            .Navigate(Paths.TrustCensus(trust.CompanyNumber));
+
+        return (page, trust);
+    }
+
+    private static void AssertPageLayout(IHtmlDocument page, Trust trust)
+    {
+        var expectedBreadcrumbs = new[]
+        {
+            ("Home", Paths.ServiceHome.ToAbsolute()),
+            ("Your trust", Paths.TrustHome(trust.CompanyNumber).ToAbsolute()),
+            ("Benchmark census data", Paths.TrustCensus(trust.CompanyNumber).ToAbsolute()),
+        };
+
+        DocumentAssert.AssertPageUrl(page, Paths.TrustCensus(trust.CompanyNumber).ToAbsolute());
+        DocumentAssert.Breadcrumbs(page, expectedBreadcrumbs);
+        DocumentAssert.TitleAndH1(page, "Benchmark census data - Financial Benchmarking and Insights Tool - GOV.UK", "Benchmark census data");
+
+        var component = page.GetElementById("compare-your-census");
+        Assert.NotNull(component);
+
+        var dataId = component.GetAttribute("data-id");
+        Assert.NotNull(dataId);
+        Assert.Equal(trust.CompanyNumber, dataId);
+
+        var dataType = component.GetAttribute("data-type");
+        Assert.NotNull(dataType);
+        Assert.Equal(OrganisationTypes.Trust, dataType);
+
+        var dataPhases = component.GetAttribute("data-phases");
+        Assert.NotNull(dataPhases);
+        string[] expectedPhases = [OverallPhaseTypes.Secondary, OverallPhaseTypes.Primary];
+        Assert.Equal(expectedPhases.ToJson(Formatting.None), dataPhases);
+        
+
+        var toolsSection = page.Body.SelectSingleNode("//main/div/div[4]");
+        DocumentAssert.Heading2(toolsSection, "Finance tools");
+
+        var toolsLinks = toolsSection.ChildNodes.QuerySelectorAll("ul> li > h3 > a").ToList();
+        Assert.Equal(2, toolsLinks.Count);
+        DocumentAssert.Link(toolsLinks[0], "Curriculum and financial planning",
+            Paths.TrustFinancialPlanning(trust.CompanyNumber).ToAbsolute());
+        DocumentAssert.Link(toolsLinks[1], "Compare your costs", Paths.TrustComparison(trust.CompanyNumber).ToAbsolute());
+    }
+}

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingComparison.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingComparison.cs
@@ -1,0 +1,124 @@
+﻿using System.Net;
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using AngleSharp.XPath;
+using AutoFixture;
+using Web.App.Domain;
+using Xunit;
+using Web.App;
+using Web.App.Extensions;
+using Newtonsoft.Json;
+
+namespace Web.Integration.Tests.Pages.Trusts;
+
+public class WhenViewingComparison(SchoolBenchmarkingWebAppClient client) : PageBase<SchoolBenchmarkingWebAppClient>(client)
+{
+    [Fact]
+    public async Task CanDisplay()
+    {
+        var (page, trust) = await SetupNavigateInitPage();
+
+        AssertPageLayout(page, trust);
+    }
+
+    [Fact]
+    public async Task CanNavigateToCensusBenchmark()
+    {
+        var (page, trust) = await SetupNavigateInitPage();
+
+        var liElements = page.QuerySelectorAll("ul.app-links > li");
+        var anchor = liElements[1].QuerySelector("h3 > a");
+        Assert.NotNull(anchor);
+
+        var newPage = await Client.Follow(anchor);
+
+        DocumentAssert.AssertPageUrl(newPage, Paths.TrustCensus(trust.CompanyNumber).ToAbsolute());
+    }
+
+    [Fact]
+    public async Task CanDisplayNotFound()
+    {
+        const string companyNumber = "12345678";
+        var page = await Client.SetupEstablishmentWithNotFound()
+            .Navigate(Paths.TrustComparison(companyNumber));
+
+        PageAssert.IsNotFoundPage(page);
+        DocumentAssert.AssertPageUrl(page, Paths.TrustComparison(companyNumber).ToAbsolute(), HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task CanDisplayProblemWithService()
+    {
+        const string companyNumber = "12345678";
+        var page = await Client.SetupEstablishmentWithException()
+            .Navigate(Paths.TrustComparison(companyNumber));
+
+        PageAssert.IsProblemPage(page);
+        DocumentAssert.AssertPageUrl(page, Paths.TrustComparison(companyNumber).ToAbsolute(), HttpStatusCode.InternalServerError);
+    }
+
+    private async Task<(IHtmlDocument page, Trust trust)> SetupNavigateInitPage()
+    {
+        var trust = Fixture.Build<Trust>()
+            .Create();
+
+        var primarySchools = Fixture.Build<School>()
+            .With(x => x.CompanyNumber, trust.CompanyNumber)
+            .With(x => x.OverallPhase, OverallPhaseTypes.Primary)
+            .CreateMany(9);
+
+        var secondarySchools = Fixture.Build<School>()
+            .With(x => x.CompanyNumber, trust.CompanyNumber)
+            .With(x => x.OverallPhase, OverallPhaseTypes.Secondary)
+            .CreateMany(11);
+
+        var schools = primarySchools.Concat(secondarySchools).ToArray();
+
+        var page = await Client.SetupEstablishment(trust, schools)
+            .SetupInsights()
+            .Navigate(Paths.TrustComparison(trust.CompanyNumber));
+
+        return (page, trust);
+    }
+
+    private static void AssertPageLayout(IHtmlDocument page, Trust trust)
+    {
+        var expectedBreadcrumbs = new[]
+        {
+            ("Home", Paths.ServiceHome.ToAbsolute()),
+            ("Your trust", Paths.TrustHome(trust.CompanyNumber).ToAbsolute()),
+            ("Compare your costs", Paths.TrustComparison(trust.CompanyNumber).ToAbsolute()),
+        };
+
+        DocumentAssert.AssertPageUrl(page, Paths.TrustComparison(trust.CompanyNumber).ToAbsolute());
+        DocumentAssert.Breadcrumbs(page, expectedBreadcrumbs);
+        DocumentAssert.TitleAndH1(page, "Compare your costs - Financial Benchmarking and Insights Tool - GOV.UK", "Compare your costs");
+
+        var component = page.GetElementById("compare-your-costs");
+        Assert.NotNull(component);
+
+        var dataId = component.GetAttribute("data-id");
+        Assert.NotNull(dataId);
+        Assert.Equal(trust.CompanyNumber, dataId);
+
+        var dataType = component.GetAttribute("data-type");
+        Assert.NotNull(dataType);
+        Assert.Equal(OrganisationTypes.Trust, dataType);
+
+        var dataPhases = component.GetAttribute("data-phases");
+        Assert.NotNull(dataPhases);
+        string[] expectedPhases = [OverallPhaseTypes.Secondary, OverallPhaseTypes.Primary];
+        Assert.Equal(expectedPhases.ToJson(Formatting.None), dataPhases);
+
+
+        var toolsSection = page.Body.SelectSingleNode("//main/div/div[4]");
+        DocumentAssert.Heading2(toolsSection, "Finance tools");
+
+        var toolsLinks = toolsSection.ChildNodes.QuerySelectorAll("ul> li > h3 > a").ToList();
+        Assert.Equal(2, toolsLinks.Count);
+        DocumentAssert.Link(toolsLinks[0], "Curriculum and financial planning",
+            Paths.TrustFinancialPlanning(trust.CompanyNumber).ToAbsolute());
+        DocumentAssert.Link(toolsLinks[1], "Benchmark census data", Paths.TrustCensus(trust.CompanyNumber).ToAbsolute());
+    }
+}
+

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -17,7 +17,9 @@ public static class Paths
     public static string SchoolHome(string? urn) => $"/school/{urn}";
     public static string TrustHome(string? companyNumber) => $"/trust/{companyNumber}";
     public static string TrustDetails(string? companyNumber) => $"/trust/{companyNumber}/details";
-
+    public static string TrustComparison(string? companyNumber) => $"/trust/{companyNumber}/comparison";
+    public static string TrustCensus(string? companyNumber) => $"/trust/{companyNumber}/census";
+    public static string TrustFinancialPlanning(string? companyNumber) => $"/trust/{companyNumber}/financial-planning";
     public static string SchoolComparatorSet(string? urn, string referrer) =>
         $"/school/{urn}/comparator-set?referrer={referrer}";
     public static string SchoolComparison(string? urn) => $"/school/{urn}/comparison";


### PR DESCRIPTION
### Context
AB#207740 - AB#209380
AB# 207739 - AB#209381

### Change proposed in this pull request
Adds integration tests for the trust compare your costs and benchmark census data pages.

### Guidance to review 
N/A

### Checklist
- [ ] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally

