### PR TITLE
List schools per cost category and RAG status in new Trust Spending Priorities page

### DIFF
--- a/platform/src/apis/Platform.Api.Insight/Db/RatingsDb.cs
+++ b/platform/src/apis/Platform.Api.Insight/Db/RatingsDb.cs
@@ -39,10 +39,10 @@ public class RatingsDb : IRatingsDb
         // To get around the error `An expression of non-boolean type specified in a context where a condition is expected`
         // use STRING_SPLIT to support the optional additional filtering of RAGs in an additional JOIN
         var costPoolJoin = costPools.Any()
-            ? " JOIN (SELECT * FROM STRING_SPLIT(@CostPoolIds, ',', 1)) c ON c.[value] = r.[Cost Pool ID]" 
+            ? " JOIN (SELECT * FROM STRING_SPLIT(@CostPoolIds, ',', 1)) c ON c.[value] = r.[Cost Pool ID]"
             : string.Empty;
-        var ragWordJoin = ragWords.Any() 
-            ? " JOIN (SELECT * FROM STRING_SPLIT(@RagWords, ',', 1)) w ON w.[value] = r.[RAGWord]" 
+        var ragWordJoin = ragWords.Any()
+            ? " JOIN (SELECT * FROM STRING_SPLIT(@RagWords, ',', 1)) w ON w.[value] = r.[RAGWord]"
             : string.Empty;
         var sql = $"SELECT * FROM [RAGRatings] r{costPoolJoin}{ragWordJoin} WHERE r.[URN] IN @URNS AND r.[PeerGroup] = 'Default'";
 

--- a/platform/src/apis/Platform.Api.Insight/RatingsFunctions.cs
+++ b/platform/src/apis/Platform.Api.Insight/RatingsFunctions.cs
@@ -48,13 +48,13 @@ public class RatingsFunctions
             try
             {
                 var urns = req.Query["urns"].ToString().Split(",");
-                
+
                 var categories = req.Query["categories"].ToString().Split(",")
                     .Select(x => int.TryParse(x, out var parsed) ? (int?)parsed : null)
                     .Where(x => x != null)
                     .OfType<int>()
                     .ToArray();
-                
+
                 var statuses = req.Query["statuses"].ToString().Split(",")
                     .Select(x => x.Equals("red", StringComparison.OrdinalIgnoreCase)
                         ? "Red"
@@ -66,7 +66,7 @@ public class RatingsFunctions
                     .Where(x => x != null)
                     .OfType<string>()
                     .ToArray();
-                
+
                 var result = await _db.Get(urns, categories, statuses);
 
                 return new JsonContentResult(result);

--- a/web/src/Web.App/Constants/BreadcrumbNodes.cs
+++ b/web/src/Web.App/Constants/BreadcrumbNodes.cs
@@ -1,82 +1,128 @@
 using SmartBreadcrumbs.Nodes;
-
 namespace Web.App;
 
 public static class BreadcrumbNodes
 {
-    public static MvcBreadcrumbNode SchoolHome(string urn)
+    public static MvcBreadcrumbNode SchoolHome(string urn) => new("Index", "School", PageTitles.SchoolHome)
     {
-        return new MvcBreadcrumbNode("Index", "School", PageTitles.SchoolHome) { RouteValues = new { urn } };
-    }
+        RouteValues = new
+        {
+            urn
+        }
+    };
 
-    public static MvcBreadcrumbNode SchoolComparison(string urn)
+    public static MvcBreadcrumbNode SchoolComparison(string urn) => new("Index", "SchoolComparison", PageTitles.Comparison)
     {
-        return new MvcBreadcrumbNode("Index", "SchoolComparison", PageTitles.Comparison)
-        { RouteValues = new { urn }, Parent = SchoolHome(urn) };
-    }
+        RouteValues = new
+        {
+            urn
+        },
+        Parent = SchoolHome(urn)
+    };
 
-    public static MvcBreadcrumbNode SchoolSpending(string urn)
+    public static MvcBreadcrumbNode SchoolSpending(string urn) => new("Index", "SchoolSpending", PageTitles.Spending)
     {
-        return new MvcBreadcrumbNode("Index", "SchoolSpending", PageTitles.Spending)
-        { RouteValues = new { urn }, Parent = SchoolHome(urn) };
-    }
+        RouteValues = new
+        {
+            urn
+        },
+        Parent = SchoolHome(urn)
+    };
 
