### PR TITLE
fix: correct comparator-set URN restriction

### DIFF
--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -492,7 +492,7 @@ def run_user_defined_rag(
     year: int,
     run_id: str,
     target_urn: int,
-    comparator_set: pd.DataFrame,
+    comparator_set: list[int],
 ):
     """
     Perform user-defined RAG calculations.
@@ -594,7 +594,7 @@ def handle_msg(
                 year=msg_payload["year"],
                 run_id=msg_payload["runId"],
                 target_urn=int(msg_payload["urn"]),
-                comparator_set=pd.DataFrame(map(int, payload["set"])),
+                comparator_set=list(map(int, payload["set"])),
             )
         else:
             msg_payload["pre_process_duration"] = pre_process_data(

--- a/data-pipeline/src/pipeline/rag.py
+++ b/data-pipeline/src/pipeline/rag.py
@@ -238,7 +238,7 @@ def compute_rag(data, comparators):
 def compute_user_defined_rag(
     data: pd.DataFrame,
     target_urn: int,
-    set_urns: pd.DataFrame,
+    set_urns: list[int],
 ) -> Generator[dict, None, None]:
     """
     Perform user-defined RAG calculation.

--- a/data-pipeline/tests/unit/rag/test_user_defined_comparator_sets.py
+++ b/data-pipeline/tests/unit/rag/test_user_defined_comparator_sets.py
@@ -1,0 +1,74 @@
+import pathlib
+
+import pandas as pd
+import pytest
+
+from src.pipeline.comparator_sets import prepare_data
+from src.pipeline.rag import compute_user_defined_rag
+
+
+msg_payload = {
+    "jobId": "ba4f078e-f32f-467f-a848-09cf9d58c8df",
+    "type": "comparator-set",
+    "runType": "default",
+    "runId": "b643f547-5d8b-401e-862d-265543786a41",
+    "year": 2023,
+    "urn": "145799",
+    "payload": {
+        "kind": "ComparatorSetPayload",
+        "set": [
+            "143058",
+            "132247",
+            "144798",
+            "147637",
+            "144241",
+            "111180",
+            "111385",
+            "111299",
+            "111363",
+            "111376",
+            "148456",
+            "145389",
+            "145710",
+            "146417",
+            "147636",
+            "143072",
+            "111298",
+            "111315",
+            "111367",
+            "111370",
+            "111309",
+            "145387",
+            "145388",
+            "111318",
+            "111369",
+            "131349",
+            "111305",
+            "111307",
+            "111308",
+            "145799",
+        ],
+    },
+}
+
+
+@pytest.mark.skip(reason="requires representative data")
+def test_run_user_defined_rag():
+    """
+    TODO: this requires a representative, pre-processed
+    `all_schools.parquet`.
+    """
+    all_schools = (
+        pathlib.Path(__file__).parent.parent.parent.parent / "all_schools.parquet"
+    )
+    all_schools = prepare_data(pd.read_parquet(all_schools))
+
+    result = list(
+        compute_user_defined_rag(
+            data=all_schools,
+            target_urn=int(msg_payload["urn"]),
+            set_urns=list(map(int, msg_payload["payload"]["set"])),
+        )
+    )
+
+    assert len(result) == 42


### PR DESCRIPTION
- use a `list` for restricting the data to just the comparator set.
  - `DataFrame` [should work](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.isin.html) but would require more coercing to the right structure.
- add a test to validate the above **_but_** `skip()` this for now due to the requirement for a representative data-set.

relates #212505
