### PR TITLE
Replaced `TempData` with session storage for `UserDefinedCharacteristicViewModel` persistence

### DIFF
--- a/web/src/Web.App/Constants/SessionKeys.cs
+++ b/web/src/Web.App/Constants/SessionKeys.cs
@@ -3,6 +3,7 @@ namespace Web.App;
 public static class SessionKeys
 {
     public static string ComparatorSet(string urn) => $"comparator-set-{urn}";
+    public static string ComparatorSetCharacteristic(string urn) => $"comparator-set-characteristic-{urn}";
     public static string ComparatorSetUserDefined(string urn) => $"comparator-set-user-defined-{urn}";
     public static string ComparatorSetUserDefined(string urn, string identifier) => $"comparator-set-user-defined-{urn}-{identifier}";
     public static string CustomData(string urn) => $"custom-data-{urn}";

--- a/web/src/Web.App/Controllers/SchoolComparatorsController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparatorsController.cs
@@ -101,7 +101,7 @@ public class SchoolComparatorsController(
             }
             catch (Exception e)
             {
-                logger.LogError(e, "An error displaying school comparators: {DisplayUrl}", Request.GetDisplayUrl());
+                logger.LogError(e, "An error reverting school comparators: {DisplayUrl}", Request.GetDisplayUrl());
                 return e is StatusCodeException s ? StatusCode((int)s.Status) : StatusCode(500);
             }
         }
@@ -126,11 +126,13 @@ public class SchoolComparatorsController(
                     comparatorSetService.ClearUserDefinedComparatorSet(urn, userData.ComparatorSet);
                 }
 
+                comparatorSetService.ClearUserDefinedComparatorSet(urn);
+                comparatorSetService.ClearUserDefinedCharacteristic(urn);
                 return RedirectToAction("Index", "School", new { urn });
             }
             catch (Exception e)
             {
-                logger.LogError(e, "An error displaying school comparators: {DisplayUrl}", Request.GetDisplayUrl());
+                logger.LogError(e, "An error reverting school comparators: {DisplayUrl}", Request.GetDisplayUrl());
                 return e is StatusCodeException s ? StatusCode((int)s.Status) : StatusCode(500);
             }
         }

--- a/web/src/Web.App/Services/ComparatorSetService.cs
+++ b/web/src/Web.App/Services/ComparatorSetService.cs
@@ -2,6 +2,7 @@ using Web.App.Domain;
 using Web.App.Extensions;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Extensions;
+using Web.App.ViewModels;
 namespace Web.App.Services;
 
 public interface IComparatorSetService
@@ -10,7 +11,10 @@ public interface IComparatorSetService
     Task<ComparatorSetUserDefined> ReadUserDefinedComparatorSet(string urn, string identifier);
     ComparatorSetUserDefined ReadUserDefinedComparatorSet(string urn);
     ComparatorSetUserDefined SetUserDefinedComparatorSet(string urn, ComparatorSetUserDefined set);
-    void ClearUserDefinedComparatorSet(string urn, string identifier);
+    void ClearUserDefinedComparatorSet(string urn, string? identifier = null);
+    UserDefinedCharacteristicViewModel? ReadUserDefinedCharacteristic(string urn);
+    UserDefinedCharacteristicViewModel SetUserDefinedCharacteristic(string urn, UserDefinedCharacteristicViewModel characteristic);
+    void ClearUserDefinedCharacteristic(string urn);
 }
 
 public class ComparatorSetService(IHttpContextAccessor httpContextAccessor, IComparatorSetApi api) : IComparatorSetService
@@ -35,9 +39,11 @@ public class ComparatorSetService(IHttpContextAccessor httpContextAccessor, ICom
         return set ?? await SetUserDefinedComparatorSet(urn, identifier);
     }
 
