### PR TITLE
Submit pending user defined comparator set and poll on result

### DIFF
--- a/platform/src/apis/Platform.Api.Benchmark/UserData/UserDataFunctions.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/UserData/UserDataFunctions.cs
@@ -31,6 +31,7 @@ public class UserDataFunctions
     [QueryStringParameter("userId", "User Id", DataType = typeof(string), Required = true)]
     [QueryStringParameter("type", "Type", DataType = typeof(string), Required = false)]
     [QueryStringParameter("status", "Status", DataType = typeof(string), Required = false)]
+    [QueryStringParameter("id", "Identifier", DataType = typeof(string), Required = false)]
     public async Task<IActionResult> QueryAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "get", Route = "user-data")]
         HttpRequest req)
@@ -48,7 +49,8 @@ public class UserDataFunctions
                 var userId = req.Query["userId"].ToString();
                 var type = req.Query["type"].ToString();
                 var status = req.Query["status"].ToString();
-                var data = await _service.QueryAsync(userId, type, status);
+                var id = req.Query["id"].ToString();
+                var data = await _service.QueryAsync(userId, type, status, id);
 
                 return new JsonContentResult(data);
             }

--- a/platform/src/apis/Platform.Api.Benchmark/UserData/UserDataService.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/UserData/UserDataService.cs
@@ -8,7 +8,7 @@ namespace Platform.Api.Benchmark.UserData;
 
 public interface IUserDataService
 {
-    Task<IEnumerable<UserData>> QueryAsync(string userId, string? type = null, string? status = null);
+    Task<IEnumerable<UserData>> QueryAsync(string userId, string? type = null, string? status = null, string? id = null);
 }
 
 [ExcludeFromCodeCoverage]
@@ -21,7 +21,7 @@ public class UserDataService : IUserDataService
         _dbFactory = dbFactory;
     }
 
-    public async Task<IEnumerable<UserData>> QueryAsync(string userId, string? type = null, string? status = null)
+    public async Task<IEnumerable<UserData>> QueryAsync(string userId, string? type = null, string? status = null, string? id = null)
     {
         var builder = new SqlBuilder();
         var template = builder.AddTemplate("SELECT * from UserData /**where**/");
@@ -36,6 +36,11 @@ public class UserDataService : IUserDataService
         if (!string.IsNullOrEmpty(status))
         {
             builder.Where("Status = @status", new { status });
+        }
+
+        if (!string.IsNullOrEmpty(id))
+        {
+            builder.Where("Id = @id", new { id });
         }
 
         using var conn = await _dbFactory.GetConnection();

--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -46,35 +46,35 @@
 }
 
 .priority.high, .priority.high .app-tag--red {
-    border: 2px solid $rag-red-colour;
+  border: 2px solid $rag-red-colour;
 }
 
 .priority.medium, .priority.medium .app-tag--yellow {
-    border: 2px solid $rag-amber-colour;
+  border: 2px solid $rag-amber-colour;
 }
 
 .priority.low, .priority.low .app-tag--green {
-    border: 2px solid $rag-green-colour;
+  border: 2px solid $rag-green-colour;
 }
 
 .app-tag--red {
-    background-color: $rag-red-colour;
-    color: $rag-red-text-colour;
+  background-color: $rag-red-colour;
+  color: $rag-red-text-colour;
 }
 
 .app-tag--yellow {
-    background-color: $rag-amber-colour;
-    color: $rag-amber-text-colour;
+  background-color: $rag-amber-colour;
+  color: $rag-amber-text-colour;
 }
 
 .app-tag--green {
-    background-color: $rag-green-colour;
-    color: $govuk-text-colour;
+  background-color: $rag-green-colour;
+  color: $govuk-text-colour;
 }
 
 p.priority .govuk-tag {
-    margin-right: 10px;
-    border-left: none !important;
+  margin-right: 10px;
+  border-left: none !important;
 }
 
 .top-categories div {
@@ -161,3 +161,13 @@ svg.rag-stack {
     fill: govuk-tint($rag-green-colour, 20%);
   }
 }
