### PR TITLE
Selection and removal of 'other' comparator trusts by name

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -61,12 +61,18 @@
       data-sort-direction="asc"
     ></div>-->
     <form method="get">
-      <div id="school-suggester" data-exclude="123456,123457"></div>
+      <!--<div id="school-suggester" data-exclude="123456,123457"></div>
       <div
         id="la-suggester"
         data-input="Kent"
         data-code="886"
         data-exclude="Leeds,Essex"
+      ></div>-->
+      <div
+        id="trust-suggester"
+        data-input="TrustEd CSAT Alliance"
+        data-companyNumber="09617166"
+        data-exclude="06511936,07375627"
       ></div>
       <button type="submit">Submit</button>
     </form>

--- a/front-end-components/src/constants.tsx
+++ b/front-end-components/src/constants.tsx
@@ -12,3 +12,4 @@ export const SchoolEstablishment = "school";
 export const TrustEstablishment = "trust";
 export const SchoolSuggesterId = "school-suggester";
 export const LaSuggesterId = "la-suggester";
+export const TrustSuggesterId = "trust-suggester";

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -21,6 +21,7 @@ import {
   VerticalBarChart3SeriesElementId,
   SchoolSuggesterId,
   LaSuggesterId,
+  TrustSuggesterId,
 } from "src/constants";
 import { HorizontalBarChart } from "./components/charts/horizontal-bar-chart";
 import { VerticalBarChart } from "./components/charts/vertical-bar-chart";
@@ -42,6 +43,7 @@ import { ExpenditureData, Census } from "./services";
 import { LineChartTooltip } from "./components/charts/line-chart-tooltip";
 import SchoolInput from "./views/find-organisation/partials/school-input";
 import LaInput from "./views/find-organisation/partials/la-input";
