### PR TITLE
Allow multiple LAs to be selected on Characteristic builder

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -62,7 +62,12 @@
     ></div>-->
     <form method="get">
       <div id="school-suggester" data-exclude="123456,123457"></div>
-      <div id="la-suggester" data-input="Kent" data-code="886"></div>
+      <div
+        id="la-suggester"
+        data-input="Kent"
+        data-code="886"
+        data-exclude="Leeds,Essex"
+      ></div>
       <button type="submit">Submit</button>
     </form>
     <script type="module" src="/src/main.tsx"></script>

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -519,11 +519,15 @@ if (schoolSuggesterElement) {
 
 const laSuggesterElement = document.getElementById(LaSuggesterId);
 if (laSuggesterElement) {
-  const { input, code } = laSuggesterElement.dataset;
+  const { input, code, exclude } = laSuggesterElement.dataset;
   const root = ReactDOM.createRoot(laSuggesterElement);
   root.render(
     <React.StrictMode>
-      <LaInput input={input || ""} code={code || ""} />
+      <LaInput
+        input={input || ""}
+        code={code || ""}
+        exclude={exclude ? exclude.split(",") : undefined}
+      />
     </React.StrictMode>
   );
 }

--- a/front-end-components/src/views/find-organisation/partials/la-input.tsx
+++ b/front-end-components/src/views/find-organisation/partials/la-input.tsx
@@ -8,24 +8,30 @@ import {
 import { v4 as uuidv4 } from "uuid";
 
 const LaInput: React.FunctionComponent<LaInputProps> = (props) => {
-  const { input, code } = props;
+  const { input, code, exclude } = props;
   const [inputValue, setInputValue] = useState<string>(input);
   const [selectedCode, setSelectedCode] = useState<string>(code);
 
   const handleSuggest = async (query: string) => {
+    const params = new URLSearchParams({
+      type: "local-authority",
+      search: query,
+    });
+    if (exclude) {
+      exclude.forEach((e) => {
+        params.append("exclude", e);
+      });
+    }
+
     try {
-      const res = await fetch(
-        "/api/suggest?" +
-          new URLSearchParams({ type: "local-authority", search: query }),
-        {
-          redirect: "manual",
-          method: "GET",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Correlation-ID": uuidv4(),
-          },
-        }
-      );
+      const res = await fetch("/api/suggest?" + params, {
+        redirect: "manual",
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Correlation-ID": uuidv4(),
+        },
+      });
 
       const response = await res.json();
       if (response.error) {

--- a/front-end-components/src/views/find-organisation/types.tsx
+++ b/front-end-components/src/views/find-organisation/types.tsx
@@ -31,6 +31,7 @@ export type SuggestResult<T> = {
 export type LaInputProps = {
   input: string;
   code: string;
+  exclude?: string[];
 };
 
 /**

--- a/platform/src/apis/Platform.Api.Establishment/LocalAuthorities/LocalAuthoritiesFunctions.cs
+++ b/platform/src/apis/Platform.Api.Establishment/LocalAuthorities/LocalAuthoritiesFunctions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using AzureFunctions.Extensions.Swashbuckle.Attribute;
@@ -89,7 +90,8 @@ public class LocalAuthoritiesFunctions
                     return new ValidationErrorsResult(validationResult.Errors);
                 }
 
-                var trusts = await _service.SuggestAsync(body);
+                var names = req.Query["names"].ToString().Split(",").Where(x => !string.IsNullOrEmpty(x)).ToArray();
+                var trusts = await _service.SuggestAsync(body, names);
                 return new JsonContentResult(trusts);
             }
             catch (Exception e)

--- a/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesSuggestLocalAuthoritiesRequest.cs
+++ b/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesSuggestLocalAuthoritiesRequest.cs
@@ -14,7 +14,7 @@ public class WhenFunctionReceivesSuggestLocalAuthoritiesRequest : LocalAuthoriti
     public async Task ShouldReturn200OnValidRequest()
     {
         Service
-            .Setup(d => d.SuggestAsync(It.IsAny<SuggestRequest>()))
+            .Setup(d => d.SuggestAsync(It.IsAny<SuggestRequest>(), It.IsAny<string[]?>()))
             .ReturnsAsync(new SuggestResponse<LocalAuthority>());
 
         Validator

--- a/web/src/Web.App/Controllers/Api/SuggestProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/SuggestProxyController.cs
@@ -27,7 +27,7 @@ ISuggestService suggestService) : Controller
                         var trusts = await suggestService.TrustSuggestions(search);
                         return new JsonResult(trusts);
                     case OrganisationTypes.LocalAuthority:
-                        var localAuthorities = await suggestService.LocalAuthoritySuggestions(search);
+                        var localAuthorities = await suggestService.LocalAuthoritySuggestions(search, exclude);
                         return new JsonResult(localAuthorities);
                     default:
                         throw new ArgumentOutOfRangeException(nameof(type));

--- a/web/src/Web.App/Infrastructure/Apis/EstablishmentApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/EstablishmentApi.cs
@@ -43,12 +43,12 @@ public class EstablishmentApi(HttpClient httpClient, string? key = default)
         });
     }
 
-    public Task<ApiResult> SuggestLocalAuthorities(string search)
+    public Task<ApiResult> SuggestLocalAuthorities(string search, ApiQuery? query = null)
     {
         return SendAsync(new HttpRequestMessage
         {
             Method = HttpMethod.Post,
-            RequestUri = new Uri("api/local-authorities/suggest", UriKind.Relative),
+            RequestUri = new Uri($"api/local-authorities/suggest{query?.ToQueryString()}", UriKind.Relative),
             Content = new JsonContent(new { SearchText = search, Size = 10, SuggesterName = "local-authority-suggester" })
         });
     }
@@ -62,5 +62,5 @@ public interface IEstablishmentApi
     Task<ApiResult> QuerySchools(ApiQuery? query);
     Task<ApiResult> SuggestSchools(string search, ApiQuery? query = null);
     Task<ApiResult> SuggestTrusts(string search);
-    Task<ApiResult> SuggestLocalAuthorities(string search);
+    Task<ApiResult> SuggestLocalAuthorities(string search, ApiQuery? query = null);
 }

--- a/web/src/Web.App/Infrastructure/Apis/Requests/PostSchoolComparatorsRequest.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Requests/PostSchoolComparatorsRequest.cs
@@ -43,13 +43,12 @@ public class PostSchoolComparatorsRequest(string urn, string? laName, UserDefine
             .ToArray())
         : null;
 
-    // todo: support multiple LAs (see #212642)
     public CharacteristicList? LAName => viewModel.LaSelection == "All"
         ? null
         : new CharacteristicList(viewModel.LaSelection switch
         {
-            "Choose" => viewModel.LaInput!,
-            _ => laName!
+            "Choose" => viewModel.LaNames,
+            _ => [laName!]
         });
 
     public CharacteristicList? SchoolPosition => IsSelected(viewModel.Deficit)

--- a/web/src/Web.App/Services/SuggestService.cs
+++ b/web/src/Web.App/Services/SuggestService.cs
@@ -8,7 +8,7 @@ public interface ISuggestService
 {
     Task<IEnumerable<SuggestValue<School>>> SchoolSuggestions(string search, string[]? excludeSchools = null);
     Task<IEnumerable<SuggestValue<Trust>>> TrustSuggestions(string search);
-    Task<IEnumerable<SuggestValue<LocalAuthority>>> LocalAuthoritySuggestions(string search);
+    Task<IEnumerable<SuggestValue<LocalAuthority>>> LocalAuthoritySuggestions(string search, string[]? excludeLas = null);
 }
 
 public class SuggestService(IEstablishmentApi establishmentApi) : ISuggestService
@@ -72,9 +72,18 @@ public class SuggestService(IEstablishmentApi establishmentApi) : ISuggestServic
         });
     }
 
-    public async Task<IEnumerable<SuggestValue<LocalAuthority>>> LocalAuthoritySuggestions(string search)
+    public async Task<IEnumerable<SuggestValue<LocalAuthority>>> LocalAuthoritySuggestions(string search, string[]? excludeLas = null)
     {
-        var suggestions = await establishmentApi.SuggestLocalAuthorities(search).GetResultOrThrow<SuggestOutput<LocalAuthority>>();
+        var query = new ApiQuery();
+        if (excludeLas != null)
+        {
+            foreach (var la in excludeLas)
+            {
+                query.AddIfNotNull("names", la);
+            }
+        }
+
+        var suggestions = await establishmentApi.SuggestLocalAuthorities(search, query).GetResultOrThrow<SuggestOutput<LocalAuthority>>();
         return suggestions.Results.Select(value =>
         {
             var text = value.Text?.Replace("*", "");

--- a/web/src/Web.App/ViewModels/UserDefinedCharacteristicViewModel.cs
+++ b/web/src/Web.App/ViewModels/UserDefinedCharacteristicViewModel.cs
@@ -3,7 +3,7 @@ using Web.App.Attributes;
 using Web.App.Domain;
 namespace Web.App.ViewModels;
 
-public record UserDefinedCharacteristicViewModel()
+public record UserDefinedCharacteristicViewModel() : IValidatableObject
 {
     public UserDefinedCharacteristicViewModel(SchoolCharacteristic? characteristic) : this()
     {
@@ -38,15 +38,11 @@ public record UserDefinedCharacteristicViewModel()
     [Required(ErrorMessage = "Select at least one school category")]
     public string?[]? OverallPhase { get; set; }
 
-    // todo: support multiple LAs (see #212642)
     [Required(ErrorMessage = "Select a local authority")]
     public string? LaSelection { get; set; }
-
-    [RequiredDepends(nameof(LaSelection), "Choose", ErrorMessage = "Select a local authority from the suggester")]
-    public string? LaInput { get; init; }
-
-    [RequiredDepends(nameof(LaSelection), "Choose", ErrorMessage = "Select a local authority from the suggester")]
-    public string? Code { get; init; }
+    public string? LaInput { get; set; }
+    public string? Code { get; set; }
+    public string[] LaNames { get; set; } = [];
 
     // number of pupils
     public string? TotalPupils { get; init; }
@@ -197,4 +193,15 @@ public record UserDefinedCharacteristicViewModel()
     [Range(-20, 20, ErrorMessage = "Enter key stage 4 progress to between -20 and 20")]
     [CompareDecimalValue(nameof(KeyStage4ProgressFrom), Operator.GreaterThanOrEqualTo)]
     public decimal? KeyStage4ProgressTo { get; init; }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        var results = new List<ValidationResult>();
+        if (LaSelection == "Choose" && !(!string.IsNullOrWhiteSpace(LaInput) && !string.IsNullOrWhiteSpace(Code) || LaNames.Length > 0))
+        {
+            results.Add(new ValidationResult("Select a local authority from the suggester", [nameof(Code)]));
+        }
+
+        return results;
+    }
 }

--- a/web/src/Web.App/Views/SchoolComparatorsCreateBy/Characteristic.cshtml
+++ b/web/src/Web.App/Views/SchoolComparatorsCreateBy/Characteristic.cshtml
@@ -255,7 +255,7 @@
                 </fieldset>
             </div>
 
-            <button type="submit" class="govuk-button" data-module="govuk-button" name="action" value="@FormAction.Continue">
+            <button type="submit" class="govuk-button" data-module="govuk-button" name="action" data-prevent-double-click="true" value="@FormAction.Continue">
                 Continue
             </button>
         </div>

--- a/web/src/Web.App/Views/SchoolComparatorsCreateBy/_LocalAuthorities.cshtml
+++ b/web/src/Web.App/Views/SchoolComparatorsCreateBy/_LocalAuthorities.cshtml
@@ -55,7 +55,7 @@
                     }
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-three-quarters">
-                            <div id="la-suggester" data-input="@chosenLaName" data-code="@chosenLaCode"></div>
+                            <div id="la-suggester" data-input="@chosenLaName" data-code="@chosenLaCode" data-exclude="@(string.Join(",", Model.LaNames))"></div>
                         </div>
                         <div class="govuk-grid-column-one-quarter">
                             <button type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button" name="action" value="@FormAction.Add">

--- a/web/src/Web.App/Views/SchoolComparatorsCreateBy/_LocalAuthorities.cshtml
+++ b/web/src/Web.App/Views/SchoolComparatorsCreateBy/_LocalAuthorities.cshtml
@@ -1,4 +1,5 @@
-﻿@using Web.App.Extensions
+﻿@using Web.App.Domain
+@using Web.App.Extensions
 @model Web.App.ViewModels.UserDefinedCharacteristicViewModel
 @{
     var value = ViewData.ModelState.GetAttemptedValueOrDefault(nameof(Model.LaSelection), Model.LaSelection);
@@ -52,7 +53,45 @@
                             <span class="govuk-visually-hidden">Error:</span> @(ViewData.ModelState[nameof(Model.LaInput)]?.Errors.FirstOrDefault()?.ErrorMessage ?? ViewData.ModelState[nameof(Model.Code)]?.Errors.First().ErrorMessage)
                         </p>
                     }
-                    <div id="la-suggester" data-input="@chosenLaName" data-code="@chosenLaCode"></div>
+                    <div class="govuk-grid-row">
+                        <div class="govuk-grid-column-three-quarters">
+                            <div id="la-suggester" data-input="@chosenLaName" data-code="@chosenLaCode"></div>
+                        </div>
+                        <div class="govuk-grid-column-one-quarter">
+                            <button type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button" name="action" value="@FormAction.Add">
+                                Add another
+                            </button>
+                        </div>
+                        @if (Model.LaNames.Length > 0)
+                        {
+                            <div class="govuk-grid-column-three-quarters">
+                                <table class="govuk-table govuk-!-margin-bottom-0">
+                                    <thead class="govuk-table__head">
+                                    <tr class="govuk-table__row govuk-visually-hidden">
+                                        <th scope="col" class="govuk-table__header">Local authority</th>
+                                        <th scope="col" class="govuk-table__header"></th>
+                                    </tr>
+                                    </thead>
+                                    <tbody class="govuk-table__body">
+                                    @foreach (var name in Model.LaNames)
+                                    {
+                                        <tr class="govuk-table__row">
+                                            <td class="govuk-table__cell govuk-!-padding-top-4">
+                                                <input type="hidden" name="@nameof(Model.LaNames)" value="@name"/>
+                                                @name
+                                            </td>
+                                            <td class="govuk-table__cell">
+                                                <button type="submit" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button" name="action" value="@FormAction.Remove-@name">
+                                                    Remove
+                                                </button>
+                                            </td>
+                                        </tr>
+                                    }
+                                    </tbody>
+                                </table>
+                            </div>
+                        }
+                    </div>
                 </div>
             </div>
         </div>

--- a/web/src/Web.App/package-lock.json
+++ b/web/src/Web.App/package-lock.json
@@ -1072,9 +1072,9 @@
       }
     },
     "node_modules/front-end": {
-      "version": "0.1.46",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-0.1.46.tgz",
-      "integrity": "sha1-W58pBWBg3T+Y0keBRB4yeOtk8IQ=",
+      "version": "0.1.47",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-0.1.47.tgz",
+      "integrity": "sha1-rkPR4zflkIVttgMqIAwqCDSHN7c=",
       "dependencies": {
         "accessible-autocomplete": "^3.0.0",
         "classnames": "^2.5.1",

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -114,6 +114,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         EstablishmentApi.Setup(api => api.GetLocalAuthority(It.IsAny<string>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.SuggestSchools(It.IsAny<string>(), It.IsAny<ApiQuery?>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.SuggestTrusts(It.IsAny<string>())).Throws(new Exception());
+        EstablishmentApi.Setup(api => api.SuggestLocalAuthorities(It.IsAny<string>(), It.IsAny<ApiQuery?>())).Throws(new Exception());
         return this;
     }
 


### PR DESCRIPTION
### Context
[AB#212642](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/212642)

### Change proposed in this pull request
When 'Choose' option is selected for LAs, it is now possible to add/remove LAs rather than select a single entry. Previous validation rules should still be upheld, and all LAs should be posted to the comparator set builder API. Previously selected LAs should be excluded from the suggester.

### Guidance to review
This has a dependency on `front-end-components` and so to test locally, the latest build will need to be copied to `Web`. A subsequent commit will pull the new version, once published. There are some known usability issues here due to the avoidance of use of any client script to get this working - most noticeably the need to scroll back down to the LA element after one has been added/removed. 

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