+
+.govuk-notification-banner--failure {
+  border-color: $govuk-error-colour;
+  background-color: $govuk-error-colour;
+
+  .govuk-notification-banner__link {
+    @include govuk-link-style-error;
+  }
+}
+

--- a/web/src/Web.App/Constants/PageTitles.cs
+++ b/web/src/Web.App/Constants/PageTitles.cs
@@ -28,6 +28,7 @@ public static class PageTitles
     public const string SchoolComparatorsCreate = "Choose your own set of schools";
     public const string SchoolComparatorsCreateBy = "How do you want to choose your set of schools?";
     public const string SchoolComparatorsCreateByName = "Choose schools to benchmark against";
+    public const string SchoolComparatorsSubmit = "Updating benchmarking data";
     public const string TrustHome = "Your trust";
     public const string HistoricData = "Historic data";
     public const string SchoolPlanningHasMixedAgeClasses = "Do you have any mixed age classes?";

--- a/web/src/Web.App/Controllers/Api/UserDataProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/UserDataProxyController.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Web.App.Domain;
+using Web.App.Extensions;
+using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Extensions;
+
+namespace Web.App.Controllers.Api;
+
+[ApiController]
+[Route("api/user-data")]
+[Authorize]
+public class UserDataProxyController(ILogger<ProxyController> logger, IUserDataApi userDataApi) : Controller
+{
+    [HttpGet]
+    [Route("{identifier}")]
+    [Produces("application/json")]
+    public async Task<IActionResult> Index(string identifier)
+    {
+        using (logger.BeginScope(new { identifier }))
+        {
+            try
+            {
+                var query = new ApiQuery()
+                    .AddIfNotNull("userId", User.UserId())
+                    .AddIfNotNull("id", identifier);
+
+                var userSets = await userDataApi.GetAsync(query).GetResultOrDefault<UserData[]>();
+                if (userSets == null || userSets.Length == 0)
+                {
+                    return new NotFoundResult();
+                }
+
+                return new JsonResult(userSets.FirstOrDefault());
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "An error getting user data {Id} for {User}", identifier, User.UserId());
+                return StatusCode(500);
+            }
+        }
+    }
+}

--- a/web/src/Web.App/Controllers/SchoolComparatorsCreateByController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparatorsCreateByController.cs
@@ -4,7 +4,6 @@ using Microsoft.FeatureManagement.Mvc;
 using Web.App.Attributes;
 using Web.App.Domain;
 using Web.App.Extensions;
-using Web.App.Identity;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Extensions;
 using Web.App.Services;
@@ -13,7 +12,7 @@ using Web.App.ViewModels;
 namespace Web.App.Controllers;
 
 [Controller]
