### PR TITLE
changes to number formatting for charts and tables

### DIFF
--- a/front-end-components/src/components/charts/table-chart/component.tsx
+++ b/front-end-components/src/components/charts/table-chart/component.tsx
@@ -4,11 +4,12 @@ import {
   TableChartProps,
 } from "src/components/charts/table-chart";
 import { SelectedSchoolContext } from "src/contexts";
+import { fullValueFormatter } from "../utils";
 
 export const TableChart: React.FC<TableChartProps<SchoolChartData>> = (
   props
 ) => {
-  const { tableHeadings, data, preventFocus } = props;
+  const { tableHeadings, data, preventFocus, valueUnit } = props;
   const selectedSchool = useContext(SelectedSchoolContext);
 
   const renderSchoolAnchor = (row: SchoolChartData) => (
@@ -61,7 +62,9 @@ export const TableChart: React.FC<TableChartProps<SchoolChartData>> = (
                       </td>
                     );
                   })}
-                <td className="govuk-table__cell">{row.value.toFixed(2)}</td>
+                <td className="govuk-table__cell">
+                  {fullValueFormatter(row.value, { valueUnit })}
+                </td>
               </tr>
             );
           })}

--- a/front-end-components/src/components/charts/table-chart/types.tsx
+++ b/front-end-components/src/components/charts/table-chart/types.tsx
@@ -1,7 +1,10 @@
+import { ChartSeriesValueUnit } from "src/components/charts/types";
+
 export type TableChartProps<TData extends SchoolChartData> = {
   tableHeadings: string[];
   data?: TData[];
   preventFocus?: boolean;
+  valueUnit?: ChartSeriesValueUnit | undefined;
 };
 
 export type SchoolChartData = {

--- a/front-end-components/src/components/charts/utils.test.ts
+++ b/front-end-components/src/components/charts/utils.test.ts
@@ -7,6 +7,7 @@ import {
   chartSeriesComparer,
   shortValueFormatter,
   statValueFormatter,
+  fullValueFormatter,
 } from "./utils";
 
 describe("Chart utils", () => {
@@ -91,12 +92,12 @@ describe("Chart utils", () => {
       it("formats the values using compact notation", () => {
         const result = values.map((v) => shortValueFormatter(v, options));
         expect(result).toEqual([
-          "-987.7",
+          "-987.65",
           "0",
           "1",
-          "2.3",
-          "12.3k",
-          "890.1m",
+          "2.35",
+          "12.35k",
+          "890.12m",
           "not-a-number",
         ]);
       });
@@ -223,6 +224,80 @@ describe("Chart utils", () => {
           "890,123,456 british pounds",
           "not-a-number",
         ]);
+      });
+    });
+  });
+
+  describe("fullValueFormatter()", () => {
+    describe("with default options", () => {
+      const options: Partial<ValueFormatterOptions> = {};
+
+      it("formats the values to two decimal places with number separators only", () => {
+        const result = values.map((v) => fullValueFormatter(v, options));
+        expect(result).toEqual([
+          "-987.65",
+          "0",
+          "1",
+          "2.35",
+          "12,345.67",
+          "890,123,456",
+          "not-a-number",
+        ]);
+      });
+    });
+
+    describe("fullValueFormatter()", () => {
+      describe("with amount options", () => {
+        const options: Partial<ValueFormatterOptions> = { valueUnit: "amount" };
+
+        it("formats the values to two decimal places with number separators only", () => {
+          const result = values.map((v) => fullValueFormatter(v, options));
+          expect(result).toEqual([
+            "-987.65",
+            "0",
+            "1",
+            "2.35",
+            "12,345.67",
+            "890,123,456",
+            "not-a-number",
+          ]);
+        });
+      });
+
+      describe("with currency option", () => {
+        const options: Partial<ValueFormatterOptions> = {
+          valueUnit: "currency",
+        };
+
+        it("formats the values to zero decimal places as GBP", () => {
+          const result = values.map((v) => fullValueFormatter(v, options));
+          expect(result).toEqual([
+            "-£988",
+            "£0",
+            "£1",
+            "£2",
+            "£12,346",
+            "£890,123,456",
+            "not-a-number",
+          ]);
+        });
+      });
+
+      describe("with percent option", () => {
+        const options: Partial<ValueFormatterOptions> = { valueUnit: "%" };
+
+        it("formats the values to one decimal place as percent", () => {
+          const result = values.map((v) => fullValueFormatter(v, options));
+          expect(result).toEqual([
+            "-987.7%",
+            "0%",
+            "1%",
+            "2.3%",
+            "12,345.7%",
+            "890,123,456%",
+            "not-a-number",
+          ]);
+        });
       });
     });
   });