-    public static MvcBreadcrumbNode SchoolPlanning(string urn)
+    public static MvcBreadcrumbNode SchoolPlanning(string urn) => new("Index", "SchoolPlanning", "Curriculum and financial planning")
     {
-        return new MvcBreadcrumbNode("Index", "SchoolPlanning", "Curriculum and financial planning")
-        { RouteValues = new { urn }, Parent = SchoolHome(urn) };
-    }
+        RouteValues = new
+        {
+            urn
+        },
+        Parent = SchoolHome(urn)
+    };
 
-    public static MvcBreadcrumbNode SchoolCensus(string urn)
+    public static MvcBreadcrumbNode SchoolCensus(string urn) => new("Index", "SchoolCensus", PageTitles.Census)
     {
-        return new MvcBreadcrumbNode("Index", "SchoolCensus", PageTitles.Census)
-        { RouteValues = new { urn }, Parent = SchoolHome(urn) };
-    }
+        RouteValues = new
+        {
+            urn
+        },
+        Parent = SchoolHome(urn)
+    };
 
-    public static MvcBreadcrumbNode SchoolCustomData(string urn)
+    public static MvcBreadcrumbNode SchoolCustomData(string urn) => new("Index", "SchoolCustomData", PageTitles.SchoolChangeData)
     {
-        return new MvcBreadcrumbNode("Index", "SchoolCustomData", PageTitles.SchoolChangeData)
-        { RouteValues = new { urn }, Parent = SchoolHome(urn) };
-    }
+        RouteValues = new
+        {
+            urn
+        },
+        Parent = SchoolHome(urn)
+    };
 
-    public static MvcBreadcrumbNode TrustHome(string companyNumber)
+    public static MvcBreadcrumbNode TrustHome(string companyNumber) => new("Index", "Trust", PageTitles.TrustHome)
     {
-        return new MvcBreadcrumbNode("Index", "Trust", PageTitles.TrustHome) { RouteValues = new { companyNumber } };
-    }
+        RouteValues = new
+        {
+            companyNumber
+        }
+    };
 
-    public static MvcBreadcrumbNode TrustComparison(string companyNumber)
+    public static MvcBreadcrumbNode TrustComparison(string companyNumber) => new("Index", "TrustComparison", PageTitles.Comparison)
     {
-        return new MvcBreadcrumbNode("Index", "TrustComparison", PageTitles.Comparison)
-        { RouteValues = new { companyNumber }, Parent = TrustHome(companyNumber) };
-    }
+        RouteValues = new
+        {
+            companyNumber
+        },
+        Parent = TrustHome(companyNumber)
+    };
 
-    public static MvcBreadcrumbNode TrustCensus(string companyNumber)
+    public static MvcBreadcrumbNode TrustCensus(string companyNumber) => new("Index", "TrustCensus", PageTitles.Census)
     {
-        return new MvcBreadcrumbNode("Index", "TrustCensus", PageTitles.Census)
-        { RouteValues = new { companyNumber }, Parent = TrustHome(companyNumber) };
-    }
+        RouteValues = new
+        {
+            companyNumber
+        },
+        Parent = TrustHome(companyNumber)
+    };
 
