### PR TITLE
fix: update school link to navigate to spending & costs

### DIFF
--- a/web/src/Web.App/Views/Trust/_SchoolsSection.cshtml
+++ b/web/src/Web.App/Views/Trust/_SchoolsSection.cshtml
@@ -16,7 +16,7 @@
         {
             <tr class="govuk-table__row">
                 <td class="govuk-body-s">
-                    <a class="govuk-link govuk-link--no-visited-state" href="@Url.Action("Index", "School", new { urn = school.Urn })">@school.Name</a>
+                    <a class="govuk-link govuk-link--no-visited-state" href="@Url.Action("Index", "SchoolSpending", new { urn = school.Urn })">@school.Name</a>
                 </td>
                 <td>
                     @await Component.InvokeAsync("RagStack", new


### PR DESCRIPTION
### Context
[AB#188333](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/188333) [AB#211087](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/211087)

### Change proposed in this pull request
Updates school link to navigate to spending & costs rather than home page

### Guidance to review 
N/A

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

