### PR TITLE
feat: user-defined comparator sets

### DIFF
--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -6,6 +6,7 @@ from contextlib import suppress
 import pandas as pd
 import tornado.iostream
 from azure.core.exceptions import ResourceNotFoundError
+from azure.storage.queue import QueueClient, QueueMessage
 from dotenv import load_dotenv
 from dask.distributed import Client
 
@@ -18,10 +19,10 @@ from src.pipeline.database import (
     insert_metric_rag,
     insert_schools_and_trusts_and_local_authorities,
     insert_non_financial_data,
-    insert_financial_data
+    insert_financial_data,
 )
 
-from src.pipeline.rag import compute_rag
+from src.pipeline.rag import compute_rag, compute_user_defined_rag
 from src.pipeline.comparator_sets import (
     compute_comparator_set,
     prepare_data,
@@ -111,7 +112,7 @@ def pre_process_ks4(set_type, year) -> pd.DataFrame:
     return ks4
 
 
-def pre_process_academy_ar(set_type, year) -> (pd.DataFrame, pd.DataFrame):
+def pre_process_academy_ar(set_type, year) -> tuple[pd.DataFrame, pd.DataFrame]:
     logger.info("Processing Academy AR Data")
     academy_ar_data = get_blob(raw_container, f"{set_type}/{year}/academy_ar.xlsx")
     aar = prepare_aar_data(academy_ar_data)
@@ -179,9 +180,7 @@ def pre_process_maintained_schools_data(set_type, year, data_ref) -> pd.DataFram
     )
 
     links_data = get_blob(
-        raw_container,
-        f"{set_type}/{year}/gias_all_links.csv",
-        encoding="cp1252"
+        raw_container, f"{set_type}/{year}/gias_all_links.csv", encoding="cp1252"
     )
 
     maintained_schools = build_maintained_school_data(
@@ -340,7 +339,14 @@ def compute_comparator_set_for(data_type, mix_type, set_type, year, data):
     insert_comparator_set(set_type, mix_type, year, result)
 
 
-def compute_comparator_sets(set_type, year):
+def compute_comparator_sets(set_type: str, year: int) -> float:
+    """
+    Determine Comparator Sets.
+
+    :param set_type: the triggering message type
+    :param year: financial year in question
+    :return: duration of calculation
+    """
     start_time = time.time()
     logger.info("Computing comparator sets")
 
@@ -350,7 +356,7 @@ def compute_comparator_sets(set_type, year):
         )
     )
 
