### PR TITLE
Ordered cost categories on Trust home page and enhanced with stacked RAG 'chart's

### DIFF
--- a/web/src/Web.App/AssetSrc/scss/_headlines.scss
+++ b/web/src/Web.App/AssetSrc/scss/_headlines.scss
@@ -11,29 +11,26 @@
 }
 
 .app-headline-high {
-  background-color: #f4cdc6;
-  border: 1px solid #942514;
+  background-color: $rag-red-colour;
 
   p {
-    color: #942514;
+    color: $rag-red-text-colour;
   }
 }
 
 .app-headline-medium {
-  background-color: #FFF7BF;
-  border: 1px solid #594D00;
+  background-color: $rag-amber-colour;
 
   p {
-    color: #594D00;
+    color: $rag-amber-text-colour;
   }
 }
 
 .app-headline-low {
-  background-color: #e5e6e7;
-  border: 1px solid #505A5F;
+  background-color: $rag-green-colour;
 
   p {
-    color: #505A5F;
+    color: $rag-green-text-colour;
   }
 }
 

--- a/web/src/Web.App/AssetSrc/scss/_variables.scss
+++ b/web/src/Web.App/AssetSrc/scss/_variables.scss
@@ -1,2 +1,9 @@
 $break-small: 576px;
 $break-medium: 768px;
+
+$rag-red-colour: govuk-tint(govuk-colour("red"), 10%);
+$rag-red-text-colour: govuk-tint(govuk-colour("red"), 90%);
+$rag-amber-colour: govuk-tint(govuk-colour("orange"), 10%);
+$rag-amber-text-colour: govuk-shade(govuk-colour("orange"), 50%);
+$rag-green-colour: govuk-tint(govuk-colour("green"), 10%);
+$rag-green-text-colour: govuk-tint(govuk-colour("green"), 90%);

--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -90,19 +90,49 @@ p.priority .govuk-tag {
   }
 }
 
