### PR TITLE
Accessibility tests for Custom Data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -416,6 +416,9 @@ local.settings.json
 # OSX
 .DS_Store
 
+# Playwright
+**/playwright/.auth
+
 **/docker/azurite
 **/docker/sql
 front-end-components/vite.config-dev.js.timestamp-*

--- a/pipelines/web/steps/run-a11y-tests.yaml
+++ b/pipelines/web/steps/run-a11y-tests.yaml
@@ -2,6 +2,7 @@ parameters:
   workspaceDir: ''
   environmentPrefix: ''
   subscription: ''
+
 steps:
   - checkout: none
   - download: current
@@ -29,4 +30,5 @@ steps:
     displayName: 'Run a11y tests'
     inputs:
       command: test
+      arguments: --filter "Category!=CustomData&Category!=FinancialPlanning" # todo: remove filter when DSI organisation available in pre-prod
       projects: '${{ parameters.workspaceDir }}/a11y-tests-files/Web.A11yTests/Web.A11yTests.dll'

--- a/platform/terraform/databases.tf
+++ b/platform/terraform/databases.tf
@@ -12,7 +12,7 @@ resource "azurerm_cosmosdb_account" "cosmosdb-account" {
   tags                = local.common-tags
 
   # Azure services, plus DFE VPN remote range if non-production
-  ip_range_filter = var.environment == "production" ? "0.0.0.0" : "0.0.0.0,208.127.46.236/30,208.127.46.240/29,208.127.46.248/31,208.127.46.250/32"
+  ip_range_filter = var.environment == "production" ? "0.0.0.0" : "0.0.0.0,208.127.46.236/30,208.127.46.240/28"
 
   consistency_policy {
     consistency_level = "Session"
@@ -164,7 +164,7 @@ resource "azurerm_mssql_firewall_rule" "sql-server-fw-dfe-remote" {
   name             = "DFE_VPN_Remote"
   server_id        = azurerm_mssql_server.sql-server.id
   start_ip_address = "208.127.46.236"
-  end_ip_address   = "208.127.46.250"
+  end_ip_address   = "208.127.46.255"
 }
 
 resource "azurerm_mssql_firewall_rule" "sql-server-fw-azure-services" {

--- a/web/README.md
+++ b/web/README.md
@@ -126,7 +126,7 @@ dotnet test tests\Web.E2ETests
 
 #### Accessibility Tests
 
-Add the following configuration in `appsetings.local.json` in the root of `Web.A11yTests`
+Add the following configuration in `appsettings.local.json` in the root of `Web.A11yTests`
 
 ```json
 {
@@ -139,13 +139,20 @@ Add the following configuration in `appsetings.local.json` in the root of `Web.A
     "Host": "[INSERT URL OF BENCHMARK API]",
     "Key": "[INSERT BENCHMARK API KEY]"
   },
+  "Authentication": {
+    "Username": "[INSERT DSI USERNAME]",
+    "Password": "[INSERT DSI PASSWORD]"
+  },
 }
 ```
 
 From the root of the `web` run
 
 ```bat
-dotnet test tests\Web.A11yTests
+dotnet test tests\Web.A11yTests --filter "Category!=CustomData&Category!=FinancialPlanning"
 ```
 
 _Playwright is used for end-to-end and accessibility testing which opens a browser and navigates like a user._
+
+> **NOTE:** Running _all_ accessibility tests locally using DSI credentials that are not configured to be able to access the
+> school defined in config will result in test failures for those in the `CustomData` and `FinancialPlanning` xUnit categories.

--- a/web/src/Web.App/Views/SchoolCustomDataChange/FinancialData.cshtml
+++ b/web/src/Web.App/Views/SchoolCustomDataChange/FinancialData.cshtml
@@ -3,21 +3,79 @@
     ViewData[ViewDataKeys.Title] = PageTitles.SchoolChangeData;
 }
 
-@await Component.InvokeAsync("EstablishmentHeading", new { title = PageTitles.SchoolChangeDataFinancialData, name = Model.School.Name, id = Model.School.Urn, kind = OrganisationTypes.School })
+@await Component.InvokeAsync("EstablishmentHeading", new
+{
+    title = PageTitles.SchoolChangeDataFinancialData,
+    name = Model.School.Name,
+    id = Model.School.Urn,
+    kind = OrganisationTypes.School
+})
 
 @await Html.PartialAsync("_ErrorSummary")
-@using (Html.BeginForm("FinancialData", "SchoolCustomDataChange", new { urn = Model.School.Urn }, FormMethod.Post, true, new { novalidate = "novalidate", id = "form-custom-data-financial" }))
+@using (Html.BeginForm("FinancialData", "SchoolCustomDataChange", new
+        {
+            urn = Model.School.Urn
+        }, FormMethod.Post, true, new
+        {
+            novalidate = "novalidate",
+            id = "form-custom-data-financial"
+        }))
 {
     <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-financial-data">
-        @await Html.PartialAsync("_AccordionSection", Model.AdministrativeSuppliesSection)
-        @await Html.PartialAsync("_AccordionSection", Model.CateringSection)
-        @await Html.PartialAsync("_AccordionSection", Model.EducationalSuppliesSection)
-        @await Html.PartialAsync("_AccordionSection", Model.ITSection)
-        @await Html.PartialAsync("_AccordionSection", Model.NonEducationalSupportStaffSection)
-        @await Html.PartialAsync("_AccordionSection", Model.PremisesAndServicesSection)
-        @await Html.PartialAsync("_AccordionSection", Model.TeachingAndTeachingSupportSection)
-        @await Html.PartialAsync("_AccordionSection", Model.UtilitiesSection)
-        @await Html.PartialAsync("_AccordionSection", Model.OtherCostsSection)
+        @await Html.PartialAsync("_AccordionSection", Model.AdministrativeSuppliesSection, new ViewDataDictionary(ViewData)
+        {
+            {
+                "Index", 1
+            }
+        })
+        @await Html.PartialAsync("_AccordionSection", Model.CateringSection, new ViewDataDictionary(ViewData)
+        {
+            {
+                "Index", 2
+            }
+        }))
+        @await Html.PartialAsync("_AccordionSection", Model.EducationalSuppliesSection, new ViewDataDictionary(ViewData)
+        {
+            {
+                "Index", 3
+            }
+        }))
+        @await Html.PartialAsync("_AccordionSection", Model.ITSection, new ViewDataDictionary(ViewData)
+        {
+            {
+                "Index", 4
+            }
+        }))
+        @await Html.PartialAsync("_AccordionSection", Model.NonEducationalSupportStaffSection, new ViewDataDictionary(ViewData)
+        {
+            {
+                "Index", 5
+            }
+        }))
+        @await Html.PartialAsync("_AccordionSection", Model.PremisesAndServicesSection, new ViewDataDictionary(ViewData)
+        {
+            {
+                "Index", 6
+            }
+        }))
+        @await Html.PartialAsync("_AccordionSection", Model.TeachingAndTeachingSupportSection, new ViewDataDictionary(ViewData)
+        {
+            {
+                "Index", 7
+            }
+        }))
+        @await Html.PartialAsync("_AccordionSection", Model.UtilitiesSection, new ViewDataDictionary(ViewData)
+        {
+            {
+                "Index", 8
+            }
+        }))
+        @await Html.PartialAsync("_AccordionSection", Model.OtherCostsSection, new ViewDataDictionary(ViewData)
+        {
+            {
+                "Index", 9
+            }
+        }))
     </div>
     <div id="custom-data-totals">
         <h2 class="govuk-heading-m">

--- a/web/src/Web.App/Views/SchoolCustomDataChange/_AccordionSection.cshtml
+++ b/web/src/Web.App/Views/SchoolCustomDataChange/_AccordionSection.cshtml
@@ -1,12 +1,12 @@
 @model Web.App.ViewModels.SchoolCustomDataSectionViewModel
 @{
-    var id = Model.Title.Replace(" ", "-").ToLower();
+    var id = ViewData["Index"] ?? Model.Title.Replace(" ", "-").ToLower();
 }
 
 <div class="govuk-accordion__section">
     <div class="govuk-accordion__section-header">
         <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-@id">
+            <span class="govuk-accordion__section-button" id="accordion-financial-data-heading-@id">
                 @Model.Title
             </span>
         </h2>

--- a/web/tests/Web.A11yTests/AuthPageBase.cs
+++ b/web/tests/Web.A11yTests/AuthPageBase.cs
@@ -1,0 +1,28 @@
+using System.Net;
+using Microsoft.Playwright;
+using Web.A11yTests.Drivers;
+using Xunit.Abstractions;
+namespace Web.A11yTests;
+
+public abstract class AuthPageBase(ITestOutputHelper testOutputHelper, WebDriver webDriver) : PageBase(testOutputHelper, webDriver)
+{
+    protected override async Task GoToPage(HttpStatusCode statusCode = HttpStatusCode.OK, IPage? basePage = null)
+    {
+        // Sign in using credentials set in config
+        var page = await webDriver.GetPage($"{ServiceUrl}/account/sign-in", HttpStatusCode.OK);
+        await page.Locator("#username").FillAsync(TestConfiguration.Authentication.Username);
+        await page.Locator("#password").FillAsync(TestConfiguration.Authentication.Password);
+        await page.GetByText("Sign in").ClickAsync();
+        await page.WaitForURLAsync($"{ServiceUrl.TrimEnd('/')}/");
+
+        // Save storage state into the file.
+        // Tests are executed in <TestProject>\bin\Debug\netX.0\ therefore relative
+        // path is used to reference playwright/.auth created in project root.
+        await page.Context.StorageStateAsync(new BrowserContextStorageStateOptions
+        {
+            Path = "../../../playwright/.auth/state.json"
+        });
+
+        await base.GoToPage(statusCode, page);
+    }
+}

--- a/web/tests/Web.A11yTests/Drivers/WebDriver.cs
+++ b/web/tests/Web.A11yTests/Drivers/WebDriver.cs
@@ -2,22 +2,38 @@ using System.Net;
 using Microsoft.Playwright;
 using Xunit;
 using Xunit.Abstractions;
-
 namespace Web.A11yTests.Drivers;
 
 public class WebDriver(IMessageSink messageSink) : IDisposable
 {
     private IBrowser? _browser;
 
-    public async Task<IPage> GetPage(string url, HttpStatusCode statusCode)
+    public async void Dispose()
+    {
+        await Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    public async Task<IPage> GetPage(string url, HttpStatusCode statusCode, IPage? basePage = null)
     {
         _browser ??= await InitialiseBrowser();
 
-        var contextOptions = new BrowserNewContextOptions { IgnoreHTTPSErrors = true };
+        var contextOptions = new BrowserNewContextOptions
+        {
+            IgnoreHTTPSErrors = true
+        };
         var browserContext = await _browser.NewContextAsync(contextOptions);
 
-        var page = await browserContext.NewPageAsync();
-        page.Response += (_, r) => messageSink.OnMessage(r.ToDiagnosticMessage());
+        IPage page;
+        if (basePage != null)
+        {
+            page = basePage;
+        }
+        else
+        {
+            page = await browserContext.NewPageAsync();
+            page.Response += (_, r) => messageSink.OnMessage(r.ToDiagnosticMessage());
+        }
 
         var response = await page.GotoAsync(url);
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
@@ -30,14 +46,11 @@ public class WebDriver(IMessageSink messageSink) : IDisposable
     private static async Task<IBrowser> InitialiseBrowser()
     {
         var playwrightInstance = await Playwright.CreateAsync();
-        var launchOptions = new BrowserTypeLaunchOptions { Headless = TestConfiguration.Headless };
+        var launchOptions = new BrowserTypeLaunchOptions
+        {
+            Headless = TestConfiguration.Headless
+        };
         return await playwrightInstance.Chromium.LaunchAsync(launchOptions);
-    }
-
-    public async void Dispose()
-    {
-        await Dispose(true);
-        GC.SuppressFinalize(this);
     }
 
     protected virtual async Task Dispose(bool disposing)

--- a/web/tests/Web.A11yTests/Pages/Schools/CustomData/WhenViewingCustomData.cs
+++ b/web/tests/Web.A11yTests/Pages/Schools/CustomData/WhenViewingCustomData.cs
@@ -1,0 +1,17 @@
+﻿using Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+namespace Web.A11yTests.Pages.Schools.CustomData;
+
+[Trait("Category", "CustomData")]
+public class WhenViewingCustomData(ITestOutputHelper testOutputHelper, WebDriver webDriver) : PageBase(testOutputHelper, webDriver)
+{
+    protected override string PageUrl => $"/school/{TestConfiguration.School}/custom-data";
+
+    [Fact]
+    public async Task ThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await EvaluatePage();
+    }
+}

--- a/web/tests/Web.A11yTests/Pages/Schools/CustomData/WhenViewingCustomDataFinancialData.cs
+++ b/web/tests/Web.A11yTests/Pages/Schools/CustomData/WhenViewingCustomDataFinancialData.cs
@@ -1,0 +1,25 @@
+﻿using Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+namespace Web.A11yTests.Pages.Schools.CustomData;
+
+[Trait("Category", "CustomData")]
+public class WhenViewingCustomDataFinancialData(ITestOutputHelper testOutputHelper, WebDriver webDriver) : AuthPageBase(testOutputHelper, webDriver)
+{
+    protected override string PageUrl => $"/school/{TestConfiguration.School}/custom-data/financial-data";
+
+    [Fact]
+    public async Task ThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await EvaluatePage();
+    }
+
+    [Fact]
+    public async Task ShowAllSectionsThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await Page.Locator(".govuk-accordion__show-all").ClickAsync();
+        await EvaluatePage();
+    }
+}

--- a/web/tests/Web.A11yTests/Pages/Schools/CustomData/WhenViewingCustomDataNonFinancialData.cs
+++ b/web/tests/Web.A11yTests/Pages/Schools/CustomData/WhenViewingCustomDataNonFinancialData.cs
@@ -1,0 +1,17 @@
+﻿using Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+namespace Web.A11yTests.Pages.Schools.CustomData;
+
+[Trait("Category", "CustomData")]
+public class WhenViewingCustomDataNonFinancialData(ITestOutputHelper testOutputHelper, WebDriver webDriver) : AuthPageBase(testOutputHelper, webDriver)
+{
+    protected override string PageUrl => $"/school/{TestConfiguration.School}/custom-data/school-characteristics";
+
+    [Fact]
+    public async Task ThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await EvaluatePage();
+    }
+}

--- a/web/tests/Web.A11yTests/Pages/Schools/CustomData/WhenViewingCustomDataWorkforceData.cs
+++ b/web/tests/Web.A11yTests/Pages/Schools/CustomData/WhenViewingCustomDataWorkforceData.cs
@@ -1,0 +1,17 @@
+﻿using Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+namespace Web.A11yTests.Pages.Schools.CustomData;
+
+[Trait("Category", "CustomData")]
+public class WhenViewingCustomDataWorkforceData(ITestOutputHelper testOutputHelper, WebDriver webDriver) : AuthPageBase(testOutputHelper, webDriver)
+{
+    protected override string PageUrl => $"/school/{TestConfiguration.School}/custom-data/workforce";
+
+    [Fact]
+    public async Task ThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await EvaluatePage();
+    }
+}

--- a/web/tests/Web.A11yTests/Pages/Schools/FinancialPlanning/WhenViewingFinancialPlanning.cs
+++ b/web/tests/Web.A11yTests/Pages/Schools/FinancialPlanning/WhenViewingFinancialPlanning.cs
@@ -1,13 +1,13 @@
 ﻿using Web.A11yTests.Drivers;
 using Xunit;
 using Xunit.Abstractions;
-
 namespace Web.A11yTests.Pages.Schools.FinancialPlanning;
 
-/*public class WhenViewingFinancialPlanning(
+/*[Trait("Category", "FinancialPlanning")]
+public class WhenViewingFinancialPlanning(
     ITestOutputHelper testOutputHelper,
     WebDriver webDriver)
-    : PageBase(testOutputHelper, webDriver)
+    : AuthPageBase(testOutputHelper, webDriver)
 {
     protected override string PageUrl => $"/school/{TestConfiguration.School}/financial-planning";
 

--- a/web/tests/Web.A11yTests/TestConfiguration.cs
+++ b/web/tests/Web.A11yTests/TestConfiguration.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.Configuration;
-
 namespace Web.A11yTests;
 
 public static class TestConfiguration
@@ -8,7 +7,7 @@ public static class TestConfiguration
 #if !DEBUG
         .AddJsonFile("appsettings.json", optional: false)
 #else
-        .AddJsonFile("appsettings.local.json", optional: false)
+        .AddJsonFile("appsettings.local.json", false)
 #endif
         .Build();
 
@@ -21,9 +20,19 @@ public static class TestConfiguration
 
     public static bool Headless => Instance.GetValue<bool?>("Headless") ?? true;
 
+    public static AuthenticationSettings Authentication => Instance.GetSection(nameof(Authentication)).Get<AuthenticationSettings>() ??
+                                                           throw new InvalidOperationException(
+                                                               "Authentication settings missing from configuration");
+
     public record ApiEndpoint
     {
         public string? Host { get; init; }
         public string? Key { get; init; }
+    }
+
+    public record AuthenticationSettings
+    {
+        public string Username { get; init; } = string.Empty;
+        public string Password { get; init; } = string.Empty;
     }
 }

--- a/web/tests/Web.A11yTests/appsettings.json
+++ b/web/tests/Web.A11yTests/appsettings.json
@@ -1,8 +1,12 @@
 {
-    "ServiceUrl": "__service-url__",
-    "SchoolUrn": "__school-urn__",
-    "Benchmark": {
-        "Host": "__benchmark-host__",
-        "Key": "__benchmark-host-key__"
-    }
+  "ServiceUrl": "__service-url__",
+  "SchoolUrn": "__school-urn__",
+  "Benchmark": {
+    "Host": "__benchmark-host__",
+    "Key": "__benchmark-host-key__"
+  },
+  "Authentication": {
+    "Username": "__dfe-signin-test-username__",
+    "Password": "__dfe-signin-test-password__"
+  }
 }

--- a/web/tests/Web.Integration.Tests/TestExtensions.cs
+++ b/web/tests/Web.Integration.Tests/TestExtensions.cs
@@ -1,4 +1,5 @@
 using AngleSharp.Io;
+using Web.App.Extensions;
 using Xunit.Sdk;
 
 namespace Web.Integration.Tests;
@@ -18,6 +19,7 @@ public static class TestExtensions
 
     public static DiagnosticMessage ToDiagnosticMessage(this DocumentRequest request)
     {
-        return new DiagnosticMessage($"Submitting form : {request.Method} {request.Target}");
+        var bodyStream = new StreamReader(request.Body);
+        return new DiagnosticMessage($"Submitting form : {request.Method} {request.Target} {bodyStream.ReadToEnd()}");
     }
 }


### PR DESCRIPTION
### Context
[AB#208021](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/208021) [AB#198080](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/198080)

### Change proposed in this pull request
Accessibility tests for Custom Data pages, as well as a fix for ARIA tags on a GDS Accordion. New `AuthPageBase` that should be inherited from for a11y tests that require the user to be authenticated.

### Guidance to review 
Added Traits to filter out authentication-dependent a11y tests during CI until suitable credentials are available. When running locally tests marked with the `Category` `CustomData` or `FinancialPlanning` will fail unless valid username/password set in configuration that corresponds to a pre-prod DSI account with correct organisational access. This is documented in the README and those categories are skipped during the CI test run.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