--- a/front-end-components/src/components/charts/utils.ts
+++ b/front-end-components/src/components/charts/utils.ts
@@ -39,7 +39,12 @@ export function shortValueFormatter(
           ? "percent"
           : undefined,
     currency: options?.valueUnit === "currency" ? "GBP" : undefined,
-    maximumFractionDigits: options?.valueUnit === "currency" ? undefined : 1,
+    maximumFractionDigits:
+      options?.valueUnit === "currency"
+        ? undefined
+        : options?.valueUnit === "%"
+          ? 1
+          : 2,
   })
     .format(options?.valueUnit === "%" ? value / 100 : value)
     .toLowerCase();
@@ -65,6 +70,33 @@ export function statValueFormatter(
     currency: options?.valueUnit === "currency" ? "GBP" : undefined,
     currencyDisplay: options?.currencyAsName ? "name" : "symbol",
     maximumFractionDigits: options?.compact ? undefined : 0,
+  })
+    .format(options?.valueUnit === "%" ? value / 100 : value)
+    .toLowerCase();
+}
+
+export function fullValueFormatter(
+  value: ValueFormatterValue,
+  options?: Partial<ValueFormatterOptions>
+): string {
+  if (typeof value !== "number") {
+    return String(value) || "";
+  }
+
+  return new Intl.NumberFormat("en-GB", {
+    style:
+      options?.valueUnit === "currency"
+        ? "currency"
+        : options?.valueUnit === "%"
+          ? "percent"
+          : undefined,
+    currency: options?.valueUnit === "currency" ? "GBP" : undefined,
+    maximumFractionDigits:
+      options?.valueUnit === "currency"
+        ? 0
+        : options?.valueUnit === "%"
+          ? 1
+          : 2,
   })
     .format(options?.valueUnit === "%" ? value / 100 : value)
     .toLowerCase();

--- a/front-end-components/src/composed/historic-chart-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/component.tsx
@@ -6,6 +6,7 @@ import { LineChart } from "src/components/charts/line-chart";
 import {
   shortValueFormatter,
   statValueFormatter,
+  fullValueFormatter,
 } from "src/components/charts/utils.ts";
 import { LineChartTooltip } from "src/components/charts/line-chart-tooltip";
 import { ResolvedStat } from "src/components/charts/resolved-stat";
@@ -90,7 +91,7 @@ export const HistoricChart: React.FC<HistoricChartProps<ChartDataSeries>> = ({
                   <tr className="govuk-table__row">
                     <td className="govuk-table__cell">{String(item.term)}</td>
                     <td className="govuk-table__cell">
-                      {shortValueFormatter(item[valueField], {
+                      {fullValueFormatter(item[valueField], {
                         valueUnit: valueUnit ?? dimension.unit,
                       })}
                     </td>

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -137,6 +137,7 @@ export function HorizontalBarChartWrapper<TData extends SchoolChartData>(
                   tableHeadings={data.tableHeadings}
                   data={sortedDataPoints}
                   preventFocus={mode !== ChartModeTable}
+                  valueUnit={valueUnit ?? dimension.unit}
                 />
               </div>
             </>


### PR DESCRIPTION
### Context
[AB#210058](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/210058) - [AB#211769](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/211769)

### Change proposed in this pull request
Updates charts and tables to use the following number formatting
currency - to zero decimal places
percentage - to one decimal place
ratio - to two decimal places

adds fullValueFormatter for use in the tables to show the complete value but formatted as specified above

alters shortValueFormatter to show maximumFractionDigits as 2 as default and 1 only for percentage but preserves all other existing behaviour

### Guidance to review 
N/A

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

