### PR TITLE
 Added school suggester and add/remove to user defined comparator school list

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -44,10 +44,10 @@
       id="vertical-chart-3-series"
       data-json='[{"group":"Reception","pupilsOnRoll":14.2,"teacherCost":12.9,"teachingAssistantCost":14.3,"id":0},{"group":"Year 1","pupilsOnRoll":16.3,"teacherCost":16.1,"teachingAssistantCost":14.3,"id":1},{"group":"Year 2","pupilsOnRoll":14.1,"teacherCost":12.8,"teachingAssistantCost":14.3,"id":2},{"group":"Year 3","pupilsOnRoll":12.9,"teacherCost":12.5,"teachingAssistantCost":14.3,"id":3},{"group":"Year 4","pupilsOnRoll":15.2,"teacherCost":12.6,"teachingAssistantCost":14.3,"id":4},{"group":"Year 5","pupilsOnRoll":14.2,"teacherCost":12.4,"teachingAssistantCost":14.3,"id":5},{"group":"Year 6","pupilsOnRoll":14.1,"teacherCost":12.8,"teachingAssistantCost":14.3,"id":6},{"group":"Intervention","teacherCost":3.2,"id":7},{"group":"Learning support","teacherCost":4,"id":8},{"group":"Dyslexia support","teacherCost":2.5,"id":9}]'
     ></div>-->
-    <div
+    <!--<div
       id="line-chart-1-series"
       data-json='[{"term":"2018-19","inYearBalance":null},{"term":"2019-20","inYearBalance":2654321},{"term":"2020-21","inYearBalance":2500000},{"term":"2021-22","inYearBalance":2438700},{"term":"2022-23","inYearBalance":2876543}]'
-    ></div>
+    ></div>-->
     <!--<div
       data-spending-and-costs-composed
       data-json='[{"urn":"100000","amount":4746.93},{"urn":"100001","amount":2500.00},{"urn":"100002","amount":2800.00},{"urn":"100003","amount":2900.00},{"urn":"100004","amount":1000.00},{"urn":"100005","amount":1000.00},{"urn":"100006","amount":1250.00},{"urn":"100007","amount":1100.00},{"urn":"100008","amount":2200.00},{"urn":"100009","amount":2700.00},{"urn":"100010","amount":2150.00},{"urn":"100011","amount":2000.00},{"urn":"100012","amount":5500.00},{"urn":"100013","amount":5000.00},{"urn":"100014","amount":3500.00},{"urn":"100015","amount":3400.00},{"urn":"100016","amount":3800.00},{"urn":"100017","amount":3200.00},{"urn":"100018","amount":3200.00},{"urn":"100019","amount":3400.00},{"urn":"100020","amount":3400.00},{"urn":"100021","amount":3300.00},{"urn":"100022","amount":3200.00},{"urn":"100023","amount":3100.00},{"urn":"100024","amount":3500.00},{"urn":"100025","amount":3450.00},{"urn":"100026","amount":3100.00},{"urn":"100027","amount":2900.00},{"urn":"100028","amount":2800.00},{"urn":"100029","amount":4000.00}]'
@@ -60,6 +60,10 @@
       data-highlight="143310"
       data-sort-direction="asc"
     ></div>-->
+    <form method="get">
+      <div id="school-suggester"></div>
+      <button type="submit">Submit</button>
+    </form>
     <script type="module" src="/src/main.tsx"></script>
     <script
       type="module"

--- a/front-end-components/src/constants.tsx
+++ b/front-end-components/src/constants.tsx
@@ -10,3 +10,4 @@ export const SpendingAndCostsComposedElementId = "spending-and-costs-composed";
 export const FindOrganisationElementId = "find-organisation";
 export const SchoolEstablishment = "school";
 export const TrustEstablishment = "trust";
+export const SchoolSuggesterId = "school-suggester";

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -19,6 +19,7 @@ import {
   SpendingAndCostsComposedElementId,
   VerticalBarChart2SeriesElementId,
   VerticalBarChart3SeriesElementId,
+  SchoolSuggesterId,
 } from "src/constants";
 import { HorizontalBarChart } from "./components/charts/horizontal-bar-chart";
 import { VerticalBarChart } from "./components/charts/vertical-bar-chart";
