### PR TITLE
View set of user-defined Trusts

### DIFF
--- a/web/src/Web.App/Constants/PageTitles.cs
+++ b/web/src/Web.App/Constants/PageTitles.cs
@@ -58,4 +58,5 @@ public static class PageTitles
     public const string TrustComparatorsCreateByCharacteristic = "Choose characteristics to find matching trusts";
     public const string TrustComparatorsPreview = "Trusts successfully matched";
     public const string TrustComparatorsSubmit = "Generating benchmarking data";
+    public const string TrustComparatorsUserDefined = "Your set of trusts";
 }

--- a/web/src/Web.App/Controllers/TrustComparatorsController.cs
+++ b/web/src/Web.App/Controllers/TrustComparatorsController.cs
@@ -1,10 +1,80 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement.Mvc;
+using Web.App.Domain;
+using Web.App.Extensions;
+using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Extensions;
+using Web.App.Services;
+using Web.App.ViewModels;
 namespace Web.App.Controllers;
 
 [Controller]
+[FeatureGate(FeatureFlags.Trusts)]
 [Route("trust/{companyNumber}/comparators")]
-public class TrustComparatorsController(ILogger<TrustComparatorsController> logger) : Controller
+public class TrustComparatorsController(
+    ILogger<TrustComparatorsController> logger,
+    IEstablishmentApi establishmentApi,
+    IComparatorSetApi comparatorSetApi,
+    ITrustInsightApi trustInsightApi,
+    IUserDataService userDataService) : Controller
 {
     [HttpGet]
     public IActionResult Index(string companyNumber) => new StatusCodeResult(StatusCodes.Status302Found);
+
+    [HttpGet]
+    [Route("user-defined")]
+    [Authorize]
+    [FeatureGate(FeatureFlags.UserDefinedComparators)]
+    public async Task<IActionResult> UserDefined(string companyNumber)
+    {
+        using (logger.BeginScope(new
+        {
+            companyNumber
+        }))
+        {
+            try
+            {
+                ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.SchoolComparators(companyNumber);
+
+                var trust = await establishmentApi.GetTrust(companyNumber).GetResultOrThrow<Trust>();
+                var userData = await userDataService.GetTrustDataAsync(User.UserId(), companyNumber);
+                TrustCharacteristicUserDefined[]? trusts = null;
+
+                if (userData.ComparatorSet != null)
+                {
+                    var userDefinedSet = await comparatorSetApi.GetUserDefinedTrustAsync(companyNumber, userData.ComparatorSet)
+                        .GetResultOrDefault<UserDefinedSchoolComparatorSet>();
+                    if (userDefinedSet != null)
+                    {
+                        trusts = await GetTrustCharacteristics<TrustCharacteristicUserDefined>(userDefinedSet.Set);
+                    }
+                }
+
+                var viewModel = new TrustComparatorsViewModel(trust, userDefined: trusts, userDefinedSetId: userData.ComparatorSet);
+                return View(viewModel);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "An error displaying trust comparators: {DisplayUrl}", Request.GetDisplayUrl());
+                return e is StatusCodeException s ? StatusCode((int)s.Status) : StatusCode(500);
+            }
+        }
+    }
+
+    private async Task<T[]?> GetTrustCharacteristics<T>(IEnumerable<string> set)
+    {
+        var query = new ApiQuery();
+        var trusts = set as string[] ?? set.ToArray();
+        if (trusts.Length != 0)
+        {
+            foreach (var companyNumber in trusts)
+            {
+                query.AddIfNotNull("companyNumbers", companyNumber);
+            }
+        }
+
+        return await trustInsightApi.GetCharacteristicsAsync(query).GetResultOrDefault<T[]>();
+    }
 }

--- a/web/src/Web.App/Services/UserDataService.cs
+++ b/web/src/Web.App/Services/UserDataService.cs
@@ -1,7 +1,6 @@
 ﻿using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Extensions;
-
 namespace Web.App.Services;
 
 public interface IUserDataService
@@ -10,6 +9,7 @@ public interface IUserDataService
     Task<UserData?> GetCustomDataAsync(string userId, string identifier, string urn);
     Task<UserData?> GetTrustComparatorSetAsync(string userId, string identifier, string companyNumber);
     Task<(string? CustomData, string? ComparatorSet)> GetSchoolDataAsync(string userId, string urn);
+    Task<(string? CustomData, string? ComparatorSet)> GetTrustDataAsync(string userId, string companyNumber);
 }
 
 public class UserDataService(IUserDataApi api) : IUserDataService
@@ -64,6 +64,18 @@ public class UserDataService(IUserDataApi api) : IUserDataService
             .AddIfNotNull("userId", userId)
             .AddIfNotNull("organisationType", OrganisationSchool)
             .AddIfNotNull("organisationId", urn);
