### PR TITLE
Added Balance tab to Trust-to-Trust comparison

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -88,7 +88,7 @@
       ></div>
       <button type="submit">Submit</button>
     </form>-->
-    <div id="compare-your-costs-trust" data-id="07465701"></div>
+    <div id="compare-your-trust" data-id="07465701"></div>
     <!--<div id="compare-your-costs" data-type="school" data-id="140565"></div>-->
     <script type="module" src="/src/main.tsx"></script>
     <script

--- a/front-end-components/src/components/chart-dimensions/component.tsx
+++ b/front-end-components/src/components/chart-dimensions/component.tsx
@@ -1,16 +1,16 @@
+import React from "react";
 import { ChartDimensionsProps } from "src/components/chart-dimensions";
-import React, { useContext } from "react";
-import { ChartModeContext } from "src/contexts";
 import { ChartModeChart } from "src/components";
+import { useChartModeContext } from "src/contexts";
 
 export const ChartDimensions: React.FC<ChartDimensionsProps> = (props) => {
   const { dimensions, elementId, handleChange, defaultValue } = props;
-  const mode = useContext(ChartModeContext);
+  const { chartMode } = useChartModeContext();
 
   return (
     <div className="govuk-form-group">
       <label className="govuk-label" htmlFor={`${elementId}-dimension`}>
-        {mode == ChartModeChart ? "View graph as" : "View table as"}
+        {chartMode == ChartModeChart ? "View graph as" : "View table as"}
       </label>
       <select
         className="govuk-select"

--- a/front-end-components/src/components/chart-dimensions/component.tsx
+++ b/front-end-components/src/components/chart-dimensions/component.tsx
@@ -4,7 +4,7 @@ import { ChartModeChart } from "src/components";
 import { useChartModeContext } from "src/contexts";
 
 export const ChartDimensions: React.FC<ChartDimensionsProps> = (props) => {
-  const { dimensions, elementId, handleChange, defaultValue } = props;
+  const { dimensions, elementId, handleChange, value } = props;
   const { chartMode } = useChartModeContext();
 
   return (
@@ -17,7 +17,7 @@ export const ChartDimensions: React.FC<ChartDimensionsProps> = (props) => {
         name="dimension"
         id={`${elementId}-dimension`}
         onChange={handleChange}
-        defaultValue={defaultValue}
+        value={value}
       >
         {dimensions.map((dimension) => {
           return (

--- a/front-end-components/src/components/chart-dimensions/types.tsx
+++ b/front-end-components/src/components/chart-dimensions/types.tsx
@@ -12,5 +12,5 @@ export type ChartDimensionsProps = {
   dimensions: Dimension[];
   handleChange: React.ChangeEventHandler<HTMLSelectElement>;
   elementId: string;
-  defaultValue: string;
+  value: string;
 };

--- a/front-end-components/src/components/chart-mode/component.tsx
+++ b/front-end-components/src/components/chart-mode/component.tsx
@@ -6,7 +6,7 @@ import {
 } from "src/components/chart-mode";
 
 export const ChartMode: React.FC<ChartModeProps> = (props) => {
-  const { displayMode, handleChange, prefix } = props;
+  const { chartMode: displayMode, handleChange, prefix } = props;
 
   return (
     <div className="govuk-form-group">
@@ -25,7 +25,7 @@ export const ChartMode: React.FC<ChartModeProps> = (props) => {
               name={prefix ? `${prefix}ChangedChartMode` : "changedChartMode"}
               type="radio"
               value={ChartModeChart}
-              onChange={handleChange}
+              onChange={(e) => handleChange(e.target.value)}
               checked={displayMode == ChartModeChart}
             />
             <label
@@ -42,7 +42,7 @@ export const ChartMode: React.FC<ChartModeProps> = (props) => {
               name={prefix ? `${prefix}ChangedChartMode` : "changedChartMode"}
               type="radio"
               value={ChartModeTable}
-              onChange={handleChange}
+              onChange={(e) => handleChange(e.target.value)}
               checked={displayMode == ChartModeTable}
             />
             <label

--- a/front-end-components/src/components/chart-mode/types.tsx
+++ b/front-end-components/src/components/chart-mode/types.tsx
@@ -1,8 +1,6 @@
-import React from "react";
-
 export type ChartModeProps = {
-  displayMode: string;
-  handleChange: React.ChangeEventHandler<HTMLInputElement>;
+  chartMode: string | undefined;
+  handleChange: (value: string) => void;
   prefix?: string;
 };
 

--- a/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
@@ -211,7 +211,7 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
               x={0}
               label={{
                 position: "bottom",
-                offset: 9,
+                offset: 8,
                 value: valueFormatter
                   ? valueFormatter(0, { valueUnit })
                   : String(0),

--- a/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
@@ -204,8 +204,20 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
             width={tickWidth}
             axisLine={hasNegativeValues ? false : undefined}
             tickLine={hasNegativeValues ? false : undefined}
+            tickMargin={hasNegativeValues ? 50 : undefined}
           ></YAxis>
-          {hasNegativeValues && <ReferenceLine x={0} />}
+          {hasNegativeValues && (
+            <ReferenceLine
+              x={0}
+              label={{
+                position: "bottom",
+                offset: 9,
+                value: valueFormatter
+                  ? valueFormatter(0, { valueUnit })
+                  : String(0),
+              }}
+            />
+          )}
           {legend && (
             <Legend
               align="right"
@@ -224,15 +236,19 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
 
 function LabelListContent(props: LabelListContentProps) {
   const { valueFormatter, height, value, width, x, y } = props;
+  let dx =
+    (x as number) +
+    ((width as number) > 0 ? (width as number) : 0) +
+    (height as number) / 2;
+  const parsedValue = parseInt(value?.toString() || "");
+  if (!isNaN(parsedValue) && parsedValue < 0) {
+    dx += (width as number) - (height as number) * 3;
+  }
 
   return (
     <g>
       <Text
-        x={
-          (x as number) +
-          ((width as number) > 0 ? (width as number) : 0) +
-          (height as number) / 2
-        }
+        x={dx}
         y={(y as number) + (height as number) / 2}
         textAnchor="start"
         dominantBaseline="middle"

--- a/front-end-components/src/components/charts/table-chart/types.tsx
+++ b/front-end-components/src/components/charts/table-chart/types.tsx
@@ -22,4 +22,5 @@ export type TrustChartData = {
   schoolValue?: number;
   centralValue?: number;
   totalValue?: number;
+  type?: "expenditure" | "balance";
 };

--- a/front-end-components/src/components/charts/trust-data-tooltip/component.tsx
+++ b/front-end-components/src/components/charts/trust-data-tooltip/component.tsx
@@ -15,11 +15,13 @@ export function TrustDataTooltip<
     value === undefined ? "" : shortValueFormatter(value, { valueUnit });
 
   if (active && payload && payload.length) {
-    const trust = payload[0].payload as TrustChartData;
+    const { trustName, totalValue, schoolValue, centralValue, type } =
+      payload[0].payload as TrustChartData;
+    const label = type === "balance" ? type : "spend";
     return (
       <table className="govuk-table govuk-table--small-text-until-tablet tooltip-table">
         <caption className="govuk-table__caption govuk-table__caption--s">
-          {trust.trustName}
+          {trustName}
         </caption>
         <thead className="govuk-table__head govuk-visually-hidden">
           <tr className="govuk-table__row">
@@ -34,21 +36,21 @@ export function TrustDataTooltip<
         <tbody className="govuk-table__body">
           <tr className="govuk-table__row">
             <th scope="row" className="govuk-table__header">
-              Total spend
+              Overall {label}
             </th>
-            <td className="govuk-table__cell">{format(trust.totalValue)}</td>
+            <td className="govuk-table__cell">{format(totalValue)}</td>
           </tr>
           <tr className="govuk-table__row">
             <th scope="row" className="govuk-table__header">
-              School spend
+              School {label}
             </th>
-            <td className="govuk-table__cell">{format(trust.schoolValue)}</td>
+            <td className="govuk-table__cell">{format(schoolValue)}</td>
           </tr>
           <tr className="govuk-table__row">
             <th scope="row" className="govuk-table__header">
-              Central spend
+              Central {label}
             </th>
-            <td className="govuk-table__cell">{format(trust.centralValue)}</td>
+            <td className="govuk-table__cell">{format(centralValue)}</td>
           </tr>
         </tbody>
       </table>

--- a/front-end-components/src/components/include-breakdown/component.tsx
+++ b/front-end-components/src/components/include-breakdown/component.tsx
@@ -33,7 +33,7 @@ export const IncludeBreakdown: React.FC<IncludeBreakdownProps> = (props) => {
               }
               type="radio"
               value={BreakdownInclude}
-              onChange={handleChange}
+              onChange={(e) => handleChange(e.target.value)}
               checked={breakdown == BreakdownInclude}
             />
             <label
@@ -56,7 +56,7 @@ export const IncludeBreakdown: React.FC<IncludeBreakdownProps> = (props) => {
               }
               type="radio"
               value={BreakdownExclude}
-              onChange={handleChange}
+              onChange={(e) => handleChange(e.target.value)}
               checked={breakdown == BreakdownExclude}
             />
             <label

--- a/front-end-components/src/components/include-breakdown/types.tsx
+++ b/front-end-components/src/components/include-breakdown/types.tsx
@@ -1,8 +1,6 @@
-import React from "react";
-
 export type IncludeBreakdownProps = {
   breakdown: string | undefined;
-  handleChange: React.ChangeEventHandler<HTMLInputElement>;
+  handleChange: (value: string) => void;
   prefix?: string;
 };
 

--- a/front-end-components/src/composed/historic-chart-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/component.tsx
@@ -13,7 +13,7 @@ import { ResolvedStat } from "src/components/charts/resolved-stat";
 import { ChartDataSeries } from "src/components/charts/types";
 import { ChartDimensionContext } from "src/contexts";
 
-export const HistoricChart: React.FC<HistoricChartProps<ChartDataSeries>> = ({
+export function HistoricChart<TData extends ChartDataSeries>({
   chartName,
   data,
   seriesConfig,
@@ -22,7 +22,7 @@ export const HistoricChart: React.FC<HistoricChartProps<ChartDataSeries>> = ({
   valueUnit,
   axisLabel,
   columnHeading,
-}) => {
+}: HistoricChartProps<TData>) {
   const mode = useContext(ChartModeContext);
   const dimension = useContext(ChartDimensionContext);
 
@@ -104,4 +104,4 @@ export const HistoricChart: React.FC<HistoricChartProps<ChartDataSeries>> = ({
       )}
     </>
   );
-};
+}

--- a/front-end-components/src/composed/historic-chart-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/component.tsx
@@ -1,7 +1,6 @@
 import { useContext } from "react";
 import { ChartModeChart } from "src/components";
 import { HistoricChartProps } from "src/composed/historic-chart-composed";
-import { ChartModeContext } from "src/contexts";
 import { LineChart } from "src/components/charts/line-chart";
 import {
   shortValueFormatter,
@@ -11,7 +10,7 @@ import {
 import { LineChartTooltip } from "src/components/charts/line-chart-tooltip";
 import { ResolvedStat } from "src/components/charts/resolved-stat";
 import { ChartDataSeries } from "src/components/charts/types";
-import { ChartDimensionContext } from "src/contexts";
+import { ChartDimensionContext, useChartModeContext } from "src/contexts";
 
 export function HistoricChart<TData extends ChartDataSeries>({
   chartName,
@@ -23,13 +22,13 @@ export function HistoricChart<TData extends ChartDataSeries>({
   axisLabel,
   columnHeading,
 }: HistoricChartProps<TData>) {
-  const mode = useContext(ChartModeContext);
+  const { chartMode } = useChartModeContext();
   const dimension = useContext(ChartDimensionContext);
 
   return (
     <>
       {children}
-      {mode == ChartModeChart ? (
+      {chartMode == ChartModeChart ? (
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-three-quarters">
             <div style={{ height: 200 }}>

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -7,10 +7,10 @@ import {
 } from "src/components/charts/table-chart";
 import {
   ChartDimensionContext,
-  ChartModeContext,
   SelectedEstablishmentContext,
   HasIncompleteDataContext,
-  IncludeBreakdownContext,
+  useChartModeContext,
+  useIncludeBreakdownContext,
 } from "src/contexts";
 import { Loading } from "src/components/loading";
 import { ChartHandler, ChartSeriesConfigItem } from "src/components/charts";
@@ -34,11 +34,11 @@ export function HorizontalBarChartWrapper<
   TData extends SchoolChartData | TrustChartData,
 >(props: HorizontalBarChartWrapperProps<TData>) {
   const { chartName, children, data, sort, valueUnit } = props;
-  const mode = useContext(ChartModeContext);
+  const { chartMode } = useChartModeContext();
   const dimension = useContext(ChartDimensionContext);
   const selectedEstabishment = useContext(SelectedEstablishmentContext);
   const { hasIncompleteData, hasNoData } = useContext(HasIncompleteDataContext);
-  const breakdown = useContext(IncludeBreakdownContext);
+  const { breakdown } = useIncludeBreakdownContext();
   const ref = createRef<ChartHandler>();
   const [imageLoading, setImageLoading] = useState<boolean>();
   const isTrust = breakdown !== undefined;
@@ -98,7 +98,7 @@ export function HorizontalBarChartWrapper<
     <>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">{children}</div>
-        {mode == ChartModeChart && (
+        {chartMode == ChartModeChart && (
           <div className="govuk-grid-column-one-third">
             <button
               className="govuk-button govuk-button--secondary"
@@ -125,7 +125,7 @@ export function HorizontalBarChartWrapper<
         <div className="govuk-grid-column-full">
           {sortedDataPoints.length > 0 ? (
             <>
-              {mode == ChartModeChart && (
+              {chartMode == ChartModeChart && (
                 <div style={{ height: 22 * data.dataPoints.length + 75 }}>
                   <HorizontalBarChart
                     barCategoryGap={2}
@@ -181,13 +181,13 @@ export function HorizontalBarChartWrapper<
               )}
               <div
                 className={
-                  mode == ChartModeTable ? "" : "govuk-visually-hidden"
+                  chartMode == ChartModeTable ? "" : "govuk-visually-hidden"
                 }
               >
                 <TableChart
                   tableHeadings={data.tableHeadings}
                   data={sortedDataPoints}
-                  preventFocus={mode !== ChartModeTable}
+                  preventFocus={chartMode !== ChartModeTable}
                   valueUnit={valueUnit ?? dimension.unit}
                 />
               </div>

--- a/front-end-components/src/constants.tsx
+++ b/front-end-components/src/constants.tsx
@@ -1,5 +1,5 @@
 export const CompareCostsElementId = "compare-your-costs";
-export const CompareCostsTrustElementId = "compare-your-costs-trust";
+export const CompareTrustElementId = "compare-your-trust";
 export const CompareCensusElementId = "compare-your-census";
 export const DeploymentPlanElementId = "deployment-plan";
 export const HorizontalBarChart1SeriesElementId = "horizontal-chart-1-series";

--- a/front-end-components/src/contexts/contexts.tsx
+++ b/front-end-components/src/contexts/contexts.tsx
@@ -1,8 +1,15 @@
 import { createContext } from "react";
-import { ChartModeChart } from "src/components/chart-mode";
 import { Dimension } from "src/components";
 
-export const ChartModeContext = createContext(ChartModeChart);
+interface ChartModeContextValue {
+  chartMode: string;
+  setChartMode: React.Dispatch<React.SetStateAction<string>>;
+}
+
+export const ChartModeContext = createContext<
+  ChartModeContextValue | undefined
+>(undefined);
+
 export const ChartDimensionContext = createContext<Dimension>({
   label: "",
   value: "",
@@ -18,6 +25,11 @@ export const HasIncompleteDataContext = createContext<HasIncompleteData>({});
 
 export const PhaseContext = createContext<string | undefined>(undefined);
 
-export const IncludeBreakdownContext = createContext<string | undefined>(
-  undefined
-);
+interface IncludeBreakdownContextValue {
+  breakdown: string;
+  setBreakdown: React.Dispatch<React.SetStateAction<string>>;
+}
+
+export const IncludeBreakdownContext = createContext<
+  IncludeBreakdownContextValue | undefined
+>(undefined);

--- a/front-end-components/src/contexts/hooks.tsx
+++ b/front-end-components/src/contexts/hooks.tsx
@@ -1,0 +1,22 @@
+import { useContext } from "react";
+import { ChartModeContext, IncludeBreakdownContext } from "./contexts";
+
+export const useChartModeContext = () => {
+  const chartModeContext = useContext(ChartModeContext);
+  if (chartModeContext === undefined) {
+    throw new Error("chartModeContext must be inside a <ChartModeProvider>");
+  }
+
+  return chartModeContext;
+};
+
+export const useIncludeBreakdownContext = () => {
+  const includeBreakdownContext = useContext(IncludeBreakdownContext);
+  if (includeBreakdownContext === undefined) {
+    throw new Error(
+      "includeBreakdownContext must be inside an <IncludeBreakdownProvider>"
+    );
+  }
+
+  return includeBreakdownContext;
+};

--- a/front-end-components/src/contexts/index.tsx
+++ b/front-end-components/src/contexts/index.tsx
@@ -1,2 +1,4 @@
 /* eslint-disable react-refresh/only-export-components */
 export * from "src/contexts/contexts";
+export * from "src/contexts/hooks";
+export * from "src/contexts/providers";

--- a/front-end-components/src/contexts/providers.tsx
+++ b/front-end-components/src/contexts/providers.tsx
@@ -1,0 +1,34 @@
+import { PropsWithChildren, useState } from "react";
+import { ChartModeContext, IncludeBreakdownContext } from "./contexts";
+
+type ChartModeProviderProps = PropsWithChildren<{
+  initialValue: string;
+}>;
+
+export const ChartModeProvider = ({
+  children,
+  initialValue,
+}: ChartModeProviderProps) => {
+  const [chartMode, setChartMode] = useState<string>(initialValue);
+  return (
+    <ChartModeContext.Provider value={{ chartMode, setChartMode }}>
+      {children}
+    </ChartModeContext.Provider>
+  );
+};
+
+type IncludeBreakdownProviderProps = PropsWithChildren<{
+  initialValue: string;
+}>;
+
+export const IncludeBreakdownProvider = ({
+  children,
+  initialValue,
+}: IncludeBreakdownProviderProps) => {
+  const [breakdown, setBreakdown] = useState<string>(initialValue);
+  return (
+    <IncludeBreakdownContext.Provider value={{ breakdown, setBreakdown }}>
+      {children}
+    </IncludeBreakdownContext.Provider>
+  );
+};

--- a/front-end-components/src/index.css
+++ b/front-end-components/src/index.css
@@ -47,7 +47,8 @@
   stroke: var(--grid-colour);
 }
 
-.recharts-wrapper .recharts-cartesian-axis .recharts-text {
+.recharts-wrapper .recharts-cartesian-axis .recharts-text,
+.recharts-wrapper .recharts-reference-line .recharts-text {
   fill: var(--label-colour);
   stroke: none;
 }

--- a/front-end-components/src/index.css
+++ b/front-end-components/src/index.css
@@ -139,7 +139,9 @@
 
 .chart-stat-summary {
   display: grid;
-  grid-template-columns: calc(calc(100% - 30px) / 3) calc(calc(100% - 30px) / 3) calc(calc(100% - 30px) / 3);
+  grid-template-columns: calc(calc(100% - 30px) / 3) calc(calc(100% - 30px) / 3) calc(
+      calc(100% - 30px) / 3
+    );
   padding: 0;
   gap: 15px;
   width: 100%;
@@ -356,6 +358,9 @@
 
 .trust-options {
   grid-template-columns: 50% 50%;
+  border-bottom: 1px solid #b1b4b6;
+  padding-bottom: 0;
+  margin-bottom: 30px;
 }
 
 @media (max-width: 640px) {

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -24,7 +24,7 @@ import {
   LaSuggesterId,
   TrustSuggesterId,
   HorizontalChartTrustFinancialElementId,
-  CompareCostsTrustElementId,
+  CompareTrustElementId,
 } from "src/constants";
 import { HorizontalBarChart } from "./components/charts/horizontal-bar-chart";
 import { VerticalBarChart } from "./components/charts/vertical-bar-chart";
@@ -106,9 +106,7 @@ if (compareCostsElement) {
   }
 }
 
-const compareCostsTrustElement = document.getElementById(
-  CompareCostsTrustElementId
-);
+const compareCostsTrustElement = document.getElementById(CompareTrustElementId);
 
 if (compareCostsTrustElement) {
   const { id } = compareCostsTrustElement.dataset;

--- a/front-end-components/src/services/balance-api.tsx
+++ b/front-end-components/src/services/balance-api.tsx
@@ -1,21 +1,17 @@
-import { BalanceHistory } from "src/services/types";
+import { SchoolBalanceHistory } from "src/services/types";
 import { v4 as uuidv4 } from "uuid";
 
 export class BalanceApi {
   static async history(
     type: string,
     id: string,
-    dimension: string,
-    includeBreakdown?: boolean
-  ): Promise<BalanceHistory[]> {
+    dimension: string
+  ): Promise<SchoolBalanceHistory[]> {
     const params = new URLSearchParams({
       type: type,
       id: id,
       dimension: dimension,
     });
-    if (includeBreakdown !== undefined) {
-      params.append("includeBreakdown", includeBreakdown ? "true" : "false");
-    }
 
     return fetch("/api/balance/history?" + params, {
       redirect: "manual",

--- a/front-end-components/src/services/balance-api.tsx
+++ b/front-end-components/src/services/balance-api.tsx
@@ -1,4 +1,4 @@
-import { SchoolBalanceHistory } from "src/services/types";
+import { SchoolBalanceHistory, TrustBalance } from "src/services/types";
 import { v4 as uuidv4 } from "uuid";
 
 export class BalanceApi {
@@ -14,6 +14,39 @@ export class BalanceApi {
     });
 
     return fetch("/api/balance/history?" + params, {
+      redirect: "manual",
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Correlation-ID": uuidv4(),
+      },
+    })
+      .then((res) => res.json())
+      .then((res) => {
+        if (res.error) {
+          throw res.error;
+        }
+
+        return res;
+      });
+  }
+
+  static async trust(
+    id: string,
+    dimension: string,
+    includeBreakdown?: boolean
+  ): Promise<TrustBalance[]> {
+    const params = new URLSearchParams({
+      type: "trust",
+      id: id,
+      dimension: dimension,
+    });
+
+    if (includeBreakdown !== undefined) {
+      params.append("includeBreakdown", includeBreakdown ? "true" : "false");
+    }
+
+    return fetch("/api/balance/user-defined?" + params, {
       redirect: "manual",
       method: "GET",
       headers: {

--- a/front-end-components/src/services/expenditure-api.tsx
+++ b/front-end-components/src/services/expenditure-api.tsx
@@ -39,13 +39,13 @@ export class ExpenditureApi {
       });
   }
 
-  static async query(
+  static async query<T extends SchoolExpenditure>(
     type: string,
     id: string,
     dimension: string,
     category: string,
     phase?: string
-  ): Promise<SchoolExpenditure[]> {
+  ): Promise<T[]> {
     const params = new URLSearchParams({
       type: type,
       id: id,
@@ -75,12 +75,12 @@ export class ExpenditureApi {
       });
   }
 
-  static async trust(
+  static async trust<T extends TrustExpenditure>(
     id: string,
     dimension: string,
     category: string,
     includeBreakdown?: boolean
-  ): Promise<TrustExpenditure[]> {
+  ): Promise<T[]> {
     const params = new URLSearchParams({
       type: "trust",
       id: id,

--- a/front-end-components/src/services/types.tsx
+++ b/front-end-components/src/services/types.tsx
@@ -315,12 +315,6 @@ export type SchoolBalanceHistory = BalanceBase & {
   term: string;
 };
 
-export type TrustBalanceHistory = TrustBalanceBase & {
-  companyNumber: string;
-  year: number;
-  term: string;
-};
-
 type CensusBase = {
   urn: string;
   totalPupils: bigint;

--- a/front-end-components/src/services/types.tsx
+++ b/front-end-components/src/services/types.tsx
@@ -1,32 +1,182 @@
-export type ExpenditureBase = {
-  schoolTotalExpenditure: number;
-  schoolTotalTeachingSupportStaffCosts: number;
-  schoolTeachingStaffCosts: number;
-  schoolSupplyTeachingStaffCosts: number;
-  schoolEducationalConsultancyCosts: number;
-  schoolEducationSupportStaffCosts: number;
-  schoolAgencySupplyTeachingStaffCosts: number;
-  schoolTotalNonEducationalSupportStaffCosts: number;
-  schoolAdministrativeClericalStaffCosts: number;
-  schoolAuditorsCosts: number;
-  schoolOtherStaffCosts: number;
-  schoolProfessionalServicesNonCurriculumCosts: number;
-  schoolTotalEducationalSuppliesCosts: number;
-  schoolExaminationFeesCosts: number;
-  schoolLearningResourcesNonIctCosts: number;
+export type SchoolExpenditure = {
+  urn: string;
+  schoolName: string;
+  schoolType: string;
+  laName: string;
+  totalPupils: bigint;
+  totalInternalFloorArea: number;
+};
+
+type AdministrativeSuppliesExpenditureBase = {
+  administrativeSuppliesCosts: number;
+};
+
+export type AdministrativeSuppliesExpenditure = SchoolExpenditure &
+  AdministrativeSuppliesExpenditureBase;
+
+type CateringStaffServicesExpenditureBase = {
+  totalGrossCateringCosts: number;
+  cateringStaffCosts: number;
+  cateringSuppliesCosts: number;
+};
+
+export type CateringStaffServicesExpenditure = SchoolExpenditure &
+  CateringStaffServicesExpenditureBase;
+
+type EducationalIctExpenditureBase = {
+  learningResourcesIctCosts: number;
+};
+
+export type EducationalIctExpenditure = SchoolExpenditure &
+  EducationalIctExpenditureBase;
+
+type EducationalSuppliesExpenditureBase = {
+  totalEducationalSuppliesCosts: number;
+  examinationFeesCosts: number;
+  learningResourcesNonIctCosts: number;
+};
+
+export type EducationalSuppliesExpenditure = SchoolExpenditure &
+  EducationalSuppliesExpenditureBase;
+
+type NonEducationalSupportStaffExpenditureBase = {
+  totalNonEducationalSupportStaffCosts: number;
+  administrativeClericalStaffCosts: number;
+  auditorsCosts: number;
+  otherStaffCosts: number;
+  professionalServicesNonCurriculumCosts: number;
+};
+
+export type NonEducationalSupportStaffExpenditure = SchoolExpenditure &
+  NonEducationalSupportStaffExpenditureBase;
+
+type OtherCostsDataExpenditureBase = {
+  totalOtherCosts: number;
+  otherInsurancePremiumsCosts: number;
+  directRevenueFinancingCosts: number;
+  groundsMaintenanceCosts: number;
+  indirectEmployeeExpenses: number;
+  interestChargesLoanBank: number;
+  privateFinanceInitiativeCharges: number;
+  rentRatesCosts: number;
+  specialFacilitiesCosts: number;
+  staffDevelopmentTrainingCosts: number;
+  staffRelatedInsuranceCosts: number;
+  supplyTeacherInsurableCosts: number;
+  communityFocusedSchoolStaff: number;
+  communityFocusedSchoolCosts: number;
+};
+
+export type OtherCostsDataExpenditure = SchoolExpenditure &
+  OtherCostsDataExpenditureBase;
+
+type PremisesStaffServicesExpenditureBase = {
+  totalPremisesStaffServiceCosts: number;
+  cleaningCaretakingCosts: number;
+  maintenancePremisesCosts: number;
+  otherOccupationCosts: number;
+  premisesStaffCosts: number;
+};
+
+export type PremisesStaffServicesExpenditure = SchoolExpenditure &
+  PremisesStaffServicesExpenditureBase;
+
+type TeachingSupportStaffExpenditureBase = {
+  totalTeachingSupportStaffCosts: number;
+  teachingStaffCosts: number;
+  supplyTeachingStaffCosts: number;
+  educationalConsultancyCosts: number;
+  educationSupportStaffCosts: number;
+  agencySupplyTeachingStaffCosts: number;
+};
+
+export type TeachingSupportStaffExpenditure = SchoolExpenditure &
+  TeachingSupportStaffExpenditureBase;
+
+type TotalExpenditureExpenditureBase = {
+  totalExpenditure: number;
+};
+
+export type TotalExpenditureExpenditure = SchoolExpenditure &
+  TotalExpenditureExpenditureBase;
+
+type UtilitiesExpenditureBase = {
+  totalUtilitiesCosts: number;
+  energyCosts: number;
+  waterSewerageCosts: number;
+};
+
+export type UtilitiesExpenditure = SchoolExpenditure & UtilitiesExpenditureBase;
+
+export type TrustExpenditure = {
+  companyNumber: string;
+  trustName: string;
+};
+
+type AdministrativeSuppliesTrustExpenditureBase =
+  AdministrativeSuppliesExpenditureBase & {
+    schoolAdministrativeSuppliesCosts: number;
+    centralAdministrativeSuppliesCosts: number;
+  };
+
+export type AdministrativeSuppliesTrustExpenditure = TrustExpenditure &
+  AdministrativeSuppliesTrustExpenditureBase;
+
+type CateringStaffServicesTrustExpenditureBase =
+  CateringStaffServicesExpenditureBase & {
+    schoolTotalGrossCateringCosts: number;
+    schoolCateringStaffCosts: number;
+    schoolCateringSuppliesCosts: number;
+
+    centralTotalGrossCateringCosts: number;
+    centralCateringStaffCosts: number;
+    centralCateringSuppliesCosts: number;
+  };
+
+export type CateringStaffServicesTrustExpenditure = TrustExpenditure &
+  CateringStaffServicesTrustExpenditureBase;
+
+type EducationalIctTrustExpenditureBase = EducationalIctExpenditureBase & {
   schoolLearningResourcesIctCosts: number;
-  schoolTotalPremisesStaffServiceCosts: number;
-  schoolCleaningCaretakingCosts: number;
-  schoolMaintenancePremisesCosts: number;
-  schoolOtherOccupationCosts: number;
-  schoolPremisesStaffCosts: number;
-  schoolTotalUtilitiesCosts: number;
-  schoolEnergyCosts: number;
-  schoolWaterSewerageCosts: number;
-  schoolAdministrativeSuppliesCosts: number;
-  schoolTotalGrossCateringCosts: number;
-  schoolCateringStaffCosts: number;
-  schoolCateringSuppliesCosts: number;
+  centralLearningResourcesIctCosts: number;
+};
+
+export type EducationalIctTrustExpenditure = TrustExpenditure &
+  EducationalIctTrustExpenditureBase;
+
+type EducationalSuppliesTrustExpenditureBase =
+  EducationalSuppliesExpenditureBase & {
+    schoolTotalEducationalSuppliesCosts: number;
+    schoolExaminationFeesCosts: number;
+    schoolLearningResourcesNonIctCosts: number;
+
+    centralTotalEducationalSuppliesCosts: number;
+    centralExaminationFeesCosts: number;
+    centralLearningResourcesNonIctCosts: number;
+  };
+
+export type EducationalSuppliesTrustExpenditure = TrustExpenditure &
+  EducationalSuppliesTrustExpenditureBase;
+
+type NonEducationalSupportStaffTrustExpenditureBase =
+  NonEducationalSupportStaffExpenditureBase & {
+    schoolTotalNonEducationalSupportStaffCosts: number;
+    schoolAdministrativeClericalStaffCosts: number;
+    schoolAuditorsCosts: number;
+    schoolOtherStaffCosts: number;
+    schoolProfessionalServicesNonCurriculumCosts: number;
+
+    centralTotalNonEducationalSupportStaffCosts: number;
+    centralAdministrativeClericalStaffCosts: number;
+    centralAuditorsCosts: number;
+    centralOtherStaffCosts: number;
+    centralProfessionalServicesNonCurriculumCosts: number;
+  };
+
+export type NonEducationalSupportStaffTrustExpenditure = TrustExpenditure &
+  NonEducationalSupportStaffTrustExpenditureBase;
+
+type OtherCostsDataTrustExpenditureBase = OtherCostsDataExpenditureBase & {
   schoolTotalOtherCosts: number;
   schoolDirectRevenueFinancingCosts: number;
   schoolGroundsMaintenanceCosts: number;
@@ -42,34 +192,6 @@ export type ExpenditureBase = {
   schoolCommunityFocusedSchoolStaff: number;
   schoolCommunityFocusedSchoolCosts: number;
 
-  centralTotalExpenditure: number;
-  centralTotalTeachingSupportStaffCosts: number;
-  centralTeachingStaffCosts: number;
-  centralSupplyTeachingStaffCosts: number;
-  centralEducationalConsultancyCosts: number;
-  centralEducationSupportStaffCosts: number;
-  centralAgencySupplyTeachingStaffCosts: number;
-  centralTotalNonEducationalSupportStaffCosts: number;
-  centralAdministrativeClericalStaffCosts: number;
-  centralAuditorsCosts: number;
-  centralOtherStaffCosts: number;
-  centralProfessionalServicesNonCurriculumCosts: number;
-  centralTotalEducationalSuppliesCosts: number;
-  centralExaminationFeesCosts: number;
-  centralLearningResourcesNonIctCosts: number;
-  centralLearningResourcesIctCosts: number;
-  centralTotalPremisesStaffServiceCosts: number;
-  centralCleaningCaretakingCosts: number;
-  centralMaintenancePremisesCosts: number;
-  centralOtherOccupationCosts: number;
-  centralPremisesStaffCosts: number;
-  centralTotalUtilitiesCosts: number;
-  centralEnergyCosts: number;
-  centralWaterSewerageCosts: number;
-  centralAdministrativeSuppliesCosts: number;
-  centralTotalGrossCateringCosts: number;
-  centralCateringStaffCosts: number;
-  centralCateringSuppliesCosts: number;
   centralTotalOtherCosts: number;
   centralDirectRevenueFinancingCosts: number;
   centralGroundsMaintenanceCosts: number;
@@ -84,79 +206,122 @@ export type ExpenditureBase = {
   centralSupplyTeacherInsurableCosts: number;
   centralCommunityFocusedSchoolStaff: number;
   centralCommunityFocusedSchoolCosts: number;
-
-  totalExpenditure: number;
-  totalTeachingSupportStaffCosts: number;
-  teachingStaffCosts: number;
-  supplyTeachingStaffCosts: number;
-  educationalConsultancyCosts: number;
-  educationSupportStaffCosts: number;
-  agencySupplyTeachingStaffCosts: number;
-  totalNonEducationalSupportStaffCosts: number;
-  administrativeClericalStaffCosts: number;
-  auditorsCosts: number;
-  otherStaffCosts: number;
-  professionalServicesNonCurriculumCosts: number;
-  totalEducationalSuppliesCosts: number;
-  examinationFeesCosts: number;
-  learningResourcesNonIctCosts: number;
-  learningResourcesIctCosts: number;
-  totalPremisesStaffServiceCosts: number;
-  cleaningCaretakingCosts: number;
-  maintenancePremisesCosts: number;
-  otherOccupationCosts: number;
-  premisesStaffCosts: number;
-  totalUtilitiesCosts: number;
-  energyCosts: number;
-  waterSewerageCosts: number;
-  administrativeSuppliesCosts: number;
-  totalGrossCateringCosts: number;
-  cateringStaffCosts: number;
-  cateringSuppliesCosts: number;
-  totalOtherCosts: number;
-  directRevenueFinancingCosts: number;
-  groundsMaintenanceCosts: number;
-  indirectEmployeeExpenses: number;
-  interestChargesLoanBank: number;
-  otherInsurancePremiumsCosts: number;
-  privateFinanceInitiativeCharges: number;
-  rentRatesCosts: number;
-  specialFacilitiesCosts: number;
-  staffDevelopmentTrainingCosts: number;
-  staffRelatedInsuranceCosts: number;
-  supplyTeacherInsurableCosts: number;
-  communityFocusedSchoolStaff: number;
-  communityFocusedSchoolCosts: number;
 };
 
-export type SchoolExpenditure = ExpenditureBase & {
-  urn: string;
-  schoolName: string;
-  schoolType: string;
-  laName: string;
-  totalPupils: bigint;
-  totalInternalFloorArea: number;
+export type OtherCostsDataTrustExpenditure = TrustExpenditure &
+  OtherCostsDataTrustExpenditureBase;
+
+type PremisesStaffServicesTrustExpenditureBase =
+  PremisesStaffServicesExpenditureBase & {
+    schoolTotalPremisesStaffServiceCosts: number;
+    schoolCleaningCaretakingCosts: number;
+    schoolMaintenancePremisesCosts: number;
+    schoolOtherOccupationCosts: number;
+    schoolPremisesStaffCosts: number;
+
+    centralTotalPremisesStaffServiceCosts: number;
+    centralCleaningCaretakingCosts: number;
+    centralMaintenancePremisesCosts: number;
+    centralOtherOccupationCosts: number;
+    centralPremisesStaffCosts: number;
+  };
+
+export type PremisesStaffServicesTrustExpenditure = TrustExpenditure &
+  PremisesStaffServicesTrustExpenditureBase;
+
+type TeachingSupportStaffTrustExpenditureBase =
+  TeachingSupportStaffExpenditureBase & {
+    schoolTotalTeachingSupportStaffCosts: number;
+    schoolTeachingStaffCosts: number;
+    schoolSupplyTeachingStaffCosts: number;
+    schoolEducationalConsultancyCosts: number;
+    schoolEducationSupportStaffCosts: number;
+    schoolAgencySupplyTeachingStaffCosts: number;
+
+    centralTotalTeachingSupportStaffCosts: number;
+    centralTeachingStaffCosts: number;
+    centralSupplyTeachingStaffCosts: number;
+    centralEducationalConsultancyCosts: number;
+    centralEducationSupportStaffCosts: number;
+    centralAgencySupplyTeachingStaffCosts: number;
+  };
+
+export type TeachingSupportStaffTrustExpenditure = TrustExpenditure &
+  TeachingSupportStaffTrustExpenditureBase;
+
+type TotalExpenditureTrustExpenditureBase = TotalExpenditureExpenditureBase & {
+  schoolTotalExpenditure: number;
+  centralTotalExpenditure: number;
 };
 
-export type SchoolExpenditureHistory = ExpenditureBase & {
-  urn: string;
-  year: number;
-  term: string;
+export type TotalExpenditureTrustExpenditure = TrustExpenditure &
+  TotalExpenditureTrustExpenditureBase;
+
+type UtilitiesTrustExpenditureBase = UtilitiesExpenditureBase & {
+  schoolTotalUtilitiesCosts: number;
+  schoolEnergyCosts: number;
+  schoolWaterSewerageCosts: number;
+
+  centralTotalUtilitiesCosts: number;
+  centralEnergyCosts: number;
+  centralWaterSewerageCosts: number;
 };
 
-export type TrustExpenditure = ExpenditureBase & {
-  companyNumber: string;
-  trustName: string;
-};
+export type UtilitiesTrustExpenditure = TrustExpenditure &
+  UtilitiesTrustExpenditureBase;
 
-export type BalanceHistory = {
-  yearEnd: string;
-  term: string;
+export type SchoolExpenditureHistory = AdministrativeSuppliesExpenditureBase &
+  CateringStaffServicesExpenditureBase &
+  EducationalIctExpenditureBase &
+  EducationalSuppliesExpenditureBase &
+  NonEducationalSupportStaffExpenditureBase &
+  OtherCostsDataExpenditureBase &
+  PremisesStaffServicesExpenditureBase &
+  TeachingSupportStaffExpenditureBase &
+  TotalExpenditureExpenditureBase &
+  UtilitiesExpenditureBase & {
+    year: number;
+    term: string;
+  };
+
+type BalanceBase = {
   inYearBalance: number;
   revenueReserve: number;
 };
 
-export type Census = {
+type TrustBalanceBase = BalanceBase & {
+  schoolInYearBalance: number;
+  schoolRevenueReserve: number;
+
+  centralInYearBalance: number;
+  centralRevenueReserve: number;
+};
+
+export type SchoolBalance = BalanceBase & {
+  urn: string;
+  schoolName: string;
+  schoolType: string;
+  laName: string;
+  totalPupils: number;
+};
+
+export type TrustBalance = TrustBalanceBase & {
+  companyNumber: string;
+  trustName: string;
+};
+
+export type SchoolBalanceHistory = BalanceBase & {
+  year: number;
+  term: string;
+};
+
+export type TrustBalanceHistory = TrustBalanceBase & {
+  companyNumber: string;
+  year: number;
+  term: string;
+};
+
+type CensusBase = {
   urn: string;
   totalPupils: bigint;
   workforceFTE: number;
@@ -167,24 +332,17 @@ export type Census = {
   nonClassroomSupportStaffFTE: number;
   auxiliaryStaffFTE: number;
   percentTeacherWithQualifiedStatus: number;
+};
+
+export type Census = CensusBase & {
   schoolName: string;
   schoolType: string;
   laName: string;
 };
 
-export type CensusHistory = {
+export type CensusHistory = CensusBase & {
   year: string;
   term: string;
-  urn: string;
-  totalPupils: bigint;
-  workforceFTE: number;
-  workforceHeadcount: number;
-  teachersFTE: number;
-  seniorLeadershipFTE: number;
-  teachingAssistantFTE: number;
-  nonClassroomSupportStaffFTE: number;
-  auxiliaryStaffFTE: number;
-  percentTeacherWithQualifiedStatus: number;
 };
 
 export type Income = {

--- a/front-end-components/src/views/compare-your-census/partials/auxiliary-staff.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/auxiliary-staff.tsx
@@ -94,7 +94,7 @@ export const AuxiliaryStaff: React.FC<{ type: string; id: string }> = ({
             dimensions={CensusCategories}
             handleChange={handleSelectChange}
             elementId="auxiliary-staff"
-            defaultValue={dimension.value}
+            value={dimension.value}
           />
         </HorizontalBarChartWrapper>
       </ChartDimensionContext.Provider>

--- a/front-end-components/src/views/compare-your-census/partials/headcount.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/headcount.tsx
@@ -98,7 +98,7 @@ export const Headcount: React.FC<{ type: string; id: string }> = ({
             )}
             handleChange={handleSelectChange}
             elementId="headcount"
-            defaultValue={dimension.value}
+            value={dimension.value}
           />
         </HorizontalBarChartWrapper>
       </ChartDimensionContext.Provider>

--- a/front-end-components/src/views/compare-your-census/partials/non-classroom-support.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/non-classroom-support.tsx
@@ -95,7 +95,7 @@ export const NonClassroomSupport: React.FC<{ type: string; id: string }> = ({
             dimensions={CensusCategories}
             handleChange={handleSelectChange}
             elementId="nonclassroom-support"
-            defaultValue={dimension.value}
+            value={dimension.value}
           />
         </HorizontalBarChartWrapper>
       </ChartDimensionContext.Provider>

--- a/front-end-components/src/views/compare-your-census/partials/school-workforce.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/school-workforce.tsx
@@ -97,7 +97,7 @@ export const SchoolWorkforce: React.FC<{ type: string; id: string }> = ({
             )}
             handleChange={handleSelectChange}
             elementId="school-workforce"
-            defaultValue={dimension.value}
+            value={dimension.value}
           />
         </HorizontalBarChartWrapper>
       </ChartDimensionContext.Provider>

--- a/front-end-components/src/views/compare-your-census/partials/senior-leadership.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/senior-leadership.tsx
@@ -94,7 +94,7 @@ export const SeniorLeadership: React.FC<{ type: string; id: string }> = ({
             dimensions={CensusCategories}
             handleChange={handleSelectChange}
             elementId="senior-leadership"
-            defaultValue={dimension.value}
+            value={dimension.value}
           />
         </HorizontalBarChartWrapper>
       </ChartDimensionContext.Provider>

--- a/front-end-components/src/views/compare-your-census/partials/teaching-assistants.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/teaching-assistants.tsx
@@ -94,7 +94,7 @@ export const TeachingAssistants: React.FC<{ type: string; id: string }> = ({
             dimensions={CensusCategories}
             handleChange={handleSelectChange}
             elementId="teaching-assistants"
-            defaultValue={dimension.value}
+            value={dimension.value}
           />
         </HorizontalBarChartWrapper>
       </ChartDimensionContext.Provider>

--- a/front-end-components/src/views/compare-your-census/partials/total-teachers.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/total-teachers.tsx
@@ -94,7 +94,7 @@ export const TotalTeachers: React.FC<{ type: string; id: string }> = ({
             dimensions={CensusCategories}
             handleChange={handleSelectChange}
             elementId="total-teachers"
-            defaultValue={dimension.value}
+            value={dimension.value}
           />
         </HorizontalBarChartWrapper>
       </ChartDimensionContext.Provider>

--- a/front-end-components/src/views/compare-your-census/view.tsx
+++ b/front-end-components/src/views/compare-your-census/view.tsx
@@ -3,8 +3,9 @@ import { CompareYourCensusViewProps } from "src/views";
 import { ChartMode, ChartModeChart } from "src/components";
 import {
   SelectedEstablishmentContext,
-  ChartModeContext,
   PhaseContext,
+  ChartModeProvider,
+  useChartModeContext,
 } from "src/contexts";
 import {
   AuxiliaryStaff,
@@ -21,14 +22,10 @@ export const CompareYourCensus: React.FC<CompareYourCensusViewProps> = (
   props
 ) => {
   const { type, id, phases } = props;
-  const [displayMode, setDisplayMode] = useState<string>(ChartModeChart);
+  const { chartMode, setChartMode } = useChartModeContext();
   const [phase, setPhase] = useState<string | undefined>(
     phases ? phases[0] : undefined
   );
-
-  const toggleChartMode = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setDisplayMode(e.target.value);
-  };
 
   const handlePhaseChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setPhase(e.target.value);
@@ -37,38 +34,35 @@ export const CompareYourCensus: React.FC<CompareYourCensusViewProps> = (
   return (
     <SelectedEstablishmentContext.Provider value={id}>
       <PhaseContext.Provider value={phase}>
-        <div className="chart-options">
-          <div>
-            {phases && (
-              <div className="govuk-form-group">
-                <label className="govuk-label govuk-label--s" htmlFor="phase">
-                  Phase
-                </label>
-                <select
-                  className="govuk-select"
-                  name="phase"
-                  id="phase"
-                  onChange={handlePhaseChange}
-                >
-                  {phases.map((phase) => {
-                    return (
-                      <option key={phase} value={phase}>
-                        {phase}
-                      </option>
-                    );
-                  })}
-                </select>
-              </div>
-            )}
+        <ChartModeProvider initialValue={ChartModeChart}>
+          <div className="chart-options">
+            <div>
+              {phases && (
+                <div className="govuk-form-group">
+                  <label className="govuk-label govuk-label--s" htmlFor="phase">
+                    Phase
+                  </label>
+                  <select
+                    className="govuk-select"
+                    name="phase"
+                    id="phase"
+                    onChange={handlePhaseChange}
+                  >
+                    {phases.map((phase) => {
+                      return (
+                        <option key={phase} value={phase}>
+                          {phase}
+                        </option>
+                      );
+                    })}
+                  </select>
+                </div>
+              )}
+            </div>
+            <div>
+              <ChartMode chartMode={chartMode} handleChange={setChartMode} />
+            </div>
           </div>
-          <div>
-            <ChartMode
-              displayMode={displayMode}
-              handleChange={toggleChartMode}
-            />
-          </div>
-        </div>
-        <ChartModeContext.Provider value={displayMode}>
           <SchoolWorkforce id={id} type={type} />
           <TotalTeachers id={id} type={type} />
           <TotalTeachersQualified id={id} type={type} />
@@ -77,7 +71,7 @@ export const CompareYourCensus: React.FC<CompareYourCensusViewProps> = (
           <NonClassroomSupport id={id} type={type} />
           <AuxiliaryStaff id={id} type={type} />
           <Headcount id={id} type={type} />
-        </ChartModeContext.Provider>
+        </ChartModeProvider>
       </PhaseContext.Provider>
     </SelectedEstablishmentContext.Provider>
   );

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/administrative-supplies.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/administrative-supplies.tsx
@@ -18,7 +18,10 @@ import {
 } from "src/composed/horizontal-bar-chart-wrapper";
 import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
-import { SchoolExpenditure, ExpenditureApi } from "src/services";
+import {
+  ExpenditureApi,
+  AdministrativeSuppliesExpenditure,
+} from "src/services";
 
 export const AdministrativeSupplies: React.FC<{
   type: string;
@@ -26,10 +29,12 @@ export const AdministrativeSupplies: React.FC<{
 }> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const phase = useContext(PhaseContext);
-  const [data, setData] = useState<SchoolExpenditure[] | null>();
+  const [data, setData] = useState<
+    AdministrativeSuppliesExpenditure[] | null
+  >();
   const getData = useCallback(async () => {
     setData(null);
-    return await ExpenditureApi.query(
+    return await ExpenditureApi.query<AdministrativeSuppliesExpenditure>(
       type,
       id,
       dimension.value,

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/administrative-supplies.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/administrative-supplies.tsx
@@ -118,7 +118,7 @@ export const AdministrativeSupplies: React.FC<{
               dimensions={CostCategories}
               handleChange={handleSelectChange}
               elementId="administrative-supplies-non-eductional"
-              defaultValue={dimension.value}
+              value={dimension.value}
             />
           </HorizontalBarChartWrapper>
         </div>

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
@@ -142,7 +142,7 @@ export const CateringStaffServices: React.FC<{
               dimensions={CostCategories}
               handleChange={handleSelectChange}
               elementId="total-catering-costs"
-              defaultValue={dimension.value}
+              value={dimension.value}
             />
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
@@ -18,7 +18,7 @@ import {
 } from "src/composed/horizontal-bar-chart-wrapper";
 import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
-import { SchoolExpenditure, ExpenditureApi } from "src/services";
+import { ExpenditureApi, CateringStaffServicesExpenditure } from "src/services";
 
 export const CateringStaffServices: React.FC<{
   type: string;
@@ -26,10 +26,10 @@ export const CateringStaffServices: React.FC<{
 }> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const phase = useContext(PhaseContext);
-  const [data, setData] = useState<SchoolExpenditure[] | null>();
+  const [data, setData] = useState<CateringStaffServicesExpenditure[] | null>();
   const getData = useCallback(async () => {
     setData(null);
-    return await ExpenditureApi.query(
+    return await ExpenditureApi.query<CateringStaffServicesExpenditure>(
       type,
       id,
       dimension.value,

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-ict.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-ict.tsx
@@ -18,7 +18,7 @@ import {
 } from "src/composed/horizontal-bar-chart-wrapper";
 import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
-import { SchoolExpenditure, ExpenditureApi } from "src/services";
+import { ExpenditureApi, EducationalIctExpenditure } from "src/services";
 
 export const EducationalIct: React.FC<{
   type: string;
@@ -26,10 +26,10 @@ export const EducationalIct: React.FC<{
 }> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const phase = useContext(PhaseContext);
-  const [data, setData] = useState<SchoolExpenditure[] | null>();
+  const [data, setData] = useState<EducationalIctExpenditure[] | null>();
   const getData = useCallback(async () => {
     setData(null);
-    return await ExpenditureApi.query(
+    return await ExpenditureApi.query<EducationalIctExpenditure>(
       type,
       id,
       dimension.value,

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-ict.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-ict.tsx
@@ -113,7 +113,7 @@ export const EducationalIct: React.FC<{
               dimensions={CostCategories}
               handleChange={handleSelectChange}
               elementId="eductional-learning-resources-costs"
-              defaultValue={dimension.value}
+              value={dimension.value}
             />
           </HorizontalBarChartWrapper>
         </div>

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-supplies.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-supplies.tsx
@@ -144,7 +144,7 @@ export const EducationalSupplies: React.FC<{
               dimensions={CostCategories}
               handleChange={handleSelectChange}
               elementId="total-educational-supplies-costs"
-              defaultValue={dimension.value}
+              value={dimension.value}
             />
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-supplies.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-supplies.tsx
@@ -18,7 +18,7 @@ import {
 } from "src/composed/horizontal-bar-chart-wrapper";
 import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
-import { SchoolExpenditure, ExpenditureApi } from "src/services";
+import { ExpenditureApi, EducationalSuppliesExpenditure } from "src/services";
 
 export const EducationalSupplies: React.FC<{
   type: string;
@@ -26,10 +26,10 @@ export const EducationalSupplies: React.FC<{
 }> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const phase = useContext(PhaseContext);
-  const [data, setData] = useState<SchoolExpenditure[] | null>();
+  const [data, setData] = useState<EducationalSuppliesExpenditure[] | null>();
   const getData = useCallback(async () => {
     setData(null);
-    return await ExpenditureApi.query(
+    return await ExpenditureApi.query<EducationalSuppliesExpenditure>(
       type,
       id,
       dimension.value,

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/non-educational-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/non-educational-support-staff.tsx
@@ -177,7 +177,7 @@ export const NonEducationalSupportStaff: React.FC<{
               dimensions={CostCategories}
               handleChange={handleSelectChange}
               elementId="total-non-educational-support-staff-costs"
-              defaultValue={dimension.value}
+              value={dimension.value}
             />
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/non-educational-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/non-educational-support-staff.tsx
@@ -18,7 +18,10 @@ import {
 } from "src/composed/horizontal-bar-chart-wrapper";
 import classNames from "classnames";
 import { useHash } from "src/hooks/useHash";
-import { SchoolExpenditure, ExpenditureApi } from "src/services";
+import {
+  ExpenditureApi,
+  NonEducationalSupportStaffExpenditure,
+} from "src/services";
 
 export const NonEducationalSupportStaff: React.FC<{
   type: string;
@@ -26,10 +29,12 @@ export const NonEducationalSupportStaff: React.FC<{
 }> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const phase = useContext(PhaseContext);
-  const [data, setData] = useState<SchoolExpenditure[] | null>();
+  const [data, setData] = useState<
+    NonEducationalSupportStaffExpenditure[] | null
+  >();
   const getData = useCallback(async () => {
     setData(null);
-    return await ExpenditureApi.query(
+    return await ExpenditureApi.query<NonEducationalSupportStaffExpenditure>(
       type,
       id,
       dimension.value,

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/other-costs.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/other-costs.tsx
@@ -296,7 +296,7 @@ export const OtherCosts: React.FC<{
               dimensions={CostCategories}
               handleChange={handleSelectChange}
               elementId="total-otehr-costs"
-              defaultValue={dimension.value}
+              value={dimension.value}
             />
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/other-costs.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/other-costs.tsx
@@ -18,7 +18,7 @@ import {
 } from "src/composed/horizontal-bar-chart-wrapper";
 import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
-import { SchoolExpenditure, ExpenditureApi } from "src/services";
+import { ExpenditureApi, OtherCostsDataExpenditure } from "src/services";
 
 export const OtherCosts: React.FC<{
   type: string;
@@ -26,10 +26,10 @@ export const OtherCosts: React.FC<{
 }> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const phase = useContext(PhaseContext);
-  const [data, setData] = useState<SchoolExpenditure[] | null>();
+  const [data, setData] = useState<OtherCostsDataExpenditure[] | null>();
   const getData = useCallback(async () => {
     setData(null);
-    return await ExpenditureApi.query(
+    return await ExpenditureApi.query<OtherCostsDataExpenditure>(
       type,
       id,
       dimension.value,

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
@@ -18,7 +18,7 @@ import {
 } from "src/composed/horizontal-bar-chart-wrapper";
 import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
-import { SchoolExpenditure, ExpenditureApi } from "src/services";
+import { ExpenditureApi, PremisesStaffServicesExpenditure } from "src/services";
 
 export const PremisesStaffServices: React.FC<{
   type: string;
@@ -26,10 +26,10 @@ export const PremisesStaffServices: React.FC<{
 }> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerMetreSq);
   const phase = useContext(PhaseContext);
-  const [data, setData] = useState<SchoolExpenditure[] | null>();
+  const [data, setData] = useState<PremisesStaffServicesExpenditure[] | null>();
   const getData = useCallback(async () => {
     setData(null);
-    return await ExpenditureApi.query(
+    return await ExpenditureApi.query<PremisesStaffServicesExpenditure>(
       type,
       id,
       dimension.value,

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
@@ -172,7 +172,7 @@ export const PremisesStaffServices: React.FC<{
               dimensions={PremisesCategories}
               handleChange={handleSelectChange}
               elementId="total-premises-staff-service-costs"
-              defaultValue={dimension.value}
+              value={dimension.value}
             />
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/teaching-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/teaching-support-staff.tsx
@@ -18,7 +18,7 @@ import {
 } from "src/composed/horizontal-bar-chart-wrapper";
 import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
-import { SchoolExpenditure, ExpenditureApi } from "src/services";
+import { ExpenditureApi, TeachingSupportStaffExpenditure } from "src/services";
 
 export const TeachingSupportStaff: React.FC<{ type: string; id: string }> = ({
   type,
@@ -26,10 +26,10 @@ export const TeachingSupportStaff: React.FC<{ type: string; id: string }> = ({
 }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const phase = useContext(PhaseContext);
-  const [data, setData] = useState<SchoolExpenditure[] | null>();
+  const [data, setData] = useState<TeachingSupportStaffExpenditure[] | null>();
   const getData = useCallback(async () => {
     setData(null);
-    return await ExpenditureApi.query(
+    return await ExpenditureApi.query<TeachingSupportStaffExpenditure>(
       type,
       id,
       dimension.value,

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/teaching-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/teaching-support-staff.tsx
@@ -186,7 +186,7 @@ export const TeachingSupportStaff: React.FC<{ type: string; id: string }> = ({
               dimensions={CostCategories}
               handleChange={handleSelectChange}
               elementId="total-teaching-support-staff-cost"
-              defaultValue={dimension.value}
+              value={dimension.value}
             />
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/utilities.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/utilities.tsx
@@ -142,7 +142,7 @@ export const Utilities: React.FC<{
               dimensions={PremisesCategories}
               handleChange={handleSelectChange}
               elementId="total-utilities-costs"
-              defaultValue={dimension.value}
+              value={dimension.value}
             />
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/utilities.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/utilities.tsx
@@ -18,7 +18,7 @@ import {
 } from "src/composed/horizontal-bar-chart-wrapper";
 import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
-import { SchoolExpenditure, ExpenditureApi } from "src/services";
+import { ExpenditureApi, UtilitiesExpenditure } from "src/services";
 
 export const Utilities: React.FC<{
   type: string;
@@ -26,10 +26,10 @@ export const Utilities: React.FC<{
 }> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerMetreSq);
   const phase = useContext(PhaseContext);
-  const [data, setData] = useState<SchoolExpenditure[] | null>();
+  const [data, setData] = useState<UtilitiesExpenditure[] | null>();
   const getData = useCallback(async () => {
     setData(null);
-    return await ExpenditureApi.query(
+    return await ExpenditureApi.query<UtilitiesExpenditure>(
       type,
       id,
       dimension.value,

--- a/front-end-components/src/views/compare-your-costs/partials/total-expenditure.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/total-expenditure.tsx
@@ -17,7 +17,7 @@ import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
-import { SchoolExpenditure, ExpenditureApi } from "src/services";
+import { ExpenditureApi, TotalExpenditureExpenditure } from "src/services";
 
 export const TotalExpenditure: React.FC<{ type: string; id: string }> = ({
   type,
@@ -25,10 +25,10 @@ export const TotalExpenditure: React.FC<{ type: string; id: string }> = ({
 }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const phase = useContext(PhaseContext);
-  const [data, setData] = useState<SchoolExpenditure[] | null>();
+  const [data, setData] = useState<TotalExpenditureExpenditure[] | null>();
   const getData = useCallback(async () => {
     setData(null);
-    return await ExpenditureApi.query(
+    return await ExpenditureApi.query<TotalExpenditureExpenditure>(
       type,
       id,
       dimension.value,

--- a/front-end-components/src/views/compare-your-costs/partials/total-expenditure.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/total-expenditure.tsx
@@ -84,7 +84,7 @@ export const TotalExpenditure: React.FC<{ type: string; id: string }> = ({
           })}
           handleChange={handleSelectChange}
           elementId="total-expenditure"
-          defaultValue={dimension.value}
+          value={dimension.value}
         />
       </HorizontalBarChartWrapper>
     </ChartDimensionContext.Provider>

--- a/front-end-components/src/views/compare-your-costs/view.tsx
+++ b/front-end-components/src/views/compare-your-costs/view.tsx
@@ -7,9 +7,10 @@ import { CompareYourCostsViewProps } from "src/views/compare-your-costs";
 import { ChartMode, ChartModeChart } from "src/components";
 import {
   SelectedEstablishmentContext,
-  ChartModeContext,
   //HasIncompleteDataContext,
   PhaseContext,
+  useChartModeContext,
+  ChartModeProvider,
 } from "src/contexts";
 import { useGovUk } from "src/hooks/useGovUk";
 
@@ -17,16 +18,12 @@ export const CompareYourCosts: React.FC<CompareYourCostsViewProps> = (
   props
 ) => {
   const { type, id, phases } = props;
-  const [displayMode, setDisplayMode] = useState<string>(ChartModeChart);
+  const { chartMode, setChartMode } = useChartModeContext();
   const [phase, setPhase] = useState<string | undefined>(
     phases ? phases[0] : undefined
   );
 
   useGovUk();
-
-  const toggleChartMode = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setDisplayMode(e.target.value);
-  };
 
   const handlePhaseChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setPhase(e.target.value);
@@ -35,45 +32,42 @@ export const CompareYourCosts: React.FC<CompareYourCostsViewProps> = (
   return (
     <SelectedEstablishmentContext.Provider value={id}>
       <PhaseContext.Provider value={phase}>
-        <div className="chart-options">
-          <div>
-            {phases && (
-              <div className="govuk-form-group">
-                <label className="govuk-label govuk-label--s" htmlFor="phase">
-                  Phase
-                </label>
-                <select
-                  className="govuk-select"
-                  name="phase"
-                  id="phase"
-                  onChange={handlePhaseChange}
-                >
-                  {phases.map((phase) => {
-                    return (
-                      <option key={phase} value={phase}>
-                        {phase}
-                      </option>
-                    );
-                  })}
-                </select>
-              </div>
-            )}
+        <ChartModeProvider initialValue={ChartModeChart}>
+          <div className="chart-options">
+            <div>
+              {phases && (
+                <div className="govuk-form-group">
+                  <label className="govuk-label govuk-label--s" htmlFor="phase">
+                    Phase
+                  </label>
+                  <select
+                    className="govuk-select"
+                    name="phase"
+                    id="phase"
+                    onChange={handlePhaseChange}
+                  >
+                    {phases.map((phase) => {
+                      return (
+                        <option key={phase} value={phase}>
+                          {phase}
+                        </option>
+                      );
+                    })}
+                  </select>
+                </div>
+              )}
+            </div>
+            <div>
+              <ChartMode chartMode={chartMode} handleChange={setChartMode} />
+            </div>
           </div>
-          <div>
-            <ChartMode
-              displayMode={displayMode}
-              handleChange={toggleChartMode}
-            />
-          </div>
-        </div>
-        {/*<HasIncompleteDataContext.Provider*/}
-        {/*  value={{ hasIncompleteData, hasNoData }}*/}
-        {/*>*/}
-        <ChartModeContext.Provider value={displayMode}>
+          {/*<HasIncompleteDataContext.Provider*/}
+          {/*  value={{ hasIncompleteData, hasNoData }}*/}
+          {/*>*/}
           <TotalExpenditure id={id} type={type} />
           <ExpenditureAccordion id={id} type={type} />
-        </ChartModeContext.Provider>
-        {/*</HasIncompleteDataContext.Provider>*/}
+          {/*</HasIncompleteDataContext.Provider>*/}
+        </ChartModeProvider>
       </PhaseContext.Provider>
     </SelectedEstablishmentContext.Provider>
   );

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/administrative-supplies.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/administrative-supplies.tsx
@@ -12,16 +12,21 @@ import {
 } from "src/composed/horizontal-bar-chart-wrapper";
 import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
-import { TrustExpenditure, ExpenditureApi } from "src/services";
+import {
+  ExpenditureApi,
+  AdministrativeSuppliesTrustExpenditure,
+} from "src/services";
 
 export const AdministrativeSupplies: React.FC<{
   id: string;
 }> = ({ id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
-  const [data, setData] = useState<TrustExpenditure[] | null>();
+  const [data, setData] = useState<
+    AdministrativeSuppliesTrustExpenditure[] | null
+  >();
   const getData = useCallback(async () => {
     setData(null);
-    return await ExpenditureApi.trust(
+    return await ExpenditureApi.trust<AdministrativeSuppliesTrustExpenditure>(
       id,
       dimension.value,
       "AdministrationSupplies",

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/administrative-supplies.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/administrative-supplies.tsx
@@ -112,7 +112,7 @@ export const AdministrativeSupplies: React.FC<{
               dimensions={CostCategories}
               handleChange={handleSelectChange}
               elementId="administrative-supplies-non-eductional"
-              defaultValue={dimension.value}
+              value={dimension.value}
             />
           </HorizontalBarChartWrapper>
         </div>

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/administrative-supplies.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/administrative-supplies.tsx
@@ -60,14 +60,16 @@ export const AdministrativeSupplies: React.FC<{
 
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.administrativeSuppliesCosts ?? 0,
-              schoolValue: trust.schoolAdministrativeSuppliesCosts ?? 0,
-              centralValue: trust.centralAdministrativeSuppliesCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.administrativeSuppliesCosts ?? 0,
+                  schoolValue: trust.schoolAdministrativeSuppliesCosts ?? 0,
+                  centralValue: trust.centralAdministrativeSuppliesCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, dimension]);

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/catering-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/catering-staff-services.tsx
@@ -63,14 +63,16 @@ export const CateringStaffServices: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.totalGrossCateringCosts ?? 0,
-              schoolValue: trust.schoolTotalGrossCateringCosts ?? 0,
-              centralValue: trust.centralTotalGrossCateringCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.totalGrossCateringCosts ?? 0,
+                  schoolValue: trust.schoolTotalGrossCateringCosts ?? 0,
+                  centralValue: trust.centralTotalGrossCateringCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -79,14 +81,16 @@ export const CateringStaffServices: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.cateringStaffCosts ?? 0,
-              schoolValue: trust.schoolCateringStaffCosts ?? 0,
-              centralValue: trust.centralCateringStaffCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.cateringStaffCosts ?? 0,
+                  schoolValue: trust.schoolCateringStaffCosts ?? 0,
+                  centralValue: trust.centralCateringStaffCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -95,14 +99,16 @@ export const CateringStaffServices: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.cateringSuppliesCosts ?? 0,
-              schoolValue: trust.schoolCateringSuppliesCosts ?? 0,
-              centralValue: trust.centralCateringSuppliesCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.cateringSuppliesCosts ?? 0,
+                  schoolValue: trust.schoolCateringSuppliesCosts ?? 0,
+                  centralValue: trust.centralCateringSuppliesCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/catering-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/catering-staff-services.tsx
@@ -149,7 +149,7 @@ export const CateringStaffServices: React.FC<{
               dimensions={CostCategories}
               handleChange={handleSelectChange}
               elementId="total-catering-costs"
-              defaultValue={dimension.value}
+              value={dimension.value}
             />
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/catering-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/catering-staff-services.tsx
@@ -12,16 +12,21 @@ import {
 } from "src/composed/horizontal-bar-chart-wrapper";
 import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
-import { TrustExpenditure, ExpenditureApi } from "src/services";
+import {
+  ExpenditureApi,
+  CateringStaffServicesTrustExpenditure,
+} from "src/services";
 
 export const CateringStaffServices: React.FC<{
   id: string;
 }> = ({ id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
-  const [data, setData] = useState<TrustExpenditure[] | null>();
+  const [data, setData] = useState<
+    CateringStaffServicesTrustExpenditure[] | null
+  >();
   const getData = useCallback(async () => {
     setData(null);
-    return await ExpenditureApi.trust(
+    return await ExpenditureApi.trust<CateringStaffServicesTrustExpenditure>(
       id,
       dimension.value,
       "CateringStaffServices",

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-ict.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-ict.tsx
@@ -12,16 +12,16 @@ import {
 } from "src/composed/horizontal-bar-chart-wrapper";
 import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
-import { TrustExpenditure, ExpenditureApi } from "src/services";
+import { ExpenditureApi, EducationalIctTrustExpenditure } from "src/services";
 
 export const EducationalIct: React.FC<{
   id: string;
 }> = ({ id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
-  const [data, setData] = useState<TrustExpenditure[] | null>();
+  const [data, setData] = useState<EducationalIctTrustExpenditure[] | null>();
   const getData = useCallback(async () => {
     setData(null);
-    return await ExpenditureApi.trust(
+    return await ExpenditureApi.trust<EducationalIctTrustExpenditure>(
       id,
       dimension.value,
       "EducationalIct",

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-ict.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-ict.tsx
@@ -55,14 +55,16 @@ export const EducationalIct: React.FC<{
 
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.learningResourcesIctCosts ?? 0,
-              schoolValue: trust.schoolLearningResourcesIctCosts ?? 0,
-              centralValue: trust.centralLearningResourcesIctCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.learningResourcesIctCosts ?? 0,
+                  schoolValue: trust.schoolLearningResourcesIctCosts ?? 0,
+                  centralValue: trust.centralLearningResourcesIctCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [dimension, data]);

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-ict.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-ict.tsx
@@ -107,7 +107,7 @@ export const EducationalIct: React.FC<{
               dimensions={CostCategories}
               handleChange={handleSelectChange}
               elementId="eductional-learning-resources-costs"
-              defaultValue={dimension.value}
+              value={dimension.value}
             />
           </HorizontalBarChartWrapper>
         </div>

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-supplies.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-supplies.tsx
@@ -12,16 +12,21 @@ import {
 } from "src/composed/horizontal-bar-chart-wrapper";
 import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
-import { TrustExpenditure, ExpenditureApi } from "src/services";
+import {
+  ExpenditureApi,
+  EducationalSuppliesTrustExpenditure,
+} from "src/services";
 
 export const EducationalSupplies: React.FC<{
   id: string;
 }> = ({ id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
-  const [data, setData] = useState<TrustExpenditure[] | null>();
+  const [data, setData] = useState<
+    EducationalSuppliesTrustExpenditure[] | null
+  >();
   const getData = useCallback(async () => {
     setData(null);
-    return await ExpenditureApi.trust(
+    return await ExpenditureApi.trust<EducationalSuppliesTrustExpenditure>(
       id,
       dimension.value,
       "EducationalSupplies",

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-supplies.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-supplies.tsx
@@ -151,7 +151,7 @@ export const EducationalSupplies: React.FC<{
               dimensions={CostCategories}
               handleChange={handleSelectChange}
               elementId="total-educational-supplies-costs"
-              defaultValue={dimension.value}
+              value={dimension.value}
             />
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-supplies.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-supplies.tsx
@@ -63,14 +63,16 @@ export const EducationalSupplies: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.totalEducationalSuppliesCosts ?? 0,
-              schoolValue: trust.schoolTotalEducationalSuppliesCosts ?? 0,
-              centralValue: trust.centralTotalEducationalSuppliesCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.totalEducationalSuppliesCosts ?? 0,
+                  schoolValue: trust.schoolTotalEducationalSuppliesCosts ?? 0,
+                  centralValue: trust.centralTotalEducationalSuppliesCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -79,14 +81,16 @@ export const EducationalSupplies: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.examinationFeesCosts ?? 0,
-              schoolValue: trust.schoolExaminationFeesCosts ?? 0,
-              centralValue: trust.centralExaminationFeesCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.examinationFeesCosts ?? 0,
+                  schoolValue: trust.schoolExaminationFeesCosts ?? 0,
+                  centralValue: trust.centralExaminationFeesCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -95,14 +99,16 @@ export const EducationalSupplies: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.learningResourcesNonIctCosts ?? 0,
-              schoolValue: trust.schoolLearningResourcesNonIctCosts ?? 0,
-              centralValue: trust.centralLearningResourcesNonIctCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.learningResourcesNonIctCosts ?? 0,
+                  schoolValue: trust.schoolLearningResourcesNonIctCosts ?? 0,
+                  centralValue: trust.centralLearningResourcesNonIctCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/non-educational-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/non-educational-support-staff.tsx
@@ -12,16 +12,21 @@ import {
 } from "src/composed/horizontal-bar-chart-wrapper";
 import classNames from "classnames";
 import { useHash } from "src/hooks/useHash";
-import { TrustExpenditure, ExpenditureApi } from "src/services";
+import {
+  ExpenditureApi,
+  NonEducationalSupportStaffTrustExpenditure,
+} from "src/services";
 
 export const NonEducationalSupportStaff: React.FC<{
   id: string;
 }> = ({ id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
-  const [data, setData] = useState<TrustExpenditure[] | null>();
+  const [data, setData] = useState<
+    NonEducationalSupportStaffTrustExpenditure[] | null
+  >();
   const getData = useCallback(async () => {
     setData(null);
-    return await ExpenditureApi.trust(
+    return await ExpenditureApi.trust<NonEducationalSupportStaffTrustExpenditure>(
       id,
       dimension.value,
       "NonEducationalSupportStaff",

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/non-educational-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/non-educational-support-staff.tsx
@@ -193,7 +193,7 @@ export const NonEducationalSupportStaff: React.FC<{
               dimensions={CostCategories}
               handleChange={handleSelectChange}
               elementId="total-non-educational-support-staff-costs"
-              defaultValue={dimension.value}
+              value={dimension.value}
             />
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/non-educational-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/non-educational-support-staff.tsx
@@ -63,14 +63,18 @@ export const NonEducationalSupportStaff: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.administrativeClericalStaffCosts ?? 0,
-              schoolValue: trust.schoolAdministrativeClericalStaffCosts ?? 0,
-              centralValue: trust.centralAdministrativeClericalStaffCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.administrativeClericalStaffCosts ?? 0,
+                  schoolValue:
+                    trust.schoolAdministrativeClericalStaffCosts ?? 0,
+                  centralValue:
+                    trust.centralAdministrativeClericalStaffCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -79,16 +83,18 @@ export const NonEducationalSupportStaff: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.totalNonEducationalSupportStaffCosts ?? 0,
-              schoolValue:
-                trust.schoolTotalNonEducationalSupportStaffCosts ?? 0,
-              centralValue:
-                trust.centralTotalNonEducationalSupportStaffCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.totalNonEducationalSupportStaffCosts ?? 0,
+                  schoolValue:
+                    trust.schoolTotalNonEducationalSupportStaffCosts ?? 0,
+                  centralValue:
+                    trust.centralTotalNonEducationalSupportStaffCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -97,14 +103,16 @@ export const NonEducationalSupportStaff: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.auditorsCosts ?? 0,
-              schoolValue: trust.schoolAuditorsCosts ?? 0,
-              centralValue: trust.centralAuditorsCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.auditorsCosts ?? 0,
+                  schoolValue: trust.schoolAuditorsCosts ?? 0,
+                  centralValue: trust.centralAuditorsCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -113,14 +121,16 @@ export const NonEducationalSupportStaff: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.otherStaffCosts ?? 0,
-              schoolValue: trust.schoolOtherStaffCosts ?? 0,
-              centralValue: trust.centralOtherStaffCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.otherStaffCosts ?? 0,
+                  schoolValue: trust.schoolOtherStaffCosts ?? 0,
+                  centralValue: trust.centralOtherStaffCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -129,16 +139,18 @@ export const NonEducationalSupportStaff: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.professionalServicesNonCurriculumCosts ?? 0,
-              schoolValue:
-                trust.schoolProfessionalServicesNonCurriculumCosts ?? 0,
-              centralValue:
-                trust.centralProfessionalServicesNonCurriculumCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.professionalServicesNonCurriculumCosts ?? 0,
+                  schoolValue:
+                    trust.schoolProfessionalServicesNonCurriculumCosts ?? 0,
+                  centralValue:
+                    trust.centralProfessionalServicesNonCurriculumCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/other-costs.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/other-costs.tsx
@@ -12,16 +12,21 @@ import {
 } from "src/composed/horizontal-bar-chart-wrapper";
 import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
-import { TrustExpenditure, ExpenditureApi } from "src/services";
+import { ExpenditureApi, OtherCostsDataTrustExpenditure } from "src/services";
 
 export const OtherCosts: React.FC<{
   id: string;
 }> = ({ id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
-  const [data, setData] = useState<TrustExpenditure[] | null>();
+  const [data, setData] = useState<OtherCostsDataTrustExpenditure[] | null>();
   const getData = useCallback(async () => {
     setData(null);
-    return await ExpenditureApi.trust(id, dimension.value, "Other", true);
+    return await ExpenditureApi.trust<OtherCostsDataTrustExpenditure>(
+      id,
+      dimension.value,
+      "Other",
+      true
+    );
   }, [id, dimension]);
 
   useEffect(() => {

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/other-costs.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/other-costs.tsx
@@ -58,14 +58,16 @@ export const OtherCosts: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.totalOtherCosts ?? 0,
-              schoolValue: trust.schoolTotalOtherCosts ?? 0,
-              centralValue: trust.centralTotalOtherCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.totalOtherCosts ?? 0,
+                  schoolValue: trust.schoolTotalOtherCosts ?? 0,
+                  centralValue: trust.centralTotalOtherCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -74,14 +76,16 @@ export const OtherCosts: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.otherInsurancePremiumsCosts ?? 0,
-              schoolValue: trust.schoolOtherInsurancePremiumsCosts ?? 0,
-              centralValue: trust.centralOtherInsurancePremiumsCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.otherInsurancePremiumsCosts ?? 0,
+                  schoolValue: trust.schoolOtherInsurancePremiumsCosts ?? 0,
+                  centralValue: trust.centralOtherInsurancePremiumsCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -90,14 +94,16 @@ export const OtherCosts: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.directRevenueFinancingCosts ?? 0,
-              schoolValue: trust.schoolDirectRevenueFinancingCosts ?? 0,
-              centralValue: trust.centralDirectRevenueFinancingCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.directRevenueFinancingCosts ?? 0,
+                  schoolValue: trust.schoolDirectRevenueFinancingCosts ?? 0,
+                  centralValue: trust.centralDirectRevenueFinancingCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -106,14 +112,16 @@ export const OtherCosts: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.groundsMaintenanceCosts ?? 0,
-              schoolValue: trust.schoolGroundsMaintenanceCosts ?? 0,
-              centralValue: trust.centralGroundsMaintenanceCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.groundsMaintenanceCosts ?? 0,
+                  schoolValue: trust.schoolGroundsMaintenanceCosts ?? 0,
+                  centralValue: trust.centralGroundsMaintenanceCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -122,14 +130,16 @@ export const OtherCosts: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.indirectEmployeeExpenses ?? 0,
-              schoolValue: trust.schoolIndirectEmployeeExpenses ?? 0,
-              centralValue: trust.centralIndirectEmployeeExpenses ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.indirectEmployeeExpenses ?? 0,
+                  schoolValue: trust.schoolIndirectEmployeeExpenses ?? 0,
+                  centralValue: trust.centralIndirectEmployeeExpenses ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -138,14 +148,16 @@ export const OtherCosts: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.interestChargesLoanBank ?? 0,
-              schoolValue: trust.schoolInterestChargesLoanBank ?? 0,
-              centralValue: trust.centralInterestChargesLoanBank ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.interestChargesLoanBank ?? 0,
+                  schoolValue: trust.schoolInterestChargesLoanBank ?? 0,
+                  centralValue: trust.centralInterestChargesLoanBank ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -154,14 +166,17 @@ export const OtherCosts: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.privateFinanceInitiativeCharges ?? 0,
-              schoolValue: trust.schoolPrivateFinanceInitiativeCharges ?? 0,
-              centralValue: trust.centralPrivateFinanceInitiativeCharges ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.privateFinanceInitiativeCharges ?? 0,
+                  schoolValue: trust.schoolPrivateFinanceInitiativeCharges ?? 0,
+                  centralValue:
+                    trust.centralPrivateFinanceInitiativeCharges ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -170,14 +185,16 @@ export const OtherCosts: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.rentRatesCosts ?? 0,
-              schoolValue: trust.schoolRentRatesCosts ?? 0,
-              centralValue: trust.centralRentRatesCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.rentRatesCosts ?? 0,
+                  schoolValue: trust.schoolRentRatesCosts ?? 0,
+                  centralValue: trust.centralRentRatesCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -186,14 +203,16 @@ export const OtherCosts: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.specialFacilitiesCosts ?? 0,
-              schoolValue: trust.schoolSpecialFacilitiesCosts ?? 0,
-              centralValue: trust.centralSpecialFacilitiesCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.specialFacilitiesCosts ?? 0,
+                  schoolValue: trust.schoolSpecialFacilitiesCosts ?? 0,
+                  centralValue: trust.centralSpecialFacilitiesCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -202,14 +221,16 @@ export const OtherCosts: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.staffDevelopmentTrainingCosts ?? 0,
-              schoolValue: trust.schoolStaffDevelopmentTrainingCosts ?? 0,
-              centralValue: trust.centralStaffDevelopmentTrainingCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.staffDevelopmentTrainingCosts ?? 0,
+                  schoolValue: trust.schoolStaffDevelopmentTrainingCosts ?? 0,
+                  centralValue: trust.centralStaffDevelopmentTrainingCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -218,14 +239,16 @@ export const OtherCosts: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.staffRelatedInsuranceCosts ?? 0,
-              schoolValue: trust.schoolStaffRelatedInsuranceCosts ?? 0,
-              centralValue: trust.centralStaffRelatedInsuranceCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.staffRelatedInsuranceCosts ?? 0,
+                  schoolValue: trust.schoolStaffRelatedInsuranceCosts ?? 0,
+                  centralValue: trust.centralStaffRelatedInsuranceCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -234,14 +257,16 @@ export const OtherCosts: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.supplyTeacherInsurableCosts ?? 0,
-              schoolValue: trust.schoolSupplyTeacherInsurableCosts ?? 0,
-              centralValue: trust.centralSupplyTeacherInsurableCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.supplyTeacherInsurableCosts ?? 0,
+                  schoolValue: trust.schoolSupplyTeacherInsurableCosts ?? 0,
+                  centralValue: trust.centralSupplyTeacherInsurableCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -250,14 +275,16 @@ export const OtherCosts: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.communityFocusedSchoolStaff ?? 0,
-              schoolValue: trust.schoolCommunityFocusedSchoolStaff ?? 0,
-              centralValue: trust.centralCommunityFocusedSchoolStaff ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.communityFocusedSchoolStaff ?? 0,
+                  schoolValue: trust.schoolCommunityFocusedSchoolStaff ?? 0,
+                  centralValue: trust.centralCommunityFocusedSchoolStaff ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -266,14 +293,16 @@ export const OtherCosts: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.communityFocusedSchoolCosts ?? 0,
-              schoolValue: trust.schoolCommunityFocusedSchoolCosts ?? 0,
-              centralValue: trust.centralCommunityFocusedSchoolCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.communityFocusedSchoolCosts ?? 0,
+                  schoolValue: trust.schoolCommunityFocusedSchoolCosts ?? 0,
+                  centralValue: trust.centralCommunityFocusedSchoolCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/other-costs.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/other-costs.tsx
@@ -343,7 +343,7 @@ export const OtherCosts: React.FC<{
               dimensions={CostCategories}
               handleChange={handleSelectChange}
               elementId="total-otehr-costs"
-              defaultValue={dimension.value}
+              value={dimension.value}
             />
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/premises-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/premises-staff-services.tsx
@@ -63,14 +63,17 @@ export const PremisesStaffServices: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.totalPremisesStaffServiceCosts ?? 0,
-              schoolValue: trust.schoolTotalPremisesStaffServiceCosts ?? 0,
-              centralValue: trust.centralTotalPremisesStaffServiceCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.totalPremisesStaffServiceCosts ?? 0,
+                  schoolValue: trust.schoolTotalPremisesStaffServiceCosts ?? 0,
+                  centralValue:
+                    trust.centralTotalPremisesStaffServiceCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -79,14 +82,16 @@ export const PremisesStaffServices: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.cleaningCaretakingCosts ?? 0,
-              schoolValue: trust.schoolCleaningCaretakingCosts ?? 0,
-              centralValue: trust.centralCleaningCaretakingCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.cleaningCaretakingCosts ?? 0,
+                  schoolValue: trust.schoolCleaningCaretakingCosts ?? 0,
+                  centralValue: trust.centralCleaningCaretakingCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -95,14 +100,16 @@ export const PremisesStaffServices: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.maintenancePremisesCosts ?? 0,
-              schoolValue: trust.schoolMaintenancePremisesCosts ?? 0,
-              centralValue: trust.centralMaintenancePremisesCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.maintenancePremisesCosts ?? 0,
+                  schoolValue: trust.schoolMaintenancePremisesCosts ?? 0,
+                  centralValue: trust.centralMaintenancePremisesCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -111,14 +118,16 @@ export const PremisesStaffServices: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.otherOccupationCosts ?? 0,
-              schoolValue: trust.schoolOtherOccupationCosts ?? 0,
-              centralValue: trust.centralOtherOccupationCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.otherOccupationCosts ?? 0,
+                  schoolValue: trust.schoolOtherOccupationCosts ?? 0,
+                  centralValue: trust.centralOtherOccupationCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -127,14 +136,16 @@ export const PremisesStaffServices: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.premisesStaffCosts ?? 0,
-              schoolValue: trust.schoolPremisesStaffCosts ?? 0,
-              centralValue: trust.centralPremisesStaffCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.premisesStaffCosts ?? 0,
+                  schoolValue: trust.schoolPremisesStaffCosts ?? 0,
+                  centralValue: trust.centralPremisesStaffCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/premises-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/premises-staff-services.tsx
@@ -12,16 +12,21 @@ import {
 } from "src/composed/horizontal-bar-chart-wrapper";
 import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
-import { TrustExpenditure, ExpenditureApi } from "src/services";
+import {
+  ExpenditureApi,
+  PremisesStaffServicesTrustExpenditure,
+} from "src/services";
 
 export const PremisesStaffServices: React.FC<{
   id: string;
 }> = ({ id }) => {
   const [dimension, setDimension] = useState(PoundsPerMetreSq);
-  const [data, setData] = useState<TrustExpenditure[] | null>();
+  const [data, setData] = useState<
+    PremisesStaffServicesTrustExpenditure[] | null
+  >();
   const getData = useCallback(async () => {
     setData(null);
-    return await ExpenditureApi.trust(
+    return await ExpenditureApi.trust<PremisesStaffServicesTrustExpenditure>(
       id,
       dimension.value,
       "PremisesStaffServices",

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/premises-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/premises-staff-services.tsx
@@ -188,7 +188,7 @@ export const PremisesStaffServices: React.FC<{
               dimensions={PremisesCategories}
               handleChange={handleSelectChange}
               elementId="total-premises-staff-service-costs"
-              defaultValue={dimension.value}
+              value={dimension.value}
             />
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/teaching-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/teaching-support-staff.tsx
@@ -61,14 +61,17 @@ export const TeachingSupportStaff: React.FC<{ id: string }> = ({ id }) => {
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.totalTeachingSupportStaffCosts ?? 0,
-              schoolValue: trust.schoolTotalTeachingSupportStaffCosts ?? 0,
-              centralValue: trust.centralTotalTeachingSupportStaffCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.totalTeachingSupportStaffCosts ?? 0,
+                  schoolValue: trust.schoolTotalTeachingSupportStaffCosts ?? 0,
+                  centralValue:
+                    trust.centralTotalTeachingSupportStaffCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -77,14 +80,16 @@ export const TeachingSupportStaff: React.FC<{ id: string }> = ({ id }) => {
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.teachingStaffCosts ?? 0,
-              schoolValue: trust.schoolTeachingStaffCosts ?? 0,
-              centralValue: trust.centralTeachingStaffCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.teachingStaffCosts ?? 0,
+                  schoolValue: trust.schoolTeachingStaffCosts ?? 0,
+                  centralValue: trust.centralTeachingStaffCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -93,14 +98,16 @@ export const TeachingSupportStaff: React.FC<{ id: string }> = ({ id }) => {
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.supplyTeachingStaffCosts ?? 0,
-              schoolValue: trust.schoolSupplyTeachingStaffCosts ?? 0,
-              centralValue: trust.centralSupplyTeachingStaffCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.supplyTeachingStaffCosts ?? 0,
+                  schoolValue: trust.schoolSupplyTeachingStaffCosts ?? 0,
+                  centralValue: trust.centralSupplyTeachingStaffCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -109,14 +116,16 @@ export const TeachingSupportStaff: React.FC<{ id: string }> = ({ id }) => {
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.educationalConsultancyCosts ?? 0,
-              schoolValue: trust.schoolEducationalConsultancyCosts ?? 0,
-              centralValue: trust.centralEducationalConsultancyCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.educationalConsultancyCosts ?? 0,
+                  schoolValue: trust.schoolEducationalConsultancyCosts ?? 0,
+                  centralValue: trust.centralEducationalConsultancyCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -125,14 +134,16 @@ export const TeachingSupportStaff: React.FC<{ id: string }> = ({ id }) => {
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.educationSupportStaffCosts ?? 0,
-              schoolValue: trust.schoolEducationSupportStaffCosts ?? 0,
-              centralValue: trust.centralEducationSupportStaffCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.educationSupportStaffCosts ?? 0,
+                  schoolValue: trust.schoolEducationSupportStaffCosts ?? 0,
+                  centralValue: trust.centralEducationSupportStaffCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -141,14 +152,17 @@ export const TeachingSupportStaff: React.FC<{ id: string }> = ({ id }) => {
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.agencySupplyTeachingStaffCosts ?? 0,
-              schoolValue: trust.schoolAgencySupplyTeachingStaffCosts ?? 0,
-              centralValue: trust.centralAgencySupplyTeachingStaffCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.agencySupplyTeachingStaffCosts ?? 0,
+                  schoolValue: trust.schoolAgencySupplyTeachingStaffCosts ?? 0,
+                  centralValue:
+                    trust.centralAgencySupplyTeachingStaffCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/teaching-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/teaching-support-staff.tsx
@@ -12,14 +12,19 @@ import {
 } from "src/composed/horizontal-bar-chart-wrapper";
 import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
-import { TrustExpenditure, ExpenditureApi } from "src/services";
+import {
+  ExpenditureApi,
+  TeachingSupportStaffTrustExpenditure,
+} from "src/services";
 
 export const TeachingSupportStaff: React.FC<{ id: string }> = ({ id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
-  const [data, setData] = useState<TrustExpenditure[] | null>();
+  const [data, setData] = useState<
+    TeachingSupportStaffTrustExpenditure[] | null
+  >();
   const getData = useCallback(async () => {
     setData(null);
-    return await ExpenditureApi.trust(
+    return await ExpenditureApi.trust<TeachingSupportStaffTrustExpenditure>(
       id,
       dimension.value,
       "TeachingTeachingSupportStaff",

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/teaching-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/teaching-support-staff.tsx
@@ -205,7 +205,7 @@ export const TeachingSupportStaff: React.FC<{ id: string }> = ({ id }) => {
               dimensions={CostCategories}
               handleChange={handleSelectChange}
               elementId="total-teaching-support-staff-cost"
-              defaultValue={dimension.value}
+              value={dimension.value}
             />
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/utilities.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/utilities.tsx
@@ -58,14 +58,16 @@ export const Utilities: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.totalUtilitiesCosts ?? 0,
-              schoolValue: trust.schoolTotalUtilitiesCosts ?? 0,
-              centralValue: trust.centralTotalUtilitiesCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.totalUtilitiesCosts ?? 0,
+                  schoolValue: trust.schoolTotalUtilitiesCosts ?? 0,
+                  centralValue: trust.centralTotalUtilitiesCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -74,14 +76,16 @@ export const Utilities: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.energyCosts ?? 0,
-              schoolValue: trust.schoolEnergyCosts ?? 0,
-              centralValue: trust.centralEnergyCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.energyCosts ?? 0,
+                  schoolValue: trust.schoolEnergyCosts ?? 0,
+                  centralValue: trust.centralEnergyCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);
@@ -90,14 +94,16 @@ export const Utilities: React.FC<{
     useMemo(() => {
       return {
         dataPoints:
-          data?.map((trust) => {
-            return {
-              ...trust,
-              totalValue: trust.waterSewerageCosts ?? 0,
-              schoolValue: trust.schoolWaterSewerageCosts ?? 0,
-              centralValue: trust.centralWaterSewerageCosts ?? 0,
-            };
-          }) ?? [],
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.waterSewerageCosts ?? 0,
+                  schoolValue: trust.schoolWaterSewerageCosts ?? 0,
+                  centralValue: trust.centralWaterSewerageCosts ?? 0,
+                };
+              })
+            : [],
         tableHeadings,
       };
     }, [data, tableHeadings]);

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/utilities.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/utilities.tsx
@@ -144,7 +144,7 @@ export const Utilities: React.FC<{
               dimensions={PremisesCategories}
               handleChange={handleSelectChange}
               elementId="total-utilities-costs"
-              defaultValue={dimension.value}
+              value={dimension.value}
             />
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/utilities.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/utilities.tsx
@@ -12,16 +12,21 @@ import {
 } from "src/composed/horizontal-bar-chart-wrapper";
 import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
-import { TrustExpenditure, ExpenditureApi } from "src/services";
+import { ExpenditureApi, UtilitiesTrustExpenditure } from "src/services";
 
 export const Utilities: React.FC<{
   id: string;
 }> = ({ id }) => {
   const [dimension, setDimension] = useState(PoundsPerMetreSq);
-  const [data, setData] = useState<TrustExpenditure[] | null>();
+  const [data, setData] = useState<UtilitiesTrustExpenditure[] | null>();
   const getData = useCallback(async () => {
     setData(null);
-    return await ExpenditureApi.trust(id, dimension.value, "Utilities", true);
+    return await ExpenditureApi.trust<UtilitiesTrustExpenditure>(
+      id,
+      dimension.value,
+      "Utilities",
+      true
+    );
   }, [id, dimension]);
 
   useEffect(() => {

--- a/front-end-components/src/views/compare-your-trust/partials/balance-section.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/balance-section.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import {
+  BalanceSectionProps,
+  InYearBalance,
+} from "src/views/compare-your-trust/partials";
+import { ChartMode } from "src/components";
+import { IncludeBreakdown } from "src/components/include-breakdown";
+import { useChartModeContext, useIncludeBreakdownContext } from "src/contexts";
+
+export const BalanceSection: React.FC<BalanceSectionProps> = ({ id }) => {
+  const { chartMode, setChartMode } = useChartModeContext();
+  const { breakdown, setBreakdown } = useIncludeBreakdownContext();
+
+  return (
+    <>
+      <div className="chart-options trust-options">
+        <div>
+          <ChartMode
+            chartMode={chartMode}
+            handleChange={setChartMode}
+            prefix="balance"
+          />
+        </div>
+        <div>
+          <IncludeBreakdown
+            breakdown={breakdown}
+            handleChange={setBreakdown}
+            prefix="balance"
+          />
+        </div>
+      </div>
+      <div>
+        <InYearBalance id={id} />
+      </div>
+    </>
+  );
+};

--- a/front-end-components/src/views/compare-your-trust/partials/balance-section.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/balance-section.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {
   BalanceSectionProps,
-  InYearBalance,
+  Balance,
 } from "src/views/compare-your-trust/partials";
 import { ChartMode } from "src/components";
 import { IncludeBreakdown } from "src/components/include-breakdown";
@@ -30,7 +30,7 @@ export const BalanceSection: React.FC<BalanceSectionProps> = ({ id }) => {
         </div>
       </div>
       <div>
-        <InYearBalance id={id} />
+        <Balance id={id} />
       </div>
     </>
   );

--- a/front-end-components/src/views/compare-your-trust/partials/balance.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/balance.tsx
@@ -12,7 +12,7 @@ import {
 } from "src/composed/horizontal-bar-chart-wrapper";
 import { BalanceApi, TrustBalance } from "src/services";
 
-export const InYearBalance: React.FC<{
+export const Balance: React.FC<{
   id: string;
 }> = ({ id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
@@ -46,6 +46,33 @@ export const InYearBalance: React.FC<{
                   totalValue: trust.inYearBalance ?? 0,
                   schoolValue: trust.schoolInYearBalance ?? 0,
                   centralValue: trust.centralInYearBalance ?? 0,
+                  type: "balance",
+                };
+              })
+            : [],
+        tableHeadings,
+      };
+    }, [dimension, data]);
+
+  const revenueReserveChartData: HorizontalBarChartWrapperData<BalanceData> =
+    useMemo(() => {
+      const tableHeadings = [
+        "Trust name",
+        `Total ${dimension.heading}`,
+        `School ${dimension.heading}`,
+        `Central ${dimension.heading}`,
+      ];
+
+      return {
+        dataPoints:
+          data && Array.isArray(data)
+            ? data.map((trust) => {
+                return {
+                  ...trust,
+                  totalValue: trust.revenueReserve ?? 0,
+                  schoolValue: trust.schoolRevenueReserve ?? 0,
+                  centralValue: trust.centralRevenueReserve ?? 0,
+                  type: "balance",
                 };
               })
             : [],
@@ -73,7 +100,19 @@ export const InYearBalance: React.FC<{
           dimensions={CostCategories}
           handleChange={handleSelectChange}
           elementId="in-year-balance"
-          defaultValue={dimension.value}
+          value={dimension.value}
+        />
+      </HorizontalBarChartWrapper>
+      <HorizontalBarChartWrapper
+        data={revenueReserveChartData}
+        chartName="revenue reserve"
+      >
+        <h2 className="govuk-heading-m">Revenue reserve</h2>
+        <ChartDimensions
+          dimensions={CostCategories}
+          handleChange={handleSelectChange}
+          elementId="in-year-balance"
+          value={dimension.value}
         />
       </HorizontalBarChartWrapper>
     </ChartDimensionContext.Provider>

--- a/front-end-components/src/views/compare-your-trust/partials/in-year-balance.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/in-year-balance.tsx
@@ -1,31 +1,25 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { TotalExpenditureData } from "src/views/compare-your-trust/partials";
+import { BalanceData } from "src/views/compare-your-trust/partials";
 import { ChartDimensionContext } from "src/contexts";
 import {
   CostCategories,
   PoundsPerPupil,
   ChartDimensions,
-  PercentageExpenditure,
 } from "src/components";
 import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
-import { ExpenditureApi, TotalExpenditureTrustExpenditure } from "src/services";
+import { BalanceApi, TrustBalance } from "src/services";
 
-export const TotalExpenditure: React.FC<{
+export const InYearBalance: React.FC<{
   id: string;
 }> = ({ id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
-  const [data, setData] = useState<TotalExpenditureTrustExpenditure[] | null>();
+  const [data, setData] = useState<TrustBalance[] | null>();
   const getData = useCallback(async () => {
     setData(null);
-    return await ExpenditureApi.trust<TotalExpenditureTrustExpenditure>(
-      id,
-      dimension.value,
-      "TotalExpenditure",
-      true
-    );
+    return await BalanceApi.trust(id, dimension.value, true);
   }, [id, dimension]);
 
   useEffect(() => {
@@ -34,7 +28,7 @@ export const TotalExpenditure: React.FC<{
     });
   }, [getData]);
 
-  const chartData: HorizontalBarChartWrapperData<TotalExpenditureData> =
+  const inYearBalanceChartData: HorizontalBarChartWrapperData<BalanceData> =
     useMemo(() => {
       const tableHeadings = [
         "Trust name",
@@ -49,9 +43,9 @@ export const TotalExpenditure: React.FC<{
             ? data.map((trust) => {
                 return {
                   ...trust,
-                  totalValue: trust.totalExpenditure ?? 0,
-                  schoolValue: trust.schoolTotalExpenditure ?? 0,
-                  centralValue: trust.centralTotalExpenditure ?? 0,
+                  totalValue: trust.inYearBalance ?? 0,
+                  schoolValue: trust.schoolInYearBalance ?? 0,
+                  centralValue: trust.centralInYearBalance ?? 0,
                 };
               })
             : [],
@@ -70,14 +64,15 @@ export const TotalExpenditure: React.FC<{
 
   return (
     <ChartDimensionContext.Provider value={dimension}>
-      <HorizontalBarChartWrapper data={chartData} chartName="total expenditure">
-        <h2 className="govuk-heading-m">Total Expenditure</h2>
+      <HorizontalBarChartWrapper
+        data={inYearBalanceChartData}
+        chartName="in year balance"
+      >
+        <h2 className="govuk-heading-m">In-year balance</h2>
         <ChartDimensions
-          dimensions={CostCategories.filter(function (category) {
-            return category !== PercentageExpenditure;
-          })}
+          dimensions={CostCategories}
           handleChange={handleSelectChange}
-          elementId="total-expenditure"
+          elementId="in-year-balance"
           defaultValue={dimension.value}
         />
       </HorizontalBarChartWrapper>

--- a/front-end-components/src/views/compare-your-trust/partials/index.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/index.tsx
@@ -3,5 +3,5 @@ export * from "src/views/compare-your-trust/partials/total-expenditure";
 export * from "src/views/compare-your-trust/partials/expenditure-accordion";
 export * from "src/views/compare-your-trust/partials/spending-section";
 export * from "src/views/compare-your-trust/partials/balance-section";
-export * from "src/views/compare-your-trust/partials/in-year-balance";
+export * from "src/views/compare-your-trust/partials/balance";
 export * from "src/views/compare-your-trust/partials/types";

--- a/front-end-components/src/views/compare-your-trust/partials/index.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/index.tsx
@@ -2,4 +2,6 @@
 export * from "src/views/compare-your-trust/partials/total-expenditure";
 export * from "src/views/compare-your-trust/partials/expenditure-accordion";
 export * from "src/views/compare-your-trust/partials/spending-section";
+export * from "src/views/compare-your-trust/partials/balance-section";
+export * from "src/views/compare-your-trust/partials/in-year-balance";
 export * from "src/views/compare-your-trust/partials/types";

--- a/front-end-components/src/views/compare-your-trust/partials/spending-section.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/spending-section.tsx
@@ -1,53 +1,39 @@
-import React, { useState } from "react";
+import React from "react";
 import {
   TotalExpenditure,
   ExpenditureAccordion,
   SpendingSectionProps,
 } from "src/views/compare-your-trust/partials";
-import { ChartMode, ChartModeChart } from "src/components";
-import {
-  SelectedEstablishmentContext,
-  ChartModeContext,
-  IncludeBreakdownContext,
-} from "src/contexts";
-import {
-  BreakdownInclude,
-  IncludeBreakdown,
-} from "src/components/include-breakdown";
+import { ChartMode } from "src/components";
+import { IncludeBreakdown } from "src/components/include-breakdown";
+import { useChartModeContext, useIncludeBreakdownContext } from "src/contexts";
 
 export const SpendingSection: React.FC<SpendingSectionProps> = ({ id }) => {
-  const [displayMode, setDisplayMode] = useState<string>(ChartModeChart);
-  const [breakdown, setBreakdown] = useState<string | undefined>(
-    BreakdownInclude
-  );
-
-  const toggleChartMode = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setDisplayMode(e.target.value);
-  };
-
-  const toggleBreakdown = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setBreakdown(e.target.value);
-  };
+  const { chartMode, setChartMode } = useChartModeContext();
+  const { breakdown, setBreakdown } = useIncludeBreakdownContext();
 
   return (
-    <SelectedEstablishmentContext.Provider value={id}>
+    <>
       <div className="chart-options trust-options">
         <div>
-          <ChartMode displayMode={displayMode} handleChange={toggleChartMode} />
+          <ChartMode
+            chartMode={chartMode}
+            handleChange={setChartMode}
+            prefix="spending"
+          />
         </div>
         <div>
           <IncludeBreakdown
             breakdown={breakdown}
-            handleChange={toggleBreakdown}
+            handleChange={setBreakdown}
+            prefix="spending"
           />
         </div>
       </div>
-      <ChartModeContext.Provider value={displayMode}>
-        <IncludeBreakdownContext.Provider value={breakdown}>
-          <TotalExpenditure id={id} />
-          <ExpenditureAccordion id={id} />
-        </IncludeBreakdownContext.Provider>
-      </ChartModeContext.Provider>
-    </SelectedEstablishmentContext.Provider>
+      <div>
+        <TotalExpenditure id={id} />
+        <ExpenditureAccordion id={id} />
+      </div>
+    </>
   );
 };

--- a/front-end-components/src/views/compare-your-trust/partials/total-expenditure.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/total-expenditure.tsx
@@ -78,7 +78,7 @@ export const TotalExpenditure: React.FC<{
           })}
           handleChange={handleSelectChange}
           elementId="total-expenditure"
-          defaultValue={dimension.value}
+          value={dimension.value}
         />
       </HorizontalBarChartWrapper>
     </ChartDimensionContext.Provider>

--- a/front-end-components/src/views/compare-your-trust/partials/total-expenditure.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/total-expenditure.tsx
@@ -11,16 +11,16 @@ import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
-import { TrustExpenditure, ExpenditureApi } from "src/services";
+import { ExpenditureApi, TotalExpenditureTrustExpenditure } from "src/services";
 
 export const TotalExpenditure: React.FC<{
   id: string;
 }> = ({ id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
-  const [data, setData] = useState<TrustExpenditure[] | null>();
+  const [data, setData] = useState<TotalExpenditureTrustExpenditure[] | null>();
   const getData = useCallback(async () => {
     setData(null);
-    return await ExpenditureApi.trust(
+    return await ExpenditureApi.trust<TotalExpenditureTrustExpenditure>(
       id,
       dimension.value,
       "TotalExpenditure",

--- a/front-end-components/src/views/compare-your-trust/partials/types.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/types.tsx
@@ -13,3 +13,15 @@ export type TotalExpenditureData = {
 export type SpendingSectionProps = {
   id: string;
 };
+
+export type BalanceSectionProps = {
+  id: string;
+};
+
+export type BalanceData = {
+  companyNumber: string;
+  trustName: string;
+  schoolInYearBalance?: number;
+  centralInYearBalance?: number;
+  inYearBalance?: number;
+};

--- a/front-end-components/src/views/compare-your-trust/view.tsx
+++ b/front-end-components/src/views/compare-your-trust/view.tsx
@@ -2,6 +2,14 @@ import React from "react";
 import { CompareYourTrustViewProps } from "src/views/compare-your-trust";
 import { useGovUk } from "src/hooks/useGovUk";
 import { SpendingSection } from "./partials/spending-section";
+import { BalanceSection } from "./partials";
+import { ChartModeChart } from "src/components";
+import { BreakdownInclude } from "src/components/include-breakdown";
+import {
+  ChartModeProvider,
+  IncludeBreakdownProvider,
+  SelectedEstablishmentContext,
+} from "src/contexts";
 
 export const CompareYourTrust: React.FC<CompareYourTrustViewProps> = ({
   id,
@@ -16,10 +24,24 @@ export const CompareYourTrust: React.FC<CompareYourTrustViewProps> = ({
             Spending
           </a>
         </li>
+        <li className="govuk-tabs__list-item govuk-tabs__list-item--selected">
+          <a className="govuk-tabs__tab" href="#balance">
+            Balance
+          </a>
+        </li>
       </ul>
-      <div className="govuk-tabs__panel" id="spending">
-        <SpendingSection id={id} />
-      </div>
+      <SelectedEstablishmentContext.Provider value={id}>
+        <ChartModeProvider initialValue={ChartModeChart}>
+          <IncludeBreakdownProvider initialValue={BreakdownInclude}>
+            <div className="govuk-tabs__panel" id="spending">
+              <SpendingSection id={id} />
+            </div>
+            <div className="govuk-tabs__panel" id="balance">
+              <BalanceSection id={id} />
+            </div>
+          </IncludeBreakdownProvider>
+        </ChartModeProvider>
+      </SelectedEstablishmentContext.Provider>
     </div>
   );
 };

--- a/front-end-components/src/views/historic-data/partials/balance-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/balance-section.tsx
@@ -7,7 +7,7 @@ import {
   CostCategories,
 } from "src/components";
 import { ChartModeContext, ChartDimensionContext } from "src/contexts";
-import { BalanceHistory, BalanceApi } from "src/services";
+import { SchoolBalanceHistory, BalanceApi } from "src/services";
 import { HistoricChart } from "src/composed/historic-chart-composed";
 import { Loading } from "src/components/loading";
 
@@ -18,9 +18,9 @@ export const BalanceSection: React.FC<{ type: string; id: string }> = ({
   const defaultDimension = Actual;
   const [displayMode, setDisplayMode] = useState<string>(ChartModeChart);
   const [dimension, setDimension] = useState(defaultDimension);
-  const [data, setData] = useState(new Array<BalanceHistory>());
+  const [data, setData] = useState(new Array<SchoolBalanceHistory>());
   const getData = useCallback(async () => {
-    setData(new Array<BalanceHistory>());
+    setData(new Array<SchoolBalanceHistory>());
     return await BalanceApi.history(type, id, dimension.value);
   }, [type, id, dimension]);
 

--- a/front-end-components/src/views/historic-data/partials/balance-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/balance-section.tsx
@@ -6,7 +6,11 @@ import {
   ChartModeChart,
   CostCategories,
 } from "src/components";
-import { ChartModeContext, ChartDimensionContext } from "src/contexts";
+import {
+  ChartDimensionContext,
+  ChartModeProvider,
+  useChartModeContext,
+} from "src/contexts";
 import { SchoolBalanceHistory, BalanceApi } from "src/services";
 import { HistoricChart } from "src/composed/historic-chart-composed";
 import { Loading } from "src/components/loading";
@@ -16,7 +20,7 @@ export const BalanceSection: React.FC<{ type: string; id: string }> = ({
   id,
 }) => {
   const defaultDimension = Actual;
-  const [displayMode, setDisplayMode] = useState<string>(ChartModeChart);
+  const { chartMode, setChartMode } = useChartModeContext();
   const [dimension, setDimension] = useState(defaultDimension);
   const [data, setData] = useState(new Array<SchoolBalanceHistory>());
   const getData = useCallback(async () => {
@@ -30,12 +34,6 @@ export const BalanceSection: React.FC<{ type: string; id: string }> = ({
     });
   }, [getData]);
 
-  const handleModeChange: React.ChangeEventHandler<HTMLInputElement> = (
-    event
-  ) => {
-    setDisplayMode(event.target.value);
-  };
-
   const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
     event
   ) => {
@@ -46,7 +44,7 @@ export const BalanceSection: React.FC<{ type: string; id: string }> = ({
   };
 
   return (
-    <ChartModeContext.Provider value={displayMode}>
+    <ChartModeProvider initialValue={ChartModeChart}>
       <ChartDimensionContext.Provider value={dimension}>
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-two-thirds">
@@ -59,8 +57,8 @@ export const BalanceSection: React.FC<{ type: string; id: string }> = ({
           </div>
           <div className="govuk-grid-column-one-third">
             <ChartMode
-              displayMode={displayMode}
-              handleChange={handleModeChange}
+              chartMode={chartMode}
+              handleChange={setChartMode}
               prefix="balance"
             />
           </div>
@@ -155,6 +153,6 @@ export const BalanceSection: React.FC<{ type: string; id: string }> = ({
           <Loading />
         )}
       </ChartDimensionContext.Provider>
-    </ChartModeContext.Provider>
+    </ChartModeProvider>
   );
 };

--- a/front-end-components/src/views/historic-data/partials/balance-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/balance-section.tsx
@@ -52,7 +52,7 @@ export const BalanceSection: React.FC<{ type: string; id: string }> = ({
               dimensions={CostCategories}
               handleChange={handleSelectChange}
               elementId="balance"
-              defaultValue={dimension.value}
+              value={dimension.value}
             />
           </div>
           <div className="govuk-grid-column-one-third">

--- a/front-end-components/src/views/historic-data/partials/census-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/census-section.tsx
@@ -49,7 +49,7 @@ export const CensusSection: React.FC<{ id: string }> = ({ id }) => {
               dimensions={CensusCategories}
               handleChange={handleSelectChange}
               elementId="census"
-              defaultValue={dimension.value}
+              value={dimension.value}
             />
           </div>
           <div className="govuk-grid-column-one-third">

--- a/front-end-components/src/views/historic-data/partials/census-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/census-section.tsx
@@ -6,14 +6,18 @@ import {
   PupilsPerStaffRole,
   CensusCategories,
 } from "src/components";
-import { ChartModeContext, ChartDimensionContext } from "src/contexts";
+import {
+  ChartDimensionContext,
+  useChartModeContext,
+  ChartModeProvider,
+} from "src/contexts";
 import { CensusHistory, CensusApi } from "src/services";
 import { HistoricChart } from "src/composed/historic-chart-composed";
 import { Loading } from "src/components/loading";
 
 export const CensusSection: React.FC<{ id: string }> = ({ id }) => {
   const defaultDimension = PupilsPerStaffRole;
-  const [displayMode, setDisplayMode] = useState<string>(ChartModeChart);
+  const { chartMode, setChartMode } = useChartModeContext();
   const [dimension, setDimension] = useState(defaultDimension);
   const [data, setData] = useState(new Array<CensusHistory>());
   const getData = useCallback(async () => {
@@ -27,12 +31,6 @@ export const CensusSection: React.FC<{ id: string }> = ({ id }) => {
     });
   }, [getData]);
 
-  const handleModeChange: React.ChangeEventHandler<HTMLInputElement> = (
-    event
-  ) => {
-    setDisplayMode(event.target.value);
-  };
-
   const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
     event
   ) => {
@@ -43,7 +41,7 @@ export const CensusSection: React.FC<{ id: string }> = ({ id }) => {
   };
 
   return (
-    <ChartModeContext.Provider value={displayMode}>
+    <ChartModeProvider initialValue={ChartModeChart}>
       <ChartDimensionContext.Provider value={dimension}>
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-two-thirds">
@@ -56,8 +54,8 @@ export const CensusSection: React.FC<{ id: string }> = ({ id }) => {
           </div>
           <div className="govuk-grid-column-one-third">
             <ChartMode
-              displayMode={displayMode}
-              handleChange={handleModeChange}
+              chartMode={chartMode}
+              handleChange={setChartMode}
               prefix="census"
             />
           </div>
@@ -353,6 +351,6 @@ export const CensusSection: React.FC<{ id: string }> = ({ id }) => {
           <Loading />
         )}
       </ChartDimensionContext.Provider>
-    </ChartModeContext.Provider>
+    </ChartModeProvider>
   );
 };

--- a/front-end-components/src/views/historic-data/partials/income-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/income-section.tsx
@@ -55,7 +55,7 @@ export const IncomeSection: React.FC<{ type: string; id: string }> = ({
               dimensions={CostCategories}
               handleChange={handleSelectChange}
               elementId="income"
-              defaultValue={dimension.value}
+              value={dimension.value}
             />
           </div>
           <div className="govuk-grid-column-one-third">

--- a/front-end-components/src/views/historic-data/partials/income-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/income-section.tsx
@@ -7,7 +7,11 @@ import {
   CostCategories,
 } from "src/components";
 import { Income, IncomeApi } from "src/services";
-import { ChartModeContext, ChartDimensionContext } from "src/contexts";
+import {
+  ChartDimensionContext,
+  ChartModeProvider,
+  useChartModeContext,
+} from "src/contexts";
 import { Loading } from "src/components/loading";
 import { IncomeSectionGrantFunding } from "src/views/historic-data/partials/income-section-grant-funding";
 import { IncomeSectionSelfGenerated } from "src/views/historic-data/partials/income-section-self-generated";
@@ -19,7 +23,7 @@ export const IncomeSection: React.FC<{ type: string; id: string }> = ({
   id,
 }) => {
   const defaultDimension = Actual;
-  const [displayMode, setDisplayMode] = useState<string>(ChartModeChart);
+  const { chartMode, setChartMode } = useChartModeContext();
   const [dimension, setDimension] = useState(defaultDimension);
   const [data, setData] = useState(new Array<Income>());
   const getData = useCallback(async () => {
@@ -33,12 +37,6 @@ export const IncomeSection: React.FC<{ type: string; id: string }> = ({
     });
   }, [getData]);
 
-  const handleModeChange: React.ChangeEventHandler<HTMLInputElement> = (
-    event
-  ) => {
-    setDisplayMode(event.target.value);
-  };
-
   const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
     event
   ) => {
@@ -49,7 +47,7 @@ export const IncomeSection: React.FC<{ type: string; id: string }> = ({
   };
 
   return (
-    <ChartModeContext.Provider value={displayMode}>
+    <ChartModeProvider initialValue={ChartModeChart}>
       <ChartDimensionContext.Provider value={dimension}>
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-two-thirds">
@@ -62,8 +60,8 @@ export const IncomeSection: React.FC<{ type: string; id: string }> = ({
           </div>
           <div className="govuk-grid-column-one-third">
             <ChartMode
-              displayMode={displayMode}
-              handleChange={handleModeChange}
+              chartMode={chartMode}
+              handleChange={setChartMode}
               prefix="income"
             />
           </div>
@@ -153,6 +151,6 @@ export const IncomeSection: React.FC<{ type: string; id: string }> = ({
           </div>
         </div>
       </ChartDimensionContext.Provider>
-    </ChartModeContext.Provider>
+    </ChartModeProvider>
   );
 };

--- a/front-end-components/src/views/historic-data/partials/spending-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section.tsx
@@ -61,7 +61,7 @@ export const SpendingSection: React.FC<{ type: string; id: string }> = ({
               dimensions={CostCategories}
               handleChange={handleSelectChange}
               elementId="expenditure"
-              defaultValue={dimension.value}
+              value={dimension.value}
             />
           </div>
           <div className="govuk-grid-column-one-third">

--- a/front-end-components/src/views/historic-data/partials/spending-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section.tsx
@@ -7,7 +7,11 @@ import {
   CostCategories,
 } from "src/components";
 import { SchoolExpenditureHistory, ExpenditureApi } from "src/services";
-import { ChartDimensionContext, ChartModeContext } from "src/contexts";
+import {
+  ChartDimensionContext,
+  ChartModeProvider,
+  useChartModeContext,
+} from "src/contexts";
 import { HistoricChart } from "src/composed/historic-chart-composed";
 import { Loading } from "src/components/loading";
 import { SpendingSectionTeachingCosts } from "src/views/historic-data/partials/spending-section-teaching-costs";
@@ -25,7 +29,7 @@ export const SpendingSection: React.FC<{ type: string; id: string }> = ({
   id,
 }) => {
   const defaultDimension = Actual;
-  const [displayMode, setDisplayMode] = useState<string>(ChartModeChart);
+  const { chartMode, setChartMode } = useChartModeContext();
   const [dimension, setDimension] = useState(defaultDimension);
   const [data, setData] = useState(new Array<SchoolExpenditureHistory>());
   const getData = useCallback(async () => {
@@ -39,12 +43,6 @@ export const SpendingSection: React.FC<{ type: string; id: string }> = ({
     });
   }, [getData]);
 
-  const handleModeChange: React.ChangeEventHandler<HTMLInputElement> = (
-    event
-  ) => {
-    setDisplayMode(event.target.value);
-  };
-
   const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
     event
   ) => {
@@ -55,7 +53,7 @@ export const SpendingSection: React.FC<{ type: string; id: string }> = ({
   };
 
   return (
-    <ChartModeContext.Provider value={displayMode}>
+    <ChartModeProvider initialValue={ChartModeChart}>
       <ChartDimensionContext.Provider value={dimension}>
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-two-thirds">
@@ -68,8 +66,8 @@ export const SpendingSection: React.FC<{ type: string; id: string }> = ({
           </div>
           <div className="govuk-grid-column-one-third">
             <ChartMode
-              displayMode={displayMode}
-              handleChange={handleModeChange}
+              chartMode={chartMode}
+              handleChange={setChartMode}
               prefix="expenditure"
             />
           </div>
@@ -279,6 +277,6 @@ export const SpendingSection: React.FC<{ type: string; id: string }> = ({
           </div>
         </div>
       </ChartDimensionContext.Provider>
-    </ChartModeContext.Provider>
+    </ChartModeProvider>
   );
 };

--- a/web/src/Web.App/Controllers/Api/BalanceProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/BalanceProxyController.cs
@@ -1,16 +1,23 @@
-﻿using Microsoft.AspNetCore.Http.Extensions;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Web.App.Domain;
+using Web.App.Extensions;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Extensions;
+using Web.App.Services;
 namespace Web.App.Controllers.Api;
 
 [ApiController]
 [Route("api/balance")]
-public class BalanceProxyController(ILogger<BalanceProxyController> logger, IBalanceApi api) : Controller
+public class BalanceProxyController(
+    ILogger<BalanceProxyController> logger,
+    IBalanceApi api,
+    IUserDataService userDataService,
+    ITrustComparatorSetService trustComparatorSetService) : Controller
 {
-    /// <param name="type" example="trust"></param>
-    /// <param name="id" example="07465701"></param>
+    /// <param name="type" example="school"></param>
+    /// <param name="id" example="148793"></param>
     /// <param name="dimension" example="PerUnit"></param>
     /// <param name="includeBreakdown"></param>
     [HttpGet]
@@ -32,14 +39,14 @@ public class BalanceProxyController(ILogger<BalanceProxyController> logger, IBal
         {
             try
             {
-                var query = new ApiQuery()
-                    .AddIfNotNull("dimension", dimension)
-                    .AddIfNotNull("includeBreakdown", includeBreakdown);
-
                 var result = type.ToLower() switch
                 {
-                    OrganisationTypes.School => await api.SchoolHistory(id, query).GetResultOrDefault<BalanceHistory[]>(),
-                    OrganisationTypes.Trust => await api.TrustHistory(id, query).GetResultOrDefault<BalanceHistory[]>(),
+                    OrganisationTypes.School => await api
+                        .SchoolHistory(id, BuildQuery(dimension, includeBreakdown))
+                        .GetResultOrDefault<BalanceHistory[]>(),
+                    OrganisationTypes.Trust => await api
+                        .TrustHistory(id, BuildQuery(dimension, includeBreakdown))
+                        .GetResultOrDefault<BalanceHistory[]>(),
                     _ => throw new ArgumentOutOfRangeException(nameof(type))
                 };
 
@@ -51,5 +58,76 @@ public class BalanceProxyController(ILogger<BalanceProxyController> logger, IBal
                 return StatusCode(500);
             }
         }
+    }
+
+    /// <param name="type" example="trust"></param>
+    /// <param name="id" example="07465701"></param>
+    /// <param name="dimension" example="PerUnit"></param>
+    /// <param name="includeBreakdown"></param>
+    [HttpGet]
+    [Produces("application/json")]
+    [ProducesResponseType<TrustBalance[]>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [Route("user-defined")]
+    [Authorize]
+    public async Task<IActionResult> UserDefined(
+        [FromQuery] string type,
+        [FromQuery] string id,
+        [FromQuery] string dimension,
+        [FromQuery] bool? includeBreakdown)
+    {
+        using (logger.BeginScope(new
+        {
+            type,
+            id
+        }))
+        {
+            try
+            {
+                return type.ToLower() switch
+                {
+                    OrganisationTypes.Trust => await TrustBalanceUserDefined(id, dimension, includeBreakdown),
+                    _ => throw new ArgumentOutOfRangeException(nameof(type))
+                };
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "An error getting user-defined balance data: {DisplayUrl}", Request.GetDisplayUrl());
+                return StatusCode(500);
+            }
+        }
+    }
+
+    private async Task<IActionResult> TrustBalanceUserDefined(string id, string? dimension, bool? includeBreakdown)
+    {
+        var userData = await userDataService.GetTrustDataAsync(User.UserId(), id);
+        if (string.IsNullOrEmpty(userData.ComparatorSet))
+        {
+            return new NotFoundResult();
+        }
+
+        var userDefinedSet = await trustComparatorSetService.ReadUserDefinedComparatorSet(id, userData.ComparatorSet);
+        var userDefinedResult = await api
+            .QueryTrusts(BuildQuery(dimension, includeBreakdown, userDefinedSet.Set, "companyNumbers"))
+            .GetResultOrThrow<TrustBalance[]>();
+
+        return new JsonResult(userDefinedResult);
+    }
+
+    private static ApiQuery BuildQuery(string? dimension, bool? includeBreakdown, IEnumerable<string>? ids = null, string? idQueryName = null)
+    {
+        var query = new ApiQuery()
+            .AddIfNotNull("dimension", dimension)
+            .AddIfNotNull("includeBreakdown", includeBreakdown);
+
+        if (ids != null && !string.IsNullOrWhiteSpace(idQueryName))
+        {
+            foreach (var id in ids)
+            {
+                query.AddIfNotNull(idQueryName, id);
+            }
+        }
+
+        return query;
     }
 }

--- a/web/src/Web.App/Controllers/Api/ExpenditureProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/ExpenditureProxyController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http.Extensions;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Web.App.Domain;
 using Web.App.Extensions;
@@ -119,6 +120,7 @@ public class ExpenditureProxyController(
     [ProducesResponseType<TrustExpenditure[]>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [Authorize]
     public async Task<IActionResult> UserDefined(
         [FromQuery] string type,
         [FromQuery] string id,

--- a/web/src/Web.App/Infrastructure/Apis/Insight/BalanceApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Insight/BalanceApi.cs
@@ -6,27 +6,18 @@ public interface IBalanceApi
     Task<ApiResult> Trust(string? companyNo, ApiQuery? query = null);
     Task<ApiResult> SchoolHistory(string? urn, ApiQuery? query = null);
     Task<ApiResult> TrustHistory(string? companyNo, ApiQuery? query = null);
+    Task<ApiResult> QueryTrusts(ApiQuery? query = null);
 }
 
 public class BalanceApi(HttpClient httpClient, string? key = default) : ApiBase(httpClient, key), IBalanceApi
 {
-    public async Task<ApiResult> School(string? urn, ApiQuery? query = null)
-    {
-        return await GetAsync($"api/balance/school/{urn}{query?.ToQueryString()}");
-    }
+    public async Task<ApiResult> School(string? urn, ApiQuery? query = null) => await GetAsync($"api/balance/school/{urn}{query?.ToQueryString()}");
 
-    public async Task<ApiResult> SchoolHistory(string? urn, ApiQuery? query = null)
-    {
-        return await GetAsync($"api/balance/school/{urn}/history{query?.ToQueryString()}");
-    }
+    public async Task<ApiResult> SchoolHistory(string? urn, ApiQuery? query = null) => await GetAsync($"api/balance/school/{urn}/history{query?.ToQueryString()}");
 
-    public async Task<ApiResult> Trust(string? companyNo, ApiQuery? query = null)
-    {
-        return await GetAsync($"api/balance/trust/{companyNo}{query?.ToQueryString()}");
-    }
+    public async Task<ApiResult> Trust(string? companyNo, ApiQuery? query = null) => await GetAsync($"api/balance/trust/{companyNo}{query?.ToQueryString()}");
 
-    public async Task<ApiResult> TrustHistory(string? companyNo, ApiQuery? query = null)
-    {
-        return await GetAsync($"api/balance/trust/{companyNo}/history{query?.ToQueryString()}");
-    }
+    public async Task<ApiResult> TrustHistory(string? companyNo, ApiQuery? query = null) => await GetAsync($"api/balance/trust/{companyNo}/history{query?.ToQueryString()}");
+
+    public async Task<ApiResult> QueryTrusts(ApiQuery? query = null) => await GetAsync($"api/balance/trusts{query?.ToQueryString()}");
 }

--- a/web/src/Web.App/Views/TrustComparators/Index.cshtml
+++ b/web/src/Web.App/Views/TrustComparators/Index.cshtml
@@ -64,4 +64,4 @@
     className = "govuk-grid-column-full"
 })
 
-<div id="compare-your-costs-trust" data-type="@OrganisationTypes.Trust" data-id="@Model.CompanyNumber"></div>
+<div id="compare-your-trust" data-type="@OrganisationTypes.Trust" data-id="@Model.CompanyNumber"></div>

--- a/web/tests/Web.A11yTests/AuthPageBase.cs
+++ b/web/tests/Web.A11yTests/AuthPageBase.cs
@@ -10,7 +10,7 @@ public abstract partial class AuthPageBase(ITestOutputHelper testOutputHelper, W
     protected override async Task GoToPage(HttpStatusCode statusCode = HttpStatusCode.OK, IPage? basePage = null)
     {
         // Sign in using credentials set in config
-        var page = await webDriver.GetPage($"{ServiceUrl}/account/sign-in", HttpStatusCode.OK);
+        var page = await webDriver.GetPage($"{ServiceUrl}/sign-in", HttpStatusCode.OK);
         await page.Locator("#username").FillAsync(TestConfiguration.Authentication.Username);
         await page.Locator("#password").FillAsync(TestConfiguration.Authentication.Password);
         await page.GetByText("Sign in").ClickAsync();


### PR DESCRIPTION
### Context
[AB#213659](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/213659) [AB#207092](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/207092)

### Change proposed in this pull request
Added the 'Balance' tab to this view, including new API action. Refactored ChartMode and IncludeBreakdown contexts to manage their own state via custom Providers. Fixed various typings on Expenditure, Balance and History definitions and related components. Fixed negative value labels on horizontal charts.

### Guidance to review 
To test locally, build and copy `front-end-components` to `Web`. The `front-end` version will be bumped in a future commit, once this has PR been merged. 

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

