### PR TITLE
Trust user-defined comparator set submission, polling and result display

### DIFF
--- a/web/src/Web.App/Constants/PageTitles.cs
+++ b/web/src/Web.App/Constants/PageTitles.cs
@@ -57,4 +57,5 @@ public static class PageTitles
     public const string TrustComparatorsCreateByName = "Choose trusts to benchmark against";
     public const string TrustComparatorsCreateByCharacteristic = "Choose characteristics to find matching trusts";
     public const string TrustComparatorsPreview = "Trusts successfully matched";
+    public const string TrustComparatorsSubmit = "Generating benchmarking data";
 }

--- a/web/src/Web.App/Constants/SessionKeys.cs
+++ b/web/src/Web.App/Constants/SessionKeys.cs
@@ -9,4 +9,5 @@ public static class SessionKeys
     public static string CustomData(string urn) => $"custom-data-{urn}";
     public static string TrustComparatorSetCharacteristic(string urn) => $"trust-comparator-set-characteristic-{urn}";
     public static string TrustComparatorSetUserDefined(string companyNumber) => $"trust-comparator-set-user-defined-{companyNumber}";
+    public static string TrustComparatorSetUserDefined(string companyNumber, string identifier) => $"trust-comparator-set-user-defined-{companyNumber}-{identifier}";
 }

--- a/web/src/Web.App/Controllers/Api/UserDataProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/UserDataProxyController.cs
@@ -2,7 +2,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Web.App.Extensions;
 using Web.App.Services;
-
 namespace Web.App.Controllers.Api;
 
 [ApiController]