+import TrustInput from "./views/find-organisation/partials/trust-input";
 
 const historicDataElement = document.getElementById(HistoricDataElementId);
 if (historicDataElement) {
@@ -526,6 +528,21 @@ if (laSuggesterElement) {
       <LaInput
         input={input || ""}
         code={code || ""}
+        exclude={exclude ? exclude.split(",") : undefined}
+      />
+    </React.StrictMode>
+  );
+}
+
+const trustSuggesterElement = document.getElementById(TrustSuggesterId);
+if (trustSuggesterElement) {
+  const { input, companyNumber, exclude } = trustSuggesterElement.dataset;
+  const root = ReactDOM.createRoot(trustSuggesterElement);
+  root.render(
+    <React.StrictMode>
+      <TrustInput
+        input={input || ""}
+        companyNumber={companyNumber || ""}
         exclude={exclude ? exclude.split(",") : undefined}
       />
     </React.StrictMode>

--- a/front-end-components/src/views/find-organisation/partials/trust-input.tsx
+++ b/front-end-components/src/views/find-organisation/partials/trust-input.tsx
@@ -8,24 +8,31 @@ import {
 import { v4 as uuidv4 } from "uuid";
 
 const TrustInput: React.FunctionComponent<TrustInputProps> = (props) => {
-  const { input, companyNumber } = props;
+  const { input, companyNumber, exclude } = props;
   const [inputValue, setInputValue] = useState<string>(input);
   const [selectedCompanyNumber, setSelectedCompanyNumber] =
     useState<string>(companyNumber);
 
   const handleSuggest = async (query: string) => {
+    const params = new URLSearchParams({
+      type: "trust",
+      search: query,
+    });
+    if (exclude) {
+      exclude.forEach((e) => {
+        params.append("exclude", e);
+      });
+    }
+
     try {
-      const res = await fetch(
-        "/api/suggest?" + new URLSearchParams({ type: "trust", search: query }),
-        {
-          redirect: "manual",
-          method: "GET",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Correlation-ID": uuidv4(),
-          },
-        }
-      );
+      const res = await fetch("/api/suggest?" + params, {
+        redirect: "manual",
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Correlation-ID": uuidv4(),
+        },
+      });
 
       const response = await res.json();
       if (response.error) {

--- a/front-end-components/src/views/find-organisation/types.tsx
+++ b/front-end-components/src/views/find-organisation/types.tsx
@@ -1,6 +1,7 @@
 export type TrustInputProps = {
   input: string;
   companyNumber: string;
+  exclude?: string[];
 };
 
 export type FindOrganisationProps = {

--- a/platform/src/apis/Platform.Api.Establishment/LocalAuthorities/LocalAuthoritiesFunctions.cs
+++ b/platform/src/apis/Platform.Api.Establishment/LocalAuthorities/LocalAuthoritiesFunctions.cs
@@ -91,8 +91,8 @@ public class LocalAuthoritiesFunctions
                 }
 
                 var names = req.Query["names"].ToString().Split(",").Where(x => !string.IsNullOrEmpty(x)).ToArray();
-                var trusts = await _service.SuggestAsync(body, names);
-                return new JsonContentResult(trusts);
+                var localAuthorities = await _service.SuggestAsync(body, names);
+                return new JsonContentResult(localAuthorities);
             }
             catch (Exception e)
             {

--- a/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesSuggestTrustsRequest.cs
+++ b/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesSuggestTrustsRequest.cs
@@ -14,7 +14,7 @@ public class WhenFunctionReceivesSuggestTrustsRequest : TrustsFunctionsTestBase
     public async Task ShouldReturn200OnValidRequest()
     {
         Service
-            .Setup(d => d.SuggestAsync(It.IsAny<SuggestRequest>()))
+            .Setup(d => d.SuggestAsync(It.IsAny<SuggestRequest>(), It.IsAny<string[]?>()))
             .ReturnsAsync(new SuggestResponse<Trust>());
 
         Validator

--- a/web/src/Web.App/Constants/PageTitles.cs
+++ b/web/src/Web.App/Constants/PageTitles.cs
@@ -54,4 +54,5 @@ public static class PageTitles
     public const string LocalAuthorityHome = "Your local authority";
     public const string TrustSpending = "Spending priorities for this trust";
     public const string TrustComparatorsCreateBy = "How do you want to choose your own set of trusts?";
+    public const string TrustComparatorsCreateByName = "Choose trusts to benchmark against";
 }

--- a/web/src/Web.App/Constants/SessionKeys.cs
+++ b/web/src/Web.App/Constants/SessionKeys.cs
@@ -7,4 +7,5 @@ public static class SessionKeys
     public static string ComparatorSetUserDefined(string urn) => $"comparator-set-user-defined-{urn}";
     public static string ComparatorSetUserDefined(string urn, string identifier) => $"comparator-set-user-defined-{urn}-{identifier}";
     public static string CustomData(string urn) => $"custom-data-{urn}";
+    public static string TrustComparatorSetUserDefined(string companyNumber) => $"trust-comparator-set-user-defined-{companyNumber}";
 }

--- a/web/src/Web.App/Controllers/Api/CensusProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/CensusProxyController.cs
@@ -5,7 +5,6 @@ using Web.App.Extensions;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Extensions;
 using Web.App.Services;
-
 namespace Web.App.Controllers.Api;
 
 [ApiController]
@@ -14,7 +13,7 @@ public class CensusProxyController(
     ILogger<ProxyController> logger,
     IEstablishmentApi establishmentApi,
     ICensusApi censusApi,
-    IComparatorSetService comparatorSetService,
+    ISchoolComparatorSetService schoolComparatorSetService,
     IUserDataService userDataService)
     : Controller
 {
@@ -22,7 +21,11 @@ public class CensusProxyController(
     [Produces("application/json")]
     public async Task<IActionResult> Query([FromQuery] string type, [FromQuery] string id, [FromQuery] string category, [FromQuery] string dimension, [FromQuery] string? phase)
     {
-        using (logger.BeginScope(new { type, id }))
+        using (logger.BeginScope(new
+        {
+            type,
+            id
+        }))
         {
             try
             {
@@ -51,7 +54,10 @@ public class CensusProxyController(
     [Route("history")]
     public async Task<IActionResult> History([FromQuery] string id, [FromQuery] string dimension)
     {
-        using (logger.BeginScope(new { id }))
+        using (logger.BeginScope(new
+        {
+            id
+        }))
         {
             try
             {
@@ -72,11 +78,11 @@ public class CensusProxyController(
         var userData = await userDataService.GetSchoolDataAsync(User.UserId(), id);
         if (string.IsNullOrEmpty(userData.ComparatorSet))
         {
-            var defaultSet = await comparatorSetService.ReadComparatorSet(id);
+            var defaultSet = await schoolComparatorSetService.ReadComparatorSet(id);
             return defaultSet.Pupil;
         }
 
-        var userDefinedSet = await comparatorSetService.ReadUserDefinedComparatorSet(id, userData.ComparatorSet);
+        var userDefinedSet = await schoolComparatorSetService.ReadUserDefinedComparatorSet(id, userData.ComparatorSet);
         return userDefinedSet.Set;
     }
 

--- a/web/src/Web.App/Controllers/Api/ProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/ProxyController.cs
@@ -5,7 +5,6 @@ using Web.App.Extensions;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Extensions;
 using Web.App.Services;
-
 namespace Web.App.Controllers.Api;
 
 [ApiController]
@@ -14,7 +13,7 @@ public class ProxyController(
     ILogger<ProxyController> logger,
     IEstablishmentApi establishmentApi,
     IFinanceService financeService,
-    IComparatorSetService comparatorSetService,
+    ISchoolComparatorSetService schoolComparatorSetService,
     IUserDataService userDataService)
     : Controller
 {
@@ -23,7 +22,11 @@ public class ProxyController(
     [Route("establishments/expenditure")]
     public async Task<IActionResult> EstablishmentExpenditure([FromQuery] string type, [FromQuery] string id, [FromQuery] string? phase)
     {
-        using (logger.BeginScope(new { type, id }))
+        using (logger.BeginScope(new
+        {
+            type,
+            id
+        }))
         {
             try
             {
@@ -52,7 +55,11 @@ public class ProxyController(
     [Route("establishments/expenditure/history")]
     public async Task<IActionResult> EstablishmentExpenditureHistory([FromQuery] string type, [FromQuery] string id, [FromQuery] string dimension)
     {
-        using (logger.BeginScope(new { type, id }))
+        using (logger.BeginScope(new
+        {
+            type,
+            id
+        }))
         {
             try
             {
@@ -100,12 +107,12 @@ public class ProxyController(
         var userData = await userDataService.GetSchoolDataAsync(User.UserId(), id);
         if (string.IsNullOrEmpty(userData.ComparatorSet))
         {
-            var defaultSet = await comparatorSetService.ReadComparatorSet(id);
+            var defaultSet = await schoolComparatorSetService.ReadComparatorSet(id);
             var defaultResult = await financeService.GetExpenditure(defaultSet.Pupil);
             return new JsonResult(defaultResult);
         }
 
-        var userDefinedSet = await comparatorSetService.ReadUserDefinedComparatorSet(id, userData.ComparatorSet);
+        var userDefinedSet = await schoolComparatorSetService.ReadUserDefinedComparatorSet(id, userData.ComparatorSet);
         var userDefinedResult = await financeService.GetExpenditure(userDefinedSet.Set);
         return new JsonResult(userDefinedResult);
     }

--- a/web/src/Web.App/Controllers/Api/SuggestProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/SuggestProxyController.cs
@@ -24,7 +24,7 @@ ISuggestService suggestService) : Controller
                         var schools = await suggestService.SchoolSuggestions(search, exclude);
                         return new JsonResult(schools);
                     case OrganisationTypes.Trust:
-                        var trusts = await suggestService.TrustSuggestions(search);
+                        var trusts = await suggestService.TrustSuggestions(search, exclude);
                         return new JsonResult(trusts);
                     case OrganisationTypes.LocalAuthority:
                         var localAuthorities = await suggestService.LocalAuthoritySuggestions(search, exclude);

--- a/web/src/Web.App/Controllers/SchoolComparatorsController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparatorsController.cs
@@ -8,7 +8,6 @@ using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Extensions;
 using Web.App.Services;
 using Web.App.ViewModels;
-
 namespace Web.App.Controllers;
 
 [Controller]
@@ -19,19 +18,22 @@ public class SchoolComparatorsController(
     IComparatorSetApi comparatorSetApi,
     ISchoolInsightApi schoolInsightApi,
     IUserDataService userDataService,
-    IComparatorSetService comparatorSetService) : Controller
+    ISchoolComparatorSetService schoolComparatorSetService) : Controller
 {
     [HttpGet]
     public async Task<IActionResult> Index(string urn)
     {
-        using (logger.BeginScope(new { urn }))
+        using (logger.BeginScope(new
+        {
+            urn
+        }))
         {
             try
             {
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.SchoolComparators(urn);
 
                 var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
-                var set = await comparatorSetApi.GetDefaultSchoolAsync(urn).GetResultOrThrow<ComparatorSet>();
+                var set = await comparatorSetApi.GetDefaultSchoolAsync(urn).GetResultOrThrow<SchoolComparatorSet>();
                 var pupil = await GetSchoolCharacteristics<SchoolCharacteristicPupil>(set.Pupil);
                 var building = await GetSchoolCharacteristics<SchoolCharacteristicBuilding>(set.Building);
 
@@ -52,7 +54,10 @@ public class SchoolComparatorsController(
     [FeatureGate(FeatureFlags.UserDefinedComparators)]
     public async Task<IActionResult> UserDefined(string urn)
     {
-        using (logger.BeginScope(new { urn }))
+        using (logger.BeginScope(new
+        {
+            urn
+        }))
         {
             try
             {
@@ -65,7 +70,7 @@ public class SchoolComparatorsController(
                 if (userData.ComparatorSet != null)
                 {
                     var userDefinedSet = await comparatorSetApi.GetUserDefinedSchoolAsync(urn, userData.ComparatorSet)
-                        .GetResultOrDefault<ComparatorSetUserDefined>();
+                        .GetResultOrDefault<UserDefinedSchoolComparatorSet>();
                     if (userDefinedSet != null)
                     {
                         schools = await GetSchoolCharacteristics<SchoolCharacteristicUserDefined>(userDefinedSet.Set);
@@ -89,7 +94,10 @@ public class SchoolComparatorsController(
     [FeatureGate(FeatureFlags.UserDefinedComparators)]
     public async Task<IActionResult> Revert(string urn)
     {
-        using (logger.BeginScope(new { urn }))
+        using (logger.BeginScope(new
+        {
+            urn
+        }))
         {
             try
             {
@@ -113,7 +121,10 @@ public class SchoolComparatorsController(
     [FeatureGate(FeatureFlags.UserDefinedComparators)]
     public async Task<IActionResult> RevertSet(string urn)
     {
-        using (logger.BeginScope(new { urn }))
+        using (logger.BeginScope(new
+        {
+            urn
+        }))
         {
             try
             {
@@ -123,12 +134,15 @@ public class SchoolComparatorsController(
                 if (userData.ComparatorSet != null)
                 {
                     await comparatorSetApi.RemoveUserDefinedSchoolAsync(urn, userData.ComparatorSet).EnsureSuccess();
-                    comparatorSetService.ClearUserDefinedComparatorSet(urn, userData.ComparatorSet);
+                    schoolComparatorSetService.ClearUserDefinedComparatorSet(urn, userData.ComparatorSet);
                 }
 
-                comparatorSetService.ClearUserDefinedComparatorSet(urn);
-                comparatorSetService.ClearUserDefinedCharacteristic(urn);
-                return RedirectToAction("Index", "School", new { urn });
+                schoolComparatorSetService.ClearUserDefinedComparatorSet(urn);
+                schoolComparatorSetService.ClearUserDefinedCharacteristic(urn);
+                return RedirectToAction("Index", "School", new
+                {
+                    urn
+                });
             }
             catch (Exception e)
             {

--- a/web/src/Web.App/Controllers/SchoolComparatorsCreateByController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparatorsCreateByController.cs
@@ -19,7 +19,7 @@ namespace Web.App.Controllers;
 public class SchoolComparatorsCreateByController(
     ILogger<SchoolComparatorsCreateByController> logger,
     IEstablishmentApi establishmentApi,
-    IComparatorSetService comparatorSetService,
+    ISchoolComparatorSetService schoolComparatorSetService,
     ISchoolInsightApi schoolInsightApi,
     IComparatorSetApi comparatorSetApi,
     IComparatorApi comparatorApi
@@ -94,16 +94,16 @@ public class SchoolComparatorsCreateByController(
                 }));
 
                 var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
-                ComparatorSetUserDefined userDefinedSet;
+                UserDefinedSchoolComparatorSet userDefinedSet;
                 if (string.IsNullOrEmpty(identifier))
                 {
-                    userDefinedSet = comparatorSetService.ReadUserDefinedComparatorSet(urn);
+                    userDefinedSet = schoolComparatorSetService.ReadUserDefinedComparatorSet(urn);
                 }
                 else
                 {
-                    userDefinedSet = await comparatorSetService.ReadUserDefinedComparatorSet(urn, identifier);
-                    comparatorSetService.ClearUserDefinedComparatorSet(urn, identifier);
-                    comparatorSetService.SetUserDefinedComparatorSet(urn, userDefinedSet);
+                    userDefinedSet = await schoolComparatorSetService.ReadUserDefinedComparatorSet(urn, identifier);
+                    schoolComparatorSetService.ClearUserDefinedComparatorSet(urn, identifier);
+                    schoolComparatorSetService.SetUserDefinedComparatorSet(urn, userDefinedSet);
                 }
 
                 var schoolsQuery = new ApiQuery();
@@ -134,7 +134,7 @@ public class SchoolComparatorsCreateByController(
             return RedirectToAction("Name");
         }
 
-        var userDefinedSet = comparatorSetService.ReadUserDefinedComparatorSet(urn);
+        var userDefinedSet = schoolComparatorSetService.ReadUserDefinedComparatorSet(urn);
         if (!string.IsNullOrWhiteSpace(viewModel.Urn) && !userDefinedSet.Set.Contains(viewModel.Urn))
         {
             var countOthers = userDefinedSet.Set.Count(s => s != urn);
@@ -145,7 +145,7 @@ public class SchoolComparatorsCreateByController(
             }
 
             userDefinedSet.Set = userDefinedSet.Set.ToList().Append(viewModel.Urn).ToArray();
-            comparatorSetService.SetUserDefinedComparatorSet(urn, userDefinedSet);
+            schoolComparatorSetService.SetUserDefinedComparatorSet(urn, userDefinedSet);
         }
 
         return RedirectToAction("Name", new
@@ -166,13 +166,13 @@ public class SchoolComparatorsCreateByController(
             });
         }
 
-        var userDefinedSet = comparatorSetService.ReadUserDefinedComparatorSet(urn);
+        var userDefinedSet = schoolComparatorSetService.ReadUserDefinedComparatorSet(urn);
         if (!string.IsNullOrWhiteSpace(viewModel.Urn) && userDefinedSet.Set.Contains(viewModel.Urn))
         {
             var set = userDefinedSet.Set.ToList();
             set.Remove(viewModel.Urn);
             userDefinedSet.Set = set.ToArray();
-            comparatorSetService.SetUserDefinedComparatorSet(urn, userDefinedSet);
+            schoolComparatorSetService.SetUserDefinedComparatorSet(urn, userDefinedSet);
         }
 
         return RedirectToAction("Name", new
@@ -193,7 +193,7 @@ public class SchoolComparatorsCreateByController(
             try
             {
                 var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
-                var userDefinedSet = comparatorSetService.ReadUserDefinedComparatorSet(urn);
+                var userDefinedSet = schoolComparatorSetService.ReadUserDefinedComparatorSet(urn);
                 if (userDefinedSet.Set.Length == 0)
                 {
                     return RedirectToAction("Index", new
@@ -219,8 +219,8 @@ public class SchoolComparatorsCreateByController(
                 };
 
                 await comparatorSetApi.UpsertUserDefinedSchoolAsync(request).EnsureSuccess();
-                comparatorSetService.ClearUserDefinedComparatorSet(urn);
-                comparatorSetService.ClearUserDefinedCharacteristic(urn);
+                schoolComparatorSetService.ClearUserDefinedComparatorSet(urn);
+                schoolComparatorSetService.ClearUserDefinedCharacteristic(urn);
                 var viewModel = new SchoolComparatorsSubmittedViewModel(school, request);
                 return View(viewModel);
             }
@@ -255,7 +255,7 @@ public class SchoolComparatorsCreateByController(
                     urn
                 });
 
-                var userDefinedCharacteristic = comparatorSetService.ReadUserDefinedCharacteristic(urn);
+                var userDefinedCharacteristic = schoolComparatorSetService.ReadUserDefinedCharacteristic(urn);
                 var viewModel = new SchoolComparatorsByCharacteristicViewModel(school, characteristics?.FirstOrDefault(), userDefinedCharacteristic);
                 return View(viewModel);
             }
@@ -300,7 +300,7 @@ public class SchoolComparatorsCreateByController(
                     }
 
                     viewModel.LaNamesMutated = true;
-                    comparatorSetService.SetUserDefinedCharacteristic(urn, viewModel);
+                    schoolComparatorSetService.SetUserDefinedCharacteristic(urn, viewModel);
                     return RedirectToAction(nameof(Characteristic), new
                     {
                         urn
@@ -323,7 +323,7 @@ public class SchoolComparatorsCreateByController(
                         ModelState.SetModelValue(nameof(viewModel.Code), null, null);
                     }
 
-                    comparatorSetService.ClearUserDefinedCharacteristic(urn);
+                    schoolComparatorSetService.ClearUserDefinedCharacteristic(urn);
                     return RedirectToAction(nameof(Characteristic));
                 }
 
@@ -348,8 +348,8 @@ public class SchoolComparatorsCreateByController(
                     return RedirectToAction(nameof(Characteristic));
                 }
 
-                comparatorSetService.SetUserDefinedCharacteristic(urn, viewModel);
-                comparatorSetService.SetUserDefinedComparatorSet(urn, new ComparatorSetUserDefined
+                schoolComparatorSetService.SetUserDefinedCharacteristic(urn, viewModel);
+                schoolComparatorSetService.SetUserDefinedComparatorSet(urn, new UserDefinedSchoolComparatorSet
                 {
                     Set = results.Schools.ToArray(),
                     TotalSchools = results.TotalSchools
@@ -386,7 +386,7 @@ public class SchoolComparatorsCreateByController(
                 }));
 
                 var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
-                var userDefinedSet = comparatorSetService.ReadUserDefinedComparatorSet(urn);
+                var userDefinedSet = schoolComparatorSetService.ReadUserDefinedComparatorSet(urn);
                 if (userDefinedSet.Set.Length <= 1)
                 {
                     return RedirectToAction(nameof(Characteristic), new
@@ -395,7 +395,7 @@ public class SchoolComparatorsCreateByController(
                     });
                 }
 
-                var userDefinedCharacteristic = comparatorSetService.ReadUserDefinedCharacteristic(urn);
+                var userDefinedCharacteristic = schoolComparatorSetService.ReadUserDefinedCharacteristic(urn);
                 var characteristics = await GetSchoolCharacteristics<SchoolCharacteristic>(userDefinedSet.Set.Where(s => s != urn));
                 var viewModel = new SchoolComparatorsPreviewViewModel(
                     school,

--- a/web/src/Web.App/Controllers/SchoolSpendingController.cs
+++ b/web/src/Web.App/Controllers/SchoolSpendingController.cs
@@ -6,24 +6,26 @@ using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Extensions;
 using Web.App.Services;
 using Web.App.ViewModels;
-
 namespace Web.App.Controllers;
 
 [Controller]
 [Route("school/{urn}/spending-and-costs")]
 public class SchoolSpendingController(
-        ILogger<SchoolController> logger,
-        IEstablishmentApi establishmentApi,
-        IFinanceService financeService,
-        IComparatorSetService comparatorSetService,
-        IMetricRagRatingApi metricRagRatingApi,
-        IUserDataService userDataService)
+    ILogger<SchoolController> logger,
+    IEstablishmentApi establishmentApi,
+    IFinanceService financeService,
+    ISchoolComparatorSetService schoolComparatorSetService,
+    IMetricRagRatingApi metricRagRatingApi,
+    IUserDataService userDataService)
     : Controller
 {
     [HttpGet]
     public async Task<IActionResult> Index(string urn)
     {
-        using (logger.BeginScope(new { urn }))
+        using (logger.BeginScope(new
+        {
+            urn
+        }))
         {
             try
             {
@@ -33,7 +35,7 @@ public class SchoolSpendingController(
                 var userData = await userDataService.GetSchoolDataAsync(User.UserId(), urn);
 
                 var ratings = await metricRagRatingApi.GetDefaultAsync(new ApiQuery().AddIfNotNull("urns", urn)).GetResultOrThrow<RagRating[]>();
-                var set = await comparatorSetService.ReadComparatorSet(urn);
+                var set = await schoolComparatorSetService.ReadComparatorSet(urn);
 
                 var pupilExpenditure = await financeService.GetExpenditure(set.Pupil);
                 var areaExpenditure = await financeService.GetExpenditure(set.Building);

--- a/web/src/Web.App/Controllers/TrustComparatorsCreateByController.cs
+++ b/web/src/Web.App/Controllers/TrustComparatorsCreateByController.cs
@@ -2,9 +2,12 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.FeatureManagement.Mvc;
+using Web.App.Attributes;
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Extensions;
+using Web.App.Services;
+using Web.App.TagHelpers;
 using Web.App.ViewModels;
 namespace Web.App.Controllers;
 
@@ -14,7 +17,9 @@ namespace Web.App.Controllers;
 [Route("trust/{companyNumber}/comparators/create")]
 public class TrustComparatorsCreateByController(
     ILogger<TrustComparatorsCreateByController> logger,
-    IEstablishmentApi establishmentApi
+    IEstablishmentApi establishmentApi,
+    ITrustComparatorSetService trustComparatorSetService,
+    ITrustInsightApi trustInsightApi
 ) : Controller
 {
     [HttpGet]
@@ -69,9 +74,86 @@ public class TrustComparatorsCreateByController(
 
     [HttpGet]
     [Route("by/name")]
-    public IActionResult Name(string companyNumber) => new StatusCodeResult(StatusCodes.Status302Found);
+    [ImportModelState]
+    public async Task<IActionResult> Name(string companyNumber)
+    {
+        using (logger.BeginScope(new
+        {
+            companyNumber,
+        }))
+        {
+            try
+            {
+                ViewData[ViewDataKeys.Backlink] = new BacklinkInfo(Url.Action(nameof(Index), new
+                {
+                    companyNumber
+                }));
+
+                var trust = await establishmentApi.GetTrust(companyNumber).GetResultOrThrow<Trust>();
+                var userDefinedSet = trustComparatorSetService.ReadUserDefinedComparatorSet(companyNumber);
+                var trustsQuery = new ApiQuery();
+                foreach (var selectedCompanyNumber in userDefinedSet.Set)
+                {
+                    trustsQuery.AddIfNotNull("companyNumbers", selectedCompanyNumber);
+                }
+
+                var trustCharacteristics = await GetTrustCharacteristics<TrustCharacteristicUserDefined>(userDefinedSet.Set);
+                var viewModel = new TrustComparatorsByNameViewModel(trust, trustCharacteristics);
+                return View(viewModel);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "An error displaying create trust comparators by name: {DisplayUrl}", Request.GetDisplayUrl());
+                return e is StatusCodeException s ? StatusCode((int)s.Status) : StatusCode(500);
+            }
+        }
+    }
+
+    [HttpPost]
+    [Route("by/name")]
+    [ExportModelState]
+    public IActionResult Name([FromRoute] string companyNumber, [FromForm] TrustComparatorsCompanyNumberViewModel viewModel)
+    {
+        if (!ModelState.IsValid)
+        {
+            return RedirectToAction("Name");
+        }
+
+        var userDefinedSet = trustComparatorSetService.ReadUserDefinedComparatorSet(companyNumber);
+        if (!string.IsNullOrWhiteSpace(viewModel.CompanyNumber) && !userDefinedSet.Set.Contains(viewModel.CompanyNumber))
+        {
+            var countOthers = userDefinedSet.Set.Count(s => s != companyNumber);
+            if (countOthers >= 9)
+            {
+                ModelState.AddModelError(nameof(TrustComparatorsCompanyNumberViewModel.CompanyNumber), "Maximum number of comparison trusts reached");
+                return RedirectToAction("Name");
+            }
+
+            userDefinedSet.Set = userDefinedSet.Set.ToList().Append(viewModel.CompanyNumber).ToArray();
+            trustComparatorSetService.SetUserDefinedComparatorSet(companyNumber, userDefinedSet);
+        }
+
+        return RedirectToAction("Name", new
+        {
+            companyNumber
+        });
+    }
 
     [HttpGet]
     [Route("by/characteristic")]
     public IActionResult Characteristic(string companyNumber) => new StatusCodeResult(StatusCodes.Status302Found);
+
+    private async Task<T[]?> GetTrustCharacteristics<T>(IEnumerable<string> set)
+    {
+        var query = new ApiQuery();
+        var trusts = set as string[] ?? set.ToArray();
+        if (trusts.Length != 0)
+        {
+            foreach (var companyNumber in trusts)
+            {
+                query.AddIfNotNull("companyNumbers", companyNumber);
+            }
+        }
+        return await trustInsightApi.GetCharacteristicsAsync(query).GetResultOrDefault<T[]>();
+    }
 }

--- a/web/src/Web.App/Controllers/TrustComparatorsCreateByController.cs
+++ b/web/src/Web.App/Controllers/TrustComparatorsCreateByController.cs
@@ -28,7 +28,7 @@ public class TrustComparatorsCreateByController(
     {
         using (logger.BeginScope(new
         {
-            urn = companyNumber
+            companyNumber
         }))
         {
             try
@@ -79,7 +79,7 @@ public class TrustComparatorsCreateByController(
     {
         using (logger.BeginScope(new
         {
-            companyNumber,
+            companyNumber
         }))
         {
             try
@@ -138,6 +138,37 @@ public class TrustComparatorsCreateByController(
             companyNumber
         });
     }
+
+    [HttpPost]
+    [Route("remove")]
+    public IActionResult Remove([FromRoute] string companyNumber, [FromForm] TrustComparatorsCompanyNumberViewModel viewModel)
+    {
+        if (!ModelState.IsValid)
+        {
+            return RedirectToAction("Name", new
+            {
+                companyNumber
+            });
+        }
+
+        var userDefinedSet = trustComparatorSetService.ReadUserDefinedComparatorSet(companyNumber);
+        if (!string.IsNullOrWhiteSpace(viewModel.CompanyNumber) && userDefinedSet.Set.Contains(viewModel.CompanyNumber))
+        {
+            var set = userDefinedSet.Set.ToList();
+            set.Remove(viewModel.CompanyNumber);
+            userDefinedSet.Set = set.ToArray();
+            trustComparatorSetService.SetUserDefinedComparatorSet(companyNumber, userDefinedSet);
+        }
+
+        return RedirectToAction("Name", new
+        {
+            companyNumber
+        });
+    }
+
+    [HttpGet]
+    [Route("submit")]
+    public IActionResult Submit(string companyNumber) => new StatusCodeResult(StatusCodes.Status302Found);
 
     [HttpGet]
     [Route("by/characteristic")]

--- a/web/src/Web.App/Domain/SchoolComparatorSet.cs
+++ b/web/src/Web.App/Domain/SchoolComparatorSet.cs
@@ -2,13 +2,13 @@ using System.Diagnostics.CodeAnalysis;
 namespace Web.App.Domain;
 
 [ExcludeFromCodeCoverage]
-public record ComparatorSet
+public record SchoolComparatorSet
 {
     public IEnumerable<string> Pupil { get; set; } = Array.Empty<string>();
     public IEnumerable<string> Building { get; set; } = Array.Empty<string>();
 }
 
-public record ComparatorSetUserDefined
+public record UserDefinedSchoolComparatorSet
 {
     public string? RunId { get; set; }
     public long? TotalSchools { get; set; }

--- a/web/src/Web.App/Domain/TrustCharacteristic.cs
+++ b/web/src/Web.App/Domain/TrustCharacteristic.cs
@@ -1,0 +1,24 @@
+﻿namespace Web.App.Domain;
+
+public record TrustCharacteristic
+{
+    public string? CompanyNumber { get; set; }
+    public string? TrustName { get; set; }
+    public string? Address { get; set; }
+
+    public double? TotalPupils { get; set; }
+    public double? SchoolsInTrust { get; set; }
+    public double? TotalIncome { get; set; }
+    public string[]? PhasesCovered { get; set; }
+    public DateTime? OpenDate { get; set; }
+    public double? PercentFreeSchoolMeals { get; set; }
+    public double? PercentSpecialEducationNeeds { get; set; }
+    public double? TotalInternalFloorArea { get; set; }
+}
+
+public record TrustCharacteristicUserDefined
+{
+    public string? CompanyNumber { get; set; }
+    public string? TrustName { get; set; }
+    public string? Address { get; set; }
+}

--- a/web/src/Web.App/Domain/TrustCharacteristic.cs
+++ b/web/src/Web.App/Domain/TrustCharacteristic.cs
@@ -4,21 +4,17 @@ public record TrustCharacteristic
 {
     public string? CompanyNumber { get; set; }
     public string? TrustName { get; set; }
-    public string? Address { get; set; }
 
-    public double? TotalPupils { get; set; }
-    public double? SchoolsInTrust { get; set; }
-    public double? TotalIncome { get; set; }
-    public string[]? PhasesCovered { get; set; }
-    public DateTime? OpenDate { get; set; }
-    public double? PercentFreeSchoolMeals { get; set; }
-    public double? PercentSpecialEducationNeeds { get; set; }
-    public double? TotalInternalFloorArea { get; set; }
+    public decimal? TotalPupils { get; set; }
+    public decimal? SchoolsInTrust { get; set; }
+    public decimal? TotalIncome { get; set; }
 }
 
 public record TrustCharacteristicUserDefined
 {
     public string? CompanyNumber { get; set; }
     public string? TrustName { get; set; }
-    public string? Address { get; set; }
+    public decimal? TotalPupils { get; set; }
+    public decimal? SchoolsInTrust { get; set; }
+    public decimal? TotalIncome { get; set; }
 }

--- a/web/src/Web.App/Domain/TrustComparatorSet.cs
+++ b/web/src/Web.App/Domain/TrustComparatorSet.cs
@@ -1,0 +1,7 @@
+namespace Web.App.Domain;
+
+public record TrustComparatorSetUserDefined
+{
+    public long? TotalTrusts { get; set; }
+    public string[] Set { get; set; } = [];
+}

--- a/web/src/Web.App/Infrastructure/Apis/EstablishmentApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/EstablishmentApi.cs
@@ -33,12 +33,12 @@ public class EstablishmentApi(HttpClient httpClient, string? key = default)
         });
     }
 
-    public Task<ApiResult> SuggestTrusts(string search)
+    public Task<ApiResult> SuggestTrusts(string search, ApiQuery? query = null)
     {
         return SendAsync(new HttpRequestMessage
         {
             Method = HttpMethod.Post,
-            RequestUri = new Uri("api/trusts/suggest", UriKind.Relative),
+            RequestUri = new Uri($"api/trusts/suggest{query?.ToQueryString()}", UriKind.Relative),
             Content = new JsonContent(new { SearchText = search, Size = 10, SuggesterName = "trust-suggester" })
         });
     }
@@ -61,6 +61,6 @@ public interface IEstablishmentApi
     Task<ApiResult> GetLocalAuthority(string? identifier);
     Task<ApiResult> QuerySchools(ApiQuery? query);
     Task<ApiResult> SuggestSchools(string search, ApiQuery? query = null);
-    Task<ApiResult> SuggestTrusts(string search);
+    Task<ApiResult> SuggestTrusts(string search, ApiQuery? query = null);
     Task<ApiResult> SuggestLocalAuthorities(string search, ApiQuery? query = null);
 }

--- a/web/src/Web.App/Infrastructure/Apis/TrustInsightApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/TrustInsightApi.cs
@@ -1,0 +1,24 @@
+﻿using Web.App.Domain;
+namespace Web.App.Infrastructure.Apis;
+
+public class TrustInsightApi(HttpClient httpClient, string? key = default) : ApiBase(httpClient, key), ITrustInsightApi
+{
+    public Task<ApiResult> GetCharacteristicsAsync(ApiQuery? query = null)
+    {
+        var stubCompanies = query?
+            .Where(q => q.Key == "companyNumbers")
+            .Select(q => new TrustCharacteristicUserDefined
+            {
+                CompanyNumber = q.Value,
+                TrustName = "ACME Trust",
+                Address = "Stub Street, Fakesville"
+            }) ?? [];
+
+        return Task.FromResult(ApiResult.Ok(stubCompanies));
+    }
+}
+
+public interface ITrustInsightApi
+{
+    Task<ApiResult> GetCharacteristicsAsync(ApiQuery? query = null);
+}

--- a/web/src/Web.App/Infrastructure/Apis/TrustInsightApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/TrustInsightApi.cs
@@ -10,8 +10,10 @@ public class TrustInsightApi(HttpClient httpClient, string? key = default) : Api
             .Select(q => new TrustCharacteristicUserDefined
             {
                 CompanyNumber = q.Value,
-                TrustName = "ACME Trust",
-                Address = "Stub Street, Fakesville"
+                TrustName = "ACME Trust " + q.Value,
+                SchoolsInTrust = 12,
+                TotalPupils = 345,
+                TotalIncome = 123_456_789
             }) ?? [];
 
         return Task.FromResult(ApiResult.Ok(stubCompanies));

--- a/web/src/Web.App/Program.cs
+++ b/web/src/Web.App/Program.cs
@@ -14,7 +14,6 @@ using Web.App.Infrastructure.Apis;
 using Web.App.Middleware;
 using Web.App.Services;
 using Web.App.Validators;
-
 [assembly: InternalsVisibleTo("Web.Tests")]
 
 CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-GB");
@@ -44,6 +43,7 @@ builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<IFinanceService, FinanceService>();
 builder.Services.AddScoped<IFinancialPlanService, FinancialPlanService>();
 builder.Services.AddScoped<ISchoolComparatorSetService, SchoolComparatorSetService>();
+builder.Services.AddScoped<ITrustComparatorSetService, TrustComparatorSetService>();
 builder.Services.AddScoped<ISuggestService, SuggestService>();
 builder.Services.AddScoped<IFinancialPlanStageValidator, FinancialPlanStageValidator>();
 builder.Services.AddScoped<ICustomDataService, CustomDataService>();
@@ -122,6 +122,9 @@ if (!builder.Environment.IsIntegration())
 
     builder.Services.AddHttpClient<IUserDataApi, UserDataApi>()
         .ConfigureHttpClientForApi(Constants.BenchmarkApi);
+
+    builder.Services.AddHttpClient<ITrustInsightApi, TrustInsightApi>()
+        .ConfigureHttpClientForApi(Constants.InsightApi);
 }
 
 var app = builder.Build();

--- a/web/src/Web.App/Program.cs
+++ b/web/src/Web.App/Program.cs
@@ -43,7 +43,7 @@ builder.Services.AddHealthChecks();
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<IFinanceService, FinanceService>();
 builder.Services.AddScoped<IFinancialPlanService, FinancialPlanService>();
-builder.Services.AddScoped<IComparatorSetService, ComparatorSetService>();
+builder.Services.AddScoped<ISchoolComparatorSetService, SchoolComparatorSetService>();
 builder.Services.AddScoped<ISuggestService, SuggestService>();
 builder.Services.AddScoped<IFinancialPlanStageValidator, FinancialPlanStageValidator>();
 builder.Services.AddScoped<ICustomDataService, CustomDataService>();

--- a/web/src/Web.App/Services/SchoolComparatorSetService.cs
+++ b/web/src/Web.App/Services/SchoolComparatorSetService.cs
@@ -5,36 +5,36 @@ using Web.App.Infrastructure.Extensions;
 using Web.App.ViewModels;
 namespace Web.App.Services;
 
-public interface IComparatorSetService
+public interface ISchoolComparatorSetService
 {
-    Task<ComparatorSet> ReadComparatorSet(string urn);
-    Task<ComparatorSetUserDefined> ReadUserDefinedComparatorSet(string urn, string identifier);
-    ComparatorSetUserDefined ReadUserDefinedComparatorSet(string urn);
-    ComparatorSetUserDefined SetUserDefinedComparatorSet(string urn, ComparatorSetUserDefined set);
+    Task<SchoolComparatorSet> ReadComparatorSet(string urn);
+    Task<UserDefinedSchoolComparatorSet> ReadUserDefinedComparatorSet(string urn, string identifier);
+    UserDefinedSchoolComparatorSet ReadUserDefinedComparatorSet(string urn);
+    UserDefinedSchoolComparatorSet SetUserDefinedComparatorSet(string urn, UserDefinedSchoolComparatorSet set);
     void ClearUserDefinedComparatorSet(string urn, string? identifier = null);
     UserDefinedCharacteristicViewModel? ReadUserDefinedCharacteristic(string urn);
     UserDefinedCharacteristicViewModel SetUserDefinedCharacteristic(string urn, UserDefinedCharacteristicViewModel characteristic);
     void ClearUserDefinedCharacteristic(string urn);
 }
 
-public class ComparatorSetService(IHttpContextAccessor httpContextAccessor, IComparatorSetApi api) : IComparatorSetService
+public class SchoolComparatorSetService(IHttpContextAccessor httpContextAccessor, IComparatorSetApi api) : ISchoolComparatorSetService
 {
-    public async Task<ComparatorSet> ReadComparatorSet(string urn)
+    public async Task<SchoolComparatorSet> ReadComparatorSet(string urn)
     {
         var key = SessionKeys.ComparatorSet(urn);
         var context = httpContextAccessor.HttpContext;
 
-        var set = context?.Session.Get<ComparatorSet>(key);
+        var set = context?.Session.Get<SchoolComparatorSet>(key);
 
         return set ?? await SetComparatorSet(urn);
     }
 
-    public async Task<ComparatorSetUserDefined> ReadUserDefinedComparatorSet(string urn, string identifier)
+    public async Task<UserDefinedSchoolComparatorSet> ReadUserDefinedComparatorSet(string urn, string identifier)
     {
         var key = SessionKeys.ComparatorSetUserDefined(urn, identifier);
         var context = httpContextAccessor.HttpContext;
 
-        var set = context?.Session.Get<ComparatorSetUserDefined>(key);
+        var set = context?.Session.Get<UserDefinedSchoolComparatorSet>(key);
 
         return set ?? await SetUserDefinedComparatorSet(urn, identifier);
     }
@@ -49,17 +49,17 @@ public class ComparatorSetService(IHttpContextAccessor httpContextAccessor, ICom
         context?.Session.Remove(key);
     }
 
-    public ComparatorSetUserDefined ReadUserDefinedComparatorSet(string urn)
+    public UserDefinedSchoolComparatorSet ReadUserDefinedComparatorSet(string urn)
     {
         var key = SessionKeys.ComparatorSetUserDefined(urn);
         var context = httpContextAccessor.HttpContext;
 
-        var set = context?.Session.Get<ComparatorSetUserDefined>(key);
+        var set = context?.Session.Get<UserDefinedSchoolComparatorSet>(key);
 
-        return set ?? SetUserDefinedComparatorSet(urn, new ComparatorSetUserDefined());
+        return set ?? SetUserDefinedComparatorSet(urn, new UserDefinedSchoolComparatorSet());
     }
 
-    public ComparatorSetUserDefined SetUserDefinedComparatorSet(string urn, ComparatorSetUserDefined set)
+    public UserDefinedSchoolComparatorSet SetUserDefinedComparatorSet(string urn, UserDefinedSchoolComparatorSet set)
     {
         var key = SessionKeys.ComparatorSetUserDefined(urn);
         var context = httpContextAccessor.HttpContext;
@@ -91,24 +91,24 @@ public class ComparatorSetService(IHttpContextAccessor httpContextAccessor, ICom
         context?.Session.Remove(key);
     }
 
-    private async Task<ComparatorSet> SetComparatorSet(string urn)
+    private async Task<SchoolComparatorSet> SetComparatorSet(string urn)
     {
         var key = SessionKeys.ComparatorSet(urn);
         var context = httpContextAccessor.HttpContext;
 
-        var set = await api.GetDefaultSchoolAsync(urn).GetResultOrThrow<ComparatorSet>();
+        var set = await api.GetDefaultSchoolAsync(urn).GetResultOrThrow<SchoolComparatorSet>();
 
         context?.Session.Set(key, set);
 
         return set;
     }
 
-    private async Task<ComparatorSetUserDefined> SetUserDefinedComparatorSet(string urn, string identifier)
+    private async Task<UserDefinedSchoolComparatorSet> SetUserDefinedComparatorSet(string urn, string identifier)
     {
         var key = SessionKeys.ComparatorSetUserDefined(urn, identifier);
         var context = httpContextAccessor.HttpContext;
 
-        var set = await api.GetUserDefinedSchoolAsync(urn, identifier).GetResultOrThrow<ComparatorSetUserDefined>();
+        var set = await api.GetUserDefinedSchoolAsync(urn, identifier).GetResultOrThrow<UserDefinedSchoolComparatorSet>();
         context?.Session.Set(key, set);
 
         return set;

--- a/web/src/Web.App/Services/SuggestService.cs
+++ b/web/src/Web.App/Services/SuggestService.cs
@@ -7,7 +7,7 @@ namespace Web.App.Services;
 public interface ISuggestService
 {
     Task<IEnumerable<SuggestValue<School>>> SchoolSuggestions(string search, string[]? excludeSchools = null);
-    Task<IEnumerable<SuggestValue<Trust>>> TrustSuggestions(string search);
+    Task<IEnumerable<SuggestValue<Trust>>> TrustSuggestions(string search, string[]? excludeTrusts = null);
     Task<IEnumerable<SuggestValue<LocalAuthority>>> LocalAuthoritySuggestions(string search, string[]? excludeLas = null);
 }
 
@@ -51,9 +51,18 @@ public class SuggestService(IEstablishmentApi establishmentApi) : ISuggestServic
         });
     }
 
-    public async Task<IEnumerable<SuggestValue<Trust>>> TrustSuggestions(string search)
+    public async Task<IEnumerable<SuggestValue<Trust>>> TrustSuggestions(string search, string[]? excludeTrusts = null)
     {
-        var suggestions = await establishmentApi.SuggestTrusts(search).GetResultOrThrow<SuggestOutput<Trust>>();
+        var query = new ApiQuery();
+        if (excludeTrusts != null)
+        {
+            foreach (var school in excludeTrusts)
+            {
+                query.AddIfNotNull("companyNumbers", school);
+            }
+        }
+
+        var suggestions = await establishmentApi.SuggestTrusts(search, query).GetResultOrThrow<SuggestOutput<Trust>>();
         return suggestions.Results.Select(value =>
         {
             var text = value.Text?.Replace("*", "");

--- a/web/src/Web.App/Services/TrustComparatorSetService.cs
+++ b/web/src/Web.App/Services/TrustComparatorSetService.cs
@@ -1,0 +1,32 @@
+using Web.App.Domain;
+using Web.App.Extensions;
+namespace Web.App.Services;
+
+public interface ITrustComparatorSetService
+{
+    TrustComparatorSetUserDefined ReadUserDefinedComparatorSet(string companyNumber);
+    TrustComparatorSetUserDefined SetUserDefinedComparatorSet(string companyNumber, TrustComparatorSetUserDefined set);
+}
+
+public class TrustComparatorSetService(IHttpContextAccessor httpContextAccessor) : ITrustComparatorSetService
+{
+    public TrustComparatorSetUserDefined ReadUserDefinedComparatorSet(string companyNumber)
+    {
+        var key = SessionKeys.TrustComparatorSetUserDefined(companyNumber);
+        var context = httpContextAccessor.HttpContext;
+
+        var set = context?.Session.Get<TrustComparatorSetUserDefined>(key);
+
+        return set ?? SetUserDefinedComparatorSet(companyNumber, new TrustComparatorSetUserDefined());
+    }
+
+    public TrustComparatorSetUserDefined SetUserDefinedComparatorSet(string companyNumber, TrustComparatorSetUserDefined set)
+    {
+        var key = SessionKeys.TrustComparatorSetUserDefined(companyNumber);
+        var context = httpContextAccessor.HttpContext;
+
+        context?.Session.Set(key, set);
+
+        return set;
+    }
+}

--- a/web/src/Web.App/ViewModels/TrustComparatorsByNameViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustComparatorsByNameViewModel.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Web.App.Domain;
+namespace Web.App.ViewModels;
+
+public class TrustComparatorsByNameViewModel(Trust trust, TrustCharacteristicUserDefined[]? trustCharacteristics)
+{
+    public string? CompanyNumber => trust.CompanyNumber;
+    public string? Name => trust.TrustName;
+    public TrustCharacteristicUserDefined[]? Trusts => trustCharacteristics;
+    public int ComparatorCount => trustCharacteristics?.Count(t => t.CompanyNumber != trust.CompanyNumber) ?? 0;
+    public string[] ExcludeCompanyNumbers => (trustCharacteristics?.Select(t => t.CompanyNumber) ?? [])
+        .Concat([trust.CompanyNumber])
+        .OfType<string>()
+        .ToArray();
+}
+
+public record TrustComparatorsCompanyNumberViewModel
+{
+    [Required(ErrorMessage = "Select a trust from the suggester")]
+    public string? CompanyNumber { get; init; }
+}

--- a/web/src/Web.App/ViewModels/TrustComparatorsChosenTrustsViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustComparatorsChosenTrustsViewModel.cs
@@ -1,0 +1,8 @@
+﻿using Web.App.Domain;
+namespace Web.App.ViewModels;
+
+public class TrustComparatorsChosenTrustsViewModel(string? companyNumber, TrustCharacteristicUserDefined[]? trustCharacteristics)
+{
+    public string? CompanyNumber => companyNumber;
+    public IOrderedEnumerable<TrustCharacteristicUserDefined>? Trusts => trustCharacteristics?.OrderBy(c => c.TrustName);
+}

--- a/web/src/Web.App/Views/TrustComparatorsCreateBy/Name.cshtml
+++ b/web/src/Web.App/Views/TrustComparatorsCreateBy/Name.cshtml
@@ -1,5 +1,6 @@
 ﻿@using Web.App.Domain
 @using Web.App.TagHelpers
+@using Web.App.ViewModels
 @model Web.App.ViewModels.TrustComparatorsByNameViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.TrustComparatorsCreateByName;
@@ -49,6 +50,17 @@
         }
     </div>
 </div>
+
+@using (Html.BeginForm("Remove", "TrustComparatorsCreateBy", new
+        {
+            companyNumber = Model.CompanyNumber
+        }, FormMethod.Post, true, new
+        {
+            novalidate = "novalidate"
+        }))
+{
+    @await Html.PartialAsync("_ChosenTrusts", new TrustComparatorsChosenTrustsViewModel(Model.CompanyNumber, Model.Trusts))
+}
 
 @section scripts
 {

--- a/web/src/Web.App/Views/TrustComparatorsCreateBy/Name.cshtml
+++ b/web/src/Web.App/Views/TrustComparatorsCreateBy/Name.cshtml
@@ -1,0 +1,59 @@
+﻿@using Web.App.Domain
+@using Web.App.TagHelpers
+@model Web.App.ViewModels.TrustComparatorsByNameViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.TrustComparatorsCreateByName;
+    var comparatorSetFull = Model.ComparatorCount >= 9;
+}
+
+@await Component.InvokeAsync("EstablishmentHeading", new
+{
+    title = ViewData[ViewDataKeys.Title],
+    name = Model.Name,
+    id = Model.CompanyNumber,
+    kind = OrganisationTypes.Trust
+})
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <p class="govuk-body">Choose between 4 and 9 trusts for best results.</p>
+    </div>
+    <div class="govuk-grid-column-full">
+        @await Html.PartialAsync("_ErrorSummary")
+        @using (Html.BeginForm("Name", "TrustComparatorsCreateBy", new
+                {
+                    companyNumber = Model.CompanyNumber
+                }, FormMethod.Post, true, new
+                {
+                    novalidate = "novalidate"
+                }))
+        {
+            <p class="govuk-body govuk-hint">Search by trust name or company number</p>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-three-quarters">
+                    <div id="trust-suggester" data-exclude="@(string.Join(",", Model.ExcludeCompanyNumbers))"></div>
+                </div>
+                <div class="govuk-grid-column-one-quarter">
+                    <button
+                        type="submit"
+                        class="govuk-button"
+                        data-module="govuk-button"
+                        name="action"
+                        value="@FormAction.Add"
+                        @(comparatorSetFull ? "disabled aria-disabled=\"true\"" : string.Empty)
+                        id="choose-trust">
+                        Choose trust
+                    </button>
+                </div>
+            </div>
+        }
+    </div>
+</div>
+
+@section scripts
+{
+    <script type="module" add-nonce="true">
+      import { initAll } from '/js/govuk-frontend.min.js'
+      initAll()
+    </script>
+}

--- a/web/src/Web.App/Views/TrustComparatorsCreateBy/_ChosenTrusts.cshtml
+++ b/web/src/Web.App/Views/TrustComparatorsCreateBy/_ChosenTrusts.cshtml
@@ -1,0 +1,48 @@
+﻿@using Web.App.Extensions
+@model Web.App.ViewModels.TrustComparatorsChosenTrustsViewModel
+
+@if (Model.Trusts != null && Model.Trusts.Any())
+{
+    <h1 class="govuk-heading-m">Chosen trusts (@Model.Trusts.Count(x => x.CompanyNumber != Model.CompanyNumber))</h1>
+    <a
+        href="@Url.Action("Submit", new { companyNumber = Model.CompanyNumber })"
+        role="button"
+        draggable="false"
+        class="govuk-button"
+        data-module="govuk-button"
+        id="create-set">
+        Create a set using these trusts
+    </a>
+    <table class="govuk-table">
+        <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden">Chosen trusts (@Model.Trusts.Count(x => x.CompanyNumber != Model.CompanyNumber))</caption>
+        <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header govuk-!-width-one-third">Trust</th>
+            <th scope="col" class="govuk-table__header">Schools</th>
+            <th scope="col" class="govuk-table__header">Number of pupils</th>
+            <th scope="col" class="govuk-table__header">Total income</th>
+            <th scope="col" class="govuk-table__header"></th>
+        </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        @foreach (var trust in Model.Trusts.Where(x => x.CompanyNumber != Model.CompanyNumber))
+        {
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell">
+                    <span class="govuk-body govuk-!-font-weight-bold">@trust.TrustName</span>
+                    <br/>
+                    <span class="govuk-hint">@trust.CompanyNumber</span>
+                </td>
+                <td class="govuk-table__cell">@trust.SchoolsInTrust.GetValueOrDefault().ToSimpleDisplay()</td>
+                <td class="govuk-table__cell">@trust.TotalPupils.GetValueOrDefault().ToSimpleDisplay()</td>
+                <td class="govuk-table__cell">@trust.TotalIncome?.ToCurrency(0)</td>
+                <td class="govuk-table__cell">
+                    <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button" name="companyNumber" value="@trust.CompanyNumber">
+                        Remove
+                    </button>
+                </td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -29,6 +29,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     public Mock<IUserDataApi> UserDataApi { get; } = new();
     public Mock<IBalanceApi> BalanceApi { get; } = new();
     public Mock<ISchoolInsightApi> SchoolInsightApi { get; } = new();
+    public Mock<ITrustInsightApi> TrustInsightApi { get; } = new();
     public Mock<IHttpContextAccessor> HttpContextAccessor { get; } = new();
 
     protected override void Configure(IServiceCollection services)
@@ -45,6 +46,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         services.AddSingleton(MetricRagRatingApi.Object);
         services.AddSingleton(BalanceApi.Object);
         services.AddSingleton(SchoolInsightApi.Object);
+        services.AddSingleton(TrustInsightApi.Object);
         services.AddSingleton(HttpContextAccessor.Object);
     }
 
@@ -192,6 +194,13 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     {
         SchoolInsightApi.Reset();
         SchoolInsightApi.Setup(api => api.GetCharacteristicsAsync(It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(characteristics ?? Array.Empty<SchoolCharacteristic>()));
+        return this;
+    }
+
+    public BenchmarkingWebAppClient SetupTrustInsightApi(IEnumerable<TrustCharacteristic>? characteristics = null)
+    {
+        TrustInsightApi.Reset();
+        TrustInsightApi.Setup(api => api.GetCharacteristicsAsync(It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(characteristics ?? Array.Empty<TrustCharacteristic>()));
         return this;
     }
 

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -51,7 +51,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     public BenchmarkingWebAppClient SetupEstablishment(SuggestOutput<Trust> trustTestData)
     {
         EstablishmentApi.Reset();
-        EstablishmentApi.Setup(api => api.SuggestTrusts(It.IsAny<string>())).ReturnsAsync(ApiResult.Ok(trustTestData));
+        EstablishmentApi.Setup(api => api.SuggestTrusts(It.IsAny<string>(), It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(trustTestData));
         return this;
     }
 
@@ -117,7 +117,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         EstablishmentApi.Setup(api => api.GetTrust(It.IsAny<string>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.GetLocalAuthority(It.IsAny<string>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.SuggestSchools(It.IsAny<string>(), It.IsAny<ApiQuery?>())).Throws(new Exception());
-        EstablishmentApi.Setup(api => api.SuggestTrusts(It.IsAny<string>())).Throws(new Exception());
+        EstablishmentApi.Setup(api => api.SuggestTrusts(It.IsAny<string>(), It.IsAny<ApiQuery?>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.SuggestLocalAuthorities(It.IsAny<string>(), It.IsAny<ApiQuery?>())).Throws(new Exception());
         return this;
     }

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -246,7 +246,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
 
         ComparatorSetApi
             .Setup(api => api.GetDefaultSchoolAsync(It.IsAny<string>()))
-            .ReturnsAsync(ApiResult.Ok(new ComparatorSet
+            .ReturnsAsync(ApiResult.Ok(new SchoolComparatorSet
             {
                 Building = schools.Select(x => x.URN ?? "Missing urn"),
                 Pupil = schools.Select(x => x.URN ?? "Missing urn")

--- a/web/tests/Web.Integration.Tests/Pages/Schools/Comparators/WhenViewingComparatorsCreatePreview.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/Comparators/WhenViewingComparatorsCreatePreview.cs
@@ -24,7 +24,7 @@ public class WhenViewingComparatorsCreatePreview(SchoolBenchmarkingWebAppClient 
             .Create();
 
         var key = SessionKeys.ComparatorSetUserDefined(school.URN!);
-        var set = new ComparatorSetUserDefined
+        var set = new UserDefinedSchoolComparatorSet
         {
             Set = ["1", "2", "3"],
             TotalSchools = 123

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/Comparators/WhenViewingComparatorsCreateBy.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/Comparators/WhenViewingComparatorsCreateBy.cs
@@ -32,7 +32,7 @@ public class WhenViewingComparatorsCreateBy(SchoolBenchmarkingWebAppClient clien
             });
         });
 
-        DocumentAssert.AssertPageUrl(page, Paths.TrustComparatorsCreateByName(trust.CompanyNumber).ToAbsolute(), HttpStatusCode.Found);
+        DocumentAssert.AssertPageUrl(page, Paths.TrustComparatorsCreateByName(trust.CompanyNumber).ToAbsolute());
     }
 
     [Fact]

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/Comparators/WhenViewingComparatorsCreateByName.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/Comparators/WhenViewingComparatorsCreateByName.cs
@@ -1,0 +1,68 @@
+﻿using AngleSharp.Html.Dom;
+using AutoFixture;
+using Web.App.Domain;
+using Xunit;
+namespace Web.Integration.Tests.Pages.Trusts.Comparators;
+
+public class WhenViewingComparatorsCreateByName(SchoolBenchmarkingWebAppClient client) : PageBase<SchoolBenchmarkingWebAppClient>(client)
+{
+    [Fact]
+    public async Task CanDisplay()
+    {
+        var (page, trust) = await SetupNavigateInitPage();
+        AssertPageLayout(page, trust);
+    }
+
+    [Fact]
+    public async Task CanAddTrustByName()
+    {
+        var (page, trust) = await SetupNavigateInitPage();
+        var action = page.QuerySelector("#choose-trust");
+        Assert.NotNull(action);
+
+        page = await Client.SubmitForm(page.Forms[0], action, f =>
+        {
+            f.InnerHtml += "<input name=\"trustInput\" value=\"Abbey Academies Trust\" />" +
+                           "<input name=\"companyNumber\" value=\"07318714\" />";
+        });
+
+        DocumentAssert.AssertPageUrl(page, Paths.TrustComparatorsCreateByName(trust.CompanyNumber).ToAbsolute());
+
+        var cta = page.QuerySelector("#create-set");
+        DocumentAssert.PrimaryCta(cta, "Create a set using these trusts", Paths.TrustComparatorsCreateSubmit(trust.CompanyNumber));
+    }
+
+    private async Task<(IHtmlDocument page, Trust trust)> SetupNavigateInitPage()
+    {
+        var trust = Fixture.Build<Trust>()
+            .With(x => x.CompanyNumber, "87654321")
+            .Create();
+
+        var page = await Client.SetupEstablishment(trust)
+            .SetupTrustInsightApi(new[]
+            {
+                new TrustCharacteristic
+                {
+                    CompanyNumber = "07318714",
+                    TrustName = "Abbey Academies Trust",
+                    SchoolsInTrust = 12,
+                    TotalPupils = 345,
+                    TotalIncome = 123_456_789
+                }
+            })
+            .SetupHttpContextAccessor()
+            .Navigate(Paths.TrustComparatorsCreateByName(trust.CompanyNumber));
+
+        return (page, trust);
+    }
+
+    private static void AssertPageLayout(IHtmlDocument page, Trust trust)
+    {
+        DocumentAssert.BackLink(page, "Back", Paths.TrustComparatorsCreateBy(trust.CompanyNumber).ToAbsolute());
+        DocumentAssert.TitleAndH1(page,
+            "Choose trusts to benchmark against - Financial Benchmarking and Insights Tool - GOV.UK",
+            "Choose trusts to benchmark against");
+        var cta = page.QuerySelector(".govuk-button");
+        DocumentAssert.PrimaryCta(cta, "Choose trust", Paths.TrustComparatorsCreateByName(trust.CompanyNumber));
+    }
+}

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -76,6 +76,7 @@ public static class Paths
     public static string TrustComparatorsCreateBy(string? companyNumber) => $"/trust/{companyNumber}/comparators/create/by";
     public static string TrustComparatorsCreateByName(string? companyNumber) => $"/trust/{companyNumber}/comparators/create/by/name";
     public static string TrustComparatorsCreateByCharacteristic(string? companyNumber) => $"/trust/{companyNumber}/comparators/create/by/characteristic";
+    public static string TrustComparatorsCreateSubmit(string? companyNumber) => $"/trust/{companyNumber}/comparators/create/submit";
 
     public static string ApiSuggest(string search, string type) => $"api/suggest?search={search}&type={type}";
     public static string ApiEstablishmentExpenditure(string? type, string? id) => $"api/establishments/expenditure?type={type}&id={id}";


### PR DESCRIPTION
### Context
[AB#213058](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/213058) [AB#206777](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/206777)

### Change proposed in this pull request
Search for trusts (excluding current or already selected trusts) by name or company number. Add trusts to user defined set. Remove trusts from set. Submit set scaffolding. Renamed some comparator set-related classes to allow distinction between School and Trust.

### Guidance to review 
Characteristics endpoint for Trusts is currently stubbed, but apart from that the add/remove/submit for manually selected Trusts should work as expected as long as `front-end-component` is built and copied over to `Web` first. This will be bumped in a future PR.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

