### PR TITLE
Trust comparator set choice page

### DIFF
--- a/web/src/Web.App/Constants/BreadcrumbNodes.cs
+++ b/web/src/Web.App/Constants/BreadcrumbNodes.cs
@@ -109,6 +109,15 @@ public static class BreadcrumbNodes
         Parent = TrustHome(companyNumber)
     };
 
+    public static MvcBreadcrumbNode TrustComparators(string companyNumber) => new("Index", "TrustComparators", "Comparator sets")
+    {
+        RouteValues = new
+        {
+            companyNumber
+        },
+        Parent = TrustHome(companyNumber)
+    };
+
     public static MvcBreadcrumbNode LocalAuthorityHome(string code) => new("Index", "LocalAuthority", PageTitles.LocalAuthorityHome)
     {
         RouteValues = new

--- a/web/src/Web.App/Constants/PageTitles.cs
+++ b/web/src/Web.App/Constants/PageTitles.cs
@@ -53,4 +53,5 @@ public static class PageTitles
     public const string SchoolChangeDataWorkforceData = "Change workforce data";
     public const string LocalAuthorityHome = "Your local authority";
     public const string TrustSpending = "Spending priorities for this trust";
+    public const string TrustComparatorsCreateBy = "How do you want to choose your own set of trusts?";
 }

--- a/web/src/Web.App/Controllers/TrustComparatorsController.cs
+++ b/web/src/Web.App/Controllers/TrustComparatorsController.cs
@@ -1,0 +1,10 @@
+using Microsoft.AspNetCore.Mvc;
+namespace Web.App.Controllers;
+
+[Controller]
+[Route("trust/{companyNumber}/comparators")]
+public class TrustComparatorsController(ILogger<TrustComparatorsController> logger) : Controller
+{
+    [HttpGet]
+    public IActionResult Index(string companyNumber) => new StatusCodeResult(StatusCodes.Status302Found);
+}

--- a/web/src/Web.App/Controllers/TrustComparatorsCreateByController.cs
+++ b/web/src/Web.App/Controllers/TrustComparatorsCreateByController.cs
@@ -1,0 +1,77 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement.Mvc;
+using Web.App.Domain;
+using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Extensions;
+using Web.App.ViewModels;
+namespace Web.App.Controllers;
+
+[Controller]
+[Authorize]
+[FeatureGate(FeatureFlags.UserDefinedComparators, FeatureFlags.Trusts)]
+[Route("trust/{companyNumber}/comparators/create")]
+public class TrustComparatorsCreateByController(
+    ILogger<TrustComparatorsCreateByController> logger,
+    IEstablishmentApi establishmentApi
+) : Controller
+{
+    [HttpGet]
+    [Route("by")]
+    public async Task<IActionResult> Index(string companyNumber)
+    {
+        using (logger.BeginScope(new
+        {
+            urn = companyNumber
+        }))
+        {
+            try
+            {
+                ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.TrustComparators(companyNumber);
+
+                var trust = await establishmentApi.GetTrust(companyNumber).GetResultOrThrow<Trust>();
+                var viewModel = new TrustComparatorsViewModel(trust);
+                return View(viewModel);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "An error displaying create trust comparators by: {DisplayUrl}", Request.GetDisplayUrl());
+                return e is StatusCodeException s ? StatusCode((int)s.Status) : StatusCode(500);
+            }
+        }
+    }
+
+    [HttpPost]
+    [Route("by")]
+    public async Task<IActionResult> Index(string companyNumber, [FromForm] string? by)
+    {
+        if (!string.IsNullOrWhiteSpace(by))
+        {
+            return by.Equals("name", StringComparison.OrdinalIgnoreCase)
+                ? RedirectToAction("Name", new
+                {
+                    companyNumber
+                })
+                : RedirectToAction("Characteristic", new
+                {
+                    companyNumber
+                });
+        }
+
+        ModelState.AddModelError(nameof(by), "Select whether to choose trusts by name or characteristic");
+        ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.TrustComparators(companyNumber);
+
+        var trust = await establishmentApi.GetTrust(companyNumber).GetResultOrThrow<Trust>();
+        var viewModel = new TrustComparatorsViewModel(trust, by);
+        return View(viewModel);
+    }
+
+    [HttpGet]
+    [Route("by/name")]
+    public IActionResult Name(string companyNumber) => new StatusCodeResult(StatusCodes.Status302Found);
+
+    [HttpGet]
+    [Route("by/characteristic")]
+    public IActionResult Characteristic(string companyNumber) => new StatusCodeResult(StatusCodes.Status302Found);
+}