-    public static MvcBreadcrumbNode TrustPlanning(string companyNumber)
+    public static MvcBreadcrumbNode TrustPlanning(string companyNumber) => new("Index", "TrustPlanning", "Curriculum and financial planning")
     {
-        return new MvcBreadcrumbNode("Index", "TrustPlanning", "Curriculum and financial planning")
-        { RouteValues = new { companyNumber }, Parent = TrustHome(companyNumber) };
-    }
+        RouteValues = new
+        {
+            companyNumber
+        },
+        Parent = TrustHome(companyNumber)
+    };
 
-    public static MvcBreadcrumbNode LocalAuthorityHome(string code)
+    public static MvcBreadcrumbNode TrustSpending(string companyNumber) => new("Index", "TrustSpending", PageTitles.TrustSpending)
     {
-        return new MvcBreadcrumbNode("Index", "LocalAuthority", PageTitles.LocalAuthorityHome)
-        { RouteValues = new { code } };
-    }
+        RouteValues = new
+        {
+            companyNumber
+        },
+        Parent = TrustHome(companyNumber)
+    };
 
-    public static MvcBreadcrumbNode LocalAuthorityComparison(string code)
+    public static MvcBreadcrumbNode LocalAuthorityHome(string code) => new("Index", "LocalAuthority", PageTitles.LocalAuthorityHome)
     {
-        return new MvcBreadcrumbNode("Index", "LocalAuthorityComparison", PageTitles.Comparison)
-        { RouteValues = new { code }, Parent = LocalAuthorityHome(code) };
-    }
+        RouteValues = new
+        {
+            code
+        }
+    };
 
-    public static MvcBreadcrumbNode LocalAuthorityCensus(string code)
+    public static MvcBreadcrumbNode LocalAuthorityComparison(string code) => new("Index", "LocalAuthorityComparison", PageTitles.Comparison)
     {
-        return new MvcBreadcrumbNode("Index", "LocalAuthorityCensus", PageTitles.Census)
-        { RouteValues = new { code }, Parent = LocalAuthorityHome(code) };
-    }
+        RouteValues = new
+        {
+            code
+        },
+        Parent = LocalAuthorityHome(code)
+    };
+
+    public static MvcBreadcrumbNode LocalAuthorityCensus(string code) => new("Index", "LocalAuthorityCensus", PageTitles.Census)
+    {
+        RouteValues = new
+        {
+            code
+        },
+        Parent = LocalAuthorityHome(code)
+    };
 }

--- a/web/src/Web.App/Constants/PageTitles.cs
+++ b/web/src/Web.App/Constants/PageTitles.cs
@@ -46,4 +46,5 @@ public static class PageTitles
     public const string SchoolChangeDataNonFinancialData = "Change non-financial data";
     public const string SchoolChangeDataWorkforceData = "Change workforce data";
     public const string LocalAuthorityHome = "Your local authority";
+    public const string TrustSpending = "Spending priorities for this trust";
 }