-.rag-stack {
+.govuk-table.table-cost-category-rag {
+  tbody {
+    tr {
+      td {
+        border-bottom: 0;
+        padding-bottom: 0;
+      }
+    }
+  }
+}
+
+svg.rag-stack {
   width: 100%;
 
   // colours taken from node_modules/govuk-frontend/dist/govuk/components/tag/_tag.scss
-  .rag-stack-red {
+  rect.rag-stack-red {
     fill: $rag-red-colour;
   }
 
-  .rag-stack-amber {
-    fill: $rag-orange-colour;
+  rect.rag-stack-amber {
+    fill: $rag-amber-colour;
   }
 
-  .rag-stack-green {
+  rect.rag-stack-green {
     fill: $rag-green-colour;
+  }
+
+  a {
+    cursor: pointer;
+  }
+
+  a:hover rect.rag-stack-red,
+  a:active rect.rag-stack-red {
+    fill: govuk-tint($rag-red-colour, 20%);
+  }
+
+  a:hover rect.rag-stack-amber,
+  a:active rect.rag-stack-amber {
+    fill: govuk-tint($rag-amber-colour, 20%);
+  }
+
+  a:hover rect.rag-stack-green,
+  a:active rect.rag-stack-green {
+    fill: govuk-tint($rag-green-colour, 20%);
   }
 }

--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -89,3 +89,20 @@ p.priority .govuk-tag {
     }
   }
 }
+
+.rag-stack {
+  width: 100%;
+
+  // colours taken from node_modules/govuk-frontend/dist/govuk/components/tag/_tag.scss
+  .rag-stack-red {
+    fill: $rag-red-colour;
+  }
+
+  .rag-stack-amber {
+    fill: $rag-orange-colour;
+  }
+
+  .rag-stack-green {
+    fill: $rag-green-colour;
+  }
+}

--- a/web/src/Web.App/Domain/RagRating.cs
+++ b/web/src/Web.App/Domain/RagRating.cs
@@ -1,4 +1,5 @@
-﻿namespace Web.App.Domain;
+﻿using Web.App.Extensions;
+namespace Web.App.Domain;
 
 public record RagRating
 {
@@ -10,7 +11,7 @@ public record RagRating
     public string? Urn { get; set; }
     public int CostCategoryId { get; set; }
     public string? CostCategory { get; set; }
-    public string CostCategoryAnchorId => string.IsNullOrWhiteSpace(CostCategory) ? string.Empty : CostCategory.ToLower().Replace(" ", "-");
+    public string CostCategoryAnchorId => string.IsNullOrWhiteSpace(CostCategory) ? string.Empty : CostCategory.ToSlug();
     public string? CostGroup { get; private set; }
     public decimal Value { get; set; }
     public decimal Median { get; set; }
@@ -37,34 +38,76 @@ public static class Lookups
 {
     public static Dictionary<string, (TagColour Colour, string DisplayText, string Class)> StatusPriorityMap => new()
     {
-        { "Red", (TagColour.Red, "High priority", "high") },
-        { "Amber", (TagColour.Yellow, "Medium priority", "medium") },
-        { "Green", (TagColour.Grey, "Low priority", "low") },
+        {
+            "Red", (TagColour.Red, "High priority", "high")
+        },
+        {
+            "Amber", (TagColour.Yellow, "Medium priority", "medium")
+        },
+        {
+            "Green", (TagColour.Grey, "Low priority", "low")
+        }
     };
 
     public static Dictionary<int, string> CategoryResourcePartialMap => new()
     {
-        { 1, "CommercialResource/_TeachingStaff" },
-        { 2, "CommercialResource/_NonEducationalSupportStaff" },
-        { 3, "CommercialResource/_EducationalSupplies" },
-        { 4, "CommercialResource/_EducationalIct" },
-        { 5, "CommercialResource/_PremisesStaffServices" },
-        { 6, "CommercialResource/_Utilities" },
-        { 7, "CommercialResource/_AdministrativeSupplies" },
-        { 8, "CommercialResource/_CateringStaffServices" },
-        { 9, "CommercialResource/_OtherCosts" }
+        {
+            1, "CommercialResource/_TeachingStaff"
+        },
+        {
+            2, "CommercialResource/_NonEducationalSupportStaff"
+        },
+        {
+            3, "CommercialResource/_EducationalSupplies"
+        },
+        {
+            4, "CommercialResource/_EducationalIct"
+        },
+        {
+            5, "CommercialResource/_PremisesStaffServices"
+        },
+        {
+            6, "CommercialResource/_Utilities"
+        },
+        {
+            7, "CommercialResource/_AdministrativeSupplies"
+        },
+        {
+            8, "CommercialResource/_CateringStaffServices"
+        },
+        {
+            9, "CommercialResource/_OtherCosts"
+        }
     };
 
     public static Dictionary<int, string> CategoryUnitMap => new()
     {
-        { 1, "per pupil" },
-        { 2, "per pupil" },
-        { 3, "per pupil"  },
-        { 4, "per pupil"  },
-        { 5, "per square metre" },
-        { 6, "per square metre" },
-        { 7, "per pupil"  },
-        { 8, "per pupil"  },
-        { 9, "per pupil"  }
+        {
+            1, "per pupil"
+        },
+        {
+            2, "per pupil"
+        },
+        {
+            3, "per pupil"
+        },
+        {
+            4, "per pupil"
+        },
+        {
+            5, "per square metre"
+        },
+        {
+            6, "per square metre"
+        },
+        {
+            7, "per pupil"
+        },
+        {
+            8, "per pupil"
+        },
+        {
+            9, "per pupil"
+        }
     };
 }

--- a/web/src/Web.App/Extensions/StringExtensions.cs
+++ b/web/src/Web.App/Extensions/StringExtensions.cs
@@ -2,33 +2,34 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
-
 namespace Web.App.Extensions;
 
 [ExcludeFromCodeCoverage]
-public static class StringExtensions
+public static partial class StringExtensions
 {
     private static readonly TextInfo TextInfo = CultureInfo.CurrentCulture.TextInfo;
-    public static string Santise(this string source)
-    {
-        return TextInfo.ToTitleCase(Regex.Replace(source, @"\s{2,}", " ")).Trim();
-    }
+
+    public static string Sanitise(this string source)
+        => TextInfo.ToTitleCase(Regex.Replace(source, @"\s{2,}", " ")).Trim();
 
     public static int? ToInt(this string? source)
-    {
-        return int.TryParse(source, out var val) ? val : null;
-    }
+        => int.TryParse(source, out var val) ? val : null;
 
     public static string Truncate(this string value, int maxLength)
     {
-        if (string.IsNullOrEmpty(value)) return value;
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
         return value.Length <= maxLength ? value : value.Substring(0, maxLength);
     }
 
     public static string SubstringToLast(this string source, char c)
     {
         if (string.IsNullOrWhiteSpace(source))
+        {
             return source;
+        }
 
         var index = source.LastIndexOf(c);
         return index > 0 ? source.Substring(0, index) : source;
@@ -37,7 +38,9 @@ public static class StringExtensions
     public static string SubstringFromLast(this string source, char c)
     {
         if (string.IsNullOrWhiteSpace(source))
+        {
             return source;
+        }
 
         var index = source.LastIndexOf(c) + 1;
         return index > 0 ? source.Substring(index, source.Length - index) : source;
@@ -46,7 +49,9 @@ public static class StringExtensions
     public static string SplitPascalCase(this string source)
     {
         if (string.IsNullOrWhiteSpace(source))
+        {
             return source;
+        }
 
         var stringBuilder = new StringBuilder(source.Length + 10);
         for (var index = 0; index < source.Length; ++index)
@@ -54,7 +59,9 @@ public static class StringExtensions
             var c = source[index];
 
             if (char.IsUpper(c) && (index > 1 && !char.IsUpper(source[index - 1]) || index + 1 < source.Length && !char.IsUpper(source[index + 1])))
+            {
                 stringBuilder.Append(' ');
+            }
 
             if (index > 1
                 && stringBuilder[Math.Min(stringBuilder.Length - 1, index + 1)] == ' '
@@ -74,7 +81,9 @@ public static class StringExtensions
     public static string Capitalise(this string source)
     {
         if (string.IsNullOrWhiteSpace(source))
+        {
             return source;
+        }
 
         return char.IsLower(source[0]) ? $"{char.ToUpper(source[0])}{source.Substring(1)}" : source;
     }
@@ -82,7 +91,9 @@ public static class StringExtensions
     public static string Uncapitalise(this string source)
     {
         if (string.IsNullOrWhiteSpace(source))
+        {
             return source;
+        }
 
         return char.IsUpper(source[0]) ? $"{char.ToLower(source[0])}{source.Substring(1)}" : source;
     }
@@ -90,13 +101,40 @@ public static class StringExtensions
     public static string GetIndefiniteArticle(this string source)
     {
         if (string.IsNullOrWhiteSpace(source))
+        {
             return source;
+        }
 
         var first = char.ToLower(source[0]);
 
         if (first == 'a' || first == 'e' || first == 'i' || first == 'o' || first == 'u')
+        {
             return "an";
+        }
 
         return "a";
     }
+
+    public static string ToSlug(this string source)
+    {
+        if (string.IsNullOrWhiteSpace(source))
+        {
+            return source;
+        }
+
+        return source
+            .Trim()
+            .Replace(WhitespaceRegex(), "-")
+            .Replace(NonAlphanumericOrHyphenRegex(), string.Empty)
+            .ToLower();
+    }
+
+    public static string Replace(this string source, Regex regex, string replacement)
+        => string.IsNullOrWhiteSpace(source) ? source : regex.Replace(source, replacement);
+
+    [GeneratedRegex("[^a-z0-9\\-]", RegexOptions.IgnoreCase, "en-GB")]
+    private static partial Regex NonAlphanumericOrHyphenRegex();
+
+    [GeneratedRegex("\\s+")]
+    private static partial Regex WhitespaceRegex();
 }

--- a/web/src/Web.App/ViewComponents/RagStack.cs
+++ b/web/src/Web.App/ViewComponents/RagStack.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Web.App.ViewModels.Components;
+namespace Web.App.ViewComponents;
+
+public class RagStack : ViewComponent
+{
+    public IViewComponentResult Invoke(string identifier, int red, int amber, int green, int? height = null) => View(new RagStackViewModel(identifier, red, amber, green, height ?? 25));
+}

--- a/web/src/Web.App/ViewComponents/RagStack.cs
+++ b/web/src/Web.App/ViewComponents/RagStack.cs
@@ -4,5 +4,19 @@ namespace Web.App.ViewComponents;
 
 public class RagStack : ViewComponent
 {
-    public IViewComponentResult Invoke(string identifier, int red, int amber, int green, int? height = null) => View(new RagStackViewModel(identifier, red, amber, green, height ?? 25));
+    public IViewComponentResult Invoke(
+        string identifier,
+        int red,
+        int amber,
+        int green,
+        int? height = null,
+        string? redHref = null,
+        string? amberHref = null,
+        string? greenHref = null)
+        => View(new RagStackViewModel(identifier, red, amber, green, height ?? 25)
+        {
+            RedHref = redHref,
+            AmberHref = amberHref,
+            GreenHref = greenHref
+        });
 }

--- a/web/src/Web.App/ViewModels/Components/RagStackViewModel.cs
+++ b/web/src/Web.App/ViewModels/Components/RagStackViewModel.cs
@@ -1,0 +1,11 @@
+﻿namespace Web.App.ViewModels.Components;
+
+public class RagStackViewModel(string identifier, int red, int amber, int green, int height)
+{
+    private decimal Total => red + amber + green;
+    public string Identifier => identifier;
+    public decimal Red => red / Total * 100;
+    public decimal Amber => amber / Total * 100;
+    public decimal Green => green / Total * 100;
+    public int Height => height;
+}

--- a/web/src/Web.App/ViewModels/Components/RagStackViewModel.cs
+++ b/web/src/Web.App/ViewModels/Components/RagStackViewModel.cs
@@ -2,10 +2,20 @@
 
 public class RagStackViewModel(string identifier, int red, int amber, int green, int height)
 {
-    private decimal Total => red + amber + green;
     public string Identifier => identifier;
-    public decimal Red => red / Total * 100;
-    public decimal Amber => amber / Total * 100;
-    public decimal Green => green / Total * 100;
+
+    public decimal Red => red;
+    public decimal Amber => amber;
+    public decimal Green => green;
+    private decimal Total => red + amber + green;
+
+    public decimal RedPercentage => red / Total * 100;
+    public decimal AmberPercentage => amber / Total * 100;
+    public decimal GreenPercentage => green / Total * 100;
+
+    public string? RedHref { get; init; }
+    public string? AmberHref { get; init; }
+    public string? GreenHref { get; init; }
+
     public int Height => height;
 }

--- a/web/src/Web.App/ViewModels/TrustViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustViewModel.cs
@@ -1,5 +1,4 @@
 using Web.App.Domain;
-
 namespace Web.App.ViewModels;
 
 public class TrustViewModel(Trust trust, IReadOnlyCollection<School> schools, IEnumerable<RagRating> ratings)
@@ -12,11 +11,17 @@ public class TrustViewModel(Trust trust, IReadOnlyCollection<School> schools, IE
     public int Medium => ratings.Count(x => x.Status == "Amber");
     public int High => ratings.Count(x => x.Status == "Red");
 
-    public IEnumerable<(string? Status, string? Category, int Count)> Ratings => ratings
-        .Where(x => x.Status is "Red" or "Amber")
-        .GroupBy(x => (x.Status, x.StatusOrder, x.CostCategory))
-        .OrderBy(x => x.Key.StatusOrder)
-        .ThenByDescending(x => x.Count())
-        .Select(x => (x.Key.Status, x.Key.CostCategory, x.Count()))
-        .Take(3);
+    public IEnumerable<(string Category, int Red, int Amber, int Green)> Ratings => ratings
+        .GroupBy(x => (x.Status, x.CostCategory))
+        .Select(x => (x.Key.Status, x.Key.CostCategory, Count: x.Count()))
+        .GroupBy(x => x.CostCategory)
+        .Where(x => x.Key != "Other")
+        .Select(x => (
+            x.Key!,
+            x.Where(r => r.Status == "Red").Select(r => r.Count).SingleOrDefault(),
+            x.Where(a => a.Status == "Amber").Select(a => a.Count).SingleOrDefault(),
+            x.Where(g => g.Status == "Green").Select(g => g.Count).SingleOrDefault()
+            ))
+        .OrderByDescending(x => x.Item2)
+        .ThenByDescending(x => x.Item3);
 }

--- a/web/src/Web.App/Views/SchoolCustomDataChange/_AccordionSection.cshtml
+++ b/web/src/Web.App/Views/SchoolCustomDataChange/_AccordionSection.cshtml
@@ -1,6 +1,7 @@
+@using Web.App.Extensions
 @model Web.App.ViewModels.SchoolCustomDataSectionViewModel
 @{
-    var id = ViewData["Index"] ?? Model.Title.Replace(" ", "-").ToLower();
+    var id = ViewData["Index"] ?? Model.Title.ToSlug();
 }
 
 <div class="govuk-accordion__section">

--- a/web/src/Web.App/Views/SchoolCustomDataChange/_CustomDataEntryTable.cshtml
+++ b/web/src/Web.App/Views/SchoolCustomDataChange/_CustomDataEntryTable.cshtml
@@ -1,6 +1,7 @@
+@using Web.App.Extensions
 @model Web.App.ViewModels.SchoolCustomDataSectionViewModel
 @{
-    var id = Model.Title.Replace(" ", "-").ToLower();
+    var id = Model.Title.ToSlug();
 }
 
 <table class="govuk-table table-custom-data" id="govuk-table-custom-data-@id">

--- a/web/src/Web.App/Views/SchoolCustomDataChange/_CustomDataEntryTableRow.cshtml
+++ b/web/src/Web.App/Views/SchoolCustomDataChange/_CustomDataEntryTableRow.cshtml
@@ -3,7 +3,7 @@
 @using Web.App.ViewModels
 @model Web.App.ViewModels.SchoolCustomDataValueViewModel
 @{
-    var id = Model.Title.Replace(" ", "-").ToLower();
+    var id = Model.Title.ToSlug();
     var customValueFormatted = ViewData.ModelState.GetAttemptedValueOrDefault(Model.Name, Model.Custom.HasValue ? Model.Custom.ToString() : string.Empty);
     var currentValue = Model.Current.GetValueOrDefault();
     var currentValueFormatted = currentValue.ToString(CultureInfo.InvariantCulture);

--- a/web/src/Web.App/Views/Shared/Components/RagStack/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/RagStack/Default.cshtml
@@ -1,7 +1,54 @@
+@using Web.App.Extensions
 @model Web.App.ViewModels.Components.RagStackViewModel
+@{
+    var id = Model.Identifier.ToSlug();
+}
 
-<svg style="height:@(Model.Height)px;" class="rag-stack">
-    <rect x="0" y="0" width="@Model.Red%" height="100%" class="rag-stack-red"/>
-    <rect x="@Model.Red%" y="0" width="@Model.Amber%" height="100%" class="rag-stack-amber"/>
-    <rect x="@(Model.Red + Model.Amber)%" y="0" width="@Model.Green%" height="100%" class="rag-stack-green"/>
-</svg>
+<svg style="height:@(Model.Height)px;" class="rag-stack" role="img" aria-labelledby="@id-rag">
+    <title id="@id-rag">RAG ratings for @Model.Identifier: @Model.Red red, @Model.Amber amber and @Model.Green green</title>
+    @if (!string.IsNullOrWhiteSpace(Model.RedHref))
+    {
+        @:<a href="@Model.RedHref" aria-label="@Model.Red red">
+    }
+    <rect
+        role="presentation"
+        x="0"
+        y="0"
+        width="@Model.RedPercentage%"
+        height="100%"
+        class="rag-stack-red"/>
+    @if (!string.IsNullOrWhiteSpace(Model.RedHref))
+    {
+        @:</a>
+    }
+    @if (!string.IsNullOrWhiteSpace(Model.AmberHref))
+    {
+        @:<a href="@Model.AmberHref" aria-label="@Model.Amber amber">
+    }
+    <rect
+        role="presentation"
+        x="@Model.RedPercentage%"
+        y="0"
+        width="@Model.AmberPercentage%"
+        height="100%"
+        class="rag-stack-amber"/>
+    @if (!string.IsNullOrWhiteSpace(Model.AmberHref))
+    {
+        @:</a>
+    }
+    @if (!string.IsNullOrWhiteSpace(Model.GreenHref))
+    {
+        @:<a href="@Model.GreenHref" aria-label="@Model.Green green">
+    }
+    <rect
+        role="presentation"
+        x="@(Model.RedPercentage + Model.AmberPercentage)%"
+        y="0"
+        width="@Model.GreenPercentage%"
+        height="100%"
+        class="rag-stack-green"/>
+    @if (!string.IsNullOrWhiteSpace(Model.GreenHref))
+    {
+        @:</a>
+    }
+</svg >

--- a/web/src/Web.App/Views/Shared/Components/RagStack/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/RagStack/Default.cshtml
@@ -1,0 +1,7 @@
+@model Web.App.ViewModels.Components.RagStackViewModel
+
+<svg style="height:@(Model.Height)px;" class="rag-stack">
+    <rect x="0" y="0" width="@Model.Red%" height="100%" class="rag-stack-red"/>
+    <rect x="@Model.Red%" y="0" width="@Model.Amber%" height="100%" class="rag-stack-amber"/>
+    <rect x="@(Model.Red + Model.Amber)%" y="0" width="@Model.Green%" height="100%" class="rag-stack-green"/>
+</svg>

--- a/web/src/Web.App/Views/Trust/Index.cshtml
+++ b/web/src/Web.App/Views/Trust/Index.cshtml
@@ -1,5 +1,3 @@
-@using Web.App.Domain
-@using Web.App.TagHelpers
 @using Web.App.ViewModels.Components
 @model Web.App.ViewModels.TrustViewModel
 @{
@@ -10,7 +8,7 @@
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l govuk-!-margin-bottom-1">@Model.Name</h1>
         <p class="govuk-body">
-            <a href="@Url.Action("Index", "FindOrganisation", new { method = OrganisationTypes.Trust})" class="govuk-link govuk-link--no-visited-state">Change trust</a>
+            <a href="@Url.Action("Index", "FindOrganisation", new { method = OrganisationTypes.Trust })" class="govuk-link govuk-link--no-visited-state">Change trust</a>
         </p>
     </div>
 </div>
@@ -54,31 +52,67 @@
     </div>
 </div>
 
-<h2 class="govuk-heading-m">Top priority costs</h2>
-<div class="top-categories">
+<table class="govuk-table">
+    <caption class="govuk-table__caption govuk-table__caption--m">Cost categories</caption>
+    <thead class="govuk-table__head govuk-visually-hidden">
+    <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Category</th>
+        <th scope="col" class="govuk-table__header">Sum of Red/Amber/Green schools</th>
+    </tr>
+    </thead>
+    <tbody class="govuk-table__body">
     @foreach (var rating in Model.Ratings)
     {
-        <div>
-            @{
-                (TagColour Colour, string DisplayText, string Class)?  tag = rating.Status != null ? Lookups.StatusPriorityMap[rating.Status] : null;
-            }
-            <h4 class="govuk-heading-s">@rating.Category</h4>
-            <p class="priority @tag?.Class govuk-body">
-                @await Component.InvokeAsync("Tag", new { tag?.Colour, tag?.DisplayText })
-                @rating.Count out of @Model.NumberSchools academies are in the @tag?.DisplayText.ToLower() range.
-            </p>
-        </div>
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell govuk-!-width-one-third">
+                @rating.Category
+            </td>
+            <td class="govuk-table__cell">
+                @await Component.InvokeAsync("RagStack", new
+                {
+                    identifer = rating.Category,
+                    red = rating.Red,
+                    amber = rating.Amber,
+                    green = rating.Green
+                })
+            </td>
+        </tr>
     }
+    </tbody>
+</table>
+
+<div class="top-categories">
+
 </div>
-<h3 class="govuk-heading-s"><a href="#" class="govuk-link govuk-link--no-visited-state">View all spending and costs</a></h3>
+<h3 class="govuk-heading-s">
+    <a href="#" class="govuk-link govuk-link--no-visited-state">View all spending and costs</a>
+</h3>
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-@await Component.InvokeAsync("TrustFinanceTools", new { identifier = Model.CompanyNumber, tools = new[] { FinanceTools.CompareYourCosts, FinanceTools.FinancialPlanning, FinanceTools.BenchmarkCensus } })
+@await Component.InvokeAsync("TrustFinanceTools", new
+{
+    identifier = Model.CompanyNumber,
+    tools = new[]
+    {
+        FinanceTools.CompareYourCosts,
+        FinanceTools.FinancialPlanning,
+        FinanceTools.BenchmarkCensus
+    }
+})
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-@await Component.InvokeAsync("Resources", new { identifier = Model.CompanyNumber, resources = new[] { Resources.TrustResources, Resources.TrustHistoricData, Resources.TrustDetails } })
+@await Component.InvokeAsync("Resources", new
+{
+    identifier = Model.CompanyNumber,
+    resources = new[]
+    {
+        Resources.TrustResources,
+        Resources.TrustHistoricData,
+        Resources.TrustDetails
+    }
+})
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 

--- a/web/src/Web.App/Views/Trust/Index.cshtml
+++ b/web/src/Web.App/Views/Trust/Index.cshtml
@@ -1,3 +1,4 @@
+@using Web.App.Extensions
 @using Web.App.ViewModels.Components
 @model Web.App.ViewModels.TrustViewModel
 @{
@@ -32,8 +33,8 @@
     </div>
 </div>
 
-<h2 class="govuk-heading-m">Trust-wide cost overview</h2>
-<div class="govuk-grid-row">
+<h2 class="govuk-heading-m">Trust-wide spending and costs overview</h2>
+<div class="govuk-grid-row govuk-!-margin-bottom-5">
     <div class="govuk-grid-column-full">
         <ul class="app-headline app-headline-3 govuk-!-text-align-centre">
             <li class="app-headline-high">
@@ -52,7 +53,7 @@
     </div>
 </div>
 
-<table class="govuk-table">
+<table class="govuk-table table-cost-category-rag">
     <caption class="govuk-table__caption govuk-table__caption--m">Cost categories</caption>
     <thead class="govuk-table__head govuk-visually-hidden">
     <tr class="govuk-table__row">
@@ -65,28 +66,24 @@
     {
         <tr class="govuk-table__row">
             <td class="govuk-table__cell govuk-!-width-one-third">
-                @rating.Category
+                <a href="@Url.Action("Index", "TrustComparison", new { companyNumber = Model.CompanyNumber })#@rating.Category.ToSlug()" class="govuk-link govuk-link--no-visited-state">@rating.Category</a>
             </td>
             <td class="govuk-table__cell">
                 @await Component.InvokeAsync("RagStack", new
                 {
-                    identifer = rating.Category,
+                    identifier = rating.Category,
                     red = rating.Red,
                     amber = rating.Amber,
-                    green = rating.Green
+                    green = rating.Green,
+                    redHref = $"{Url.Action("Index", "TrustComparison", new { companyNumber = Model.CompanyNumber })}#{rating.Category.ToSlug()}",
+                    amberHref = $"{Url.Action("Index", "TrustComparison", new { companyNumber = Model.CompanyNumber })}#{rating.Category.ToSlug()}",
+                    greenHref = $"{Url.Action("Index", "TrustComparison", new { companyNumber = Model.CompanyNumber })}#{rating.Category.ToSlug()}"
                 })
             </td>
         </tr>
     }
     </tbody>
 </table>
-
-<div class="top-categories">
-
-</div>
-<h3 class="govuk-heading-s">
-    <a href="#" class="govuk-link govuk-link--no-visited-state">View all spending and costs</a>
-</h3>
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 

--- a/web/src/Web.App/gulpfile.js
+++ b/web/src/Web.App/gulpfile.js
@@ -1,24 +1,27 @@
 var gulp = require("gulp");
 var sass = require("gulp-dart-sass");
 var async = require("async");
-var cleanCSS = require('gulp-clean-css');
+var cleanCSS = require("gulp-clean-css");
+var sourcemaps = require("gulp-sourcemaps");
 
 const buildSass = () => gulp.src("AssetSrc/scss/*.scss")
-	.pipe(sass().on("error", sass.logError))
-	.pipe(cleanCSS())
-	.pipe(gulp.dest("wwwroot/css"));
+    .pipe(sourcemaps.init())
+    .pipe(sass().on("error", sass.logError))
+    .pipe(sourcemaps.write("./"))
+    .pipe(cleanCSS())
+    .pipe(gulp.dest("wwwroot/css"));
 
-const copyStaticAssets = () => gulp.src(["node_modules/govuk-frontend/dist/govuk/assets/**/*"],{ encoding: false }).pipe(gulp.dest("wwwroot/assets")).on("end", () =>
-	gulp.src(["node_modules/govuk-frontend/dist/govuk/assets/images/favicon.ico"],{ encoding: false }).pipe(gulp.dest("wwwroot/"))).on("end", () =>
-	gulp.src(["node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js"]).pipe(gulp.dest("wwwroot/js/"))).on("end", () =>
-	gulp.src(["node_modules/front-end/dist/front-end.js"]).pipe(gulp.dest("wwwroot/js/"))).on("end", () =>
-	gulp.src(["node_modules/front-end/dist/front-end.css"]).pipe(gulp.dest("wwwroot/css/"))).on("end", () =>
-	gulp.src(["AssetSrc/images/*"],{ encoding: false }).pipe(gulp.dest("wwwroot/assets/images")));
+const copyStaticAssets = () => gulp.src(["node_modules/govuk-frontend/dist/govuk/assets/**/*"], {encoding: false}).pipe(gulp.dest("wwwroot/assets")).on("end", () =>
+    gulp.src(["node_modules/govuk-frontend/dist/govuk/assets/images/favicon.ico"], {encoding: false}).pipe(gulp.dest("wwwroot/"))).on("end", () =>
+    gulp.src(["node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js"]).pipe(gulp.dest("wwwroot/js/"))).on("end", () =>
+    gulp.src(["node_modules/front-end/dist/front-end.js"]).pipe(gulp.dest("wwwroot/js/"))).on("end", () =>
+    gulp.src(["node_modules/front-end/dist/front-end.css"]).pipe(gulp.dest("wwwroot/css/"))).on("end", () =>
+    gulp.src(["AssetSrc/images/*"], {encoding: false}).pipe(gulp.dest("wwwroot/assets/images")));
 
 
 gulp.task("build-fe", () => {
-	return async.series([
-		(next) => buildSass().on("end", next),
-		(next) => copyStaticAssets().on("end", next)
-	])
+    return async.series([
+        (next) => buildSass().on("end", next),
+        (next) => copyStaticAssets().on("end", next)
+    ])
 }); 

--- a/web/src/Web.App/package-lock.json
+++ b/web/src/Web.App/package-lock.json
@@ -14,7 +14,8 @@
         "govuk-frontend": "^5.2.0",
         "gulp": "^5.0.0",
         "gulp-clean-css": "^4.3.0",
-        "gulp-dart-sass": "^1.1.0"
+        "gulp-dart-sass": "^1.1.0",
+        "gulp-sourcemaps": "^3.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -34,6 +35,66 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "license": "MIT"
+    },
+    "node_modules/@gulp-sourcemaps/identity-map": {
+      "version": "2.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@gulp-sourcemaps/identity-map/-/identity-map-2.0.1.tgz",
+      "integrity": "sha1-puixq+yPeQ7GviuMUA5uaAN8ABk=",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^6.4.1",
+        "normalize-path": "^3.0.0",
+        "postcss": "^7.0.16",
+        "source-map": "^0.6.0",
+        "through2": "^3.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@gulp-sourcemaps/identity-map/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@gulp-sourcemaps/identity-map/node_modules/through2": {
+      "version": "3.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/through2/-/through2-3.0.2.tgz",
+      "integrity": "sha1-mfiJMc/HYex2eLQdXXM2tbage/Q=",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "2 || 3"
+      }
+    },
+    "node_modules/@gulp-sourcemaps/map-sources": {
+      "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
+      "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-path": "^2.0.1",
+        "through2": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@gulp-sourcemaps/map-sources/node_modules/normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "license": "MIT",
+      "dependencies": {
+        "remove-trailing-separator": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/@gulpjs/messages": {
       "version": "1.1.0",
@@ -131,6 +192,18 @@
         "preact": {
           "optional": true
         }
+      }
+    },
+    "node_modules/acorn": {
+      "version": "6.4.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/acorn/-/acorn-6.4.2.tgz",
+      "integrity": "sha1-NYZv1xBSjpLeEM8GAWSY5H454eY=",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ansi-colors": {
@@ -263,6 +336,18 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
       }
     },
     "node_modules/bach": {
@@ -537,6 +622,17 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
+    "node_modules/css": {
+      "version": "3.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/css/-/css-3.0.0.tgz",
+      "integrity": "sha1-REek1Y/dAzZ8UWyp9krjZc7kql0=",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.6.0"
+      }
+    },
     "node_modules/css-line-break": {
       "version": "2.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/css-line-break/-/css-line-break-2.1.0.tgz",
@@ -546,11 +642,33 @@
         "utrie": "^1.0.2"
       }
     },
+    "node_modules/css/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha1-2A/ylNEU+w5qxQD7+FtgE31+/4E=",
       "license": "MIT"
+    },
+    "node_modules/d": {
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/d/-/d-1.0.2.tgz",
+      "integrity": "sha1-Ku/VVLgZgefcz3LWhCrnJcsX5d4=",
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
@@ -582,16 +700,54 @@
         "d3-time": "1"
       }
     },
+    "node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/debug-fabulous": {
+      "version": "1.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/debug-fabulous/-/debug-fabulous-1.1.0.tgz",
+      "integrity": "sha1-r4oIYyRlIk70F0qfBjCMPCoevI4=",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "3.X",
+        "memoizee": "0.4.X",
+        "object-assign": "4.X"
+      }
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha1-E0/TJQjxniCPT7L42sDSYmqGeTQ=",
       "license": "MIT"
     },
+    "node_modules/decode-uri-component": {
+      "version": "0.2.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha1-5p2+JdN5QRcd1UDgJMREzVGI4ek=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/detect-file": {
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "2.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/detect-newline/-/detect-newline-2.1.0.tgz",
+      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -644,6 +800,58 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/es5-ext": {
+      "version": "0.10.64",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha1-EuT/tI8boup3fx/N0ZGO9z6iFxQ=",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/es6-symbol/-/es6-symbol-3.1.4.tgz",
+      "integrity": "sha1-9OfSgBN3C0II7L8+C/FNO8tVe4w=",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.2",
+        "ext": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha1-ttofFswswNm+Q+a9v8Xn383zHVM=",
+      "license": "ISC",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/escalade/-/escalade-3.1.2.tgz",
@@ -662,6 +870,31 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha1-pNS0Olxxx+xRxRCYwdiikIH5swg=",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -678,6 +911,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha1-DqQ4PAED1g5wvpnpp/EQJ6M8T18=",
+      "license": "ISC",
+      "dependencies": {
+        "type": "^2.7.2"
       }
     },
     "node_modules/extend": {
@@ -1183,6 +1425,43 @@
         "node": ">=4"
       }
     },
+    "node_modules/gulp-sourcemaps": {
+      "version": "3.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/gulp-sourcemaps/-/gulp-sourcemaps-3.0.0.tgz",
+      "integrity": "sha1-LhVOGi7+0DPA5IATlp5vMDN7J0M=",
+      "license": "ISC",
+      "dependencies": {
+        "@gulp-sourcemaps/identity-map": "^2.0.1",
+        "@gulp-sourcemaps/map-sources": "^1.0.0",
+        "acorn": "^6.4.1",
+        "convert-source-map": "^1.0.0",
+        "css": "^3.0.0",
+        "debug-fabulous": "^1.0.0",
+        "detect-newline": "^2.0.0",
+        "graceful-fs": "^4.0.0",
+        "source-map": "^0.6.0",
+        "strip-bom-string": "^1.0.0",
+        "through2": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gulp-sourcemaps/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha1-f6rmI1P7QhM2bQypg1jSLoNosF8=",
+      "license": "MIT"
+    },
+    "node_modules/gulp-sourcemaps/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/gulplog": {
       "version": "2.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/gulplog/-/gulplog-2.2.0.tgz",
@@ -1418,6 +1697,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha1-OauVnMv5p3TPB597QMeib3YxNfE=",
+      "license": "MIT"
+    },
     "node_modules/is-relative": {
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/is-relative/-/is-relative-1.0.0.tgz",
@@ -1568,6 +1853,15 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+      "license": "MIT",
+      "dependencies": {
+        "es5-ext": "~0.10.2"
+      }
+    },
     "node_modules/map-cache": {
       "version": "0.2.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/map-cache/-/map-cache-0.2.2.tgz",
@@ -1575,6 +1869,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/memoizee": {
+      "version": "0.4.15",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/memoizee/-/memoizee-0.4.15.tgz",
+      "integrity": "sha1-5vPS2oY/MY0CIlORgppsWVZVW3I=",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.53",
+        "es6-weak-map": "^2.0.3",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.2.2",
+        "lru-queue": "^0.1.0",
+        "next-tick": "^1.1.0",
+        "timers-ext": "^0.1.7"
       }
     },
     "node_modules/micromatch": {
@@ -1590,6 +1900,12 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "license": "MIT"
+    },
     "node_modules/mute-stdout": {
       "version": "2.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/mute-stdout/-/mute-stdout-2.0.0.tgz",
@@ -1598,6 +1914,12 @@
       "engines": {
         "node": ">= 10.13.0"
       }
+    },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha1-GDbuMK1W1n7ygbIr0Zn3CUSbNes=",
+      "license": "ISC"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -1715,6 +2037,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha1-VwZw95NkaFHRuhNZlpYqutWHhZ8=",
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -1740,6 +2068,32 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha1-liQ3XZZWMOLh8sAqk1yCpZy0gwk=",
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/postcss/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -2094,6 +2448,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-resolve": {
+      "version": "0.6.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+      "integrity": "sha1-PZ34fiNrU/FtAeWBUPx3EROOXtI=",
+      "license": "MIT",
+      "dependencies": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0"
+      }
+    },
     "node_modules/sparkles": {
       "version": "2.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/sparkles/-/sparkles-2.1.0.tgz",
@@ -2178,6 +2542,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -2239,6 +2612,16 @@
         "xtend": "~4.0.1"
       }
     },
+    "node_modules/timers-ext": {
+      "version": "0.1.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/timers-ext/-/timers-ext-0.1.7.tgz",
+      "integrity": "sha1-b1ethXjgej+5+R2Th9ZWR1VeJcY=",
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "~0.10.46",
+        "next-tick": "1"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/tiny-invariant/-/tiny-invariant-1.3.2.tgz",
@@ -2268,6 +2651,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/type": {
+      "version": "2.7.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/type/-/type-2.7.2.tgz",
+      "integrity": "sha1-I3ahWjoose+g9TUNz3LSTfbvmNA=",
+      "license": "ISC"
     },
     "node_modules/unc-path-regex": {
       "version": "0.1.2",

--- a/web/src/Web.App/package.json
+++ b/web/src/Web.App/package.json
@@ -9,7 +9,8 @@
     "govuk-frontend": "^5.2.0",
     "gulp": "^5.0.0",
     "gulp-clean-css": "^4.3.0",
-    "gulp-dart-sass": "^1.1.0"
+    "gulp-dart-sass": "^1.1.0",
+    "gulp-sourcemaps": "^3.0.0"
   },
   "overrides": {
     "glob-parent": "^6.0.2"

--- a/web/tests/Web.Tests/Extensions/GivenAString.cs
+++ b/web/tests/Web.Tests/Extensions/GivenAString.cs
@@ -1,6 +1,15 @@
+using Web.App.Extensions;
+using Xunit;
 namespace Web.Tests.Extensions;
 
 public class GivenAString
 {
-
+    [Theory]
+    [InlineData("Hello, world", "hello-world")]
+    [InlineData(" Test  value: 1, 2, 3 ", "test-value-1-2-3")]
+    public void ReturnsSlugWhenToSlugIsCalled(string source, string expected)
+    {
+        var result = source.ToSlug();
+        Assert.Equal(expected, result);
+    }
 }


### PR DESCRIPTION
### Context
[AB#210318](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/210318) [AB#188333](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/188333)

### Change proposed in this pull request
Replacement of cost categories on Trust home page with stacked RAGs for each, with link through to underlying cost item (once target page available). Updates to RAG and 'headline' colour palette.

### Guidance to review 
Browse to any Trust home page to view the changes. The links for each cost category and the RAGs therein may be updated at a later stage.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