-//todo: reinstate once DSI permissions resolved [SchoolAuthorization]
+[SchoolAuthorization]
 [FeatureGate(FeatureFlags.UserDefinedComparators)]
 [Route("school/{urn}/comparators/create/by")]
 public class SchoolComparatorsCreateByController(
@@ -84,7 +83,10 @@ public class SchoolComparatorsCreateByController(
         {
             try
             {
-                ViewData[ViewDataKeys.Backlink] = new BacklinkInfo(Url.Action(nameof(Index), new { urn }));
+                ViewData[ViewDataKeys.Backlink] = new BacklinkInfo(Url.Action(nameof(Index), new
+                {
+                    urn
+                }));
 
                 var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
                 var userDefinedSet = comparatorSetService.ReadUserDefinedComparatorSet(urn);
@@ -156,16 +158,16 @@ public class SchoolComparatorsCreateByController(
             urn
         });
     }
-    
+
     [HttpGet]
     [Route("submit")]
     [ImportModelState]
     public async Task<IActionResult> Submit(string urn)
     {
         using (logger.BeginScope(new
-               {
-                   urn
-               }))
+        {
+            urn
+        }))
         {
             try
             {
@@ -179,15 +181,14 @@ public class SchoolComparatorsCreateByController(
                     });
                 }
 
-                User.TryGetClaim(ClaimNames.UserId, out var userId);
                 var request = new PutComparatorSetUserDefinedRequest
                 {
                     URN = urn,
                     Set = userDefinedSet.Set,
-                    UserId = userId
+                    UserId = User.UserId()
                 };
 
-                await comparatorSetApi.UpsertUserDefinedAsync(request).EnsureSuccess();;
+                await comparatorSetApi.UpsertUserDefinedAsync(request).EnsureSuccess();
                 comparatorSetService.SetUserDefinedComparatorSet(urn, new ComparatorSetUserDefined());
                 var viewModel = new SchoolComparatorsSubmittedViewModel(school, request);
                 return View(viewModel);
@@ -211,7 +212,10 @@ public class SchoolComparatorsCreateByController(
         {
             try
             {
-                ViewData[ViewDataKeys.Backlink] = new BacklinkInfo(Url.Action(nameof(Index), new { urn }));
+                ViewData[ViewDataKeys.Backlink] = new BacklinkInfo(Url.Action(nameof(Index), new
+                {
+                    urn
+                }));
 
                 var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
                 var viewModel = new SchoolComparatorsViewModel(school);

--- a/web/src/Web.App/Controllers/SchoolComparatorsCreateByController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparatorsCreateByController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.FeatureManagement.Mvc;
@@ -12,7 +13,7 @@ using Web.App.ViewModels;
 namespace Web.App.Controllers;
 
 [Controller]
-[SchoolAuthorization]
+[Authorize]
 [FeatureGate(FeatureFlags.UserDefinedComparators)]
 [Route("school/{urn}/comparators/create/by")]
 public class SchoolComparatorsCreateByController(

--- a/web/src/Web.App/Controllers/SchoolController.cs
+++ b/web/src/Web.App/Controllers/SchoolController.cs
@@ -5,7 +5,6 @@ using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Extensions;
 using Web.App.Services;
 using Web.App.ViewModels;
-
 namespace Web.App.Controllers;
 
 [Controller]
@@ -18,9 +17,14 @@ public class SchoolController(
     : Controller
 {
     [HttpGet]
-    public async Task<IActionResult> Index(string urn)
+    public async Task<IActionResult> Index(
+        string urn,
+        [FromQuery(Name = "comparator-generated")] bool? comparatorGenerated)
     {
-        using (logger.BeginScope(new { urn }))
+        using (logger.BeginScope(new
+        {
+            urn
+        }))
         {
             try
             {
@@ -29,7 +33,7 @@ public class SchoolController(
                 var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
                 var finances = await financeService.GetFinances(urn);
                 var ratings = await metricRagRatingApi.GetDefaultAsync(new ApiQuery().AddIfNotNull("urns", urn)).GetResultOrThrow<RagRating[]>();
-                var viewModel = new SchoolViewModel(school, finances, ratings);
+                var viewModel = new SchoolViewModel(school, finances, ratings, comparatorGenerated);
                 return View(viewModel);
             }
             catch (Exception e)

--- a/web/src/Web.App/Extensions/ClaimsPrincipalExtensions.cs
+++ b/web/src/Web.App/Extensions/ClaimsPrincipalExtensions.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Authentication;
 using Newtonsoft.Json;
 using Web.App.Identity;
 using Web.App.Identity.Models;
-
 namespace Web.App.Extensions;
 
 public static class ClaimsPrincipalExtensions
@@ -150,18 +149,5 @@ public static class ClaimsPrincipalExtensions
         }
 
         return principal;
-    }
-
-    public static bool TryGetClaim(this ClaimsPrincipal principal, string claimName, out string? value)
-    {
-        var claim = principal.Claims.FirstOrDefault(c => c.Type == claimName);
-        if (claim == null)
-        {
-            value = null;
-            return false;
-        }
-
-        value = claim.Value;
-        return true;
     }
 }

--- a/web/src/Web.App/Extensions/ClaimsPrincipalExtensions.cs
+++ b/web/src/Web.App/Extensions/ClaimsPrincipalExtensions.cs
@@ -151,4 +151,17 @@ public static class ClaimsPrincipalExtensions
 
         return principal;
     }
+
+    public static bool TryGetClaim(this ClaimsPrincipal principal, string claimName, out string? value)
+    {
+        var claim = principal.Claims.FirstOrDefault(c => c.Type == claimName);
+        if (claim == null)
+        {
+            value = null;
+            return false;
+        }
+
+        value = claim.Value;
+        return true;
+    }
 }

--- a/web/src/Web.App/Infrastructure/Apis/ComparatorSetApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/ComparatorSetApi.cs
@@ -10,12 +10,12 @@ public class ComparatorSetApi(HttpClient httpClient, string? key = default)
 
     public async Task<ApiResult> GetUserDefinedAsync(string urn, string? identifier)
     {
-        return await GetAsync($"comparator-set/{urn}/user-defined/{identifier}");
+        return await GetAsync($"api/comparator-set/{urn}/user-defined/{identifier}");
     }
 
     public async Task<ApiResult> UpsertUserDefinedAsync(PutComparatorSetUserDefinedRequest request)
     {
-        return await PutAsync($"comparator-set/{request.URN}/user-defined/{request.Identifier}", new JsonContent(request));
+        return await PutAsync($"api/comparator-set/{request.URN}/user-defined/{request.Identifier}", new JsonContent(request));
     }
 }
 

--- a/web/src/Web.App/Infrastructure/Apis/Requests/PutComparatorSetUserDefinedRequest.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Requests/PutComparatorSetUserDefinedRequest.cs
@@ -4,4 +4,6 @@ public record PutComparatorSetUserDefinedRequest
 {
     public string? URN { get; set; }
     public Guid Identifier { get; set; } = Guid.NewGuid();
+    public string[] Set { get; set; } = Array.Empty<string>();
+    public string? UserId { get; set; }
 }

--- a/web/src/Web.App/ViewModels/SchoolComparatorsChosenSchoolsViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolComparatorsChosenSchoolsViewModel.cs
@@ -4,5 +4,5 @@ namespace Web.App.ViewModels;
 public class SchoolComparatorsChosenSchoolsViewModel(string? urn, SchoolCharacteristicUserDefined[]? schoolCharacteristics)
 {
     public string? Urn => urn;
-    public SchoolCharacteristicUserDefined[]? Schools => schoolCharacteristics;
+    public IOrderedEnumerable<SchoolCharacteristicUserDefined>? Schools => schoolCharacteristics?.OrderBy(c => c.SchoolName);
 }

--- a/web/src/Web.App/ViewModels/SchoolComparatorsSubmittedViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolComparatorsSubmittedViewModel.cs
@@ -1,0 +1,10 @@
+﻿using Web.App.Domain;
+using Web.App.Infrastructure.Apis;
+namespace Web.App.ViewModels;
+
+public class SchoolComparatorsSubmittedViewModel(School school, PutComparatorSetUserDefinedRequest request)
+{
+    public string? Urn => school.URN;
+    public string? Name => school.SchoolName;
+    public Guid Identifier => request.Identifier;
+}

--- a/web/src/Web.App/ViewModels/SchoolViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolViewModel.cs
@@ -4,7 +4,8 @@ namespace Web.App.ViewModels;
 public class SchoolViewModel(
     School school,
     Finances? finances,
-    IEnumerable<RagRating> ratings)
+    IEnumerable<RagRating> ratings,
+    bool? comparatorGenerated)
 {
     public string? Name => school.SchoolName;
     public string? Urn => school.URN;
@@ -22,4 +23,5 @@ public class SchoolViewModel(
         .ThenByDescending(x => x.Decile)
         .ThenByDescending(x => x.Value)
         .Take(3);
+    public bool? ComparatorGenerated => comparatorGenerated;
 }

--- a/web/src/Web.App/Views/School/Index.cshtml
+++ b/web/src/Web.App/Views/School/Index.cshtml
@@ -23,6 +23,34 @@
             </h2>
         }
     </div>
+    <div class="govuk-grid-column-full">
+        @if (Model.ComparatorGenerated.HasValue)
+        {
+            var success = Model.ComparatorGenerated == true;
+            <div class="govuk-notification-banner govuk-notification-banner--@(success ? "success" : "failure")" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+                <div class="govuk-notification-banner__header">
+                    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                        @(success ? "Success" : "Error")
+                    </h2>
+                </div>
+                <div class="govuk-notification-banner__content">
+                    <h3 class="govuk-notification-banner__heading">@(success ? "You are now benchmarking against your own set of schools" : "Unable to benchmark against your own set of schools")</h3>
+                    @if (!success)
+                    {
+                        <p class="govuk-body">
+                            Please try again later.
+                        </p>
+                    }
+                    <p>
+                        <a class="govuk-notification-banner__link"
+                           href="@Url.Action("UserDefined", "SchoolComparators", new { urn = Model.Urn })">
+                            View and change your set of schools
+                        </a>
+                    </p>
+                </div>
+            </div>
+        }
+    </div>
 </div>
 
 @await Component.InvokeAsync("DataSource", new
@@ -89,7 +117,7 @@ else
                     }
                 </div>
             }
-            
+
             <h3 class="govuk-heading-s">
                 <a href="@Url.Action("Index", "SchoolSpending", new { urn = Model.Urn })" class="govuk-link govuk-link--no-visited-state">
                     View all spending priorities for this school
@@ -128,3 +156,11 @@ else
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
 @await Component.InvokeAsync("GetHelp")
+
+@section scripts
+{
+    <script type="module" add-nonce="true">
+      import { initAll } from '/js/govuk-frontend.min.js'
+      initAll()
+    </script>
+}

--- a/web/src/Web.App/Views/SchoolComparatorsCreateBy/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolComparatorsCreateBy/Index.cshtml
@@ -1,6 +1,5 @@
 ﻿@using Web.App.Domain
 @using Web.App.Extensions
-@using Web.App.TagHelpers
 @model Web.App.ViewModels.SchoolComparatorsViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.SchoolComparatorsCreateBy;
@@ -52,11 +51,3 @@
         }
     </div>
 </div>
-
-@section scripts
-{
-    <script type="module" add-nonce="true">
-      import { initAll } from '/js/govuk-frontend.min.js'
-      initAll()
-    </script>
-}

--- a/web/src/Web.App/Views/SchoolComparatorsCreateBy/Submit.cshtml
+++ b/web/src/Web.App/Views/SchoolComparatorsCreateBy/Submit.cshtml
@@ -16,10 +16,7 @@
 @section scripts
 {
     <script type="module" add-nonce="true">
-      import { initAll } from '/js/govuk-frontend.min.js';
-      initAll();
-      
-      // todo: refactor into its own reusable partial
+      // todo: refactor entire view its own partial/component for re-use by other async processes such as custom data submission
       let done, failed = false;
       const interval = setInterval(statusCheck, 5000);
       function statusCheck() {
@@ -37,8 +34,12 @@
             })
             .then(response => response.json())
             .then(json => {
-                if (json && json.status === "complete") {
-                    done = true;
+                if (json) {
+                    if (json.status === "complete") {
+                        done = true;
+                    } else if (json.status !== "pending") {
+                        throw new Error("Unexpected response returned from API call");
+                    }
                 }
             })
             .catch(err => {

--- a/web/src/Web.App/Views/SchoolComparatorsCreateBy/Submit.cshtml
+++ b/web/src/Web.App/Views/SchoolComparatorsCreateBy/Submit.cshtml
@@ -1,0 +1,22 @@
+﻿@model Web.App.ViewModels.SchoolComparatorsSubmittedViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.SchoolComparatorsSubmit;
+}
+
+@await Component.InvokeAsync("EstablishmentHeading", new
+{
+    title = ViewData[ViewDataKeys.Title],
+    name = Model.Name,
+    id = Model.Urn,
+    kind = OrganisationTypes.School
+})
+
+@Model.Identifier - todo
+
+@section scripts
+{
+    <script type="module" add-nonce="true">
+      import { initAll } from '/js/govuk-frontend.min.js'
+      initAll()
+    </script>
+}

--- a/web/src/Web.App/Views/SchoolComparatorsCreateBy/Submit.cshtml
+++ b/web/src/Web.App/Views/SchoolComparatorsCreateBy/Submit.cshtml
@@ -3,20 +3,48 @@
     ViewData[ViewDataKeys.Title] = PageTitles.SchoolComparatorsSubmit;
 }
 
-@await Component.InvokeAsync("EstablishmentHeading", new
-{
-    title = ViewData[ViewDataKeys.Title],
-    name = Model.Name,
-    id = Model.Urn,
-    kind = OrganisationTypes.School
-})
-
-@Model.Identifier - todo
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full loading">
+        <h1 class="govuk-heading-l">
+            @ViewData[ViewDataKeys.Title]
+        </h1>
+        <div class="spinner"></div>
+        <p class="govuk-hint">This may take a minute or two.</p>
+    </div>
+</div>
 
 @section scripts
 {
     <script type="module" add-nonce="true">
-      import { initAll } from '/js/govuk-frontend.min.js'
-      initAll()
+      import { initAll } from '/js/govuk-frontend.min.js';
+      initAll();
+      
+      // todo: refactor into its own reusable partial
+      let done, failed = false;
+      const interval = setInterval(statusCheck, 5000);
+      function statusCheck() {
+        if (done || failed) {
+            clearInterval(interval);
+            window.location.href = `/school/@Model.Urn?comparator-generated=${!failed}`;
+            return;
+        }
+
+        fetch(
+            "/api/user-data/@Model.Identifier", 
+            { 
+                method: "GET",
+                credentials: "include"
+            })
+            .then(response => response.json())
+            .then(json => {
+                if (json && json.status === "complete") {
+                    done = true;
+                }
+            })
+            .catch(err => {
+                console.error(err);
+                failed = true;
+            });
+      }
     </script>
 }

--- a/web/src/Web.App/Views/SchoolComparatorsCreateBy/_ChosenSchools.cshtml
+++ b/web/src/Web.App/Views/SchoolComparatorsCreateBy/_ChosenSchools.cshtml
@@ -3,8 +3,12 @@
 
 @if (Model.Schools != null && Model.Schools.Any())
 {
+    <h1 class="govuk-heading-m">Chosen schools (@Model.Schools.Count())</h1>
+    <a href="@Url.Action("Submit", new { urn = Model.Urn })" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+        Create a set using these schools
+    </a>
     <table class="govuk-table">
-        <caption class="govuk-table__caption govuk-table__caption--m">Chosen schools (@Model.Schools.Length)</caption>
+        <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden">Chosen schools (@Model.Schools.Count())</caption>
         <thead class="govuk-table__head">
         <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header govuk-!-width-one-third">School</th>


### PR DESCRIPTION
### Context
[AB#212120](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/212120) [AB#210705](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/210705)

### Change proposed in this pull request
Submit pending user defined comparator set to data pipeline and poll until corresponding user data entry completes or fails.

### Guidance to review 
Running locally the user data entry never moves out of the `pending` state, so this will need to be done manually to complete testing of the journey end-to-end. e.g.:

```sql
update [UserData] set [Status] = 'complete' where id = '<guid>'
```

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

