### PR TITLE
A11y tests for User Defined comparator sets

### DIFF
--- a/pipelines/web/steps/run-a11y-tests.yaml
+++ b/pipelines/web/steps/run-a11y-tests.yaml
@@ -31,5 +31,4 @@ steps:
     continueOnError: true #temp allow pipeline to continue whilst func test env is seeded with data
     inputs:
       command: test
-      arguments: --filter "Category!=CustomData&Category!=FinancialPlanning" # todo: remove filter when DSI organisation available in pre-prod
       projects: '${{ parameters.workspaceDir }}/a11y-tests-files/Web.A11yTests/Web.A11yTests.dll'

--- a/web/README.md
+++ b/web/README.md
@@ -54,11 +54,14 @@ However, if you are using deployed instances of the Platform APIs then having in
 
 Feature flags may also be defined in the `FeatureManagement` section:
 
-| Name                          | Purpose                                               |
-|-------------------------------|-------------------------------------------------------|
-| `CurriculumFinancialPlanning` | Toggles the Curriculum and Financial Planning feature |
-| `CustomData`                  | Toggles the Custom Data feature                       |
-| `Trusts`                      | Toggles the Trust feature                             |
+| Name                            | Purpose                                                              |
+|---------------------------------|----------------------------------------------------------------------|
+| `CurriculumFinancialPlanning`   | Toggles the Curriculum and Financial Planning feature                |
+| `CustomData`                    | Toggles the Custom Data feature                                      |
+| `DisableOrganisationClaimCheck` | Skips the Organisation Claim check in `SchoolAuthorizationAttribute` |
+| `LocalAuthorities`              | Toggles the Local Authorities feature                                |
+| `Trusts`                        | Toggles the Trust feature                                            |
+| `UserDefinedComparators`        | Toggles the User Defined comparators feature                         |
 
 #### DfE Sign-in (DSI) authentication
 
@@ -150,10 +153,15 @@ Add the following configuration in `appsettings.local.json` in the root of `Web.
 From the root of the `web` run
 
 ```bat
