### PR TITLE
adds year information to homepages

### DIFF
--- a/web/src/Web.App/Views/LocalAuthority/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthority/Index.cshtml
@@ -15,6 +15,8 @@
     </div>
 </div>
 
+@await Component.InvokeAsync("DataSource", new { kind = OrganisationTypes.LocalAuthority })
+
 <hr class="govuk-section-break govuk-section-break--m">
 
 <div class="govuk-grid-row">

--- a/web/src/Web.App/Views/School/Index.cshtml
+++ b/web/src/Web.App/Views/School/Index.cshtml
@@ -26,6 +26,8 @@
     </div>
 </div>
 
+@await Component.InvokeAsync("DataSource", new { kind = OrganisationTypes.School, isPartOfTrust = Model.IsPartOfTrust })
+
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <ul class="app-headline app-headline-4 govuk-!-text-align-centre">

--- a/web/src/Web.App/Views/Trust/Index.cshtml
+++ b/web/src/Web.App/Views/Trust/Index.cshtml
@@ -15,6 +15,8 @@
     </div>
 </div>
 
+@await Component.InvokeAsync("DataSource", new { kind = OrganisationTypes.Trust, isPartOfTrust = true })
+
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <ul class="app-headline app-headline-3 govuk-!-text-align-centre">
@@ -87,12 +89,6 @@
 </table>
 
 <h2 class="govuk-heading-m">Schools in this trust</h2>
-
-@await Component.InvokeAsync("DataSource", new
-{
-    kind = OrganisationTypes.Trust,
-    isPartOfTrust = true
-})
 
 @await Html.PartialAsync("_SchoolsSection", new TrustSchoolsSectionViewModel
 {

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHome.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHome.cs
@@ -147,6 +147,11 @@ public class WhenViewingHome(SchoolBenchmarkingWebAppClient client) : PageBase<S
         Assert.NotNull(authority.Name);
         DocumentAssert.TitleAndH1(page, "Your local authority - Financial Benchmarking and Insights Tool - GOV.UK", authority.Name);
 
+        var dataSourceElement = page.QuerySelector("main > div > div:nth-child(2) > div > p");
+        Assert.NotNull(dataSourceElement);
+
+        DocumentAssert.TextEqual(dataSourceElement, "This local authorities data covers the financial year April 2020 to March 2021 consistent financial reporting return (CFR).");
+
         var primarySchoolsHeading = page.GetElementById("accordion-schools-heading-1");
         Assert.NotNull(primarySchoolsHeading);
         Assert.Contains("Primary schools", primarySchoolsHeading.TextContent);

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingHome.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingHome.cs
@@ -62,6 +62,11 @@ public class WhenViewingHome(SchoolBenchmarkingWebAppClient client) : PageBase<S
         DocumentAssert.AssertPageUrl(page, Paths.TrustHome(trust.CompanyNumber).ToAbsolute());
         DocumentAssert.Breadcrumbs(page, expectedBreadcrumbs);
 
+        var dataSourceElement = page.QuerySelector("main > div > div:nth-child(2) > div > p");
+        Assert.NotNull(dataSourceElement);
+
+        DocumentAssert.TextEqual(dataSourceElement, "This trust's data covers the financial year September 2021 to August 2022 academies accounts return (AAR).");
+
         Assert.NotNull(trust.Name);
         DocumentAssert.TitleAndH1(page, "Your trust - Financial Benchmarking and Insights Tool - GOV.UK", trust.Name);
     }


### PR DESCRIPTION
### Context
[AB#209775](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/209775) - [AB#210430](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/210430)

### Change proposed in this pull request
Add financial year information to school, trust and la homepages
Adds integration tests to confirm this behaviour.

### Guidance to review 
Removed existing datasource component from trust homepage and replaced with one below the main heading on the page to align with the other pages. Happy to amend as required based on feedback on this PR.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