--- a/web/src/Web.App/Controllers/TrustSpendingController.cs
+++ b/web/src/Web.App/Controllers/TrustSpendingController.cs
@@ -18,7 +18,7 @@ public class TrustSpendingController(ILogger<TrustController> logger, IEstablish
     public async Task<IActionResult> Index(
         string companyNumber,
         [FromQuery(Name = "category")] int[]? costCategoryIds,
-        [FromQuery(Name = "priority")] string[]? statuses)
+        [FromQuery(Name = "status")] string[]? statuses)
     {
         using (logger.BeginScope(new
         {

--- a/web/src/Web.App/Controllers/TrustSpendingController.cs
+++ b/web/src/Web.App/Controllers/TrustSpendingController.cs
@@ -1,0 +1,76 @@
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement.Mvc;
+using Web.App.Domain;
+using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Extensions;
+using Web.App.TagHelpers;
+using Web.App.ViewModels;
+namespace Web.App.Controllers;
+
+[Controller]
+[FeatureGate(FeatureFlags.Trusts)]
+[Route("trust/{companyNumber}/spending-and-costs")]
+public class TrustSpendingController(ILogger<TrustController> logger, IEstablishmentApi establishmentApi, IInsightApi insightApi)
+    : Controller
+{
+    [HttpGet]
+    public async Task<IActionResult> Index(
+        string companyNumber,
+        [FromQuery(Name = "category")] int[]? costCategoryIds,
+        [FromQuery(Name = "priority")] string[]? statuses)
+    {
+        using (logger.BeginScope(new
+        {
+            companyNumber,
+            costCategoryId = costCategoryIds,
+            status = statuses
+        }))
+        {
+            try
+            {
+                ViewData[ViewDataKeys.Backlink] = new BacklinkInfo(Url.Action("Index", "Trust", new
+                {
+                    companyNumber
+                }));
+
+                var trust = await establishmentApi.GetTrust(companyNumber).GetResultOrThrow<Trust>();
+                var trustQuery = new ApiQuery().AddIfNotNull("companyNumber", companyNumber);
+                var schools = await establishmentApi.QuerySchools(trustQuery).GetResultOrDefault<School[]>() ?? [];
+
+                var schoolsQuery = new ApiQuery();
+                foreach (var school in schools)
+                {
+                    schoolsQuery.AddIfNotNull("urns", school.Urn);
+                }
+
+                if (costCategoryIds != null)
+                {
+                    foreach (var costCategoryId in costCategoryIds)
+                    {
+                        schoolsQuery.AddIfNotNull("categories", costCategoryId.ToString());
+                    }
+                }
+
+                if (statuses != null)
+                {
+                    foreach (var status in statuses)
+                    {
+                        schoolsQuery.AddIfNotNull("statuses", status);
+                    }
+                }
+
+                var ratings = await insightApi.GetRatings(schoolsQuery).GetResultOrThrow<RagRating[]>();
+                var viewModel = new TrustSpendingViewModel(trust, schools, ratings);
+
+                return View(viewModel);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "An error displaying trust spending and costs: {DisplayUrl}",
+                    Request.GetDisplayUrl());
+                return e is StatusCodeException s ? StatusCode((int)s.Status) : StatusCode(500);
+            }
+        }
+    }
+}

--- a/web/src/Web.App/ViewModels/RagViewModel.cs
+++ b/web/src/Web.App/ViewModels/RagViewModel.cs
@@ -10,9 +10,10 @@ public abstract class RagViewModel(int red, int amber, int green)
     private decimal Total => red + amber + green;
 }
 
-public class RagCostCategoryViewModel(string? category, int red, int amber, int green) : RagViewModel(red, amber, green)
+public class RagCostCategoryViewModel(string? category, int? categoryId, int red, int amber, int green) : RagViewModel(red, amber, green)
 {
     public string? Category => category;
+    public int? CategoryId => categoryId;
 }
 
 public class RagSchoolViewModel(string? urn, string? name, int red, int amber, int green) : RagViewModel(red, amber, green)

--- a/web/src/Web.App/ViewModels/TrustSpendingViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustSpendingViewModel.cs
@@ -1,0 +1,48 @@
+﻿using Web.App.Domain;
+namespace Web.App.ViewModels;
+
+public class TrustSpendingViewModel(Trust trust, IReadOnlyCollection<School> schools, IEnumerable<RagRating> ratings)
+{
+    public string? CompanyNumber => trust.CompanyNumber;
+    public string? Name => trust.Name;
+    public int NumberSchools => schools.Count;
+
+    // todo: sorting; either here or in API
+    public IEnumerable<RagSchoolsSpendingViewModel> Ratings => ratings
+        .OrderBy(x => x.CostCategory)
+        .ThenBy(x => x.StatusOrder)
+        .GroupBy(x => x.CostCategory)
+        .Select(x => new RagSchoolsSpendingViewModel(
+            x.Key,
+            x.GroupBy(y => y.Status)
+                .Select(y => new RagSchoolsSpendingStatusViewModel(
+                    y.Key,
+                    y.Select(z => z.PriorityTag).FirstOrDefault(),
+                    y.SelectMany(z => schools
+                        .Where(s => s.Urn == z.Urn)
+                        .Select(s => new RagSchoolSpendingSchoolViewModel(s)))
+                ))
+        ));
+}
+
+public class RagSchoolsSpendingViewModel(string? costCategory, IEnumerable<RagSchoolsSpendingStatusViewModel> statuses)
+{
+    public string? CostCategory => costCategory;
+    public IEnumerable<RagSchoolsSpendingStatusViewModel> Statuses => statuses;
+}
+
+public class RagSchoolsSpendingStatusViewModel(
+    string? status,
+    (TagColour Colour, string DisplayText, string Class)? priorityTag,
+    IEnumerable<RagSchoolSpendingSchoolViewModel> schools)
+{
+    public string? Status => status;
+    public (TagColour Colour, string DisplayText, string Class)? PriorityTag => priorityTag;
+    public IEnumerable<RagSchoolSpendingSchoolViewModel> Schools => schools;
+}
+
+public class RagSchoolSpendingSchoolViewModel(School? school)
+{
+    public string? Urn => school?.Urn;
+    public string? Name => school?.Name;
+}

--- a/web/src/Web.App/ViewModels/TrustSpendingViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustSpendingViewModel.cs
@@ -20,7 +20,8 @@ public class TrustSpendingViewModel(Trust trust, IReadOnlyCollection<School> sch
                     y.Select(z => z.PriorityTag).FirstOrDefault(),
                     y.SelectMany(z => schools
                         .Where(s => s.Urn == z.Urn)
-                        .Select(s => new RagSchoolSpendingSchoolViewModel(s)))
+                        .Select(s => new RagSchoolSpendingSchoolViewModel(s, z)))
+                        .OrderByDescending(s => s.Value)
                 ))
         ));
 }