--- a/web/src/Web.App/ViewModels/TrustComparatorsViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustComparatorsViewModel.cs
@@ -1,0 +1,11 @@
+﻿using Web.App.Domain;
+namespace Web.App.ViewModels;
+
+public class TrustComparatorsViewModel(
+    Trust trust,
+    string? by = null)
+{
+    public string? CompanyNumber => trust.CompanyNumber;
+    public string? Name => trust.TrustName;
+    public string? By => by;
+}

--- a/web/src/Web.App/Views/TrustComparatorsCreateBy/Index.cshtml
+++ b/web/src/Web.App/Views/TrustComparatorsCreateBy/Index.cshtml
@@ -1,0 +1,53 @@
+﻿@using Web.App.Domain
+@using Web.App.Extensions
+@model Web.App.ViewModels.TrustComparatorsViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.TrustComparatorsCreateBy;
+}
+
+@await Component.InvokeAsync("EstablishmentHeading", new
+{
+    title = ViewData[ViewDataKeys.Title],
+    name = Model.Name,
+    id = Model.CompanyNumber,
+    kind = OrganisationTypes.Trust
+})
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        @await Html.PartialAsync("_ErrorSummary")
+        @using (Html.BeginForm("Index", "TrustComparatorsCreateBy", new
+                {
+                    companyNumber = Model.CompanyNumber
+                }, FormMethod.Post, true, new
+                {
+                    novalidate = "novalidate"
+                }))
+        {
+            <div class="@(ViewData.ModelState.HasError("by") ? "govuk-form-group govuk-form-group--error" : "govuk-form-group")">
+                <fieldset class="govuk-fieldset">
+                    <div class="govuk-radios" data-module="govuk-radios">
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="by-name" name="by" type="radio" value="name">
+                            <label class="govuk-label govuk-radios__label" for="by-name">
+                                By name
+                            </label>
+                        </div>
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="by-characteristic" name="by" type="radio" value="characteristic">
+                            <label class="govuk-label govuk-radios__label" for="by-characteristic">
+                                By characteristic
+                            </label>
+                            <div id="by-characteristic-item-hint" class="govuk-hint govuk-radios__hint">
+                                For example, number of pupils or schools.
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
+            </div>
+            <button type="submit" class="govuk-button" data-module="govuk-button" name="action" value="@FormAction.Continue">
+                Continue
+            </button>
+        }
+    </div>
+</div>

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/Comparators/WhenViewingComparatorsCreateBy.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/Comparators/WhenViewingComparatorsCreateBy.cs
@@ -1,0 +1,86 @@
+﻿using System.Net;
+using AngleSharp.Html.Dom;
+using AutoFixture;
+using Web.App.Domain;
+using Xunit;
+namespace Web.Integration.Tests.Pages.Trusts.Comparators;
+
+public class WhenViewingComparatorsCreateBy(SchoolBenchmarkingWebAppClient client)
+    : PageBase<SchoolBenchmarkingWebAppClient>(client)
+{
+    [Fact]
+    public async Task CanDisplay()
+    {
+        var (page, trust) = await SetupNavigateInitPage();
+        AssertPageLayout(page, trust);
+    }
+
+    [Fact]
+    public async Task CanNavigateToComparatorsByName()
+    {
+        var (page, trust) = await SetupNavigateInitPage();
+        var action = page.QuerySelector(".govuk-button");
+        Assert.NotNull(action);
+
+        page = await Client.SubmitForm(page.Forms[0], action, f =>
+        {
+            f.SetFormValues(new Dictionary<string, string>
+            {
+                {
+                    "by", "name"
+                }
+            });
+        });
+
+        DocumentAssert.AssertPageUrl(page, Paths.TrustComparatorsCreateByName(trust.CompanyNumber).ToAbsolute(), HttpStatusCode.Found);
+    }
+
+    [Fact]
+    public async Task CanNavigateToComparatorsByCharacteristic()
+    {
+        var (page, trust) = await SetupNavigateInitPage();
+        var action = page.QuerySelector(".govuk-button");
+        Assert.NotNull(action);
+
+        page = await Client.SubmitForm(page.Forms[0], action, f =>
+        {
+            f.SetFormValues(new Dictionary<string, string>
+            {
+                {
+                    "by", "characteristic"
+                }
+            });
+        });
+
+        DocumentAssert.AssertPageUrl(page, Paths.TrustComparatorsCreateByCharacteristic(trust.CompanyNumber).ToAbsolute(), HttpStatusCode.Found);
+    }
+
+    private async Task<(IHtmlDocument page, Trust Trust)> SetupNavigateInitPage()
+    {
+        var trust = Fixture.Build<Trust>()
+            .With(x => x.CompanyNumber, "12345")
+            .Create();
+
+        var page = await Client.SetupEstablishment(trust)
+            .Navigate(Paths.TrustComparatorsCreateBy(trust.CompanyNumber));
+
+        return (page, trust);
+    }
+
+    private static void AssertPageLayout(IHtmlDocument page, Trust trust)
+    {
+        var expectedBreadcrumbs = new[]
+        {
+            ("Home", Paths.ServiceHome.ToAbsolute()),
+            ("Your trust", Paths.TrustHome(trust.CompanyNumber).ToAbsolute()),
+            ("Comparator sets", Paths.TrustComparators(trust.CompanyNumber).ToAbsolute())
+        };
+        DocumentAssert.Breadcrumbs(page, expectedBreadcrumbs);
+        DocumentAssert.TitleAndH1(page,
+            "How do you want to choose your own set of trusts? - Financial Benchmarking and Insights Tool - GOV.UK",
+            "How do you want to choose your own set of trusts?");
+
+        var cta = page.QuerySelector(".govuk-button");
+        DocumentAssert.PrimaryCta(cta, "Continue", Paths.TrustComparatorsCreateBy(trust.CompanyNumber));
+    }
+}

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -72,6 +72,10 @@ public static class Paths
     public static string SchoolComparatorsCreatePreview(string? urn) => $"/school/{urn}/comparators/create/preview";
     public static string SchoolComparatorsCreateSubmit(string? urn) => $"/school/{urn}/comparators/create/submit";
 
+    public static string TrustComparators(string? companyNumber) => $"/trust/{companyNumber}/comparators";
+    public static string TrustComparatorsCreateBy(string? companyNumber) => $"/trust/{companyNumber}/comparators/create/by";
+    public static string TrustComparatorsCreateByName(string? companyNumber) => $"/trust/{companyNumber}/comparators/create/by/name";
+    public static string TrustComparatorsCreateByCharacteristic(string? companyNumber) => $"/trust/{companyNumber}/comparators/create/by/characteristic";
 
     public static string ApiSuggest(string search, string type) => $"api/suggest?search={search}&type={type}";
     public static string ApiEstablishmentExpenditure(string? type, string? id) => $"api/establishments/expenditure?type={type}&id={id}";


### PR DESCRIPTION
### Context
[AB#213056](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/213056)

### Change proposed in this pull request
Allow the user a choice between 'by name' or 'by characteristic' for trust-to-trust comparison.

### Guidance to review 
Requires DSI login to be able to test. Currently no other page links to this new one, either.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

