### PR TITLE
Listed schools by phase within Trust, ordered by RAG status

### DIFF
--- a/web/src/Web.App/AssetSrc/scss/_headlines.scss
+++ b/web/src/Web.App/AssetSrc/scss/_headlines.scss
@@ -2,7 +2,6 @@
 
 .app-headline-figures {
   background: #5D7490;
-  border: 1px solid #5D7490;
 
   p {
     color: white;

--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -101,6 +101,17 @@ p.priority .govuk-tag {
   }
 }
 
+.govuk-table.table-school-rag {
+  thead {
+    tr {
+      th {
+        border-bottom: 0;
+        padding-bottom: 0;
+      }
+    }
+  }
+}
+
 svg.rag-stack {
   width: 100%;
 

--- a/web/src/Web.App/ViewComponents/DataSourceViewComponent.cs
+++ b/web/src/Web.App/ViewComponents/DataSourceViewComponent.cs
@@ -17,7 +17,7 @@ public class DataSourceViewComponent(IFinanceService financeService) : ViewCompo
             OrganisationTypes.School when !isPartOfTrust =>
                 $"This school's data covers the financial year April {years.Cfr - 1} to March {years.Cfr} consistent financial reporting return (CFR).",
             OrganisationTypes.Trust =>
-                $"This trust's data covers the financial September {years.Aar - 1} to August {years.Aar} academies accounts return (AAR).",
+                $"This trust's data covers the financial year September {years.Aar - 1} to August {years.Aar} academies accounts return (AAR).",
             OrganisationTypes.LocalAuthority =>
                 $"This local authorities data covers the financial year April {years.Cfr - 1} to March {years.Cfr} consistent financial reporting return (CFR).",
             _ => throw new ArgumentOutOfRangeException(nameof(kind))

--- a/web/src/Web.App/ViewComponents/RagStack.cs
+++ b/web/src/Web.App/ViewComponents/RagStack.cs
@@ -13,7 +13,7 @@ public class RagStack : ViewComponent
         string? redHref = null,
         string? amberHref = null,
         string? greenHref = null)
-        => View(new RagStackViewModel(identifier, red, amber, green, height ?? 25)
+        => View(new RagStackViewModel(identifier, red, amber, green, height ?? 30)
         {
             RedHref = redHref,
             AmberHref = amberHref,

--- a/web/src/Web.App/ViewModels/Components/RagStackViewModel.cs
+++ b/web/src/Web.App/ViewModels/Components/RagStackViewModel.cs
@@ -7,11 +7,11 @@ public class RagStackViewModel(string identifier, int red, int amber, int green,
     public decimal Red => red;
     public decimal Amber => amber;
     public decimal Green => green;
-    private decimal Total => red + amber + green;
+    public decimal Total => red + amber + green;
 
-    public decimal RedPercentage => red / Total * 100;
-    public decimal AmberPercentage => amber / Total * 100;
-    public decimal GreenPercentage => green / Total * 100;
+    public decimal RedPercentage => Total > 0 ? red / Total * 100 : 0;
+    public decimal AmberPercentage => Total > 0 ? amber / Total * 100 : 0;
+    public decimal GreenPercentage => Total > 0 ? green / Total * 100 : 0;
 
     public string? RedHref { get; init; }
     public string? AmberHref { get; init; }

--- a/web/src/Web.App/ViewModels/RagViewModel.cs
+++ b/web/src/Web.App/ViewModels/RagViewModel.cs
@@ -1,0 +1,20 @@
+﻿namespace Web.App.ViewModels;
+
+public abstract class RagViewModel(int red, int amber, int green)
+{
+    public int Red => red;
+    public int Amber => amber;
+    public int Green => green;
+    public int Weighting => red * 25 + amber * 5 + green;
+}
+
+public class RagCostCategoryViewModel(string? category, int red, int amber, int green) : RagViewModel(red, amber, green)
+{
+    public string? Category => category;
+}
+
+public class RagSchoolViewModel(string? urn, string? name, int red, int amber, int green) : RagViewModel(red, amber, green)
+{
+    public string? Urn => urn;
+    public string? Name => name;
+}

--- a/web/src/Web.App/ViewModels/TrustViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustViewModel.cs
@@ -3,25 +3,66 @@ namespace Web.App.ViewModels;
 
 public class TrustViewModel(Trust trust, IReadOnlyCollection<School> schools, IEnumerable<RagRating> ratings)
 {
+    private const string Red = "Red";
+    private const string Amber = "Amber";
+    private const string Green = "Green";
+
     public string? CompanyNumber => trust.CompanyNumber;
     public string? Name => trust.Name;
-    public IEnumerable<School> Schools => schools;
     public int NumberSchools => schools.Count;
-    public int Low => ratings.Count(x => x.Status == "Green");
-    public int Medium => ratings.Count(x => x.Status == "Amber");
-    public int High => ratings.Count(x => x.Status == "Red");
+    public int Low => ratings.Count(x => x.Status == Green);
+    public int Medium => ratings.Count(x => x.Status == Amber);
+    public int High => ratings.Count(x => x.Status == Red);
 
-    public IEnumerable<(string Category, int Red, int Amber, int Green)> Ratings => ratings
+    public IOrderedEnumerable<RagCostCategoryViewModel> Ratings => ratings
         .GroupBy(x => (x.Status, x.CostCategory))
         .Select(x => (x.Key.Status, x.Key.CostCategory, Count: x.Count()))
         .GroupBy(x => x.CostCategory)
         .Where(x => x.Key != "Other")
-        .Select(x => (
+        .Select(x => new RagCostCategoryViewModel(
             x.Key!,
-            x.Where(r => r.Status == "Red").Select(r => r.Count).SingleOrDefault(),
-            x.Where(a => a.Status == "Amber").Select(a => a.Count).SingleOrDefault(),
-            x.Where(g => g.Status == "Green").Select(g => g.Count).SingleOrDefault()
-            ))
-        .OrderByDescending(x => x.Item2)
-        .ThenByDescending(x => x.Item3);
+            x.Where(r => r.Status == Red).Select(r => r.Count).SingleOrDefault(),
+            x.Where(a => a.Status == Amber).Select(a => a.Count).SingleOrDefault(),
+            x.Where(g => g.Status == Green).Select(g => g.Count).SingleOrDefault()
+        ))
+        .OrderByDescending(x => x.Weighting);
+
+    public IEnumerable<(
+        string? OverallPhase,
+        IOrderedEnumerable<RagSchoolViewModel> Schools)> Schools => schools
+        .GroupBy(x => x.OverallPhase)
+        .Select(x => (
+            OverallPhase: x.Key,
+            Schools: x
+                .Select(s => new RagSchoolViewModel(
+                    s.Urn,
+                    s.Name,
+                    ratings.Count(r => r.Urn == s.Urn && r.Status == Red),
+                    ratings.Count(r => r.Urn == s.Urn && r.Status == Amber),
+                    ratings.Count(r => r.Urn == s.Urn && r.Status == Green)
+                ))
+                .OrderByDescending(s => s.Weighting)));
+
+    public IEnumerable<RagSchoolViewModel> PrimarySchools =>
+        Schools.Where(s => s.OverallPhase == OverallPhaseTypes.Primary)
+            .SelectMany(s => s.Schools);
+    public IEnumerable<RagSchoolViewModel> SecondarySchools =>
+        Schools.Where(s => s.OverallPhase == OverallPhaseTypes.Secondary)
+            .SelectMany(s => s.Schools);
+    public IEnumerable<RagSchoolViewModel> SpecialOrPruSchools =>
+        Schools.Where(s => s.OverallPhase is OverallPhaseTypes.Special or OverallPhaseTypes.PupilReferralUnit)
+            .SelectMany(s => s.Schools);
+    public IEnumerable<RagSchoolViewModel> OtherSchools =>
+        Schools.Where(s =>
+                s.OverallPhase != OverallPhaseTypes.Primary &&
+                s.OverallPhase != OverallPhaseTypes.Secondary &&
+                s.OverallPhase != OverallPhaseTypes.Special &&
+                s.OverallPhase != OverallPhaseTypes.PupilReferralUnit)
+            .SelectMany(s => s.Schools);
+}
+
+public class TrustSchoolsSectionViewModel
+{
+    public string Heading { get; init; } = string.Empty;
+    public IEnumerable<RagSchoolViewModel> Schools { get; init; } = [];
 }

--- a/web/src/Web.App/Views/Shared/Components/RagStack/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/RagStack/Default.cshtml
@@ -3,52 +3,58 @@
 @{
     var id = Model.Identifier.ToSlug();
 }
-
-<svg style="height:@(Model.Height)px;" class="rag-stack" role="img" aria-labelledby="@id-rag">
-    <title id="@id-rag">RAG ratings for @Model.Identifier: @Model.Red red, @Model.Amber amber and @Model.Green green</title>
-    @if (!string.IsNullOrWhiteSpace(Model.RedHref))
-    {
-        @:<a href="@Model.RedHref" aria-label="@Model.Red red">
-    }
-    <rect
-        role="presentation"
-        x="0"
-        y="0"
-        width="@Model.RedPercentage%"
-        height="100%"
-        class="rag-stack-red"/>
-    @if (!string.IsNullOrWhiteSpace(Model.RedHref))
-    {
-        @:</a>
-    }
-    @if (!string.IsNullOrWhiteSpace(Model.AmberHref))
-    {
-        @:<a href="@Model.AmberHref" aria-label="@Model.Amber amber">
-    }
-    <rect
-        role="presentation"
-        x="@Model.RedPercentage%"
-        y="0"
-        width="@Model.AmberPercentage%"
-        height="100%"
-        class="rag-stack-amber"/>
-    @if (!string.IsNullOrWhiteSpace(Model.AmberHref))
-    {
-        @:</a>
-    }
-    @if (!string.IsNullOrWhiteSpace(Model.GreenHref))
-    {
-        @:<a href="@Model.GreenHref" aria-label="@Model.Green green">
-    }
-    <rect
-        role="presentation"
-        x="@(Model.RedPercentage + Model.AmberPercentage)%"
-        y="0"
-        width="@Model.GreenPercentage%"
-        height="100%"
-        class="rag-stack-green"/>
-    @if (!string.IsNullOrWhiteSpace(Model.GreenHref))
-    {
-        @:</a>
-    }
-</svg >
+@if (Model.Total <= 0)
+{
+    <span class="govuk-body-s">Status unavailable</span>
+}
+else
+{
+    <svg style="height:@(Model.Height)px;" class="rag-stack" role="img" aria-labelledby="@id-rag">
+        <title id="@id-rag">RAG ratings for @Model.Identifier: @Model.Red red, @Model.Amber amber and @Model.Green green</title>
+        @if (!string.IsNullOrWhiteSpace(Model.RedHref))
+        {
+            @:<a href="@Model.RedHref" aria-label="@Model.Red red">
+        }
+        <rect
+            role="presentation"
+            x="0"
+            y="0"
+            width="@Model.RedPercentage%"
+            height="100%"
+            class="rag-stack-red"/>
+        @if (!string.IsNullOrWhiteSpace(Model.RedHref))
+        {
+            @:</a>
+        }
+        @if (!string.IsNullOrWhiteSpace(Model.AmberHref))
+        {
+            @:<a href="@Model.AmberHref" aria-label="@Model.Amber amber">
+        }
+        <rect
+            role="presentation"
+            x="@Model.RedPercentage%"
+            y="0"
+            width="@Model.AmberPercentage%"
+            height="100%"
+            class="rag-stack-amber"/>
+        @if (!string.IsNullOrWhiteSpace(Model.AmberHref))
+        {
+            @:</a>
+        }
+        @if (!string.IsNullOrWhiteSpace(Model.GreenHref))
+        {
+            @:<a href="@Model.GreenHref" aria-label="@Model.Green green">
+        }
+        <rect
+            role="presentation"
+            x="@(Model.RedPercentage + Model.AmberPercentage)%"
+            y="0"
+            width="@Model.GreenPercentage%"
+            height="100%"
+            class="rag-stack-green"/>
+        @if (!string.IsNullOrWhiteSpace(Model.GreenHref))
+        {
+            @:</a>
+        }
+    </svg>
+}

--- a/web/src/Web.App/Views/Trust/Index.cshtml
+++ b/web/src/Web.App/Views/Trust/Index.cshtml
@@ -1,4 +1,5 @@
 @using Web.App.Extensions
+@using Web.App.ViewModels
 @using Web.App.ViewModels.Components
 @model Web.App.ViewModels.TrustViewModel
 @{
@@ -84,6 +85,38 @@
     }
     </tbody>
 </table>
+
+<h2 class="govuk-heading-m">Schools in this trust</h2>
+
+@await Component.InvokeAsync("DataSource", new
+{
+    kind = OrganisationTypes.Trust,
+    isPartOfTrust = true
+})
+
+@await Html.PartialAsync("_SchoolsSection", new TrustSchoolsSectionViewModel
+{
+    Heading = "Primary schools",
+    Schools = Model.PrimarySchools
+})
+
+@await Html.PartialAsync("_SchoolsSection", new TrustSchoolsSectionViewModel
+{
+    Heading = "Secondary schools",
+    Schools = Model.SecondarySchools
+})
+
+@await Html.PartialAsync("_SchoolsSection", new TrustSchoolsSectionViewModel
+{
+    Heading = "Specials and Pupil Referrals units (PRUs)",
+    Schools = Model.SpecialOrPruSchools
+})
+
+@await Html.PartialAsync("_SchoolsSection", new TrustSchoolsSectionViewModel
+{
+    Heading = "Other schools",
+    Schools = Model.OtherSchools
+})
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 

--- a/web/src/Web.App/Views/Trust/_SchoolsSection.cshtml
+++ b/web/src/Web.App/Views/Trust/_SchoolsSection.cshtml
@@ -1,0 +1,34 @@
+﻿@model Web.App.ViewModels.TrustSchoolsSectionViewModel
+
+@if (Model.Schools.Any())
+{
+    <table class="govuk-table table-school-rag">
+        <caption class="govuk-table__caption govuk-visually-hidden">@Model.Heading in this trust</caption>
+        <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header govuk-!-width-one-half govuk-body-s">@Model.Heading</th>
+            <th scope="col" class="govuk-table__header govuk-body-s">Status</th>
+        </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        @foreach (var school in Model.Schools)
+        {
+            <tr class="govuk-table__row">
+                <td class="govuk-body-s">
+                    <a class="govuk-link govuk-link--no-visited-state" href="@Url.Action("Index", "School", new { urn = school.Urn })">@school.Name</a>
+                </td>
+                <td>
+                    @await Component.InvokeAsync("RagStack", new
+                    {
+                        identifier = school.Name,
+                        red = school.Red,
+                        amber = school.Amber,
+                        green = school.Green,
+                        height = 15
+                    })
+                </td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}


### PR DESCRIPTION
### Context
[AB#210606](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/210606) [AB#188333](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/188333)

### Change proposed in this pull request
Added a list of schools - along with their RAG status  - grouped by `OverallPhase`, within the Trust.

### Guidance to review 
Viewing a larger MAT such as `Oasis Community Learning` helps to give a better representation on what each RAG status corresponds to for each listed school, and how the `Weighting` was tweaked.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