@@ -41,8 +42,10 @@ public class RagSchoolsSpendingStatusViewModel(
     public IEnumerable<RagSchoolSpendingSchoolViewModel> Schools => schools;
 }
 
-public class RagSchoolSpendingSchoolViewModel(School? school)
+public class RagSchoolSpendingSchoolViewModel(School? school, RagRating? rating)
 {
     public string? Urn => school?.Urn;
     public string? Name => school?.Name;
+    public int? Decile => rating?.Decile;
+    public decimal? Value => rating?.Value;
 }

--- a/web/src/Web.App/ViewModels/TrustViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustViewModel.cs
@@ -15,11 +15,12 @@ public class TrustViewModel(Trust trust, Balance balance, IReadOnlyCollection<Sc
 
     public IEnumerable<RagCostCategoryViewModel> Ratings => ratings
         .Where(NotOther)
-        .GroupBy(x => (x.Status, x.CostCategory))
-        .Select(x => (x.Key.Status, x.Key.CostCategory, Count: x.Count()))
-        .GroupBy(x => x.CostCategory)
+        .GroupBy(x => (x.Status, x.CostCategory, x.CostCategoryId))
+        .Select(x => (x.Key.Status, x.Key.CostCategory, x.Key.CostCategoryId, Count: x.Count()))
+        .GroupBy(x => (x.CostCategory, x.CostCategoryId))
         .Select(x => new RagCostCategoryViewModel(
-            x.Key!,
+            x.Key.CostCategory!,
+            x.Key.CostCategoryId,
             x.Where(w => Red(w.Status)).Select(r => r.Count).SingleOrDefault(),
             x.Where(w => Amber(w.Status)).Select(a => a.Count).SingleOrDefault(),
             x.Where(w => Green(w.Status)).Select(g => g.Count).SingleOrDefault()

--- a/web/src/Web.App/Views/Trust/Index.cshtml
+++ b/web/src/Web.App/Views/Trust/Index.cshtml
@@ -74,7 +74,7 @@
     {
         <tr class="govuk-table__row">
             <td class="govuk-table__cell govuk-!-width-one-third">
-                <a href="@Url.Action("Index", "TrustComparison", new { companyNumber = Model.CompanyNumber })#@rating.Category.ToSlug()" class="govuk-link govuk-link--no-visited-state">@rating.Category</a>
+                <a href="@Url.Action("Index", "TrustSpending", new { companyNumber = Model.CompanyNumber, category = rating.CategoryId })" class="govuk-link govuk-link--no-visited-state">@rating.Category</a>
             </td>
             <td class="govuk-table__cell">
                 @await Component.InvokeAsync("RagStack", new
@@ -83,9 +83,9 @@
                     red = rating.Red,
                     amber = rating.Amber,
                     green = rating.Green,
-                    redHref = $"{Url.Action("Index", "TrustComparison", new { companyNumber = Model.CompanyNumber })}#{rating.Category.ToSlug()}",
-                    amberHref = $"{Url.Action("Index", "TrustComparison", new { companyNumber = Model.CompanyNumber })}#{rating.Category.ToSlug()}",
-                    greenHref = $"{Url.Action("Index", "TrustComparison", new { companyNumber = Model.CompanyNumber })}#{rating.Category.ToSlug()}"
+                    redHref = $"{Url.Action("Index", "TrustSpending", new { companyNumber = Model.CompanyNumber, category = rating.CategoryId, status = "red" })}",
+                    amberHref = $"{Url.Action("Index", "TrustSpending", new { companyNumber = Model.CompanyNumber, category = rating.CategoryId, status = "amber" })}",
+                    greenHref = $"{Url.Action("Index", "TrustSpending", new { companyNumber = Model.CompanyNumber, category = rating.CategoryId, status = "green" })}"
                 })
             </td>
         </tr>

--- a/web/src/Web.App/Views/TrustSpending/Index.cshtml
+++ b/web/src/Web.App/Views/TrustSpending/Index.cshtml
@@ -1,0 +1,48 @@
+@model Web.App.ViewModels.TrustSpendingViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.TrustSpending;
+}
+
+@await Component.InvokeAsync("EstablishmentHeading", new
+{
+    title = ViewData[ViewDataKeys.Title],
+    name = Model.Name,
+    id = Model.CompanyNumber,
+    kind = OrganisationTypes.Trust
+})
+
+@await Component.InvokeAsync("DataSource", new
+{
+    kind = OrganisationTypes.Trust,
+    isPartOfTrust = true,
+    className = "govuk-grid-column-full"
+})
+
+@foreach (var rating in Model.Ratings)
+{
+    <h2 class="govuk-heading-m">@rating.CostCategory</h2>
+    @foreach (var status in rating.Statuses)
+    {
+        <h3 class="govuk-heading-s">@status.PriorityTag?.DisplayText</h3>
+        <p class="priority @status.PriorityTag?.Class govuk-body">
+            @await Component.InvokeAsync("Tag", new
+            {
+                status.PriorityTag?.Colour,
+                status.PriorityTag?.DisplayText
+            })
+            @status.Schools.Count() out of @Model.NumberSchools school@(Model.NumberSchools == 1 ? string.Empty : "s")
+            in the @status.PriorityTag?.DisplayText.ToLower() range
+        </p>
+
+        <ul class="govuk-list govuk-list--bullet">
+            @foreach (var school in status.Schools)
+            {
+                <li>
+                    <a class="govuk-link govuk-link--no-visited-state" href="@Url.Action("Index", "SchoolSpending", new { urn = school.Urn })">@school.Name</a>
+                </li>
+            }
+        </ul>
+    }
+}
+
+@await Component.InvokeAsync("GetHelp")

--- a/web/src/Web.App/Views/TrustSpending/Index.cshtml
+++ b/web/src/Web.App/Views/TrustSpending/Index.cshtml
@@ -1,3 +1,4 @@
+@using Web.App.Extensions
 @model Web.App.ViewModels.TrustSpendingViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.TrustSpending;
@@ -24,24 +25,43 @@
     @foreach (var status in rating.Statuses)
     {
         <h3 class="govuk-heading-s">@status.PriorityTag?.DisplayText</h3>
-        <p class="priority @status.PriorityTag?.Class govuk-body">
-            @await Component.InvokeAsync("Tag", new
-            {
-                status.PriorityTag?.Colour,
-                status.PriorityTag?.DisplayText
-            })
-            @status.Schools.Count() out of @Model.NumberSchools school@(Model.NumberSchools == 1 ? string.Empty : "s")
-            in the @status.PriorityTag?.DisplayText.ToLower() range
-        </p>
 
-        <ul class="govuk-list govuk-list--bullet">
-            @foreach (var school in status.Schools)
+        <div class="top-categories">
+            <div>
+                <p class="priority @status.PriorityTag?.Class govuk-body">
+                    @await Component.InvokeAsync("Tag", new
+                    {
+                        status.PriorityTag?.Colour,
+                        status.PriorityTag?.DisplayText
+                    })
+                    @status.Schools.Count() out of @Model.NumberSchools school@(Model.NumberSchools == 1 ? string.Empty : "s")
+                    in the @status.PriorityTag?.DisplayText.ToLower() range
+                </p>
+            </div>
+        </div>
+
+        <table class="govuk-table table-trust-spending-and-costs" id="govuk-trust-spending-and-costs-@rating.CostCategory?.ToSlug()-@status.Status?.ToSlug()">
+            <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Rank</th>
+                <th scope="col" class="govuk-table__header">School</th>
+                <th scope="col" class="govuk-table__header">Expenditure</th>
+            </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+            @for (var i = 0; i < status.Schools.Count(); i++)
             {
-                <li>
-                    <a class="govuk-link govuk-link--no-visited-state" href="@Url.Action("Index", "SchoolSpending", new { urn = school.Urn })">@school.Name</a>
-                </li>
+                var school = status.Schools.ElementAt(i);
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">@(i + 1)</td>
+                    <td class="govuk-table__cell">
+                        <a class="govuk-link govuk-link--no-visited-state" href="@Url.Action("Index", "SchoolSpending", new { urn = school.Urn })">@school.Name</a>
+                    </td>
+                    <td class="govuk-table__cell">@school.Value.ToCurrency(0)</td>
+                </tr>
             }
-        </ul>
+            </tbody>
+        </table>
     }
 }
 

--- a/web/src/Web.App/Views/TrustSpending/Index.cshtml
+++ b/web/src/Web.App/Views/TrustSpending/Index.cshtml
@@ -21,7 +21,8 @@
 
 @foreach (var rating in Model.Ratings)
 {
-    <h2 class="govuk-heading-m">@rating.CostCategory</h2>
+    <h2 class="govuk-heading-m" id="@rating.CostCategory?.ToSlug()">@rating.CostCategory</h2>
+
     @foreach (var status in rating.Statuses)
     {
         <h3 class="govuk-heading-s">@status.PriorityTag?.DisplayText</h3>


### PR DESCRIPTION
### Context
[AB#211007](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/211007) [AB#211012](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/211012) [AB#192288](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/192288)

### Change proposed in this pull request
New page to list all schools in a cost category / RAG status (as a first pass).

### Guidance to review 
This intentionally omits some elements from the designs but will be iterated upon as part of the main story. Navigating from the Trust home page by Cost Category, or a RAG bar within that Cost Category will now display the details of which schools are in that Cost Category and, if applicable, RAG status. This required some API changes to be able to select only the RAGs of interest based on the category/status filter. These will be unit tested separately, but should not have an impact on the existing calls to get all RAGs by a collection of URNs. 

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