-dotnet test tests\Web.A11yTests --filter "Category!=CustomData&Category!=FinancialPlanning"
+dotnet test tests\Web.A11yTests
 ```
 
 _Playwright is used for end-to-end and accessibility testing which opens a browser and navigates like a user._
 
 > **NOTE:** Running _all_ accessibility tests locally using DSI credentials that are not configured to be able to access the
-> school defined in config will result in test failures for those in the `CustomData` and `FinancialPlanning` xUnit categories.
+> school defined in config will result in test failures for those in the `CustomData` and `FinancialPlanning` xUnit categories
+> unless the feature flag `DisableOrganisationClaimCheck` has been set to `true`. To skip these tests use the following filter:
+
+```bat
+dotnet test tests\Web.A11yTests --filter "Category!=CustomData&Category!=FinancialPlanning"
+```

--- a/web/src/Web.App/Views/SchoolComparatorsCreateBy/Characteristic.cshtml
+++ b/web/src/Web.App/Views/SchoolComparatorsCreateBy/Characteristic.cshtml
@@ -41,7 +41,7 @@
             })
 
             <div class="govuk-form-group">
-                <fieldset class="govuk-fieldset" aria-describedby="contact-hint">
+                <fieldset class="govuk-fieldset" aria-describedby="contact-hint" id="additional-characteristics">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
                         <h1 class="govuk-fieldset__heading">
                             Additional characteristics

--- a/web/src/Web.App/Views/SchoolComparatorsCreateBy/Preview.cshtml
+++ b/web/src/Web.App/Views/SchoolComparatorsCreateBy/Preview.cshtml
@@ -83,7 +83,7 @@
 
         @if (Model.Characteristics != null)
         {
-            <a href="@Url.Action("Submit", new { urn = Model.Urn })" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+            <a href="@Url.Action("Submit", new { urn = Model.Urn })" role="button" draggable="false" class="govuk-button" data-module="govuk-button" id="create-set">
                 Create a set using these schools
             </a>
 

--- a/web/src/Web.App/Views/SchoolComparatorsCreateBy/_ChosenSchools.cshtml
+++ b/web/src/Web.App/Views/SchoolComparatorsCreateBy/_ChosenSchools.cshtml
@@ -4,7 +4,7 @@
 @if (Model.Schools != null && Model.Schools.Any())
 {
     <h1 class="govuk-heading-m">Chosen schools (@Model.Schools.Count(x => x.URN != Model.Urn))</h1>
-    <a href="@Url.Action("Submit", new { urn = Model.Urn })" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+    <a href="@Url.Action("Submit", new { urn = Model.Urn })" role="button" draggable="false" class="govuk-button" data-module="govuk-button" id="create-set">
         Create a set using these schools
     </a>
     <table class="govuk-table">

--- a/web/tests/Web.A11yTests/Drivers/WebDriver.cs
+++ b/web/tests/Web.A11yTests/Drivers/WebDriver.cs
@@ -14,13 +14,14 @@ public class WebDriver(IMessageSink messageSink) : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    public async Task<IPage> GetPage(string url, HttpStatusCode statusCode, IPage? basePage = null)
+    public async Task<IPage> GetPage(string url, HttpStatusCode statusCode, IPage? basePage = null, string? storageStatePath = null)
     {
         _browser ??= await InitialiseBrowser();
 
         var contextOptions = new BrowserNewContextOptions
         {
-            IgnoreHTTPSErrors = true
+            IgnoreHTTPSErrors = true,
+            StorageStatePath = storageStatePath
         };
         var browserContext = await _browser.NewContextAsync(contextOptions);
 

--- a/web/tests/Web.A11yTests/Pages/Schools/Comparators/WhenViewingComparators.cs
+++ b/web/tests/Web.A11yTests/Pages/Schools/Comparators/WhenViewingComparators.cs
@@ -1,0 +1,16 @@
+﻿using Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+namespace Web.A11yTests.Pages.Schools.Comparators;
+
+public class WhenViewingComparators(ITestOutputHelper testOutputHelper, WebDriver webDriver) : PageBase(testOutputHelper, webDriver)
+{
+    protected override string PageUrl => $"/school/{TestConfiguration.School}/comparators";
+
+    [Fact]
+    public async Task ThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await EvaluatePage();
+    }
+}

--- a/web/tests/Web.A11yTests/Pages/Schools/Comparators/WhenViewingComparatorsBy.cs
+++ b/web/tests/Web.A11yTests/Pages/Schools/Comparators/WhenViewingComparatorsBy.cs
@@ -1,0 +1,17 @@
+﻿using Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+namespace Web.A11yTests.Pages.Schools.Comparators;
+
+[Trait("Category", "Comparators")]
+public class WhenViewingComparatorsBy(ITestOutputHelper testOutputHelper, WebDriver webDriver) : AuthPageBase(testOutputHelper, webDriver)
+{
+    protected override string PageUrl => $"/school/{TestConfiguration.School}/comparators/create/by";
+
+    [Fact]
+    public async Task ThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await EvaluatePage();
+    }
+}

--- a/web/tests/Web.A11yTests/Pages/Schools/Comparators/WhenViewingComparatorsByCharacteristic.cs
+++ b/web/tests/Web.A11yTests/Pages/Schools/Comparators/WhenViewingComparatorsByCharacteristic.cs
@@ -1,0 +1,49 @@
+﻿using Deque.AxeCore.Commons;
+using Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+namespace Web.A11yTests.Pages.Schools.Comparators;
+
+[Trait("Category", "Comparators")]
+public class WhenViewingComparatorsByCharacteristic(ITestOutputHelper testOutputHelper, WebDriver webDriver) : AuthPageBase(testOutputHelper, webDriver)
+{
+    private readonly AxeRunContext _context = new()
+    {
+        // known issues
+        Exclude =
+        [
+            // Ensures an element's role supports its ARIA attributes
+            new AxeSelector("#LaSelection-Choose")
+        ]
+    };
+
+    protected override string PageUrl => $"/school/{TestConfiguration.School}/comparators/create/by/characteristic";
+
+    [Fact]
+    public async Task ThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await EvaluatePage(_context);
+    }
+
+    [Fact]
+    public async Task WhenSelectingAllAdditionalCharacteristicsThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        foreach (var input in await Page.Locator("#additional-characteristics > div > div > input[type='checkbox']").AllAsync())
+        {
+            await input.ClickAsync();
+        }
+
+        await EvaluatePage(_context);
+    }
+
+    [Fact]
+    public async Task ValidationErrorThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await Page.Locator("#additional-characteristics > div > div > input[type='checkbox']").First.ClickAsync();
+        await Page.Locator("button[value='continue']").ClickAsync();
+        await EvaluatePage(_context);
+    }
+}

--- a/web/tests/Web.A11yTests/Pages/Schools/Comparators/WhenViewingComparatorsByName.cs
+++ b/web/tests/Web.A11yTests/Pages/Schools/Comparators/WhenViewingComparatorsByName.cs
@@ -1,0 +1,49 @@
+﻿using Deque.AxeCore.Commons;
+using Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+namespace Web.A11yTests.Pages.Schools.Comparators;
+
+[Trait("Category", "Comparators")]
+public class WhenViewingComparatorsByName(ITestOutputHelper testOutputHelper, WebDriver webDriver) : AuthPageBase(testOutputHelper, webDriver)
+{
+    private readonly AxeRunContext _context = new()
+    {
+        // known issues
+        Exclude =
+        [
+            // Ensures that every form element has a visible label and is not solely labeled using hidden labels, or the title or aria-describedby attributes
+            // Ensures every form element has a label
+            new AxeSelector("#school-input")
+        ]
+    };
+
+    protected override string PageUrl => $"/school/{TestConfiguration.School}/comparators/create/by/name";
+
+    [Fact]
+    public async Task ThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await EvaluatePage(_context);
+    }
+
+    [Fact]
+    public async Task ValidationErrorThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await Page.Locator("button[type='submit']").ClickAsync();
+        await EvaluatePage(_context);
+    }
+
+    [Fact]
+    public async Task AddSchoolThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await Page.Locator("#school-input").FillAsync("school");
+        await Page.Locator("#school-input__listbox.autocomplete__menu--visible").WaitForAsync();
+        await Page.Keyboard.DownAsync("ArrowDown");
+        await Page.Keyboard.DownAsync("Enter");
+        await Page.Locator("button[type='submit']").ClickAsync();
+        await EvaluatePage(_context);
+    }
+}

--- a/web/tests/Web.A11yTests/Pages/Schools/Comparators/WhenViewingComparatorsPreview.cs
+++ b/web/tests/Web.A11yTests/Pages/Schools/Comparators/WhenViewingComparatorsPreview.cs
@@ -1,0 +1,30 @@
+﻿using Deque.AxeCore.Commons;
+using Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+namespace Web.A11yTests.Pages.Schools.Comparators;
+
+[Trait("Category", "Comparators")]
+public class WhenViewingComparatorsPreview(ITestOutputHelper testOutputHelper, WebDriver webDriver) : AuthPageBase(testOutputHelper, webDriver)
+{
+    private readonly AxeRunContext _context = new()
+    {
+        // known issues
+        Exclude =
+        [
+            // Ensures an element's role supports its ARIA attributes
+            new AxeSelector("#LaSelection-Choose")
+        ]
+    };
+
+    protected override string PageUrl => $"/school/{TestConfiguration.School}/comparators/create/by/characteristic";
+
+    [Fact]
+    public async Task ThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await Page.Locator("button[value='continue']").ClickAsync();
+        await Page.WaitForURLAsync("**/preview");
+        await EvaluatePage(_context);
+    }
+}

--- a/web/tests/Web.A11yTests/Pages/Schools/Comparators/WhenViewingComparatorsSubmit.cs
+++ b/web/tests/Web.A11yTests/Pages/Schools/Comparators/WhenViewingComparatorsSubmit.cs
@@ -1,0 +1,25 @@
+﻿using Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+namespace Web.A11yTests.Pages.Schools.Comparators;
+
+[Trait("Category", "Comparators")]
+public class WhenViewingComparatorsSubmit(ITestOutputHelper testOutputHelper, WebDriver webDriver) : AuthPageBase(testOutputHelper, webDriver)
+{
+    protected override string PageUrl => $"/school/{TestConfiguration.School}/comparators/create/by/name";
+
+    [Fact]
+    public async Task ThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await Page.Locator("#school-input").FillAsync("school");
+        await Page.Locator("#school-input__listbox.autocomplete__menu--visible").WaitForAsync();
+        await Page.Keyboard.DownAsync("ArrowDown");
+        await Page.Keyboard.DownAsync("Enter");
+        await Page.Locator("button[type='submit']").ClickAsync();
+        await Page.Locator("#create-set").WaitForAsync();
+        await Page.Locator("#create-set").ClickAsync();
+        await Page.WaitForURLAsync("**/submit");
+        await EvaluatePage();
+    }
+}


### PR DESCRIPTION
### Context
[AB#212326](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/212326) [AB#210705](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/210705)

### Change proposed in this pull request
Added missing accessibility tests. Fixed test authentication to select first of multiple DSI organisations. Removed category filter from pipeline.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