@@ -13,9 +12,12 @@ public class UserDataProxyController(ILogger<ProxyController> logger, IUserDataS
     [HttpGet]
     [Route("school/{urn}/{identifier}")]
     [Produces("application/json")]
-    public async Task<IActionResult> Index(string urn, string identifier)
+    public async Task<IActionResult> SchoolUserData(string urn, string identifier)
     {
-        using (logger.BeginScope(new { identifier }))
+        using (logger.BeginScope(new
+        {
+            identifier
+        }))
         {
             try
             {
@@ -29,7 +31,35 @@ public class UserDataProxyController(ILogger<ProxyController> logger, IUserDataS
             }
             catch (Exception e)
             {
-                logger.LogError(e, "An error getting user data {Id} for {User}", identifier, User.UserId());
+                logger.LogError(e, "An error getting school user data {Id} for {User}", identifier, User.UserId());
+                return StatusCode(500);
+            }
+        }
+    }
+
+    [HttpGet]
+    [Route("trust/{companyNumber}/{identifier}")]
+    [Produces("application/json")]
+    public async Task<IActionResult> TrustUserData(string companyNumber, string identifier)
+    {
+        using (logger.BeginScope(new
+        {
+            identifier
+        }))
+        {
+            try
+            {
+                var userSet = await userDataService.GetTrustComparatorSetAsync(User.UserId(), identifier, companyNumber);
+                if (userSet == null)
+                {
+                    return new NotFoundResult();
+                }
+
+                return new JsonResult(userSet);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "An error getting trust user data {Id} for {User}", identifier, User.UserId());
                 return StatusCode(500);
             }
         }

--- a/web/src/Web.App/Controllers/SchoolComparatorsCreateByController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparatorsCreateByController.cs
@@ -213,12 +213,11 @@ public class SchoolComparatorsCreateByController(
                 var request = new PutComparatorSetUserDefinedRequest
                 {
                     Identifier = userDefinedSet.RunId == null ? Guid.NewGuid() : Guid.Parse(userDefinedSet.RunId),
-                    URN = urn,
                     Set = userDefinedSet.Set,
                     UserId = User.UserId()
                 };
 
-                await comparatorSetApi.UpsertUserDefinedSchoolAsync(request).EnsureSuccess();
+                await comparatorSetApi.UpsertUserDefinedSchoolAsync(urn, request).EnsureSuccess();
                 schoolComparatorSetService.ClearUserDefinedComparatorSet(urn);
                 schoolComparatorSetService.ClearUserDefinedCharacteristic(urn);
                 var viewModel = new SchoolComparatorsSubmittedViewModel(school, request);

--- a/web/src/Web.App/Controllers/TrustController.cs
+++ b/web/src/Web.App/Controllers/TrustController.cs
@@ -5,7 +5,6 @@ using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Extensions;
 using Web.App.ViewModels;
-
 namespace Web.App.Controllers;
 
 [Controller]
@@ -15,9 +14,14 @@ public class TrustController(ILogger<TrustController> logger, IEstablishmentApi 
     : Controller
 {
     [HttpGet]
-    public async Task<IActionResult> Index(string companyNumber)
+    public async Task<IActionResult> Index(
+        string companyNumber,
+        [FromQuery(Name = "comparator-generated")] bool? comparatorGenerated)
     {
-        using (logger.BeginScope(new { companyNumber }))
+        using (logger.BeginScope(new
+        {
+            companyNumber
+        }))
         {
             try
             {
@@ -35,7 +39,7 @@ public class TrustController(ILogger<TrustController> logger, IEstablishmentApi 
                 }
 
                 var ratings = await metricRagRatingApi.GetDefaultAsync(schoolsQuery).GetResultOrThrow<RagRating[]>();
-                var viewModel = new TrustViewModel(trust, balance, schools, ratings);
+                var viewModel = new TrustViewModel(trust, balance, schools, ratings, comparatorGenerated);
                 return View(viewModel);
             }
             catch (Exception e)

--- a/web/src/Web.App/Domain/TrustComparatorSet.cs
+++ b/web/src/Web.App/Domain/TrustComparatorSet.cs
@@ -8,6 +8,7 @@ public record TrustComparatorSetUserDefined
 
 public record UserDefinedTrustComparatorSet
 {
+    public string? RunId { get; set; }
     public long? TotalTrusts { get; set; }
     public string[] Set { get; set; } = [];
 }

--- a/web/src/Web.App/Infrastructure/Apis/ComparatorSetApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/ComparatorSetApi.cs
@@ -3,31 +3,28 @@
 public class ComparatorSetApi(HttpClient httpClient, string? key = default)
     : ApiBase(httpClient, key), IComparatorSetApi
 {
-    public async Task<ApiResult> GetDefaultSchoolAsync(string urn)
-    {
-        return await GetAsync($"api/comparator-set/school/{urn}/default");
-    }
+    public async Task<ApiResult> GetDefaultSchoolAsync(string urn) => await GetAsync($"api/comparator-set/school/{urn}/default");
 
-    public async Task<ApiResult> GetUserDefinedSchoolAsync(string urn, string? identifier)
-    {
-        return await GetAsync($"api/comparator-set/school/{urn}/user-defined/{identifier}");
-    }
+    public async Task<ApiResult> GetUserDefinedSchoolAsync(string urn, string? identifier) => await GetAsync($"api/comparator-set/school/{urn}/user-defined/{identifier}");
 
-    public async Task<ApiResult> RemoveUserDefinedSchoolAsync(string urn, string? identifier)
-    {
-        return await DeleteAsync($"api/comparator-set/school/{urn}/user-defined/{identifier}");
-    }
-    public async Task<ApiResult> UpsertUserDefinedSchoolAsync(PutComparatorSetUserDefinedRequest request)
-    {
-        return await PutAsync($"api/comparator-set/school/{request.URN}/user-defined/{request.Identifier}", new JsonContent(request));
-    }
+    public async Task<ApiResult> RemoveUserDefinedSchoolAsync(string urn, string? identifier) => await DeleteAsync($"api/comparator-set/school/{urn}/user-defined/{identifier}");
+
+    public async Task<ApiResult> UpsertUserDefinedSchoolAsync(string urn, PutComparatorSetUserDefinedRequest request) => await PutAsync($"api/comparator-set/school/{urn}/user-defined/{request.Identifier}", new JsonContent(request));
+
+    public async Task<ApiResult> GetUserDefinedTrustAsync(string companyNumber, string? identifier) => await GetAsync($"api/comparator-set/trust/{companyNumber}/user-defined/{identifier}");
+
+    public async Task<ApiResult> RemoveUserDefinedTrustAsync(string companyNumber, string? identifier) => await DeleteAsync($"api/comparator-set/trust/{companyNumber}/user-defined/{identifier}");
+
+    public async Task<ApiResult> UpsertUserDefinedTrustAsync(string companyNumber, PutComparatorSetUserDefinedRequest request) => await PutAsync($"api/comparator-set/trust/{companyNumber}/user-defined/{request.Identifier}", new JsonContent(request));
 }
-
 
 public interface IComparatorSetApi
 {
     Task<ApiResult> GetDefaultSchoolAsync(string urn);
     Task<ApiResult> GetUserDefinedSchoolAsync(string urn, string? identifier);
-    Task<ApiResult> UpsertUserDefinedSchoolAsync(PutComparatorSetUserDefinedRequest request);
+    Task<ApiResult> UpsertUserDefinedSchoolAsync(string urn, PutComparatorSetUserDefinedRequest request);
     Task<ApiResult> RemoveUserDefinedSchoolAsync(string urn, string? identifier);
+    Task<ApiResult> GetUserDefinedTrustAsync(string companyNumber, string? identifier);
+    Task<ApiResult> RemoveUserDefinedTrustAsync(string companyNumber, string? identifier);
+    Task<ApiResult> UpsertUserDefinedTrustAsync(string companyNumber, PutComparatorSetUserDefinedRequest request);
 }

--- a/web/src/Web.App/Infrastructure/Apis/Requests/PutComparatorSetUserDefinedRequest.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Requests/PutComparatorSetUserDefinedRequest.cs
@@ -2,8 +2,7 @@
 
 public record PutComparatorSetUserDefinedRequest
 {
-    public string? URN { get; set; }
     public Guid Identifier { get; set; } = Guid.NewGuid();
-    public string[] Set { get; set; } = Array.Empty<string>();
+    public string[] Set { get; set; } = [];
     public string? UserId { get; set; }
 }

--- a/web/src/Web.App/Services/SchoolComparatorSetService.cs
+++ b/web/src/Web.App/Services/SchoolComparatorSetService.cs
@@ -39,16 +39,6 @@ public class SchoolComparatorSetService(IHttpContextAccessor httpContextAccessor
         return set ?? await SetUserDefinedComparatorSet(urn, identifier);
     }
 
-    public void ClearUserDefinedComparatorSet(string urn, string? identifier = null)
-    {
-        var key = string.IsNullOrWhiteSpace(identifier)
-            ? SessionKeys.ComparatorSetUserDefined(urn)
-            : SessionKeys.ComparatorSetUserDefined(urn, identifier);
-        var context = httpContextAccessor.HttpContext;
-
-        context?.Session.Remove(key);
-    }
-
     public UserDefinedSchoolComparatorSet ReadUserDefinedComparatorSet(string urn)
     {
         var key = SessionKeys.ComparatorSetUserDefined(urn);
@@ -57,6 +47,16 @@ public class SchoolComparatorSetService(IHttpContextAccessor httpContextAccessor
         var set = context?.Session.Get<UserDefinedSchoolComparatorSet>(key);
 
         return set ?? SetUserDefinedComparatorSet(urn, new UserDefinedSchoolComparatorSet());
+    }
+
+    public void ClearUserDefinedComparatorSet(string urn, string? identifier = null)
+    {
+        var key = string.IsNullOrWhiteSpace(identifier)
+            ? SessionKeys.ComparatorSetUserDefined(urn)
+            : SessionKeys.ComparatorSetUserDefined(urn, identifier);
+        var context = httpContextAccessor.HttpContext;
+
+        context?.Session.Remove(key);
     }
 
     public UserDefinedSchoolComparatorSet SetUserDefinedComparatorSet(string urn, UserDefinedSchoolComparatorSet set)

--- a/web/src/Web.App/Services/TrustComparatorSetService.cs
+++ b/web/src/Web.App/Services/TrustComparatorSetService.cs
@@ -1,27 +1,41 @@
 using Web.App.Domain;
 using Web.App.Extensions;
+using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Extensions;
 using Web.App.ViewModels;
 namespace Web.App.Services;
 
 public interface ITrustComparatorSetService
 {
+    Task<UserDefinedTrustComparatorSet> ReadUserDefinedComparatorSet(string companyNumber, string identifier);
     UserDefinedTrustComparatorSet ReadUserDefinedComparatorSet(string companyNumber);
     UserDefinedTrustComparatorSet SetUserDefinedComparatorSet(string companyNumber, UserDefinedTrustComparatorSet set);
+    void ClearUserDefinedComparatorSet(string companyNumber, string? identifier = null);
     UserDefinedTrustCharacteristicViewModel? ReadUserDefinedCharacteristic(string urn);
     void SetUserDefinedCharacteristic(string companyNumber, UserDefinedTrustCharacteristicViewModel viewModel);
     void ClearUserDefinedCharacteristic(string companyNumber);
 }
 
-public class TrustComparatorSetService(IHttpContextAccessor httpContextAccessor) : ITrustComparatorSetService
+public class TrustComparatorSetService(IHttpContextAccessor httpContextAccessor, IComparatorSetApi api) : ITrustComparatorSetService
 {
-    public UserDefinedTrustComparatorSet ReadUserDefinedComparatorSet(string companyNumber)
+    public async Task<UserDefinedTrustComparatorSet> ReadUserDefinedComparatorSet(string companyNumber, string identifier)
     {
-        var key = SessionKeys.TrustComparatorSetUserDefined(companyNumber);
+        var key = SessionKeys.TrustComparatorSetUserDefined(companyNumber, identifier);
         var context = httpContextAccessor.HttpContext;
 
         var set = context?.Session.Get<UserDefinedTrustComparatorSet>(key);
 
-        return set ?? SetUserDefinedComparatorSet(companyNumber, new UserDefinedTrustComparatorSet());
+        return set ?? await SetUserDefinedComparatorSet(companyNumber, identifier);
+    }
+
+    public UserDefinedTrustComparatorSet ReadUserDefinedComparatorSet(string urn)
+    {
+        var key = SessionKeys.TrustComparatorSetUserDefined(urn);
+        var context = httpContextAccessor.HttpContext;
+
+        var set = context?.Session.Get<UserDefinedTrustComparatorSet>(key);
+
+        return set ?? SetUserDefinedComparatorSet(urn, new UserDefinedTrustComparatorSet());
     }
 
     public UserDefinedTrustComparatorSet SetUserDefinedComparatorSet(string companyNumber, UserDefinedTrustComparatorSet set)
@@ -32,6 +46,16 @@ public class TrustComparatorSetService(IHttpContextAccessor httpContextAccessor)
         context?.Session.Set(key, set);
 
         return set;
+    }
+
+    public void ClearUserDefinedComparatorSet(string companyNumber, string? identifier = null)
+    {
+        var key = string.IsNullOrWhiteSpace(identifier)
+            ? SessionKeys.TrustComparatorSetUserDefined(companyNumber)
+            : SessionKeys.TrustComparatorSetUserDefined(companyNumber, identifier);
+        var context = httpContextAccessor.HttpContext;
+
+        context?.Session.Remove(key);
     }
 
     public UserDefinedTrustCharacteristicViewModel? ReadUserDefinedCharacteristic(string urn)
@@ -53,5 +77,16 @@ public class TrustComparatorSetService(IHttpContextAccessor httpContextAccessor)
         var key = SessionKeys.TrustComparatorSetCharacteristic(urn);
         var context = httpContextAccessor.HttpContext;
         context?.Session.Remove(key);
+    }
+
+    private async Task<UserDefinedTrustComparatorSet> SetUserDefinedComparatorSet(string companyNumber, string identifier)
+    {
+        var key = SessionKeys.TrustComparatorSetUserDefined(companyNumber, identifier);
+        var context = httpContextAccessor.HttpContext;
+
+        var set = await api.GetUserDefinedTrustAsync(companyNumber, identifier).GetResultOrThrow<UserDefinedTrustComparatorSet>();
+        context?.Session.Set(key, set);
+
+        return set;
     }
 }

--- a/web/src/Web.App/ViewModels/TrustComparatorsSubmittedViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustComparatorsSubmittedViewModel.cs
@@ -1,0 +1,10 @@
+﻿using Web.App.Domain;
+using Web.App.Infrastructure.Apis;
+namespace Web.App.ViewModels;
+
+public class TrustComparatorsSubmittedViewModel(Trust trust, PutComparatorSetUserDefinedRequest request)
+{
+    public string? CompanyNumber => trust.CompanyNumber;
+    public string? Name => trust.TrustName;
+    public Guid Identifier => request.Identifier;
+}

--- a/web/src/Web.App/ViewModels/TrustViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustViewModel.cs
@@ -1,7 +1,12 @@
 using Web.App.Domain;
 namespace Web.App.ViewModels;
 
-public class TrustViewModel(Trust trust, Balance balance, IReadOnlyCollection<School> schools, IEnumerable<RagRating> ratings)
+public class TrustViewModel(
+    Trust trust,
+    Balance balance,
+    IReadOnlyCollection<School> schools,
+    IEnumerable<RagRating> ratings,
+    bool? comparatorGenerated)
 {
 
     public string? CompanyNumber => trust.CompanyNumber;
@@ -17,7 +22,7 @@ public class TrustViewModel(Trust trust, Balance balance, IReadOnlyCollection<Sc
         .Where(NotOther)
         .GroupBy(x => (x.RAG, x.Category))
         .Select(x => (x.Key.RAG, x.Key.Category, Count: x.Count()))
-        .GroupBy(x => (x.Category))
+        .GroupBy(x => x.Category)
         .Select(x => new RagCostCategoryViewModel(
             x.Key,
             x.Where(w => Red(w.RAG)).Select(r => r.Count).SingleOrDefault(),
@@ -43,6 +48,8 @@ public class TrustViewModel(Trust trust, Balance balance, IReadOnlyCollection<Sc
     public IEnumerable<RagSchoolViewModel> SpecialOrPruSchools =>
         Schools.Where(s => s.OverallPhase is OverallPhaseTypes.Special or OverallPhaseTypes.PupilReferralUnit)
             .SelectMany(s => s.Schools);
+
+    public bool? ComparatorGenerated => comparatorGenerated;
 
     private IEnumerable<(
         string? OverallPhase,

--- a/web/src/Web.App/Views/Trust/Index.cshtml
+++ b/web/src/Web.App/Views/Trust/Index.cshtml
@@ -13,6 +13,31 @@
             <a href="@Url.Action("Index", "FindOrganisation", new { method = OrganisationTypes.Trust })" class="govuk-link govuk-link--no-visited-state">Change trust</a>
         </p>
     </div>
+
+    @if (Model.ComparatorGenerated.HasValue)
+    {
+        <div class="govuk-grid-column-full">
+            @{
+                var success = Model.ComparatorGenerated == true;
+            }
+            <div class="govuk-notification-banner govuk-notification-banner--@(success ? "success" : "failure")" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+                <div class="govuk-notification-banner__header">
+                    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                        @(success ? "Success" : "Error")
+                    </h2>
+                </div>
+                <div class="govuk-notification-banner__content">
+                    <h3 class="govuk-notification-banner__heading">@(success ? "You are now benchmarking against your own set of trusts" : "Unable to benchmark against your own set of trusts")</h3>
+                    @if (!success)
+                    {
+                        <p class="govuk-body">
+                            Please try again later.
+                        </p>
+                    }
+                </div>
+            </div>
+        </div>
+    }
 </div>
 
 @await Component.InvokeAsync("DataSource", new

--- a/web/src/Web.App/Views/TrustComparatorsCreateBy/Submit.cshtml
+++ b/web/src/Web.App/Views/TrustComparatorsCreateBy/Submit.cshtml
@@ -1,0 +1,51 @@
+﻿@model Web.App.ViewModels.TrustComparatorsSubmittedViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.TrustComparatorsSubmit;
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full loading">
+        <h1 class="govuk-heading-l">
+            @ViewData[ViewDataKeys.Title]
+        </h1>
+        <div class="spinner"></div>
+        <p class="govuk-hint">This may take a minute or two.</p>
+    </div>
+</div>
+
+@section scripts
+{
+    <script type="module" add-nonce="true">
+      // todo: refactor entire view its own partial/component for re-use by other async processes such as custom data submission
+      let done, failed = false;
+      const interval = setInterval(statusCheck, 5000);
+      function statusCheck() {
+        if (done || failed) {
+            clearInterval(interval);
+            window.location.href = `/trust/@Model.CompanyNumber?comparator-generated=${!failed}`;
+            return;
+        }
+
+        fetch(
+            "/api/user-data/trust/@Model.CompanyNumber/@Model.Identifier", 
+            { 
+                method: "GET",
+                credentials: "include"
+            })
+            .then(response => response.json())
+            .then(json => {
+                if (json) {
+                    if (json.status === "complete") {
+                        done = true;
+                    } else if (json.status !== "pending") {
+                        throw new Error("Unexpected response returned from API call");
+                    }
+                }
+            })
+            .catch(err => {
+                console.error(err);
+                failed = true;
+            });
+      }
+    </script>
+}


### PR DESCRIPTION
### Context
[AB#213058](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/213058) [AB#213062](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/213062) [AB#206777](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/206777)

### Change proposed in this pull request
Submit the selected Trusts by company number for use as a new user defined comparator set. Display spinner and poll until job complete. Display banner with result of request on Trust home page.

### Guidance to review 
Process should now work end-to-end, although there is no entry point yet defined. Resultant comparator trusts will be added and managed as part of future work.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