@@ -38,6 +39,7 @@ import { SchoolTick } from "./components/charts/school-tick";
 import { SchoolCensusTooltip } from "./components/charts/school-census-tooltip";
 import { ExpenditureData, Census } from "./services";
 import { LineChartTooltip } from "./components/charts/line-chart-tooltip";
+import SchoolInput from "./views/find-organisation/partials/school-input";
 
 const historicDataElement = document.getElementById(HistoricDataElementId);
 if (historicDataElement) {
@@ -496,4 +498,14 @@ if (spendingAndCostsComposedElements) {
       );
     }
   });
+}
+
+const schoolSuggesterElement = document.getElementById(SchoolSuggesterId);
+if (schoolSuggesterElement) {
+  const root = ReactDOM.createRoot(schoolSuggesterElement);
+  root.render(
+    <React.StrictMode>
+      <SchoolInput input="" urn="" />
+    </React.StrictMode>
+  );
 }

--- a/front-end-components/vite.config-dev.ts
+++ b/front-end-components/vite.config-dev.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   server: {
     proxy: {
       "/api": {
-        target: "https://localhost:44393/api",
+        target: "https://localhost:7095/api",
         changeOrigin: true,
         secure: false,
         rewrite: (path) => path.replace(/^\/api/, ""),

--- a/web/src/Web.App/Constants/PageTitles.cs
+++ b/web/src/Web.App/Constants/PageTitles.cs
@@ -27,6 +27,7 @@ public static class PageTitles
     public const string SchoolComparatorsUserDefined = "Your set of schools";
     public const string SchoolComparatorsCreate = "Choose your own set of schools";
     public const string SchoolComparatorsCreateBy = "How do you want to choose your set of schools?";
+    public const string SchoolComparatorsCreateByName = "Choose schools to benchmark against";
     public const string TrustHome = "Your trust";
     public const string HistoricData = "Historic data";
     public const string SchoolPlanningHasMixedAgeClasses = "Do you have any mixed age classes?";

--- a/web/src/Web.App/Constants/SessionKeys.cs
+++ b/web/src/Web.App/Constants/SessionKeys.cs
@@ -3,5 +3,6 @@ namespace Web.App;
 public static class SessionKeys
 {
     public static string ComparatorSet(string urn) => $"comparator-set-{urn}";
+    public static string ComparatorSetUserDefined(string urn) => $"comparator-set-user-defined-{urn}";
     public static string CustomData(string urn) => $"custom-data-{urn}";
 }

--- a/web/src/Web.App/Domain/ComparatorSet.cs
+++ b/web/src/Web.App/Domain/ComparatorSet.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-
 namespace Web.App.Domain;
 
 [ExcludeFromCodeCoverage]
@@ -8,7 +7,6 @@ public record ComparatorSet
     public IEnumerable<string> Pupil { get; set; } = Array.Empty<string>();
     public IEnumerable<string> Building { get; set; } = Array.Empty<string>();
 }
-
 
 public record ComparatorSetUserDefined
 {

--- a/web/src/Web.App/Services/ComparatorSetService.cs
+++ b/web/src/Web.App/Services/ComparatorSetService.cs
@@ -2,12 +2,13 @@ using Web.App.Domain;
 using Web.App.Extensions;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Extensions;
-
 namespace Web.App.Services;
 
 public interface IComparatorSetService
 {
     Task<ComparatorSet> ReadComparatorSet(string urn);
+    ComparatorSetUserDefined ReadUserDefinedComparatorSet(string urn);
+    ComparatorSetUserDefined SetUserDefinedComparatorSet(string urn, ComparatorSetUserDefined set);
 }
 
 public class ComparatorSetService(IHttpContextAccessor httpContextAccessor, IComparatorSetApi api) : IComparatorSetService
@@ -20,6 +21,26 @@ public class ComparatorSetService(IHttpContextAccessor httpContextAccessor, ICom
         var set = context?.Session.Get<ComparatorSet>(key);
 
         return set ?? await SetComparatorSet(urn);
+    }
+
+    public ComparatorSetUserDefined ReadUserDefinedComparatorSet(string urn)
+    {
+        var key = SessionKeys.ComparatorSetUserDefined(urn);
+        var context = httpContextAccessor.HttpContext;
+
+        var set = context?.Session.Get<ComparatorSetUserDefined>(key);
+
+        return set ?? SetUserDefinedComparatorSet(urn, new ComparatorSetUserDefined());
+    }
+
+    public ComparatorSetUserDefined SetUserDefinedComparatorSet(string urn, ComparatorSetUserDefined set)
+    {
+        var key = SessionKeys.ComparatorSetUserDefined(urn);
+        var context = httpContextAccessor.HttpContext;
+
+        context?.Session.Set(key, set);
+
+        return set;
     }
 
     private async Task<ComparatorSet> SetComparatorSet(string urn)

--- a/web/src/Web.App/ViewModels/SchoolComparatorsByNameViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolComparatorsByNameViewModel.cs
@@ -2,14 +2,14 @@
 using Web.App.Domain;
 namespace Web.App.ViewModels;
 
-public class SchoolComparatorsByNameViewModel(School school, ComparatorSetUserDefined set)
+public class SchoolComparatorsByNameViewModel(School school, SchoolCharacteristicUserDefined[]? schoolCharacteristics)
 {
     public string? Urn => school.URN;
     public string? Name => school.SchoolName;
-    public ComparatorSetUserDefined Set => set;
+    public SchoolCharacteristicUserDefined[]? Schools => schoolCharacteristics;
 }
 
-public record SchoolComparatorsByNameAddViewModel
+public record SchoolComparatorsUrnViewModel
 {
     [Required(ErrorMessage = "Select a school from the suggester")]
     public string? Urn { get; init; }

--- a/web/src/Web.App/ViewModels/SchoolComparatorsByNameViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolComparatorsByNameViewModel.cs
@@ -1,0 +1,16 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Web.App.Domain;
+namespace Web.App.ViewModels;
+
+public class SchoolComparatorsByNameViewModel(School school, ComparatorSetUserDefined set)
+{
+    public string? Urn => school.URN;
+    public string? Name => school.SchoolName;
+    public ComparatorSetUserDefined Set => set;
+}
+
+public record SchoolComparatorsByNameAddViewModel
+{
+    [Required(ErrorMessage = "Select a school from the suggester")]
+    public string? Urn { get; init; }
+}

--- a/web/src/Web.App/ViewModels/SchoolComparatorsChosenSchoolsViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolComparatorsChosenSchoolsViewModel.cs
@@ -1,0 +1,8 @@
+using Web.App.Domain;
+namespace Web.App.ViewModels;
+
+public class SchoolComparatorsChosenSchoolsViewModel(string? urn, SchoolCharacteristicUserDefined[]? schoolCharacteristics)
+{
+    public string? Urn => urn;
+    public SchoolCharacteristicUserDefined[]? Schools => schoolCharacteristics;
+}

--- a/web/src/Web.App/Views/SchoolComparatorsCreateBy/Name.cshtml
+++ b/web/src/Web.App/Views/SchoolComparatorsCreateBy/Name.cshtml
@@ -1,0 +1,53 @@
+﻿@using Web.App.Domain
+@using Web.App.Extensions
+@using Web.App.TagHelpers
+@model Web.App.ViewModels.SchoolComparatorsByNameViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.SchoolComparatorsCreateByName;
+}
+
+@await Component.InvokeAsync("EstablishmentHeading", new
+{
+    title = ViewData[ViewDataKeys.Title],
+    name = Model.Name,
+    id = Model.Urn,
+    kind = OrganisationTypes.School
+})
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <p class="govuk-body">Choose between 10 and 30 schools for best results.</p>
+    </div>
+    <div class="govuk-grid-column-full">
+        @await Html.PartialAsync("_ErrorSummary")
+        @using (Html.BeginForm("Name", "SchoolComparatorsCreateBy", new
+                {
+                    urn = Model.Urn
+                }, FormMethod.Post, true, new
+                {
+                    novalidate = "novalidate"
+                }))
+        {
+            <p class="govuk-body govuk-hint">Search by school name, postcode or URN</p>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-three-quarters">
+                    <div id="school-suggester"></div>
+                </div>
+                <div class="govuk-grid-column-one-quarter">
+                    <button type="submit" class="govuk-button" data-module="govuk-button" name="action" value="@FormAction.Continue">
+                        Choose school
+                    </button>
+                </div>
+            </div>
+        }
+    </div>
+</div>
+<div>dump: @Model.Set.ToJson()</div>
+
+@section scripts
+{
+    <script type="module" add-nonce="true">
+      import { initAll } from '/js/govuk-frontend.min.js'
+      initAll()
+    </script>
+}

--- a/web/src/Web.App/Views/SchoolComparatorsCreateBy/Name.cshtml
+++ b/web/src/Web.App/Views/SchoolComparatorsCreateBy/Name.cshtml
@@ -1,6 +1,6 @@
 ﻿@using Web.App.Domain
-@using Web.App.Extensions
 @using Web.App.TagHelpers
+@using Web.App.ViewModels
 @model Web.App.ViewModels.SchoolComparatorsByNameViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.SchoolComparatorsCreateByName;
@@ -42,7 +42,17 @@
         }
     </div>
 </div>
-<div>dump: @Model.Set.ToJson()</div>
+
+@using (Html.BeginForm("Remove", "SchoolComparatorsCreateBy", new
+        {
+            urn = Model.Urn
+        }, FormMethod.Post, true, new
+        {
+            novalidate = "novalidate"
+        }))
+{
+    @await Html.PartialAsync("_ChosenSchools", new SchoolComparatorsChosenSchoolsViewModel(Model.Urn, Model.Schools))
+}
 
 @section scripts
 {

--- a/web/src/Web.App/Views/SchoolComparatorsCreateBy/_ChosenSchools.cshtml
+++ b/web/src/Web.App/Views/SchoolComparatorsCreateBy/_ChosenSchools.cshtml
@@ -1,0 +1,40 @@
+﻿@using Web.App.Extensions
+@model Web.App.ViewModels.SchoolComparatorsChosenSchoolsViewModel
+
+@if (Model.Schools != null && Model.Schools.Any())
+{
+    <table class="govuk-table">
+        <caption class="govuk-table__caption govuk-table__caption--m">Chosen schools (@Model.Schools.Length)</caption>
+        <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header govuk-!-width-one-third">School</th>
+            <th scope="col" class="govuk-table__header">Type</th>
+            <th scope="col" class="govuk-table__header">Number of pupils</th>
+            <th scope="col" class="govuk-table__header">Pupils with special educational needs</th>
+            <th scope="col" class="govuk-table__header">Pupils eligible for free school meals</th>
+            <th scope="col" class="govuk-table__header"></th>
+        </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        @foreach (var school in Model.Schools.Where(x => x.URN != Model.Urn))
+        {
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell">
+                    <span class="govuk-body govuk-!-font-weight-bold">@school.SchoolName</span>
+                    <br/>
+                    <span class="govuk-hint">@school.Address</span>
+                </td>
+                <td class="govuk-table__cell">@school.OverallPhase</td>
+                <td class="govuk-table__cell">@school.TotalPupils</td>
+                <td class="govuk-table__cell">@school.PercentSpecialEducationNeeds.ToPercent()</td>
+                <td class="govuk-table__cell">@school.PercentFreeSchoolMeals.ToPercent()</td>
+                <td class="govuk-table__cell">
+                    <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button" name="urn" value="@school.URN">
+                        Remove
+                    </button>
+                </td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}


### PR DESCRIPTION
### Context
[AB#212119](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/212119) [AB#210705](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/210705)

### Change proposed in this pull request
On the 'by name' journey for creating a user defined comparator set the user may use the school suggester to add and remove schools to ultimately be used for a custom comparator set.

### Guidance to review 
To run locally, the `front-end-components` will first need to be built and copied over to `Web` in order for the independent `<SchoolInput>` component to be rendered as expected. A subsequent PR will bump the version of that dependency once this one has been merged.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