-    public void ClearUserDefinedComparatorSet(string urn, string identifier)
+    public void ClearUserDefinedComparatorSet(string urn, string? identifier = null)
     {
-        var key = SessionKeys.ComparatorSetUserDefined(urn, identifier);
+        var key = string.IsNullOrWhiteSpace(identifier)
+            ? SessionKeys.ComparatorSetUserDefined(urn)
+            : SessionKeys.ComparatorSetUserDefined(urn, identifier);
         var context = httpContextAccessor.HttpContext;
 
         context?.Session.Remove(key);
@@ -61,6 +67,28 @@ public class ComparatorSetService(IHttpContextAccessor httpContextAccessor, ICom
         context?.Session.Set(key, set);
 
         return set;
+    }
+
+    public UserDefinedCharacteristicViewModel? ReadUserDefinedCharacteristic(string urn)
+    {
+        var key = SessionKeys.ComparatorSetCharacteristic(urn);
+        var context = httpContextAccessor.HttpContext;
+        return context?.Session.Get<UserDefinedCharacteristicViewModel>(key);
+    }
+
+    public UserDefinedCharacteristicViewModel SetUserDefinedCharacteristic(string urn, UserDefinedCharacteristicViewModel set)
+    {
+        var key = SessionKeys.ComparatorSetCharacteristic(urn);
+        var context = httpContextAccessor.HttpContext;
+        context?.Session.Set(key, set);
+        return set;
+    }
+
+    public void ClearUserDefinedCharacteristic(string urn)
+    {
+        var key = SessionKeys.ComparatorSetCharacteristic(urn);
+        var context = httpContextAccessor.HttpContext;
+        context?.Session.Remove(key);
     }
 
     private async Task<ComparatorSet> SetComparatorSet(string urn)

--- a/web/src/Web.App/ViewModels/SchoolComparatorsPreviewViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolComparatorsPreviewViewModel.cs
@@ -4,6 +4,7 @@ namespace Web.App.ViewModels;
 public class SchoolComparatorsPreviewViewModel(
     School school,
     SchoolCharacteristic[]? characteristics,
+    long? closestSchools,
     long? totalSchools,
     UserDefinedCharacteristicViewModel? userDefinedCharacteristics)
 {
@@ -11,6 +12,7 @@ public class SchoolComparatorsPreviewViewModel(
     public string? Name => school.SchoolName;
 
     public SchoolCharacteristic[]? Characteristics => characteristics;
+    public long? ClosestSchools => closestSchools;
     public long? TotalSchools => totalSchools;
 
     public bool AnyUniqueGroupings => AllAcademies == true || AllMaintained == true || AllNursery == true || AllPrimary == true

--- a/web/src/Web.App/Views/SchoolComparatorsCreateBy/Preview.cshtml
+++ b/web/src/Web.App/Views/SchoolComparatorsCreateBy/Preview.cshtml
@@ -1,5 +1,4 @@
-﻿@using Newtonsoft.Json
-@using Web.App.Extensions
+﻿@using Web.App.Extensions
 @model Web.App.ViewModels.SchoolComparatorsPreviewViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.SchoolComparatorsPreview;
@@ -27,7 +26,7 @@
                 @:These
             }
 
-            are the @Model.Characteristics?.Length closest matches to
+            are the @Model.ClosestSchools matches to
             @Model.Name using the characteristics you selected.
         </p>
 
@@ -77,17 +76,17 @@
         }
 
         <p class="govuk-body">
-            <a href="@Url.Action("Change", new { urn = Model.Urn, j = Model.UserDefinedCharacteristics.ToJson(Formatting.None) })" class="govuk-link govuk-link--no-visited-state">
+            <a href="@Url.Action("Characteristic", new { urn = Model.Urn })" class="govuk-link govuk-link--no-visited-state">
                 Change characteristics and create a new set
             </a>
         </p>
 
-        <a href="@Url.Action("Submit", new { urn = Model.Urn })" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
-            Create a set using these schools
-        </a>
-
         @if (Model.Characteristics != null)
         {
+            <a href="@Url.Action("Submit", new { urn = Model.Urn })" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+                Create a set using these schools
+            </a>
+            
             <table class="govuk-table">
                 <thead class="govuk-table__head">
                 <tr class="govuk-table__row">

--- a/web/src/Web.App/package-lock.json
+++ b/web/src/Web.App/package-lock.json
@@ -1072,9 +1072,9 @@
       }
     },
     "node_modules/front-end": {
-      "version": "0.1.47",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-0.1.47.tgz",
-      "integrity": "sha1-rkPR4zflkIVttgMqIAwqCDSHN7c=",
+      "version": "0.1.48",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-0.1.48.tgz",
+      "integrity": "sha1-ai1k6FYDtapkHHrfPdOiLDeg39c=",
       "dependencies": {
         "accessible-autocomplete": "^3.0.0",
         "classnames": "^2.5.1",


### PR DESCRIPTION
### Context
[AB#212851](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/212851) [AB#210705](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/210705)

### Change proposed in this pull request
New session storage key for the above to prevent the need to use query string or temp data to manage characteristics for a particular URN. Cleared down once user defined comparator set is submitted.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

