### PR TITLE
Revert user defined Trust comparator set

### DIFF
--- a/web/src/Web.App/Constants/PageTitles.cs
+++ b/web/src/Web.App/Constants/PageTitles.cs
@@ -59,4 +59,5 @@ public static class PageTitles
     public const string TrustComparatorsPreview = "Trusts successfully matched";
     public const string TrustComparatorsSubmit = "Generating benchmarking data";
     public const string TrustComparatorsUserDefined = "Your set of trusts";
+    public const string TrustComparatorsRevert = "Remove all your trusts?";
 }

--- a/web/src/Web.App/Views/Trust/Index.cshtml
+++ b/web/src/Web.App/Views/Trust/Index.cshtml
@@ -40,6 +40,12 @@
                             View and change your set of trusts
                         </a>
                     </p>
+                    <p>
+                        <a class="govuk-notification-banner__link"
+                           href="@Url.Action("Revert", "TrustComparators", new { companyNumber = Model.CompanyNumber })">
+                            Change back to the sets of trusts we chose
+                        </a>
+                    </p>
                 </div>
             </div>
         </div>

--- a/web/src/Web.App/Views/TrustComparators/Revert.cshtml
+++ b/web/src/Web.App/Views/TrustComparators/Revert.cshtml
@@ -1,0 +1,33 @@
+﻿@model Web.App.ViewModels.TrustComparatorsViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.TrustComparatorsRevert;
+}
+
+@await Component.InvokeAsync("EstablishmentHeading", new
+{
+    title = ViewData[ViewDataKeys.Title],
+    name = Model.Name,
+    id = Model.CompanyNumber,
+    kind = OrganisationTypes.Trust
+})
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <p class="govuk-body">This will return you to just viewing spending priorities for @Model.Name.</p>
+        @using (Html.BeginForm("Revert", "TrustComparators", new
+                {
+                    companyNumber = Model.CompanyNumber
+                }, FormMethod.Post, true, new
+                {
+                    novalidate = "novalidate"
+                }))
+        {
+            <div class="govuk-button-group">
+                <button type="submit" class="govuk-button" data-module="govuk-button">
+                    Remove all trusts
+                </button>
+                <a class="govuk-link" href="@Url.Action("Index", "Trust", new { companyNumber = Model.CompanyNumber })">Cancel</a>
+            </div>
+        }
+    </div>
+</div>

--- a/web/src/Web.App/Views/TrustComparatorsCreateBy/Name.cshtml
+++ b/web/src/Web.App/Views/TrustComparatorsCreateBy/Name.cshtml
@@ -62,6 +62,16 @@
     @await Html.PartialAsync("_ChosenTrusts", new TrustComparatorsChosenTrustsViewModel(Model.CompanyNumber, Model.Trusts))
 }
 
+@if (Model.Trusts != null && Model.Trusts.Any(x => x.CompanyNumber != Model.CompanyNumber))
+{
+    <p class="govuk-body govuk-!-text-align-right">
+        <a class="govuk-link govuk-link--no-visited-state"
+           href="@Url.Action("Revert", "TrustComparators", new { companyNumber = Model.CompanyNumber })">
+            Remove all your choices
+        </a>
+    </p>
+}
+
 @section scripts
 {
     <script type="module" add-nonce="true">


### PR DESCRIPTION
### Context
[AB#213059](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/213059) [AB#206777](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/206777)

### Change proposed in this pull request
Allow user defined Trust comparators to be reverted.

### Guidance to review 
~~Currently this reverts back to the 'previous' custom set rather than the defaults in some scenarios, unless this is the only custom set still active for the user/trust. To be investigated in [AB#213453](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/213453) at a later date.~~

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

