### PR TITLE
#209994/boarding pfi group comparator sets

### DIFF
--- a/data-pipeline/src/pipeline/comparator_sets.py
+++ b/data-pipeline/src/pipeline/comparator_sets.py
@@ -88,7 +88,7 @@ def _delta_range_ratio_squared(input: np.array) -> np.array:
     return np.power(_delta_range_ratio(input), 2)
 
 
-def pupils_calc(pupils: np.array, fsm: np.array, sen: np.array):
+def pupils_calc(pupils: np.array, fsm: np.array, sen: np.array) -> np.ndarray:
     """
     Perform pupil calculation (non-special).
 
@@ -117,7 +117,7 @@ def special_pupils_calc(
     pds: np.array,
     asds: np.array,
     oths: np.array,
-):
+) -> np.ndarray:
     """
     Perform pupil calculation (special).
 
@@ -156,7 +156,7 @@ def special_pupils_calc(
     return np.sqrt(pupils_) + np.sqrt(sen)
 
 
-def buildings_calc(gifa: np.array, average_age: np.array) -> np.array:
+def buildings_calc(gifa: np.array, average_age: np.array) -> np.ndarray:
     """
     Compute area metrics.
 
@@ -170,7 +170,7 @@ def buildings_calc(gifa: np.array, average_age: np.array) -> np.array:
     return np.sqrt(gifa_ + age)
 
 
-def compute_buildings_comparator(arg):
+def compute_buildings_comparator(arg) -> np.ndarray:
     """
     Computing area metrics, consuming attributes from the input data.
 
@@ -184,7 +184,7 @@ def compute_buildings_comparator(arg):
     return buildings_calc(gifa, age)
 
 
-def compute_pupils_comparator(arg) -> tuple[str, np.array, np.array]:
+def compute_pupils_comparator(arg) -> np.ndarray:
     """
     Computing pupil metrics, consuming attributes from the input data.
 
@@ -218,40 +218,107 @@ def compute_pupils_comparator(arg) -> tuple[str, np.array, np.array]:
     return pupils_calc(pupils, fsm, sen)
 
 
-def select_top_set(all_urns, all_regions, data, base_set_size=60, final_set_size=30):
-    top_index = np.argsort(data, axis=0, kind="stable")[:base_set_size]
-    top_urns = all_urns[top_index]
-    top_regions = all_regions[top_index]
-    same_region = np.argwhere(top_regions == top_regions[0]).flatten()
-    same_region_urns = top_urns[same_region]
+def select_top_set_urns(
+    urns: np.array,
+    pfi: np.array,
+    boarding: np.array,
+    regions: np.array,
+    distances: np.ndarray,
+    base_set_size=60,
+    final_set_size=30,
+) -> np.ndarray:
+    """
+    Determine the URNs of the closest orgs.
+
+    1. take the top (by default) 60 orgs. closest by distance metrics,
+       with the same PFI and Boarding status.
+    2. reduce this to those in the same region.
+    3. if fewer than (by default) 30 results, supplement this with the
+       closest by distance metrics from the original set.
+
+    :param urns: URN of each org. in this grouping.
+    :param pfi: PFI status of each org. in this grouping.
+    :param boarding: boarding status of each org. in this grouping.
+    :param regions: regional location of each org. in this grouping.
+    :param distances: computed distances of each org. from the first.
+    :return: URNs of "top" orgs. meeting criteria, orderd by distance.
+    """
+    index_by_distance = np.argsort(distances, axis=0, kind="stable")
+    urns_by_distance = urns[index_by_distance]
+
+    pfi_by_distance = pfi[index_by_distance]
+    boarding_by_distance = boarding[index_by_distance]
+    same_pfi = pfi_by_distance == pfi_by_distance[0]
+    same_boarding = boarding_by_distance == boarding_by_distance[0]
+    same_criteria = np.logical_and(
+        same_pfi,
+        same_boarding,
+    )
+    top_criteria_index = np.argwhere(same_criteria).flatten()[:base_set_size]
+
+    same_region_index = np.argwhere(regions == regions[0]).flatten()
+    top_regions_index = np.intersect1d(
+        top_criteria_index,
+        same_region_index,
+    )
+    same_region_urns = urns_by_distance[top_regions_index][:final_set_size]
+
     urns = np.append(
         same_region_urns,
-        np.delete(top_urns, same_region)[: final_set_size - len(same_region_urns)],
+        np.delete(
+            urns_by_distance,
+            same_region_index,
+        )[: final_set_size - len(same_region_urns)],
     )
+
     return urns
 
 
-def compute_distances(orig_data, grouped_data):
+# TODO: rename, this does more than distances.
+def compute_distances(
+    orig_data: pd.DataFrame,
+    grouped_data: pd.DataFrame,
+):
+    # TODO: docstring needed to explain this.
     pupils = pd.Series(index=orig_data.index, dtype=object)
     buildings = pd.Series(index=orig_data.index, dtype=object)
-    for phase, row in grouped_data.iterrows():
-        pupil_distance = compute_pupils_comparator((phase, row))
-        building_distance = compute_buildings_comparator((phase, row))
-        all_urns = np.array(row["URN"])
-        all_regions = np.array(row["GOR (name)"])
 
-        for idx in range(len(all_urns)):
-            urn = all_urns[idx]
+    for phase, row in grouped_data.iterrows():
+        # compute distances for all orgs. in this phase.
+        pupil_distances = compute_pupils_comparator((phase, row))
+        building_distances = compute_buildings_comparator((phase, row))
+        phase_urns = np.array(row["UKPRN"])
+        phase_pfi = np.array(row["PFI School"])
+        phase_boarding = np.array(row["Boarders (name)"])
+        phase_regions = np.array(row["GOR (name)"])
+
+        # TODO: compares ab/ba and aa.
+        # compute best-set for each org. individually.
+        for idx in range(len(phase_urns)):
+            ukprn = phase_urns[idx]
             try:
-                pupil_set = select_top_set(all_urns, all_regions, pupil_distance[idx])
-                building_set = select_top_set(
-                    all_urns, all_regions, building_distance[idx]
+                top_pupil_set_urns = select_top_set_urns(
+                    phase_urns,
+                    phase_pfi,
+                    phase_boarding,
+                    phase_regions,
+                    pupil_distances[idx],
+                )
+                top_building_set_urns = select_top_set_urns(
+                    phase_urns,
+                    phase_pfi,
+                    phase_boarding,
+                    phase_regions,
+                    building_distances[idx],
                 )
 
-                pupils.loc[urn] = pupil_set
-                buildings.loc[urn] = building_set
+                pupils.loc[ukprn] = top_pupil_set_urns
+                buildings.loc[ukprn] = top_building_set_urns
             except Exception as error:
-                logger.exception(f"An exception occurred {type(error).__name__} processing {urn}:", exc_info=error)
+                logger.exception(
+                    f"An exception occurred {type(error).__name__} processing {ukprn}:",
+                    exc_info=error,
+                )
                 return
 
     orig_data["Pupil"] = pupils
@@ -262,61 +329,57 @@ def compute_distances(orig_data, grouped_data):
 
 def compute_comparator_set(data: pd.DataFrame):
     # TODO: Need to add boarding and PFI groups into this logic
-    copy = (
-        data[~data.index.isna()][
-            [
-                "OfstedRating (name)",
-                "Percentage SEN",
-                "Percentage Free school meals",
-                "Number of pupils",
-                "Total Internal Floor Area",
-                "Age Average Score",
-                "GOR (name)",
-                "SchoolPhaseType",
-                "Percentage Primary Need SPLD",
-                "Percentage Primary Need MLD",
-                "Percentage Primary Need PMLD",
-                "Percentage Primary Need SEMH",
-                "Percentage Primary Need SLCN",
-                "Percentage Primary Need HI",
-                "Percentage Primary Need MSI",
-                "Percentage Primary Need PD",
-                "Percentage Primary Need ASD",
-                "Percentage Primary Need OTH",
-            ]
+    copy = data[~data.index.isna()][
+        [
+            "OfstedRating (name)",
+            "Percentage SEN",
+            "Percentage Free school meals",
+            "Number of pupils",
+            "Total Internal Floor Area",
+            "Age Average Score",
+            "PFI School",
+            "Boarders (name)",
+            "GOR (name)",
+            "SchoolPhaseType",
+            "Percentage Primary Need SPLD",
+            "Percentage Primary Need MLD",
+            "Percentage Primary Need PMLD",
+            "Percentage Primary Need SEMH",
+            "Percentage Primary Need SLCN",
+            "Percentage Primary Need HI",
+            "Percentage Primary Need MSI",
+            "Percentage Primary Need PD",
+            "Percentage Primary Need ASD",
+            "Percentage Primary Need OTH",
         ]
-        .copy()
-    )
+    ].copy()
     classes = copy.reset_index().groupby(["SchoolPhaseType"]).agg(list)
     return compute_distances(copy, classes)
 
 
 def compute_custom_comparator_set(data: pd.DataFrame):
-    copy = (
-        data[
-            [
-                "OfstedRating (name)",
-                "Percentage SEN",
-                "Percentage Free school meals",
-                "Number of pupils",
-                "Total Internal Floor Area",
-                "Age Average Score",
-                "GOR (name)",
-                "SchoolPhaseType",
-                "Percentage Primary Need SPLD",
-                "Percentage Primary Need MLD",
-                "Percentage Primary Need PMLD",
-                "Percentage Primary Need SEMH",
-                "Percentage Primary Need SLCN",
-                "Percentage Primary Need HI",
-                "Percentage Primary Need MSI",
-                "Percentage Primary Need PD",
-                "Percentage Primary Need ASD",
-                "Percentage Primary Need OTH",
-            ]
+    copy = data[
+        [
+            "OfstedRating (name)",
+            "Percentage SEN",
+            "Percentage Free school meals",
+            "Number of pupils",
+            "Total Internal Floor Area",
+            "Age Average Score",
+            "GOR (name)",
+            "SchoolPhaseType",
+            "Percentage Primary Need SPLD",
+            "Percentage Primary Need MLD",
+            "Percentage Primary Need PMLD",
+            "Percentage Primary Need SEMH",
+            "Percentage Primary Need SLCN",
+            "Percentage Primary Need HI",
+            "Percentage Primary Need MSI",
+            "Percentage Primary Need PD",
+            "Percentage Primary Need ASD",
+            "Percentage Primary Need OTH",
         ]
-        .copy()
-    )
+    ].copy()
     copy["Custom"] = "Grouper"
     classes = copy.reset_index().groupby(["Custom"]).agg(list)
     return compute_distances(copy, classes)

--- a/data-pipeline/tests/unit/comparator_sets/conftest.py
+++ b/data-pipeline/tests/unit/comparator_sets/conftest.py
@@ -1,6 +1,7 @@
 import random
 import string
 
+import numpy as np
 import pytest
 
 
@@ -21,4 +22,22 @@ def random_row() -> dict:
         "Percentage Primary Need ASD": random.uniform(0, 100),
         "Percentage Primary Need OTH": random.uniform(0, 100),
         "Percentage SEN": random.uniform(0, 100),
+    }
+
+
+@pytest.fixture
+def select_top_set_urns_defaults() -> dict:
+    """
+    Some default values for the `select_top_set_urns` function.
+
+    :return: function defaults
+    """
+    return {
+        "urns": np.array(list(string.ascii_uppercase)),  # ["A"…"Z"]
+        "pfi": np.array([True] * 26),  # [True, True…]
+        "boarding": np.array([True] * 26),  # [True, True…]
+        "regions": np.array(["A"] * 26),  # ["A"…"A"]
+        "distances": np.array([0.01 * i for i in range(26)]),  # [0.0, 0.01…0.25]
+        "base_set_size": 6,
+        "final_set_size": 3,
     }

--- a/data-pipeline/tests/unit/comparator_sets/test_top_set_urns.py
+++ b/data-pipeline/tests/unit/comparator_sets/test_top_set_urns.py
@@ -1,0 +1,77 @@
+import string
+
+import numpy as np
+import pytest
+
+from src.pipeline.comparator_sets import select_top_set_urns
+
+
+@pytest.mark.parametrize(
+    "local",
+    [
+        {
+            "pfi": np.array([i % 2 == 0 for i in range(26)]),
+            "boarding": np.array([i % 2 == 0 for i in range(26)]),
+        },
+        {
+            "pfi": np.array([i % 2 == 0 for i in range(26)]),
+            "boarding": np.array([i % 2 != 0 for i in range(26)]),
+        },
+        {
+            "pfi": np.array([i % 2 != 0 for i in range(26)]),
+            "boarding": np.array([i % 2 == 0 for i in range(26)]),
+        },
+        {
+            "pfi": np.array([i % 2 != 0 for i in range(26)]),
+            "boarding": np.array([i % 2 != 0 for i in range(26)]),
+        },
+    ],
+)
+def test_pfi_boarding(select_top_set_urns_defaults, local):
+    """
+    26 orgs. where every other org. is the same PFI/Boarding status as
+    the first: this will reduce the base-set to ACEGIK.
+
+    All are in the same region: the final set should be ACE.
+    """
+    result = select_top_set_urns(
+        **(select_top_set_urns_defaults | local),
+    )
+
+    np.testing.assert_array_equal(
+        result,
+        np.array(["A", "C", "E"]),
+    )
+
+
+def test_excludes_low_distance_region():
+    """
+    26 orgs. where every other org. is the same PFI/Boarding status:
+    this will reduce the base-set to ACEGIK.
+
+    None in the top `base_set_size` are in the same region, reducing
+    the potential final set to just A.
+
+    The final set should then be supplemented by the original set,
+    ordered by distance-metric.
+    """
+    urns = np.array(list(string.ascii_uppercase))  # ["A"…"Z"]
+    pfi = np.array([i % 2 == 0 for i in range(26)])  # [True, False, True…]
+    boarding = np.array([i % 2 == 0 for i in range(26)])  # [True, False, True…]
+    regions = np.array(["A"] + (["B"] * 24) + ["A"])  # ["A", "B"…"B", "A"]
+    distances = np.array([0.01 * i for i in range(26)])  # [0.0, 0.01…0.25]
+
+    result = select_top_set_urns(
+        urns=urns,
+        pfi=pfi,
+        boarding=boarding,
+        regions=regions,
+        distances=distances,
+        base_set_size=6,
+        final_set_size=3,
+    )
+
+    np.testing.assert_array_equal(
+        result,
+        np.array(["A", "B", "C"]),
+    )


### PR DESCRIPTION
### Context

Include PFI/Boarding status in comparator-set calculation:

[AB#209994](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/209994)

### Change proposed in this pull request

- update to the `comparator_sets.select_top_set…` function to accept and include PFI and Boarding values as part of the "top" matches criteria.
- some related refactoring.
- once-over with `make lint`.

### Guidance to review 

As discussed: the initial "60" selection should contain on those orgs. with matching PFI/Boarding statuses, prior to region restrictions.

If this selection falls short of the "30" required, this is supplemented from the _original_ list (i.e. pre-PFI-Boarding restrictions).

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally

