### PR TITLE
Skeleton Trust-to-trust landing page

### DIFF
--- a/web/src/Web.App/Constants/PageTitles.cs
+++ b/web/src/Web.App/Constants/PageTitles.cs
@@ -60,4 +60,5 @@ public static class PageTitles
     public const string TrustComparatorsSubmit = "Generating benchmarking data";
     public const string TrustComparatorsUserDefined = "Your set of trusts";
     public const string TrustComparatorsRevert = "Remove all your trusts?";
+    public const string TrustToTrustHome = "Benchmark spending for this trust";
 }

--- a/web/src/Web.App/Controllers/TrustComparatorsController.cs
+++ b/web/src/Web.App/Controllers/TrustComparatorsController.cs
@@ -11,7 +11,8 @@ using Web.App.ViewModels;
 namespace Web.App.Controllers;
 
 [Controller]
-[FeatureGate(FeatureFlags.Trusts)]
+[Authorize]
+[FeatureGate(FeatureFlags.Trusts, FeatureFlags.UserDefinedComparators)]
 [Route("trust/{companyNumber}/comparators")]
 public class TrustComparatorsController(
     ILogger<TrustComparatorsController> logger,
@@ -22,12 +23,41 @@ public class TrustComparatorsController(
     ITrustComparatorSetService trustComparatorSetService) : Controller
 {
     [HttpGet]
-    public IActionResult Index(string companyNumber) => new StatusCodeResult(StatusCodes.Status302Found);
+    public async Task<IActionResult> Index(string companyNumber,
+        [FromQuery(Name = "comparator-generated")] bool? comparatorGenerated)
+    {
+        using (logger.BeginScope(new
+        {
+            companyNumber
+        }))
+        {
+            try
+            {
+                ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.TrustComparators(companyNumber);
+
+                var trust = await establishmentApi.GetTrust(companyNumber).GetResultOrThrow<Trust>();
+                var userData = await userDataService.GetTrustDataAsync(User.UserId(), companyNumber);
+                if (userData.ComparatorSet == null)
+                {
+                    return RedirectToAction("Index", "TrustComparatorsCreateBy", new
+                    {
+                        companyNumber
+                    });
+                }
+
+                var viewModel = new TrustToTrustViewModel(trust, comparatorGenerated);
+                return View(viewModel);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "An error displaying trust-to-trust landing: {DisplayUrl}", Request.GetDisplayUrl());
+                return e is StatusCodeException s ? StatusCode((int)s.Status) : StatusCode(500);
+            }
+        }
+    }
 
     [HttpGet]
     [Route("user-defined")]
-    [Authorize]
-    [FeatureGate(FeatureFlags.UserDefinedComparators)]
     public async Task<IActionResult> UserDefined(string companyNumber)
     {
         using (logger.BeginScope(new
@@ -37,7 +67,7 @@ public class TrustComparatorsController(
         {
             try
             {
-                ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.SchoolComparators(companyNumber);
+                ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.TrustComparators(companyNumber);
 
                 var trust = await establishmentApi.GetTrust(companyNumber).GetResultOrThrow<Trust>();
                 var userData = await userDataService.GetTrustDataAsync(User.UserId(), companyNumber);
@@ -66,8 +96,6 @@ public class TrustComparatorsController(
 
     [HttpGet]
     [Route("revert")]
-    [Authorize]
-    [FeatureGate(FeatureFlags.UserDefinedComparators)]
     public async Task<IActionResult> Revert(string companyNumber)
     {
         using (logger.BeginScope(new
@@ -93,8 +121,6 @@ public class TrustComparatorsController(
 
     [HttpPost]
     [Route("revert")]
-    [Authorize]
-    [FeatureGate(FeatureFlags.UserDefinedComparators)]
     public async Task<IActionResult> RevertSet(string companyNumber)
     {
         using (logger.BeginScope(new

--- a/web/src/Web.App/Controllers/TrustController.cs
+++ b/web/src/Web.App/Controllers/TrustController.cs
@@ -15,8 +15,7 @@ public class TrustController(ILogger<TrustController> logger, IEstablishmentApi 
 {
     [HttpGet]
     public async Task<IActionResult> Index(
-        string companyNumber,
-        [FromQuery(Name = "comparator-generated")] bool? comparatorGenerated)
+        string companyNumber)
     {
         using (logger.BeginScope(new
         {
@@ -39,7 +38,7 @@ public class TrustController(ILogger<TrustController> logger, IEstablishmentApi 
                 }
 
                 var ratings = await metricRagRatingApi.GetDefaultAsync(schoolsQuery).GetResultOrThrow<RagRating[]>();
-                var viewModel = new TrustViewModel(trust, balance, schools, ratings, comparatorGenerated);
+                var viewModel = new TrustViewModel(trust, balance, schools, ratings);
                 return View(viewModel);
             }
             catch (Exception e)

--- a/web/src/Web.App/ViewModels/TrustToTrustViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustToTrustViewModel.cs
@@ -1,0 +1,11 @@
+using Web.App.Domain;
+namespace Web.App.ViewModels;
+
+public class TrustToTrustViewModel(
+    Trust trust,
+    bool? comparatorGenerated)
+{
+    public string? CompanyNumber => trust.CompanyNumber;
+    public string? Name => trust.TrustName;
+    public bool? ComparatorGenerated => comparatorGenerated;
+}

--- a/web/src/Web.App/ViewModels/TrustViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustViewModel.cs
@@ -5,8 +5,7 @@ public class TrustViewModel(
     Trust trust,
     TrustBalance balance,
     IReadOnlyCollection<School> schools,
-    IEnumerable<RagRating> ratings,
-    bool? comparatorGenerated)
+    IEnumerable<RagRating> ratings)
 {
 
     public string? CompanyNumber => trust.CompanyNumber;
@@ -48,8 +47,6 @@ public class TrustViewModel(
     public IEnumerable<RagSchoolViewModel> SpecialOrPruSchools =>
         Schools.Where(s => s.OverallPhase is OverallPhaseTypes.Special or OverallPhaseTypes.PupilReferralUnit)
             .SelectMany(s => s.Schools);
-
-    public bool? ComparatorGenerated => comparatorGenerated;
 
     private IEnumerable<(
         string? OverallPhase,

--- a/web/src/Web.App/Views/Shared/Components/TrustFinanceTools/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/TrustFinanceTools/Default.cshtml
@@ -29,21 +29,23 @@
                                 Compare your trust schools pupil and workforce data.
                             </p>
                         </li>
-                        break;                           
+                        break;
                     case FinanceTools.CentralServices:
-                        <li>
-                            <img src="/assets/images/central-services.png" alt="" class="app-view-component">
-                            <h3 class="govuk-heading-s">
-                                <a href="" class="govuk-link govuk-link--no-visited-state">Trust to trust comparison</a>
-                            </h3>
-                            <p class="govuk-body">
-                                Compare to other trusts to understand more about your priority costs.
-                            </p>
-                            <strong class="govuk-tag govuk-tag--grey">
-                                Requires login
-                            </strong>
-                        </li>
-                        break;     
+                        <feature name="@(string.Join(",", FeatureFlags.UserDefinedComparators, FeatureFlags.Trusts))">
+                            <li>
+                                <img src="/assets/images/central-services.png" alt="" class="app-view-component">
+                                <h3 class="govuk-heading-s">
+                                    <a href="@Url.Action("Index", "TrustComparators", new { companyNumber = Model.Identifier })" class="govuk-link govuk-link--no-visited-state">Trust to trust comparison</a>
+                                </h3>
+                                <p class="govuk-body">
+                                    Compare to other trusts to understand more about your priority costs.
+                                </p>
+                                <strong class="govuk-tag govuk-tag--grey">
+                                    Requires login
+                                </strong>
+                            </li>
+                        </feature>
+                        break;
                     case FinanceTools.ForecastRisk:
                         <li>
                             <img src="/assets/images/forecast-risk.png" alt="" class="app-view-component">
@@ -57,7 +59,7 @@
                                 Requires login
                             </strong>
                         </li>
-                        break;                             
+                        break;
                     case FinanceTools.FinancialPlanning:
                         <li>
                             <img src="/assets/images/curriculum-financial-planning.png" alt="" class="app-view-component">
@@ -71,7 +73,7 @@
                                 Requires login
                             </strong>
                         </li>
-                        break;                        
+                        break;
                 }
             }
         </ul>

--- a/web/src/Web.App/Views/Trust/Index.cshtml
+++ b/web/src/Web.App/Views/Trust/Index.cshtml
@@ -13,44 +13,6 @@
             <a href="@Url.Action("Index", "FindOrganisation", new { method = OrganisationTypes.Trust })" class="govuk-link govuk-link--no-visited-state">Change trust</a>
         </p>
     </div>
-
-    @if (Model.ComparatorGenerated.HasValue)
-    {
-        <div class="govuk-grid-column-full">
-            @{
-                var success = Model.ComparatorGenerated == true;
-            }
-            <div class="govuk-notification-banner govuk-notification-banner--@(success ? "success" : "failure")" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-                <div class="govuk-notification-banner__header">
-                    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-                        @(success ? "Success" : "Error")
-                    </h2>
-                </div>
-                <div class="govuk-notification-banner__content">
-                    <h3 class="govuk-notification-banner__heading">@(success ? "You are now benchmarking against your own set of trusts" : "Unable to benchmark against your own set of trusts")</h3>
-                    @if (!success)
-                    {
-                        <p class="govuk-body">
-                            Please try again later.
-                        </p>
-                    }
-                    <p>
-                        <a class="govuk-notification-banner__link"
-                           href="@Url.Action("UserDefined", "TrustComparators", new { companyNumber = Model.CompanyNumber })">
-                            View and change your set of trusts
-                        </a>
-                    </p>
-                    <p>
-                        <a class="govuk-notification-banner__link"
-                           href="@Url.Action("Revert", "TrustComparators", new { companyNumber = Model.CompanyNumber })"
-                           id="revert-set">
-                            Change back to viewing spending priorities for this trust only
-                        </a>
-                    </p>
-                </div>
-            </div>
-        </div>
-    }
 </div>
 
 @await Component.InvokeAsync("DataSource", new

--- a/web/src/Web.App/Views/TrustComparators/Index.cshtml
+++ b/web/src/Web.App/Views/TrustComparators/Index.cshtml
@@ -1,0 +1,65 @@
+@model Web.App.ViewModels.TrustToTrustViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.TrustToTrustHome;
+}
+
+@await Component.InvokeAsync("EstablishmentHeading", new
+{
+    title = ViewData[ViewDataKeys.Title],
+    name = Model.Name,
+    id = Model.CompanyNumber,
+    kind = OrganisationTypes.Trust
+})
+
+<div class="govuk-grid-row">
+    @if (Model.ComparatorGenerated.HasValue)
+    {
+        <div class="govuk-grid-column-full">
+            @{
+                var success = Model.ComparatorGenerated == true;
+            }
+            <div class="govuk-notification-banner govuk-notification-banner--@(success ? "success" : "failure")" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+                <div class="govuk-notification-banner__header">
+                    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                        @(success ? "Success" : "Error")
+                    </h2>
+                </div>
+                <div class="govuk-notification-banner__content">
+                    <h3 class="govuk-notification-banner__heading">@(success ? "You've created a set of trusts to compare" : "Unable to create a set of trusts to compare")</h3>
+                    @if (!success)
+                    {
+                        <p class="govuk-body">
+                            Please try again later.
+                        </p>
+                    }
+                    <p>
+                        <a class="govuk-notification-banner__link"
+                           href="@Url.Action("Revert", "TrustComparators", new { companyNumber = Model.CompanyNumber })"
+                           id="revert-set">
+                            Change back to viewing spending priorities for this trust only
+                        </a>
+                    </p>
+                </div>
+            </div>
+        </div>
+    }
+
+    <div class="govuk-grid-column-full">
+        <p class="govuk-body">
+            <a class="govuk-notification-banner__link"
+               href="@Url.Action("UserDefined", "TrustComparators", new { companyNumber = Model.CompanyNumber })">
+                View and change your set of trusts
+            </a>
+        </p>
+        <p class="govuk-body">
+            Compare spending costs for this trust against similar trusts.
+        </p>
+    </div>
+</div>
+
+@await Component.InvokeAsync("DataSource", new
+{
+    kind = OrganisationTypes.Trust,
+    isPartOfTrust = true,
+    className = "govuk-grid-column-full"
+})

--- a/web/src/Web.App/Views/TrustComparatorsCreateBy/Submit.cshtml
+++ b/web/src/Web.App/Views/TrustComparatorsCreateBy/Submit.cshtml
@@ -22,7 +22,7 @@
       function statusCheck() {
         if (done || failed) {
             clearInterval(interval);
-            window.location.href = `/trust/@Model.CompanyNumber?comparator-generated=${!failed}`;
+            window.location.href = `/trust/@Model.CompanyNumber/comparators?comparator-generated=${!failed}`;
             return;
         }
 

--- a/web/tests/Web.A11yTests/Pages/Trust/Comparators/WhenViewingComparators.cs
+++ b/web/tests/Web.A11yTests/Pages/Trust/Comparators/WhenViewingComparators.cs
@@ -1,0 +1,25 @@
+﻿using Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+namespace Web.A11yTests.Pages.Trust.Comparators;
+
+[Trait("Category", "Comparators")]
+public class WhenViewingComparators(ITestOutputHelper testOutputHelper, WebDriver webDriver) : AuthPageBase(testOutputHelper, webDriver)
+{
+    protected override string PageUrl => $"/trust/{TestConfiguration.Trust}/comparators/create/by/name";
+
+    [Fact]
+    public async Task ThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await Page.Locator("#trust-input").FillAsync("trust");
+        await Page.Locator("#trust-input__listbox.autocomplete__menu--visible").WaitForAsync();
+        await Page.Keyboard.DownAsync("ArrowDown");
+        await Page.Keyboard.DownAsync("Enter");
+        await Page.Locator("button[type='submit']").ClickAsync();
+        await Page.Locator("#create-set").WaitForAsync();
+        await Page.Locator("#create-set").ClickAsync();
+        await Page.WaitForURLAsync("**/comparators?comparator-generated=true");
+        await EvaluatePage();
+    }
+}

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -323,6 +323,13 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         return this;
     }
 
+    public BenchmarkingWebAppClient SetupUserDataApi(UserData[]? data = null)
+    {
+        UserDataApi.Reset();
+        UserDataApi.Setup(api => api.GetAsync(It.IsAny<ApiQuery>())).ReturnsAsync(ApiResult.Ok(data ?? []));
+        return this;
+    }
+
     public BenchmarkingWebAppClient SetupHttpContextAccessor(ConcurrentDictionary<string, byte[]>? items = null)
     {
         HttpContextAccessor.Reset();

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/Comparators/WhenViewingComparators.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/Comparators/WhenViewingComparators.cs
@@ -1,0 +1,67 @@
+﻿using AngleSharp.Html.Dom;
+using AutoFixture;
+using Web.App.Domain;
+using Xunit;
+namespace Web.Integration.Tests.Pages.Trusts.Comparators;
+
+public class WhenViewingComparators(SchoolBenchmarkingWebAppClient client)
+    : PageBase<SchoolBenchmarkingWebAppClient>(client)
+{
+    [Fact]
+    public async Task CanDisplay()
+    {
+        var (page, trust) = await SetupNavigateInitPage(true);
+        AssertPageLayout(page, trust);
+    }
+
+    [Fact]
+    public async Task DisplaysCreateByIfNoSetDefined()
+    {
+        var (page, trust) = await SetupNavigateInitPage(false);
+        DocumentAssert.TitleAndH1(page,
+            "How do you want to choose your own set of trusts? - Financial Benchmarking and Insights Tool - GOV.UK",
+            "How do you want to choose your own set of trusts?");
+    }
+
+    private async Task<(IHtmlDocument page, Trust Trust)> SetupNavigateInitPage(bool withComparatorSet)
+    {
+        var trust = Fixture.Build<Trust>()
+            .With(x => x.CompanyNumber, "12345")
+            .Create();
+
+        var comparatorSet = new[]
+        {
+            new UserData
+            {
+                Type = "custom-data",
+                Id = "123"
+            },
+            new UserData
+            {
+                Type = "comparator-set",
+                Id = "456"
+            }
+        };
+
+        var page = await Client.SetupEstablishment(trust)
+            .SetupInsights()
+            .SetupUserDataApi(withComparatorSet ? comparatorSet : null)
+            .Navigate(Paths.TrustComparators(trust.CompanyNumber));
+
+        return (page, trust);
+    }
+
+    private static void AssertPageLayout(IHtmlDocument page, Trust trust)
+    {
+        var expectedBreadcrumbs = new[]
+        {
+            ("Home", Paths.ServiceHome.ToAbsolute()),
+            ("Your trust", Paths.TrustHome(trust.CompanyNumber).ToAbsolute()),
+            ("Comparator sets", Paths.TrustComparators(trust.CompanyNumber).ToAbsolute())
+        };
+        DocumentAssert.Breadcrumbs(page, expectedBreadcrumbs);
+        DocumentAssert.TitleAndH1(page,
+            "Benchmark spending for this trust - Financial Benchmarking and Insights Tool - GOV.UK",
+            "Benchmark spending for this trust");
+    }
+}


### PR DESCRIPTION
### Context
[AB#213657](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/213657) [AB#207092](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/207092)

### Change proposed in this pull request
Wired up Trust home page link to holding trust-to-trust comparison page. If no user defined comparison set, redirect user to the beginning of that journey.

### Guidance to review 
Content for trust-to-trust landing page will come next, but this PR should enable the create user defined set end-to-end.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

