### PR TITLE
User defined comparator sets landing page, with auth-toggled CTA

### DIFF
--- a/web/src/Web.App/Constants/PageTitles.cs
+++ b/web/src/Web.App/Constants/PageTitles.cs
@@ -24,6 +24,7 @@ public static class PageTitles
     public const string SchoolPlanningTotalEducationSupport = "What is your total spend on education support staff?";
     public const string SchoolPlanningTimetableCycle = "Timetable cycle";
     public const string SchoolComparators = "Schools we chose for benchmarking";
+    public const string SchoolComparatorsCreate = "Choose your own set of schools";
     public const string TrustHome = "Your trust";
     public const string HistoricData = "Historic data";
     public const string SchoolPlanningHasMixedAgeClasses = "Do you have any mixed age classes?";

--- a/web/src/Web.App/Controllers/SchoolComparatorsCreateController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparatorsCreateController.cs
@@ -1,0 +1,66 @@
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement.Mvc;
+using Web.App.Domain;
+using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Extensions;
+using Web.App.ViewModels;
+namespace Web.App.Controllers;
+
+[Controller]
+[FeatureGate(FeatureFlags.UserDefinedComparators)]
+[Route("school/{urn}/comparators/create")]
+public class SchoolComparatorsCreateController(ILogger<SchoolComparatorsCreateController> logger, IEstablishmentApi establishmentApi) : Controller
+{
+    [HttpGet]
+    public async Task<IActionResult> Index(string urn, string referrer)
+    {
+        using (logger.BeginScope(new
+        {
+            urn,
+            referrer
+        }))
+        {
+            try
+            {
+                ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.SchoolComparators(urn);
+
+                var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
+                var viewModel = new SchoolComparatorsViewModel(school);
+                return View(viewModel);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "An error displaying create school comparators: {DisplayUrl}", Request.GetDisplayUrl());
+                return e is StatusCodeException s ? StatusCode((int)s.Status) : StatusCode(500);
+            }
+        }
+    }
+
+    // todo: next up
+    [HttpGet]
+    [Route("by")]
+    public async Task<IActionResult> By(string urn, string referrer)
+    {
+        using (logger.BeginScope(new
+        {
+            urn,
+            referrer
+        }))
+        {
+            try
+            {
+                ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.SchoolComparators(urn);
+
+                var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
+                var viewModel = new SchoolComparatorsViewModel(school);
+                return View(viewModel);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "An error displaying create school comparators by: {DisplayUrl}", Request.GetDisplayUrl());
+                return e is StatusCodeException s ? StatusCode((int)s.Status) : StatusCode(500);
+            }
+        }
+    }
+}

--- a/web/src/Web.App/Views/SchoolComparators/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolComparators/Index.cshtml
@@ -3,7 +3,13 @@
     ViewData[ViewDataKeys.Title] = PageTitles.SchoolComparators;
 }
 
-@await Component.InvokeAsync("EstablishmentHeading", new { title = ViewData[ViewDataKeys.Title], name = Model.Name, id = Model.Urn, kind = OrganisationTypes.School })
+@await Component.InvokeAsync("EstablishmentHeading", new
+{
+    title = ViewData[ViewDataKeys.Title],
+    name = Model.Name,
+    id = Model.Urn,
+    kind = OrganisationTypes.School
+})
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
@@ -12,7 +18,7 @@
         <feature name="@FeatureFlags.UserDefinedComparators">
             <p class="govuk-body">
                 <a class="govuk-link govuk-link--no-visited-state"
-                   href="">
+                   href="@Url.Action("Index", "SchoolComparatorsCreate", new { urn = Model.Urn })">
                     Choose your own set of schools
                 </a>
             </p>

--- a/web/src/Web.App/Views/SchoolComparatorsCreate/By.cshtml
+++ b/web/src/Web.App/Views/SchoolComparatorsCreate/By.cshtml
@@ -1,0 +1,26 @@
+﻿@model Web.App.ViewModels.SchoolComparatorsViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.SchoolComparatorsCreate;
+}
+
+@await Component.InvokeAsync("EstablishmentHeading", new
+{
+    title = ViewData[ViewDataKeys.Title],
+    name = Model.Name,
+    id = Model.Urn,
+    kind = OrganisationTypes.School
+})
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <p class="govuk-body">TODO: next up</p>
+    </div>
+</div>
+
+@section scripts
+{
+    <script type="module" add-nonce="true">
+      import { initAll } from '/js/govuk-frontend.min.js'
+      initAll()
+    </script>
+}

--- a/web/src/Web.App/Views/SchoolComparatorsCreate/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolComparatorsCreate/Index.cshtml
@@ -1,0 +1,54 @@
+﻿@model Web.App.ViewModels.SchoolComparatorsViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.SchoolComparatorsCreate;
+}
+
+@await Component.InvokeAsync("EstablishmentHeading", new
+{
+    title = ViewData[ViewDataKeys.Title],
+    name = Model.Name,
+    id = Model.Urn,
+    kind = OrganisationTypes.School
+})
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <p class="govuk-body">Use this to choose which schools @Model.Name is benchmarked against.</p>
+
+        @if (User.Identity is { IsAuthenticated: true })
+        {
+            @Html.ActionLink("Continue", "By", "SchoolComparatorsCreate", new
+            {
+                urn = Model.Urn
+            }, new
+            {
+                @class = "govuk-button"
+            })
+        }
+        else
+        {
+            <p class="govuk-body">
+                You will need a <a href="https://services.signin.education.gov.uk/" class="govuk-link govuk-link--no-visited-state">DfE Sign-in account</a>.
+            </p>
+
+            @Html.ActionLink("Sign in", "Signin", "Account", new
+            {
+                redirectUri = Url.Action("By", "SchoolComparatorsCreate", new
+                {
+                    urn = Model.Urn
+                })
+            }, new
+            {
+                @class = "govuk-button"
+            })
+        }
+    </div>
+</div>
+
+@section scripts
+{
+    <script type="module" add-nonce="true">
+      import { initAll } from '/js/govuk-frontend.min.js'
+      initAll()
+    </script>
+}

--- a/web/src/Web.App/Views/Shared/Components/ComparatorSetDetails/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/ComparatorSetDetails/Default.cshtml
@@ -12,7 +12,7 @@
         <feature name="@FeatureFlags.UserDefinedComparators">
             <p class="govuk-body govuk-!-margin-bottom-0">
                 <a class="govuk-link govuk-link--no-visited-state"
-                   href="">
+                   href="@Url.Action("Index", "SchoolComparatorsCreate", new { urn = Model.Identifier })">
                     Choose a new or saved set of your own schools
                 </a>
             </p>


### PR DESCRIPTION
### Context
AB#212117

### Change proposed in this pull request
Added landing page for the above feature and updated pending links to point here.

### Guidance to review 
Behaviour is different depending on whether user is logged in. This may be streamlined further on a future pass. 'Next' page on this user journey will be covered in a subsequent ticket/implementation.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

