### PR TITLE
When school financial or census data cannot be loaded, display appropriate warning rather than 404 page

### DIFF
--- a/front-end-components/src/components/error-banner/component.tsx
+++ b/front-end-components/src/components/error-banner/component.tsx
@@ -1,0 +1,17 @@
+import { ErrorBannerProps } from "src/components/error-banner";
+
+export const ErrorBanner: React.FC<ErrorBannerProps> = (props) => {
+  const { isRendered, message } = props;
+
+  return isRendered ? (
+    <div className="govuk-warning-text">
+      <span className="govuk-warning-text__icon" aria-hidden="true">
+        !
+      </span>
+      <strong className="govuk-warning-text__text">
+        <span className="govuk-visually-hidden">Warning</span>
+        {message}
+      </strong>
+    </div>
+  ) : null;
+};

--- a/front-end-components/src/components/error-banner/index.tsx
+++ b/front-end-components/src/components/error-banner/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/components/error-banner/types";
+export * from "src/components/error-banner/component";

--- a/front-end-components/src/components/error-banner/types.tsx
+++ b/front-end-components/src/components/error-banner/types.tsx
@@ -1,4 +1,4 @@
-export type WarningBannerProps = {
+export type ErrorBannerProps = {
   isRendered?: boolean;
   message: string;
 };

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -18,6 +18,7 @@ import {
 import { SchoolTick } from "src/components/charts/school-tick";
 import { SchoolCensusTooltip } from "src/components/charts/school-census-tooltip";
 import { WarningBanner } from "src/components/warning-banner";
+import { ErrorBanner } from "src/components/error-banner";
 
 export function HorizontalBarChartWrapper<TData extends SchoolChartData>(
   props: HorizontalBarChartWrapperProps<TData>
@@ -26,7 +27,7 @@ export function HorizontalBarChartWrapper<TData extends SchoolChartData>(
   const mode = useContext(ChartModeContext);
   const dimension = useContext(ChartDimensionContext);
   const selectedSchool = useContext(SelectedSchoolContext);
-  const hasIncompleteData = useContext(HasIncompleteDataContext);
+  const { hasIncompleteData, hasNoData } = useContext(HasIncompleteDataContext);
   const ref = createRef<ChartHandler>();
   const [imageLoading, setImageLoading] = useState<boolean>();
 
@@ -70,6 +71,10 @@ export function HorizontalBarChartWrapper<TData extends SchoolChartData>(
       <WarningBanner
         isRendered={hasIncompleteData}
         message="Some schools are missing data for this financial year"
+      />
+      <ErrorBanner
+        isRendered={hasNoData}
+        message="Unable to load data for this financial year"
       />
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-full">
@@ -136,7 +141,7 @@ export function HorizontalBarChartWrapper<TData extends SchoolChartData>(
               </div>
             </>
           ) : (
-            <Loading />
+            !hasNoData && <Loading />
           )}
         </div>
       </div>

--- a/front-end-components/src/contexts/contexts.tsx
+++ b/front-end-components/src/contexts/contexts.tsx
@@ -17,6 +17,10 @@ export const ChartDimensionContext = createContext<Dimension>({
 });
 export const SelectedSchoolContext = createContext(School.empty());
 
-export const HasIncompleteDataContext = createContext(false);
+interface HasIncompleteData {
+  hasIncompleteData?: boolean;
+  hasNoData?: boolean;
+}
+export const HasIncompleteDataContext = createContext<HasIncompleteData>({});
 
 export const PhaseContext = createContext<string | undefined>(undefined);

--- a/front-end-components/src/views/compare-your-census/partials/auxiliary-staff.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/auxiliary-staff.tsx
@@ -28,7 +28,7 @@ export const AuxiliaryStaff: React.FC<{ type: string; id: string }> = ({
 }) => {
   const phase = useContext(PhaseContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
-  const [data, setData] = useState(new Array<Census>());
+  const [data, setData] = useState<Census[]>();
   const getData = useCallback(async () => {
     setData(new Array<Census>());
     return await CensusApi.query(
@@ -57,12 +57,13 @@ export const AuxiliaryStaff: React.FC<{ type: string; id: string }> = ({
       ];
 
       return {
-        dataPoints: data.map((school) => {
-          return {
-            ...school,
-            value: school.auxiliaryStaffFte,
-          };
-        }),
+        dataPoints:
+          data?.map((school) => {
+            return {
+              ...school,
+              value: school.auxiliaryStaffFte,
+            };
+          }) ?? [],
         tableHeadings,
       };
     }, [dimension, data]);
@@ -76,10 +77,11 @@ export const AuxiliaryStaff: React.FC<{ type: string; id: string }> = ({
     setDimension(dimension);
   };
 
-  const hasIncompleteData = data.some((x) => x.hasIncompleteData);
+  const hasIncompleteData = data?.some((x) => x.hasIncompleteData);
+  const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={hasIncompleteData}>
+    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <HorizontalBarChartWrapper
           data={chartData}

--- a/front-end-components/src/views/compare-your-census/partials/headcount.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/headcount.tsx
@@ -30,7 +30,7 @@ export const Headcount: React.FC<{ type: string; id: string }> = ({
 }) => {
   const phase = useContext(PhaseContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
-  const [data, setData] = useState(new Array<Census>());
+  const [data, setData] = useState<Census[]>();
   const getData = useCallback(async () => {
     setData(new Array<Census>());
     return await CensusApi.query(
@@ -59,12 +59,13 @@ export const Headcount: React.FC<{ type: string; id: string }> = ({
       ];
 
       return {
-        dataPoints: data.map((school) => {
-          return {
-            ...school,
-            value: school.workforceHeadcount,
-          };
-        }),
+        dataPoints:
+          data?.map((school) => {
+            return {
+              ...school,
+              value: school.workforceHeadcount,
+            };
+          }) ?? [],
         tableHeadings,
       };
     }, [dimension, data]);
@@ -78,10 +79,11 @@ export const Headcount: React.FC<{ type: string; id: string }> = ({
     setDimension(dimension);
   };
 
-  const hasIncompleteData = data.some((x) => x.hasIncompleteData);
+  const hasIncompleteData = data?.some((x) => x.hasIncompleteData);
+  const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={hasIncompleteData}>
+    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <HorizontalBarChartWrapper
           data={chartData}

--- a/front-end-components/src/views/compare-your-census/partials/non-classroom-support.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/non-classroom-support.tsx
@@ -28,7 +28,7 @@ export const NonClassroomSupport: React.FC<{ type: string; id: string }> = ({
 }) => {
   const phase = useContext(PhaseContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
-  const [data, setData] = useState(new Array<Census>());
+  const [data, setData] = useState<Census[]>();
   const getData = useCallback(async () => {
     setData(new Array<Census>());
     return await CensusApi.query(
@@ -57,12 +57,13 @@ export const NonClassroomSupport: React.FC<{ type: string; id: string }> = ({
       ];
 
       return {
-        dataPoints: data.map((school) => {
-          return {
-            ...school,
-            value: school.nonClassroomSupportStaffFte,
-          };
-        }),
+        dataPoints:
+          data?.map((school) => {
+            return {
+              ...school,
+              value: school.nonClassroomSupportStaffFte,
+            };
+          }) ?? [],
         tableHeadings,
       };
     }, [dimension, data]);
@@ -76,10 +77,11 @@ export const NonClassroomSupport: React.FC<{ type: string; id: string }> = ({
     setDimension(dimension);
   };
 
-  const hasIncompleteData = data.some((x) => x.hasIncompleteData);
+  const hasIncompleteData = data?.some((x) => x.hasIncompleteData);
+  const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={hasIncompleteData}>
+    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <HorizontalBarChartWrapper
           data={chartData}

--- a/front-end-components/src/views/compare-your-census/partials/school-workforce.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/school-workforce.tsx
@@ -29,7 +29,7 @@ export const SchoolWorkforce: React.FC<{ type: string; id: string }> = ({
 }) => {
   const phase = useContext(PhaseContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
-  const [data, setData] = useState(new Array<Census>());
+  const [data, setData] = useState<Census[]>();
   const getData = useCallback(async () => {
     setData(new Array<Census>());
     return await CensusApi.query(
@@ -58,12 +58,13 @@ export const SchoolWorkforce: React.FC<{ type: string; id: string }> = ({
       ];
 
       return {
-        dataPoints: data.map((school) => {
-          return {
-            ...school,
-            value: school.workforceFte,
-          };
-        }),
+        dataPoints:
+          data?.map((school) => {
+            return {
+              ...school,
+              value: school.workforceFte,
+            };
+          }) ?? [],
         tableHeadings,
       };
     }, [dimension, data]);
@@ -77,10 +78,11 @@ export const SchoolWorkforce: React.FC<{ type: string; id: string }> = ({
     setDimension(dimension);
   };
 
-  const hasIncompleteData = data.some((x) => x.hasIncompleteData);
+  const hasIncompleteData = data?.some((x) => x.hasIncompleteData);
+  const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={hasIncompleteData}>
+    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <HorizontalBarChartWrapper
           data={chartData}

--- a/front-end-components/src/views/compare-your-census/partials/senior-leadership.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/senior-leadership.tsx
@@ -28,7 +28,7 @@ export const SeniorLeadership: React.FC<{ type: string; id: string }> = ({
 }) => {
   const phase = useContext(PhaseContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
-  const [data, setData] = useState(new Array<Census>());
+  const [data, setData] = useState<Census[]>();
   const getData = useCallback(async () => {
     setData(new Array<Census>());
     return await CensusApi.query(
@@ -57,12 +57,13 @@ export const SeniorLeadership: React.FC<{ type: string; id: string }> = ({
       ];
 
       return {
-        dataPoints: data.map((school) => {
-          return {
-            ...school,
-            value: school.seniorLeadershipFte,
-          };
-        }),
+        dataPoints:
+          data?.map((school) => {
+            return {
+              ...school,
+              value: school.seniorLeadershipFte,
+            };
+          }) ?? [],
         tableHeadings,
       };
     }, [dimension, data]);
@@ -76,10 +77,11 @@ export const SeniorLeadership: React.FC<{ type: string; id: string }> = ({
     setDimension(dimension);
   };
 
-  const hasIncompleteData = data.some((x) => x.hasIncompleteData);
+  const hasIncompleteData = data?.some((x) => x.hasIncompleteData);
+  const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={hasIncompleteData}>
+    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <HorizontalBarChartWrapper
           data={chartData}

--- a/front-end-components/src/views/compare-your-census/partials/teaching-assistants.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/teaching-assistants.tsx
@@ -28,7 +28,7 @@ export const TeachingAssistants: React.FC<{ type: string; id: string }> = ({
 }) => {
   const phase = useContext(PhaseContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
-  const [data, setData] = useState(new Array<Census>());
+  const [data, setData] = useState<Census[]>();
   const getData = useCallback(async () => {
     setData(new Array<Census>());
     return await CensusApi.query(
@@ -57,12 +57,13 @@ export const TeachingAssistants: React.FC<{ type: string; id: string }> = ({
       ];
 
       return {
-        dataPoints: data.map((school) => {
-          return {
-            ...school,
-            value: school.teachingAssistantsFte,
-          };
-        }),
+        dataPoints:
+          data?.map((school) => {
+            return {
+              ...school,
+              value: school.teachingAssistantsFte,
+            };
+          }) ?? [],
         tableHeadings,
       };
     }, [dimension, data]);
@@ -76,10 +77,11 @@ export const TeachingAssistants: React.FC<{ type: string; id: string }> = ({
     setDimension(dimension);
   };
 
-  const hasIncompleteData = data.some((x) => x.hasIncompleteData);
+  const hasIncompleteData = data?.some((x) => x.hasIncompleteData);
+  const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={hasIncompleteData}>
+    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <HorizontalBarChartWrapper
           data={chartData}

--- a/front-end-components/src/views/compare-your-census/partials/total-teachers-qualified.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/total-teachers-qualified.tsx
@@ -23,7 +23,7 @@ export const TotalTeachersQualified: React.FC<{ type: string; id: string }> = ({
   id,
 }) => {
   const phase = useContext(PhaseContext);
-  const [data, setData] = useState(new Array<Census>());
+  const [data, setData] = useState<Census[]>();
   const getData = useCallback(async () => {
     setData(new Array<Census>());
     return await CensusApi.query(type, id, "Total", "TeachersQualified", phase);
@@ -46,20 +46,22 @@ export const TotalTeachersQualified: React.FC<{ type: string; id: string }> = ({
       ];
 
       return {
-        dataPoints: data.map((school) => {
-          return {
-            ...school,
-            value: school.teachersQualified,
-          };
-        }),
+        dataPoints:
+          data?.map((school) => {
+            return {
+              ...school,
+              value: school.teachersQualified,
+            };
+          }) ?? [],
         tableHeadings,
       };
     }, [data]);
 
-  const hasIncompleteData = data.some((x) => x.hasIncompleteData);
+  const hasIncompleteData = data?.some((x) => x.hasIncompleteData);
+  const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={hasIncompleteData}>
+    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
       <ChartDimensionContext.Provider value={Percent}>
         <HorizontalBarChartWrapper
           data={chartData}

--- a/front-end-components/src/views/compare-your-census/partials/total-teachers.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/total-teachers.tsx
@@ -28,7 +28,7 @@ export const TotalTeachers: React.FC<{ type: string; id: string }> = ({
 }) => {
   const phase = useContext(PhaseContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
-  const [data, setData] = useState(new Array<Census>());
+  const [data, setData] = useState<Census[]>();
   const getData = useCallback(async () => {
     setData(new Array<Census>());
     return await CensusApi.query(
@@ -57,12 +57,13 @@ export const TotalTeachers: React.FC<{ type: string; id: string }> = ({
       ];
 
       return {
-        dataPoints: data.map((school) => {
-          return {
-            ...school,
-            value: school.teachersFte,
-          };
-        }),
+        dataPoints:
+          data?.map((school) => {
+            return {
+              ...school,
+              value: school.teachersFte,
+            };
+          }) ?? [],
         tableHeadings,
       };
     }, [dimension, data]);
@@ -76,10 +77,11 @@ export const TotalTeachers: React.FC<{ type: string; id: string }> = ({
     setDimension(dimension);
   };
 
-  const hasIncompleteData = data.some((x) => x.hasIncompleteData);
+  const hasIncompleteData = data?.some((x) => x.hasIncompleteData);
+  const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={hasIncompleteData}>
+    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <HorizontalBarChartWrapper
           data={chartData}

--- a/front-end-components/src/views/compare-your-costs/view.tsx
+++ b/front-end-components/src/views/compare-your-costs/view.tsx
@@ -66,6 +66,8 @@ export const CompareYourCosts: React.FC<CompareYourCostsViewProps> = (
   const hasIncompleteData =
     expenditureData?.some((x) => x.hasIncompleteData) ?? false;
 
+  const hasNoData = expenditureData?.length === 0;
+
   return (
     <SelectedSchoolContext.Provider value={selectedSchool}>
       <div className="chart-options">
@@ -96,7 +98,9 @@ export const CompareYourCosts: React.FC<CompareYourCostsViewProps> = (
           <ChartMode displayMode={displayMode} handleChange={toggleChartMode} />
         </div>
       </div>
-      <HasIncompleteDataContext.Provider value={hasIncompleteData}>
+      <HasIncompleteDataContext.Provider
+        value={{ hasIncompleteData, hasNoData }}
+      >
         <ChartModeContext.Provider value={displayMode}>
           <TotalExpenditure
             schools={

--- a/web/src/Web.App/Extensions/DecimalExtensions.cs
+++ b/web/src/Web.App/Extensions/DecimalExtensions.cs
@@ -1,15 +1,9 @@
 using System.Globalization;
-
 namespace Web.App.Extensions;
 
 public static class DecimalExtensions
 {
-    public static string ToCurrency(this decimal? value)
-    {
-        return value is { } valDecimal
-            ? valDecimal.ToCurrency()
-            : "";
-    }
+    public static string ToCurrency(this decimal? value, int decimalDigits = 2) => value.HasValue ? value.Value.ToCurrency(decimalDigits) : string.Empty;
 
     public static string ToCurrency(this decimal value, int decimalDigits = 2)
     {
@@ -18,18 +12,9 @@ public static class DecimalExtensions
         return value.ToString("C", nfi);
     }
 
-    public static string ToPercent(this decimal value)
-    {
-        return $"{value:0.##}%";
-    }
+    public static string ToPercent(this decimal value) => $"{value:0.##}%";
 
-    public static string ToSimpleDisplay(this decimal value)
-    {
-        return $"{value:0.##}";
-    }
+    public static string ToSimpleDisplay(this decimal value) => $"{value:0.##}";
 
-    public static string ToNumberSeparator(this decimal value)
-    {
-        return $"{value:N0}";
-    }
+    public static string ToNumberSeparator(this decimal value) => $"{value:N0}";
 }

--- a/web/src/Web.App/Services/FinanceService.cs
+++ b/web/src/Web.App/Services/FinanceService.cs
@@ -1,7 +1,6 @@
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Extensions;
-
 namespace Web.App.Services;
 
 public interface IFinanceService
@@ -9,7 +8,7 @@ public interface IFinanceService
     Task<SchoolExpenditure> GetSchoolExpenditure(string urn);
     Task<IEnumerable<SchoolExpenditure>> GetExpenditure(IEnumerable<string> urns);
     Task<IEnumerable<Finances>> GetFinances(IEnumerable<string> urns);
-    Task<Finances> GetFinances(string urns);
+    Task<Finances?> GetFinances(string urns);
     Task<FinanceYears> GetYears();
     Task<IEnumerable<Expenditure>> GetSchoolExpenditureHistory(string urn, string dimension);
     Task<IEnumerable<Expenditure>> GetTrustExpenditureHistory(string companyNo, string dimension);
@@ -19,15 +18,9 @@ public interface IFinanceService
 
 public class FinanceService(IInsightApi insightApi, ICensusApi censusApi) : IFinanceService
 {
-    public async Task<FinanceYears> GetYears()
-    {
-        return await insightApi.GetCurrentReturnYears().GetResultOrThrow<FinanceYears>();
-    }
+    public async Task<FinanceYears> GetYears() => await insightApi.GetCurrentReturnYears().GetResultOrThrow<FinanceYears>();
 
-    public async Task<SchoolExpenditure> GetSchoolExpenditure(string urn)
-    {
-        return await insightApi.GetSchoolExpenditure(urn).GetResultOrThrow<SchoolExpenditure>();
-    }
+    public async Task<SchoolExpenditure> GetSchoolExpenditure(string urn) => await insightApi.GetSchoolExpenditure(urn).GetResultOrThrow<SchoolExpenditure>();
 
     public async Task<IEnumerable<Expenditure>> GetSchoolExpenditureHistory(string urn, string dimension)
     {
@@ -53,20 +46,11 @@ public class FinanceService(IInsightApi insightApi, ICensusApi censusApi) : IFin
         return await insightApi.GetSchoolFinances(query).GetResultOrDefault<IEnumerable<Finances>>() ?? Array.Empty<Finances>();
     }
 
-    public async Task<Finances> GetFinances(string urn)
-    {
-        return await insightApi.GetSchoolFinances(urn).GetResultOrThrow<Finances>();
-    }
+    public async Task<Finances?> GetFinances(string urn) => await insightApi.GetSchoolFinances(urn).GetResultOrDefault<Finances>();
 
-    public async Task<Census> GetSchoolCensus(string urn)
-    {
-        return await censusApi.Get(urn).GetResultOrThrow<Census>();
-    }
+    public async Task<Census> GetSchoolCensus(string urn) => await censusApi.Get(urn).GetResultOrThrow<Census>();
 
-    public async Task<FloorAreaMetric> GetSchoolFloorArea(string urn)
-    {
-        return await insightApi.GetSchoolFloorAreaMetric(urn).GetResultOrThrow<FloorAreaMetric>();
-    }
+    public async Task<FloorAreaMetric> GetSchoolFloorArea(string urn) => await insightApi.GetSchoolFloorAreaMetric(urn).GetResultOrThrow<FloorAreaMetric>();
 
     private static ApiQuery BuildApiQueryForDimension(string dimension)
     {

--- a/web/src/Web.App/ViewModels/SchoolViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolViewModel.cs
@@ -1,10 +1,9 @@
 using Web.App.Domain;
-
 namespace Web.App.ViewModels;
 
 public class SchoolViewModel(
     School school,
-    Finances finances,
+    Finances? finances,
     IEnumerable<RagRating> ratings)
 {
     public string? Name => school.Name;
@@ -14,8 +13,9 @@ public class SchoolViewModel(
     public bool IsPartOfTrust => school.IsPartOfTrust;
     public string? TrustIdentifier => school.CompanyNumber;
     public string? TrustName => school.TrustOrCompanyName;
-    public decimal InYearBalance => finances.TotalIncome - finances.TotalExpenditure;
-    public decimal RevenueReserve => finances.RevenueReserve;
+    public decimal? InYearBalance => finances?.TotalIncome - finances?.TotalExpenditure;
+    public decimal? RevenueReserve => finances?.RevenueReserve;
+    public bool IsMissingFinancials => finances == null;
     public IEnumerable<RagRating> Ratings => ratings
         .Where(x => x.Status is "Red" or "Amber")
         .OrderBy(x => x.StatusOrder)

--- a/web/src/Web.App/Views/School/Index.cshtml
+++ b/web/src/Web.App/Views/School/Index.cshtml
@@ -1,6 +1,6 @@
-@using Web.App.ViewModels.Components
-@using Web.App.Extensions
 @using Web.App.Domain
+@using Web.App.Extensions
+@using Web.App.ViewModels.Components
 @model Web.App.ViewModels.SchoolViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.SchoolHome;
@@ -10,7 +10,7 @@
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l govuk-!-margin-bottom-1">@Model.Name</h1>
         <p class="govuk-body">
-            <a href="@Url.Action("Index", "FindOrganisation", new { method = OrganisationTypes.School})" class="govuk-link govuk-link--no-visited-state">Change school</a>
+            <a href="@Url.Action("Index", "FindOrganisation", new { method = OrganisationTypes.School })" class="govuk-link govuk-link--no-visited-state">Change school</a>
         </p>
     </div>
 </div>
@@ -26,65 +26,104 @@
     </div>
 </div>
 
-@await Component.InvokeAsync("DataSource", new { kind = OrganisationTypes.School, isPartOfTrust = Model.IsPartOfTrust })
+@await Component.InvokeAsync("DataSource", new
+{
+    kind = OrganisationTypes.School,
+    isPartOfTrust = Model.IsPartOfTrust
+})
 
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-        <ul class="app-headline app-headline-4 govuk-!-text-align-centre">
-            <li class="app-headline-figures">
-                <p class="govuk-body govuk-!-font-weight-bold">In year balance</p>
-                <p class="govuk-body">@Model.InYearBalance.ToCurrency(0)</p>
-            </li>
-            <li class="app-headline-figures">
-                <p class="govuk-body govuk-!-font-weight-bold">Revenue reserve</p>
-                <p class="govuk-body">@Model.RevenueReserve.ToCurrency(0)</p>
-            </li>
-            <li class="app-headline-figures">
-                <p class="govuk-body govuk-!-font-weight-bold">Ofsted rating</p>
-                <p class="govuk-body">@OfstedRatings.GetDescription(Model.OfstedRating)</p>
-            </li>
-            <li class="app-headline-figures">
-                <p class="govuk-body govuk-!-font-weight-bold">School phase</p>
-                <p class="govuk-body">@Model.OverallPhase</p>
-            </li>
-        </ul>
+@if (Model.IsMissingFinancials)
+{
+    <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+            <span class="govuk-visually-hidden">Warning</span>
+            Financial information could not be loaded for this establishment
+        </strong>
     </div>
-</div>
-
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-        <h2 class="govuk-heading-m">Spending and costs</h2>
-
-        <h3 class="govuk-heading-s">
-            <a href="@Url.Action("Index", "SchoolSpending", new { urn = Model.Urn })" class="govuk-link govuk-link--no-visited-state">
-                View all spending and costs
-            </a>
-        </h3>
-
-        <h3 class="govuk-heading-s">Top priority spending categories</h3>
-
-        <div class="top-categories">
-            @foreach (var rating in Model.Ratings)
-            {
-                <div>
-                    <h4 class="govuk-heading-s">@rating.CostCategory</h4>
-                    <p class="priority @rating.PriorityTag?.Class govuk-body">
-                        @await Component.InvokeAsync("Tag", new { rating.PriorityTag?.Colour, rating.PriorityTag?.DisplayText })
-                        Spends <strong>@rating.FromMedian.Difference.ToCurrency()</strong> @rating.Unit @rating.FromMedian.Description the median of similar schools.
-                    </p>
-                </div>
-            }
+}
+else
+{
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <ul class="app-headline app-headline-4 govuk-!-text-align-centre">
+                <li class="app-headline-figures">
+                    <p class="govuk-body govuk-!-font-weight-bold">In year balance</p>
+                    <p class="govuk-body">@Model.InYearBalance.ToCurrency(0)</p>
+                </li>
+                <li class="app-headline-figures">
+                    <p class="govuk-body govuk-!-font-weight-bold">Revenue reserve</p>
+                    <p class="govuk-body">@Model.RevenueReserve.ToCurrency(0)</p>
+                </li>
+                <li class="app-headline-figures">
+                    <p class="govuk-body govuk-!-font-weight-bold">Ofsted rating</p>
+                    <p class="govuk-body">@OfstedRatings.GetDescription(Model.OfstedRating)</p>
+                </li>
+                <li class="app-headline-figures">
+                    <p class="govuk-body govuk-!-font-weight-bold">School phase</p>
+                    <p class="govuk-body">@Model.OverallPhase</p>
+                </li>
+            </ul>
         </div>
     </div>
-</div>
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <h2 class="govuk-heading-m">Spending and costs</h2>
+
+            <h3 class="govuk-heading-s">
+                <a href="@Url.Action("Index", "SchoolSpending", new { urn = Model.Urn })" class="govuk-link govuk-link--no-visited-state">
+                    View all spending and costs
+                </a>
+            </h3>
+
+            <h3 class="govuk-heading-s">Top priority spending categories</h3>
+
+            <div class="top-categories">
+                @foreach (var rating in Model.Ratings)
+                {
+                    <div>
+                        <h4 class="govuk-heading-s">@rating.CostCategory</h4>
+                        <p class="priority @rating.PriorityTag?.Class govuk-body">
+                            @await Component.InvokeAsync("Tag", new
+                            {
+                                rating.PriorityTag?.Colour,
+                                rating.PriorityTag?.DisplayText
+                            })
+                            Spends <strong>@rating.FromMedian.Difference.ToCurrency()</strong> @rating.Unit @rating.FromMedian.Description the median of similar schools.
+                        </p>
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+}
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-@await Component.InvokeAsync("SchoolFinanceTools", new { identifier = Model.Urn, tools = new[] { FinanceTools.CompareYourCosts, FinanceTools.FinancialPlanning, FinanceTools.BenchmarkCensus } })
+@await Component.InvokeAsync("SchoolFinanceTools", new
+{
+    identifier = Model.Urn,
+    tools = new[]
+    {
+        FinanceTools.CompareYourCosts,
+        FinanceTools.FinancialPlanning,
+        FinanceTools.BenchmarkCensus
+    }
+})
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-@await Component.InvokeAsync("Resources", new { identifier = Model.Urn, resources = new[] { Resources.SchoolResources, Resources.SchoolHistoricData, Resources.SchoolDetails } })
+@await Component.InvokeAsync("Resources", new
+{
+    identifier = Model.Urn,
+    resources = new[]
+    {
+        Resources.SchoolResources,
+        Resources.SchoolHistoricData,
+        Resources.SchoolDetails
+    }
+})
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 

--- a/web/src/Web.App/gulpfile.js
+++ b/web/src/Web.App/gulpfile.js
@@ -7,8 +7,8 @@ var sourcemaps = require("gulp-sourcemaps");
 const buildSass = () => gulp.src("AssetSrc/scss/*.scss")
     .pipe(sourcemaps.init())
     .pipe(sass().on("error", sass.logError))
-    .pipe(sourcemaps.write("./"))
     .pipe(cleanCSS())
+    .pipe(sourcemaps.write("./"))
     .pipe(gulp.dest("wwwroot/css"));
 
 const copyStaticAssets = () => gulp.src(["node_modules/govuk-frontend/dist/govuk/assets/**/*"], {encoding: false}).pipe(gulp.dest("wwwroot/assets")).on("end", () =>


### PR DESCRIPTION
### Context
[AB#210710](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/210710) [AB#198080](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/198080)

### Change proposed in this pull request
Some schools listed under a Trust do not have a RAG status due to missing financial data. Drilling down to said schools were returning the `404` page, but it is a better user experience to instead return a partially populated page with a warning message. This is also the case for census data.

### Guidance to review 
Load a trust such as [Oasis](https://localhost:7095/trust/5398529) and observe a number of schools with 'Status unavailable'. Drill down to those schools to view the newly added warning banner instead of an error page. Other schools should work as before.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