+
+        var userSets = await api.GetAsync(query).GetResultOrDefault<UserData[]>();
+        return (userSets?.FirstOrDefault(x => x.Type == CustomData)?.Id,
+            userSets?.FirstOrDefault(x => x.Type == ComparatorSet)?.Id);
+    }
+
+    public async Task<(string? CustomData, string? ComparatorSet)> GetTrustDataAsync(string userId, string companyNumber)
+    {
+        var query = new ApiQuery()
+            .AddIfNotNull("userId", userId)
+            .AddIfNotNull("organisationType", OrganisationTrust)
+            .AddIfNotNull("organisationId", companyNumber);
 
         var userSets = await api.GetAsync(query).GetResultOrDefault<UserData[]>();
         return (userSets?.FirstOrDefault(x => x.Type == CustomData)?.Id,

--- a/web/src/Web.App/ViewModels/TrustComparatorsViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustComparatorsViewModel.cs
@@ -3,9 +3,14 @@ namespace Web.App.ViewModels;
 
 public class TrustComparatorsViewModel(
     Trust trust,
-    string? by = null)
+    string? by = null,
+    TrustCharacteristicUserDefined[]? userDefined = null,
+    string? userDefinedSetId = null)
 {
     public string? CompanyNumber => trust.CompanyNumber;
     public string? Name => trust.TrustName;
     public string? By => by;
+    public string? UserDefinedSetId => userDefinedSetId;
+
+    public IEnumerable<TrustCharacteristicUserDefined> UserDefinedTrusts => userDefined ?? [];
 }

--- a/web/src/Web.App/Views/Shared/_Layout.cshtml
+++ b/web/src/Web.App/Views/Shared/_Layout.cshtml
@@ -161,8 +161,7 @@
                         class="govuk-footer__link"
                         href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
                         rel="license">
-                        Open Government Licence v3.0
-                    </a>, except where otherwise stated
+                        Open Government Licence v3.0</a>, except where otherwise stated
                 </span>
             </div>
             <div class="govuk-footer__meta-item">

--- a/web/src/Web.App/Views/Trust/Index.cshtml
+++ b/web/src/Web.App/Views/Trust/Index.cshtml
@@ -34,6 +34,12 @@
                             Please try again later.
                         </p>
                     }
+                    <p>
+                        <a class="govuk-notification-banner__link"
+                           href="@Url.Action("UserDefined", "TrustComparators", new { companyNumber = Model.CompanyNumber })">
+                            View and change your set of trusts
+                        </a>
+                    </p>
                 </div>
             </div>
         </div>

--- a/web/src/Web.App/Views/TrustComparators/UserDefined.cshtml
+++ b/web/src/Web.App/Views/TrustComparators/UserDefined.cshtml
@@ -1,0 +1,58 @@
+﻿@using Web.App.Extensions
+@model Web.App.ViewModels.TrustComparatorsViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.TrustComparatorsUserDefined;
+}
+
+@await Component.InvokeAsync("EstablishmentHeading", new
+{
+    title = ViewData[ViewDataKeys.Title],
+    name = Model.Name,
+    id = Model.CompanyNumber,
+    kind = OrganisationTypes.Trust
+})
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <p class="govuk-body">
+            <a class="govuk-link govuk-link--no-visited-state"
+               href="@Url.Action("Name", "TrustComparatorsCreateBy", new { companyNumber = Model.CompanyNumber, identifier = Model.UserDefinedSetId })">
+                Change your set of trusts
+            </a>
+        </p>
+        <table class="govuk-table">
+            <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Trust</th>
+                <th scope="col" class="govuk-table__header">Schools</th>
+                <th scope="col" class="govuk-table__header">Number of pupils</th>
+                <th scope="col" class="govuk-table__header">Total income</th>
+            </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+
+            @foreach (var trust in Model.UserDefinedTrusts.Where(x => x.CompanyNumber != Model.CompanyNumber))
+            {
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">
+                        <strong>@trust.TrustName</strong>
+                        <br/>
+                        <span class="govuk-hint">@trust.CompanyNumber</span>
+                    </td>
+                    <td class="govuk-table__cell">@trust.SchoolsInTrust.GetValueOrDefault().ToSimpleDisplay()</td>
+                    <td class="govuk-table__cell">@trust.TotalPupils.GetValueOrDefault().ToNumberSeparator()</td>
+                    <td class="govuk-table__cell">@trust.TotalIncome?.ToCurrency(0)</td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    </div>
+</div>
+
+@section scripts
+{
+    <script type="module" add-nonce="true">
+      import { initAll } from '/js/govuk-frontend.min.js'
+      initAll()
+    </script>
+}

--- a/web/src/Web.App/Views/TrustComparatorsCreateBy/_ChosenTrusts.cshtml
+++ b/web/src/Web.App/Views/TrustComparatorsCreateBy/_ChosenTrusts.cshtml
@@ -29,7 +29,7 @@
         {
             <tr class="govuk-table__row">
                 <td class="govuk-table__cell">
-                    <span class="govuk-body govuk-!-font-weight-bold">@trust.TrustName</span>
+                    <strong>@trust.TrustName</strong>
                     <br/>
                     <span class="govuk-hint">@trust.CompanyNumber</span>
                 </td>


### PR DESCRIPTION
### Context
[AB#213444](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/213444) [AB#206777](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/206777)

### Change proposed in this pull request
Added page to view current user-defined set of Trusts (excluding current one). Includes link to edit existing set and then re-submit if any changes required.

### Guidance to review 
Link to view custom set is currently only visible from the Trust homepage after a custom set has been submitted.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

