### PR TITLE
adds company number to trust suggester

### DIFF
--- a/web/src/Web.App/Services/SuggestService.cs
+++ b/web/src/Web.App/Services/SuggestService.cs
@@ -49,10 +49,15 @@ public class SuggestService(IEstablishmentApi establishmentApi) : ISuggestServic
         {
             var text = value.Text?.Replace("*", "");
 
+            var additionalText = "";
+
+            if (!string.IsNullOrWhiteSpace(value.Document?.CompanyNumber))
+                additionalText = text == value.Document.CompanyNumber ? $" ({value.Text})" : $" ({value.Document.CompanyNumber})";
+
             if (text != value.Document?.Name)
-            {
                 value.Text = value.Document?.Name;
-            }
+
+            value.Text = $"{value.Text}{additionalText}";
 
             return value;
         });

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -38,6 +38,13 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         services.AddSingleton(HttpContextAccessor.Object);
     }
 
+    public BenchmarkingWebAppClient SetupEstablishment(SuggestOutput<Trust> trustTestData)
+    {
+        EstablishmentApi.Reset();
+        EstablishmentApi.Setup(api => api.SuggestTrusts(It.IsAny<string>())).ReturnsAsync(ApiResult.Ok(trustTestData));
+        return this;
+    }
+
     public BenchmarkingWebAppClient SetupEstablishment(School school)
     {
         EstablishmentApi.Reset();

--- a/web/tests/Web.Integration.Tests/Proxy/WhenRequestingSuggest.cs
+++ b/web/tests/Web.Integration.Tests/Proxy/WhenRequestingSuggest.cs
@@ -1,5 +1,9 @@
+using AutoFixture;
+using Newtonsoft.Json.Linq;
 using System.Net;
+using Web.App.Infrastructure.Apis;
 using Xunit;
+using Web.App.Domain;
 
 namespace Web.Integration.Tests.Proxy;
 
@@ -16,4 +20,236 @@ public class WhenRequestingSuggest(SchoolBenchmarkingWebAppClient client) : ICla
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
     }