-    ms = prepare_data(
+    maintained = prepare_data(
         pd.read_parquet(
             get_blob("pre-processed", f"{set_type}/{year}/maintained_schools.parquet")
         )
@@ -366,7 +372,7 @@ def compute_comparator_sets(set_type, year):
         "academy_comparators", "unmixed", set_type, year, academies
     )
     compute_comparator_set_for(
-        "maintained_schools_comparators", "unmixed", set_type, year, ms
+        "maintained_schools_comparators", "unmixed", set_type, year, maintained
     )
     compute_comparator_set_for(
         "mixed_comparators", "mixed", set_type, year, all_schools
@@ -381,7 +387,7 @@ def compute_comparator_sets(set_type, year):
     write_blob(
         "comparator-sets",
         f"{set_type}/{year}/maintained_schools.parquet",
-        ms.to_parquet(),
+        maintained.to_parquet(),
     )
 
     write_blob(
@@ -396,7 +402,14 @@ def compute_comparator_sets(set_type, year):
     return time_taken
 
 
-def compute_rag_for(data_type, mix_type, set_type, year, data, comparators):
+def compute_rag_for(
+    data_type: str,
+    mix_type: str,
+    set_type: str,
+    year: int,
+    data: pd.DataFrame,
+    comparators: pd.DataFrame,
+):
     st = time.time()
     logger.info(f"Computing {data_type} RAG")
     df = pd.DataFrame(compute_rag(data, comparators)).set_index("URN")
@@ -412,7 +425,14 @@ def compute_rag_for(data_type, mix_type, set_type, year, data, comparators):
     insert_metric_rag(set_type, mix_type, year, df)
 
 
-def run_compute_rag(set_type, year):
+def run_compute_rag(set_type: str, year: int):
+    """
+    Perform RAG calculations.
+
+    :param set_type: the triggering message type
+    :param year: financial year in question
+    :return: duration of RAG calculations
+    """
     start_time = time.time()
 
     ms_data = pd.read_parquet(
@@ -452,20 +472,129 @@ def run_compute_rag(set_type, year):
     return time_taken
 
 
-def handle_msg(worker_client, msg, worker_queue, complete_queue):
+def run_user_defined_rag(
+    year: int,
+    run_id: str,
+    target_urn: int,
+    comparator_set: pd.DataFrame,
+):
+    """
+    Perform user-defined RAG calculations.
+
+    Use the pre-processed "all-schools" data to guarantee coverage of
+    the user-defined comparator-set.
+
+    Note: `SetType` is _always_ "mixed" when persisted, for
+    user-defined comparator-sets; `run_type` is _always_ "default" for
+    the same.
+
+    :param year: financial year in question
+    :param run_id: unique run identifier
+    :param target_urn: URN of the "target" org.
+    :param comparator_set: user-defined comparator-set
+    :return: duration of RAG calculations
+    """
+    set_type = "mixed"
+    run_type = "default"
+
+    all_schools = prepare_data(
+        pd.read_parquet(
+            get_blob("pre-processed", f"{run_type}/{year}/all_schools.parquet")
+        )
+    )
+
+    st = time.time()
+    logger.info(f"Computing user-defined RAG ({run_id}).")
+    df = pd.DataFrame(
+        compute_user_defined_rag(
+            data=all_schools,
+            target_urn=target_urn,
+            set_urns=comparator_set,
+        )
+    ).set_index("URN")
+    logger.info(
+        f"Computing user-defined ({run_id}) RAG. Done in {time.time() - st:.2f} seconds."
+    )
+
+    write_blob(
+        "metric-rag",
+        f"{run_type}/{run_id}/user_defined.parquet",
+        df.to_parquet(),
+    )
+
+    insert_metric_rag(
+        run_type=run_type,
+        set_type=set_type,
+        year=run_id,
+        df=df,
+    )
+
+
+def handle_msg(
+    worker_client: Client,
+    msg: QueueMessage,
+    worker_queue: QueueClient,
+    complete_queue: QueueClient,
+):
+    """
+    Process an incoming message.
+
+    TODO: standard message format?
+
+    User-defined comparator set message _content_ will be of the form:
+
+    ```json
+    {
+        "jobId": "24463424-9642-4314-bb55-45424af6e812",
+        "type": "comparator-set",
+        "runId": "c321ef6a-3b1c-4ce2-8e32-0d0167bf2fa7",
+        "year": 2022,
+        "urn": "106057",
+        "payload": {
+            "kind": "ComparatorSetPayload",
+            "set": [
+                "145799",
+                "142875"
+            ]
+        }
+    }
+    ```
+
+    Note: user-defined comparator sets will assume pre-processing has
+    taken place for the year in question, failing if that does not hold
+    true.
+
+    :param worker_client: Dask client
+    :param msg: incoming message, triggering this process
+    :param worker_queue: incoming message queue (for deletion)
+    :param complete_queue: outcoming message queue (for completion)
+    :return: updated message payload
+    """
     msg_payload = json.loads(msg.content)
     try:
-        msg_payload["pre_process_duration"] = pre_process_data(
-            worker_client, msg_payload["type"], msg_payload["year"]
-        )
+        if (
+            payload := msg_payload.get("payload", {}).get("kind")
+            == "ComparatorSetPayload"
+        ):
+            msg_payload["rag_duration"] = run_user_defined_rag(
+                year=msg_payload["year"],
+                run_id=msg_payload["runId"],
+                target_urn=int(msg_payload["urn"]),
+                comparator_set=pd.DataFrame(map(int, payload["set"])),
+            )
+        else:
+            msg_payload["pre_process_duration"] = pre_process_data(
+                worker_client, msg_payload["type"], msg_payload["year"]
+            )
 
-        msg_payload["comparator_set_duration"] = compute_comparator_sets(
-            msg_payload["type"], msg_payload["year"]
-        )
+            msg_payload["comparator_set_duration"] = compute_comparator_sets(
+                msg_payload["type"],
+                msg_payload["year"],
+            )
 
-        msg_payload["rag_duration"] = run_compute_rag(
-            msg_payload["type"], msg_payload["year"]
-        )
+            msg_payload["rag_duration"] = run_compute_rag(
+                msg_payload["type"], msg_payload["year"]
+            )
 
         msg_payload["success"] = True
     except Exception as error:

--- a/data-pipeline/src/pipeline/rag.py
+++ b/data-pipeline/src/pipeline/rag.py
@@ -1,9 +1,12 @@
+import logging
 import math
 import warnings
 import time
+from typing import Generator
+
 import numpy as np
 import pandas as pd
-import logging
+
 from src.pipeline.config import rag_category_settings
 
 pd.options.mode.chained_assignment = None
@@ -230,3 +233,58 @@ def compute_rag(data, comparators):
                         exc_info=error,
                     )
                     return
+
+
+def compute_user_defined_rag(
+    data: pd.DataFrame,
+    target_urn: int,
+    set_urns: pd.DataFrame,
+) -> Generator[dict, None, None]:
+    """
+    Perform user-defined RAG calculation.
+
+    TODO: largely as per `compute_rag()` save that `set_urns` defines
+    the comparator set.
+
+    :param data: org. data for RAG computation
+    :param target_urn: URN of the reference org.
+    :param set_urns: URNs for use as the comparator-set
+    """
+    # reduce to only used columns so that extraction routines are more efficient
+    cols = data.columns.isin(base_cols) | data.columns.str.endswith("_Per Unit")
+    df = data[data.columns[cols]].fillna(0.0)
+
+    # Pre-computes the column accessors for each cost category
+    column_cache = {}
+    for category in rag_category_settings:
+        column_cache[category] = get_category_cols_predicates(category, df)
+    st = time.time()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        with np.errstate(invalid="ignore"):
+            target = df.loc[target_urn]
+            urn = target.name
+            try:
+                comparator_set = df[df.index.isin(set_urns)]
+                for category in rag_category_settings:
+                    rag_settings = rag_category_settings[category]
+                    for r in compute_category_rag(
+                        urn,
+                        category,
+                        rag_settings,
+                        target,
+                        comparator_set,
+                        column_cache,
+                    ):
+                        yield r
+                logger.debug(
+                    f"Completed user-defined RAGs in {time.time() - st:.2f} secs."
+                )
+                st = time.time()
+            except Exception as error:
+                logger.exception(
+                    f"An exception {type(error).__name__} occurred processing {urn}:",
+                    exc_info=error,
+                )
+                return


### PR DESCRIPTION
relates #212505

[AB#212505](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/212505)

### Context

Changes required to accommodate user-defined comparator sets.

### Change proposed in this pull request

- initial check in `main.py` as to whether the incoming message holds a user-defined comparator set;
- if so, skip pre-processing;
- run `run_user_defined_rag()` (a variant of the existing `run_compute_rag()` and `compute_rag_for()` functions);
- run `compute_user_defined_rag()` (similar to existing `compute_rag()`, less the comparator-set derivation);
- write to blob-storage;
- write to database.

### Guidance to review 

- have I correctly understood the pipeline flow?
- are there any specific requirements around the blob-storage/database keys?

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally

