### PR TITLE
Added filtering to Trust Spending view

### DIFF
--- a/core-infrastructure/terraform/databases.tf
+++ b/core-infrastructure/terraform/databases.tf
@@ -112,6 +112,14 @@ resource "azurerm_mssql_firewall_rule" "sql-server-fw-azure-services" {
   end_ip_address   = "0.0.0.0"
 }
 
+resource "azurerm_mssql_firewall_rule" "sql-server-fw-dfe-remote" {
+  count            = var.environment == "production" ? 0 : 1
+  name             = "DFE_VPN_Remote"
+  server_id        = azurerm_mssql_server.sql-server.id
+  start_ip_address = "208.127.46.236"
+  end_ip_address   = "208.127.46.255"
+}
+
 resource "azurerm_mssql_server_security_alert_policy" "sql-security-alert-policy" {
   #checkov:skip=CKV_AZURE_26:See ADO backlog AB#206493
   #checkov:skip=CKV_AZURE_27:See ADO backlog AB#206493

--- a/web/src/Web.App/Controllers/TrustSpendingController.cs
+++ b/web/src/Web.App/Controllers/TrustSpendingController.cs
@@ -61,7 +61,7 @@ public class TrustSpendingController(ILogger<TrustController> logger, IEstablish
                 }
 
                 var ratings = await insightApi.GetRatings(schoolsQuery).GetResultOrThrow<RagRating[]>();
-                var viewModel = new TrustSpendingViewModel(trust, schools, ratings);
+                var viewModel = new TrustSpendingViewModel(trust, schools, ratings, costCategoryIds, statuses);
 
                 return View(viewModel);
             }

--- a/web/src/Web.App/Domain/CostCategories.cs
+++ b/web/src/Web.App/Domain/CostCategories.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.ObjectModel;
-
+using Web.App.Extensions;
 namespace Web.App.Domain;
 
 public abstract class Category(decimal actual, SchoolExpenditure expenditure)
@@ -16,8 +16,64 @@ public abstract class Category(decimal actual, SchoolExpenditure expenditure)
 
     public abstract decimal Value { get; }
     public decimal Actual => actual;
-    public decimal PercentageExpenditure => decimal.Round(Actual / expenditure.TotalExpenditure * 100, 2, MidpointRounding.AwayFromZero);
-    public decimal PercentageIncome => decimal.Round(Actual / expenditure.TotalExpenditure * 100, 2, MidpointRounding.AwayFromZero);
+
+    public decimal PercentageExpenditure => expenditure.TotalExpenditure == decimal.Zero
+        ? 0
+        : decimal.Round(Actual / expenditure.TotalExpenditure * 100, 2, MidpointRounding.AwayFromZero);
+
+    public decimal PercentageIncome => expenditure.TotalExpenditure == decimal.Zero
+        ? 0
+        : decimal.Round(Actual / expenditure.TotalExpenditure * 100, 2, MidpointRounding.AwayFromZero);
+
+    public static string? FromSlug(string? slug)
+    {
+        if (slug == TeachingStaff.ToSlug())
+        {
+            return TeachingStaff;
+        }
+
+        if (slug == NonEducationalSupportStaff.ToSlug())
+        {
+            return NonEducationalSupportStaff;
+        }
+
+        if (slug == EducationalSupplies.ToSlug())
+        {
+            return EducationalSupplies;
+        }
+
+        if (slug == EducationalIct.ToSlug())
+        {
+            return EducationalIct;
+        }
+
+        if (slug == PremisesStaffServices.ToSlug())
+        {
+            return PremisesStaffServices;
+        }
+
+        if (slug == Utilities.ToSlug())
+        {
+            return Utilities;
+        }
+
+        if (slug == AdministrativeSupplies.ToSlug())
+        {
+            return AdministrativeSupplies;
+        }
+
+        if (slug == CateringStaffServices.ToSlug())
+        {
+            return CateringStaffServices;
+        }
+
+        if (slug == Other.ToSlug())
+        {
+            return Other;
+        }
+
+        return null;
+    }
 }
 
 public class PupilCategory(decimal actual, SchoolExpenditure expenditure) : Category(actual, expenditure)
@@ -25,7 +81,9 @@ public class PupilCategory(decimal actual, SchoolExpenditure expenditure) : Cate
     private readonly decimal _actual = actual;
     private readonly SchoolExpenditure _expenditure = expenditure;
 
-    public override decimal Value => decimal.Round(_actual / _expenditure.NumberOfPupils, 0, MidpointRounding.AwayFromZero);
+    public override decimal Value => _expenditure.NumberOfPupils == decimal.Zero
+        ? 0
+        : decimal.Round(_actual / _expenditure.NumberOfPupils, 0, MidpointRounding.AwayFromZero);
 }
 
 public class AreaCategory(decimal actual, SchoolExpenditure expenditure) : Category(actual, expenditure)
@@ -33,9 +91,10 @@ public class AreaCategory(decimal actual, SchoolExpenditure expenditure) : Categ
     private readonly decimal _actual = actual;
     private readonly SchoolExpenditure _expenditure = expenditure;
 
-    public override decimal Value => decimal.Round(_actual / _expenditure.FloorArea, 0, MidpointRounding.AwayFromZero);
+    public override decimal Value => _expenditure.FloorArea == decimal.Zero
+        ? 0
+        : decimal.Round(_actual / _expenditure.FloorArea, 0, MidpointRounding.AwayFromZero);
 }
-
 
 public abstract class CostCategory(RagRating rating)
 {
@@ -47,11 +106,10 @@ public abstract class CostCategory(RagRating rating)
         set => _values[index] = value;
     }
     public RagRating Rating => rating;
-    public abstract void Add(string urn, SchoolExpenditure expenditure);
 
     public ReadOnlyDictionary<string, Category> Values => _values.AsReadOnly();
+    public abstract void Add(string urn, SchoolExpenditure expenditure);
 }