+
+    [Theory]
+    [MemberData(nameof(TrustTestData))]
+    public async Task CanReturnCorrectResponseForTrust(string search, SuggestOutput<Trust> trustTestData, SuggestOutput<Trust> expected)
+    {
+        var response = await client.SetupEstablishment(trustTestData)
+            .Get(Paths.ApiSuggest(search, "trust"));
+
+        Assert.IsType<HttpResponseMessage>(response);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var resultContent = await response.Content.ReadAsStringAsync();
+
+        var resultArray = JArray.Parse(resultContent);
+
+        Assert.Equal(resultArray.Count, expected.Results.Count());
+
+        foreach (var expectedValue in expected.Results)
+        {
+            var found = false;
+            var expectedText = expectedValue.Text;
+            var expectedCompanyNumber = expectedValue.Document?.CompanyNumber;
+            var expectedName = expectedValue.Document?.Name;
+
+            foreach (var resultObj in resultArray)
+            {
+                var actualText = resultObj["text"]?.ToString();
+                var actualCompanyNumber = resultObj["document"]?["companyNumber"]?.ToString();
+                var actualName = resultObj["document"]?["name"]?.ToString();
+
+                if (actualText == expectedText &&
+                    actualCompanyNumber == expectedCompanyNumber &&
+                    actualName == expectedName)
+                {
+                    found = true;
+                    break;
+                }
+            }
+
+            Assert.True(found);
+        }
+    }
+
+    public static IEnumerable<object[]> TrustTestData =>
+        new List<object[]>
+        {
+            new object[]
+            {
+                "Test",
+                new SuggestOutput<Trust>
+                {
+                    Results =
+                    [
+                        new SuggestValue<Trust>
+                        {
+                            Text = "*Test* Trust",
+                            Document = new Trust
+                            {
+                                CompanyNumber = "12345678",
+                                Name = "Test Trust"
+                            }
+                        }
+                    ]
+                },
+                new SuggestOutput<Trust>
+                {
+                    Results =
+                    [
+                        new SuggestValue<Trust>
+                         {
+                             Text = "*Test* Trust (12345678)",
+                             Document = new Trust
+                             {
+                                 CompanyNumber = "12345678",
+                                 Name = "Test Trust"
+                             }
+                         }
+                    ]
+                }
+            },
+            new object[]
+            {
+                "123",
+                new SuggestOutput<Trust>
+                {
+                    Results =
+                    [
+                        new SuggestValue<Trust>
+                        {
+                            Text = "*123*45678",
+                            Document = new Trust
+                            {
+                                CompanyNumber = "12345678",
+                                Name = "Test Trust"
+                            }
+                        }
+                    ]
+                },
+                new SuggestOutput<Trust>
+                {
+                    Results =
+                    [
+                    new SuggestValue<Trust>
+                     {
+                         Text = "Test Trust (*123*45678)",
+                         Document = new Trust
+                         {
+                             CompanyNumber = "12345678",
+                             Name = "Test Trust"
+                         }
+                     }
+                    ]
+                }
+            },
+            new object[]
+            {
+                "Test",
+                new SuggestOutput<Trust>
+                {
+                    Results =
+                    [
+                        new SuggestValue<Trust>
+                        {
+                            Text = "*Test* Trust",
+                            Document = new Trust
+                            {
+                                CompanyNumber = "12345678",
+                                Name = "Test Trust"
+                            }
+                        },
+                        new SuggestValue<Trust>
+                        {
+                            Text = "Another *Test* Trust",
+                            Document = new Trust
+                            {
+                                CompanyNumber = "87654321",
+                                Name = "Another Test Trust"
+                            }
+                        },
+
+                    ]
+                },
+                new SuggestOutput<Trust>
+                {
+                    Results =
+                    [
+                         new SuggestValue<Trust>
+                         {
+                             Text = "*Test* Trust (12345678)",
+                             Document = new Trust
+                             {
+                                 CompanyNumber = "12345678",
+                                 Name = "Test Trust"
+                             }
+                         },
+                         new SuggestValue<Trust>
+                         {
+                             Text = "Another *Test* Trust (87654321)",
+                             Document = new Trust
+                             {
+                                 CompanyNumber = "87654321",
+                                 Name = "Another Test Trust"
+                             }
+                         }
+                     ]
+                }
+            },
+            new object[]
+            {
+                "123",
+                new SuggestOutput<Trust>
+                {
+                    Results =
+                    [
+                        new SuggestValue<Trust>
+                        {
+                            Text = "*123*45678",
+                            Document = new Trust
+                            {
+                                CompanyNumber = "12345678",
+                                Name = "Test Trust"
+                            }
+                        },
+                        new SuggestValue<Trust>
+                        {
+                            Text = "*123*45679",
+                            Document = new Trust
+                            {
+                                CompanyNumber = "12345679",
+                                Name = "Another Test Trust"
+                            }
+                        },
+                    ]
+                },
+                new SuggestOutput<Trust>
+                {
+                    Results =
+                    [
+                         new SuggestValue<Trust>
+                         {
+                             Text = "Test Trust (*123*45678)",
+                             Document = new Trust
+                             {
+                                 CompanyNumber = "12345678",
+                                 Name = "Test Trust"
+                             }
+                         },
+                         new SuggestValue<Trust>
+                         {
+                             Text = "Another Test Trust (*123*45679)",
+                             Document = new Trust
+                             {
+                                 CompanyNumber = "12345679",
+                                 Name = "Another Test Trust"
+                             }
+                         }
+                    ]
+                }
+            },
+            new object[]
+            {
+                "Test",
+                new SuggestOutput<Trust>
+                {
+                    Results = []
+                },
+                new SuggestOutput<Trust>
+                {
+                    Results = []
+                },
+            },
+        };
 }


### PR DESCRIPTION
### Context
AB#21005 - AB210708

### Change proposed in this pull request
Adds company number to the return of TrustSuggestions similar to how we append the address details for schools in SchoolSuggestions
Adds integration test for the suggest proxy end point

### Guidance to review 
N/A

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