-
 
 public class AdministrativeSupplies(RagRating rating) : CostCategory(rating)
 {

--- a/web/src/Web.App/ViewModels/TrustSpendingViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustSpendingViewModel.cs
@@ -1,11 +1,22 @@
 ﻿using Web.App.Domain;
 namespace Web.App.ViewModels;
 
-public class TrustSpendingViewModel(Trust trust, IReadOnlyCollection<School> schools, IEnumerable<RagRating> ratings)
+public class TrustSpendingViewModel(
+    Trust trust,
+    IReadOnlyCollection<School> schools,
+    IEnumerable<RagRating> ratings,
+    int[]? costCategoryIds,
+    string[]? statuses)
 {
     public string? CompanyNumber => trust.CompanyNumber;
     public string? Name => trust.TrustName;
     public int NumberSchools => schools.Count;
+
+    public int[] CostCategories => costCategoryIds ?? [];
+
+    public bool IsStatusRed => statuses != null && statuses.Contains("red", StringComparer.OrdinalIgnoreCase);
+    public bool IsStatusAmber => statuses != null && statuses.Contains("amber", StringComparer.OrdinalIgnoreCase);
+    public bool IsStatusGreen => statuses != null && statuses.Contains("green", StringComparer.OrdinalIgnoreCase);
 
     // todo: sorting; either here or in API
     public IEnumerable<RagSchoolsSpendingViewModel> Ratings => ratings

--- a/web/src/Web.App/ViewModels/TrustSpendingViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustSpendingViewModel.cs
@@ -5,18 +5,18 @@ public class TrustSpendingViewModel(
     Trust trust,
     IReadOnlyCollection<School> schools,
     IEnumerable<RagRating> ratings,
-    int[]? costCategoryIds,
-    string[]? statuses)
+    string[]? categories,
+    string[]? priorities)
 {
     public string? CompanyNumber => trust.CompanyNumber;
     public string? Name => trust.TrustName;
     public int NumberSchools => schools.Count;
 
-    public int[] CostCategories => costCategoryIds ?? [];
+    public string[] CostCategories => categories ?? [];
 
-    public bool IsStatusRed => statuses != null && statuses.Contains("red", StringComparer.OrdinalIgnoreCase);
-    public bool IsStatusAmber => statuses != null && statuses.Contains("amber", StringComparer.OrdinalIgnoreCase);
-    public bool IsStatusGreen => statuses != null && statuses.Contains("green", StringComparer.OrdinalIgnoreCase);
+    public bool IsPriorityHigh => priorities != null && priorities.Contains("high", StringComparer.OrdinalIgnoreCase);
+    public bool IsPriorityMedium => priorities != null && priorities.Contains("medium", StringComparer.OrdinalIgnoreCase);
+    public bool IsPriorityLow => priorities != null && priorities.Contains("low", StringComparer.OrdinalIgnoreCase);
 
     // todo: sorting; either here or in API
     public IEnumerable<RagSchoolsSpendingViewModel> Ratings => ratings

--- a/web/src/Web.App/Views/Shared/Components/RagStack/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/RagStack/Default.cshtml
@@ -10,12 +10,12 @@
 else
 {
     <svg style="height:@(Model.Height)px;" class="rag-stack" role="img" aria-labelledby="@id-rag">
-        <title id="@id-rag">RAG ratings for @Model.Identifier: @Model.Red red, @Model.Amber amber and @Model.Green green</title>
+        <title id="@id-rag">@Model.Red high, @Model.Amber medium and @Model.Green low priorities for @Model.Identifier</title>
         @if (Model.RedPercentage > 0)
         {
             if (!string.IsNullOrWhiteSpace(Model.RedHref))
             {
-                @:<a href="@Model.RedHref" aria-label="@Model.Red red">
+                @:<a href="@Model.RedHref" aria-label="@Model.Red high priority">
             }
             <rect
                 role="presentation"
@@ -34,7 +34,7 @@ else
         {
             if (!string.IsNullOrWhiteSpace(Model.AmberHref))
             {
-                @:<a href="@Model.AmberHref" aria-label="@Model.Amber amber">
+                @:<a href="@Model.AmberHref" aria-label="@Model.Amber medium priority">
             }
             <rect
                 role="presentation"
@@ -53,7 +53,7 @@ else
         {
             if (!string.IsNullOrWhiteSpace(Model.GreenHref))
             {
-                @:<a href="@Model.GreenHref" aria-label="@Model.Green green">
+                @:<a href="@Model.GreenHref" aria-label="@Model.Green low priority">
             }
             <rect
                 role="presentation"

--- a/web/src/Web.App/Views/Trust/Index.cshtml
+++ b/web/src/Web.App/Views/Trust/Index.cshtml
@@ -66,7 +66,7 @@
     <thead class="govuk-table__head govuk-visually-hidden">
     <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Category</th>
-        <th scope="col" class="govuk-table__header">Sum of Red/Amber/Green schools</th>
+        <th scope="col" class="govuk-table__header">Sum of High/Medium/Low priority school cost categories</th>
     </tr>
     </thead>
     <tbody class="govuk-table__body">
@@ -74,7 +74,7 @@
     {
         <tr class="govuk-table__row">
             <td class="govuk-table__cell govuk-!-width-one-third">
-                <a href="@Url.Action("Index", "TrustSpending", new { companyNumber = Model.CompanyNumber, category = rating.Category })" class="govuk-link govuk-link--no-visited-state">@rating.Category</a>
+                <a href="@Url.Action("Index", "TrustSpending", new { companyNumber = Model.CompanyNumber, category = rating.Category?.ToSlug() })" class="govuk-link govuk-link--no-visited-state">@rating.Category</a>
             </td>
             <td class="govuk-table__cell">
                 @await Component.InvokeAsync("RagStack", new
@@ -83,9 +83,9 @@
                     red = rating.Red,
                     amber = rating.Amber,
                     green = rating.Green,
-                    redHref = $"{Url.Action("Index", "TrustSpending", new { companyNumber = Model.CompanyNumber, category = rating.Category, status = "red" })}",
-                    amberHref = $"{Url.Action("Index", "TrustSpending", new { companyNumber = Model.CompanyNumber, category = rating.Category, status = "amber" })}",
-                    greenHref = $"{Url.Action("Index", "TrustSpending", new { companyNumber = Model.CompanyNumber, category = rating.Category, status = "green" })}"
+                    redHref = $"{Url.Action("Index", "TrustSpending", new { companyNumber = Model.CompanyNumber, category = rating.Category?.ToSlug(), priority = "high" })}",
+                    amberHref = $"{Url.Action("Index", "TrustSpending", new { companyNumber = Model.CompanyNumber, category = rating.Category?.ToSlug(), priority = "medium" })}",
+                    greenHref = $"{Url.Action("Index", "TrustSpending", new { companyNumber = Model.CompanyNumber, category = rating.Category?.ToSlug(), priority = "low" })}"
                 })
             </td>
         </tr>

--- a/web/src/Web.App/Views/TrustSpending/Index.cshtml
+++ b/web/src/Web.App/Views/TrustSpending/Index.cshtml
@@ -1,3 +1,5 @@
+@using Microsoft.AspNetCore.Mvc.TagHelpers
+@using Web.App.Domain
 @using Web.App.Extensions
 @model Web.App.ViewModels.TrustSpendingViewModel
 @{
@@ -25,14 +27,14 @@
 
         <form method="get">
             <div class="govuk-form-group">
-                <label class="govuk-label" for="status">
+                <label class="govuk-label" for="priority">
                     Priority
                 </label>
-                <select class="govuk-select" id="status" name="status">
+                <select class="govuk-select" id="priority" name="priority">
                     <option value="">All priorities</option>
-                    <option value="red" selected="@(Model.IsStatusRed ? "selected" : null)">High priority</option>
-                    <option value="amber" selected="@(Model.IsStatusAmber ? "selected" : null)">Medium priority</option>
-                    <option value="green" selected="@(Model.IsStatusGreen ? "selected" : null)">Low priority</option>
+                    <option value="high" selected="@(Model.IsPriorityHigh ? "selected" : null)">High priority</option>
+                    <option value="medium" selected="@(Model.IsPriorityMedium ? "selected" : null)">Medium priority</option>
+                    <option value="low" selected="@(Model.IsPriorityLow ? "selected" : null)">Low priority</option>
                 </select>
             </div>
 
@@ -42,15 +44,15 @@
                 </label>
                 <select class="govuk-select" id="category" name="category">
                     <option value="">All categories</option>
-                    <option value="1" selected="@(Model.CostCategories.Contains(1) ? "selected" : null)">Teaching and teaching support staff</option>
-                    <option value="2" selected="@(Model.CostCategories.Contains(2) ? "selected" : null)">Non-educational support staff</option>
-                    <option value="3" selected="@(Model.CostCategories.Contains(3) ? "selected" : null)">Educational supplies</option>
-                    <option value="4" selected="@(Model.CostCategories.Contains(4) ? "selected" : null)">Educational ICT</option>
-                    <option value="5" selected="@(Model.CostCategories.Contains(5) ? "selected" : null)">Premises and services</option>
-                    <option value="6" selected="@(Model.CostCategories.Contains(6) ? "selected" : null)">Utilities</option>
-                    <option value="7" selected="@(Model.CostCategories.Contains(7) ? "selected" : null)">Administrative supplies</option>
-                    <option value="8" selected="@(Model.CostCategories.Contains(8) ? "selected" : null)">Catering staff and services</option>
-                    <option value="9" selected="@(Model.CostCategories.Contains(9) ? "selected" : null)">Other</option>
+                    <option value="@Category.TeachingStaff.ToSlug()" selected="@(Model.CostCategories.Contains(Category.TeachingStaff.ToSlug()) ? "selected" : null)">@Category.TeachingStaff</option>
+                    <option value="@Category.NonEducationalSupportStaff.ToSlug()" selected="@(Model.CostCategories.Contains(Category.NonEducationalSupportStaff.ToSlug()) ? "selected" : null)">@Category.NonEducationalSupportStaff</option>
+                    <option value="@Category.EducationalSupplies.ToSlug()" selected="@(Model.CostCategories.Contains(Category.EducationalSupplies.ToSlug()) ? "selected" : null)">@Category.EducationalSupplies</option>
+                    <option value="@Category.EducationalIct.ToSlug()" selected="@(Model.CostCategories.Contains(Category.EducationalIct.ToSlug()) ? "selected" : null)">@Category.EducationalIct</option>
+                    <option value="@Category.PremisesStaffServices.ToSlug()" selected="@(Model.CostCategories.Contains(Category.PremisesStaffServices.ToSlug()) ? "selected" : null)">@Category.PremisesStaffServices</option>
+                    <option value="@Category.Utilities.ToSlug()" selected="@(Model.CostCategories.Contains(Category.Utilities.ToSlug()) ? "selected" : null)">@Category.Utilities</option>
+                    <option value="@Category.AdministrativeSupplies.ToSlug()" selected="@(Model.CostCategories.Contains(Category.AdministrativeSupplies.ToSlug()) ? "selected" : null)">@Category.AdministrativeSupplies</option>
+                    <option value="@Category.CateringStaffServices.ToSlug()" selected="@(Model.CostCategories.Contains(Category.CateringStaffServices.ToSlug()) ? "selected" : null)">@Category.CateringStaffServices</option>
+                    <option value="@Category.Other.ToSlug()" selected="@(Model.CostCategories.Contains(Category.Other.ToSlug()) ? "selected" : null)">@Category.Other</option>
                 </select>
             </div>
 

--- a/web/src/Web.App/Views/TrustSpending/Index.cshtml
+++ b/web/src/Web.App/Views/TrustSpending/Index.cshtml
@@ -19,51 +19,95 @@
     className = "govuk-grid-column-full"
 })
 
-@foreach (var rating in Model.Ratings)
-{
-    <h2 class="govuk-heading-m" id="@rating.CostCategory?.ToSlug()">@rating.CostCategory</h2>
+<div class="govuk-grid-row">
+    <aside class="govuk-grid-column-one-quarter">
+        <h3 class="govuk-heading-s">Filter priority schools</h3>
 
-    @foreach (var status in rating.Statuses)
-    {
-        <h3 class="govuk-heading-s">@status.PriorityTag?.DisplayText</h3>
-
-        <div class="top-categories">
-            <div>
-                <p class="priority @status.PriorityTag?.Class govuk-body">
-                    @await Component.InvokeAsync("Tag", new
-                    {
-                        status.PriorityTag?.Colour,
-                        status.PriorityTag?.DisplayText
-                    })
-                    @status.Schools.Count() out of @Model.NumberSchools school@(Model.NumberSchools == 1 ? string.Empty : "s")
-                    in the @status.PriorityTag?.DisplayText.ToLower() range
-                </p>
+        <form method="get">
+            <div class="govuk-form-group">
+                <label class="govuk-label" for="status">
+                    Priority
+                </label>
+                <select class="govuk-select" id="status" name="status">
+                    <option value="">All priorities</option>
+                    <option value="red" selected="@(Model.IsStatusRed ? "selected" : null)">High priority</option>
+                    <option value="amber" selected="@(Model.IsStatusAmber ? "selected" : null)">Medium priority</option>
+                    <option value="green" selected="@(Model.IsStatusGreen ? "selected" : null)">Low priority</option>
+                </select>
             </div>
-        </div>
 
-        <table class="govuk-table table-trust-spending-and-costs" id="govuk-trust-spending-and-costs-@rating.CostCategory?.ToSlug()-@status.Status?.ToSlug()">
-            <thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-                <th scope="col" class="govuk-table__header">Rank</th>
-                <th scope="col" class="govuk-table__header">School</th>
-                <th scope="col" class="govuk-table__header">Expenditure</th>
-            </tr>
-            </thead>
-            <tbody class="govuk-table__body">
-            @for (var i = 0; i < status.Schools.Count(); i++)
+            <div class="govuk-form-group">
+                <label class="govuk-label" for="category">
+                    Cost Category
+                </label>
+                <select class="govuk-select" id="category" name="category">
+                    <option value="">All categories</option>
+                    <option value="1" selected="@(Model.CostCategories.Contains(1) ? "selected" : null)">Teaching and teaching support staff</option>
+                    <option value="2" selected="@(Model.CostCategories.Contains(2) ? "selected" : null)">Non-educational support staff</option>
+                    <option value="3" selected="@(Model.CostCategories.Contains(3) ? "selected" : null)">Educational supplies</option>
+                    <option value="4" selected="@(Model.CostCategories.Contains(4) ? "selected" : null)">Educational ICT</option>
+                    <option value="5" selected="@(Model.CostCategories.Contains(5) ? "selected" : null)">Premises and services</option>
+                    <option value="6" selected="@(Model.CostCategories.Contains(6) ? "selected" : null)">Utilities</option>
+                    <option value="7" selected="@(Model.CostCategories.Contains(7) ? "selected" : null)">Administrative supplies</option>
+                    <option value="8" selected="@(Model.CostCategories.Contains(8) ? "selected" : null)">Catering staff and services</option>
+                    <option value="9" selected="@(Model.CostCategories.Contains(9) ? "selected" : null)">Other</option>
+                </select>
+            </div>
+
+            <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+                Update filter
+            </button>
+        </form>
+    </aside>
+    <div class="govuk-grid-column-three-quarters">
+        @foreach (var rating in Model.Ratings)
+        {
+            <h2 class="govuk-heading-m" id="@rating.CostCategory?.ToSlug()">@rating.CostCategory</h2>
+
+            @foreach (var status in rating.Statuses)
             {
-                var school = status.Schools.ElementAt(i);
-                <tr class="govuk-table__row">
-                    <td class="govuk-table__cell">@(i + 1)</td>
-                    <td class="govuk-table__cell">
-                        <a class="govuk-link govuk-link--no-visited-state" href="@Url.Action("Index", "SchoolSpending", new { urn = school.Urn })">@school.Name</a>
-                    </td>
-                    <td class="govuk-table__cell">@school.Value.ToCurrency(0)</td>
-                </tr>
+                <h3 class="govuk-heading-s">@status.PriorityTag?.DisplayText</h3>
+
+                <div class="top-categories">
+                    <div>
+                        <p class="priority @status.PriorityTag?.Class govuk-body">
+                            @await Component.InvokeAsync("Tag", new
+                            {
+                                status.PriorityTag?.Colour,
+                                status.PriorityTag?.DisplayText
+                            })
+                            @status.Schools.Count() out of @Model.NumberSchools school@(Model.NumberSchools == 1 ? string.Empty : "s")
+                            in the @status.PriorityTag?.DisplayText.ToLower() range
+                        </p>
+                    </div>
+                </div>
+
+                <table class="govuk-table table-trust-spending-and-costs" id="govuk-trust-spending-and-costs-@rating.CostCategory?.ToSlug()-@status.Status?.ToSlug()">
+                    <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                        <th scope="col" class="govuk-table__header">Rank</th>
+                        <th scope="col" class="govuk-table__header">School</th>
+                        <th scope="col" class="govuk-table__header">Expenditure</th>
+                    </tr>
+                    </thead>
+                    <tbody class="govuk-table__body">
+                    @for (var i = 0; i < status.Schools.Count(); i++)
+                    {
+                        var school = status.Schools.ElementAt(i);
+                        <tr class="govuk-table__row">
+                            <td class="govuk-table__cell">@(i + 1)</td>
+                            <td class="govuk-table__cell">
+                                <a class="govuk-link govuk-link--no-visited-state" href="@Url.Action("Index", "SchoolSpending", new { urn = school.Urn })">@school.Name</a>
+                            </td>
+                            <td class="govuk-table__cell">@school.Value.ToCurrency(0)</td>
+                        </tr>
+                    }
+                    </tbody>
+                </table>
             }
-            </tbody>
-        </table>
-    }
-}
+        }
+
+    </div>
+</div>
 
 @await Component.InvokeAsync("GetHelp")


### PR DESCRIPTION
### Context
[AB#211011](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/211011) [AB#192288](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/192288)

### Change proposed in this pull request
Two new `<select>`s and `<form>` now present on Trust Spending page to allow the user to switch between categories and priorities without having to go back to the Trust home page.

### Guidance to review 
Changing the filters should update the results displayed. Links through from the Trust homepage RAGs should continue to work as previously, with the filters pre-populated based on the query string.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

