### PR TITLE
Appended `data:` to CSP to re-enable 'save as image' functionality

### DIFF
--- a/web/src/Web.App/Middleware/CustomResponseHeadersMiddleware.cs
+++ b/web/src/Web.App/Middleware/CustomResponseHeadersMiddleware.cs
@@ -14,7 +14,7 @@ public class CustomResponseHeadersMiddleware(RequestDelegate next)
 
         var csp = new StringBuilder();
         csp.Append("default-src 'self';");
-        csp.Append("img-src 'self';");
+        csp.Append("img-src 'self' data:;");
         csp.Append("style-src 'self' 'unsafe-inline';");
         csp.Append($"script-src 'self' 'nonce-{context.Items["csp-nonce"]}' https://js.monitor.azure.com/scripts/b/ai.3.gbl.min.js https://js.monitor.azure.com/scripts/b/ext/ai.clck.2.min.js;");
         csp.Append("object-src 'none';");


### PR DESCRIPTION
### Context
AB#214335 AB#188391

### Change proposed in this pull request
Modified CSP for `img-src`

### Guidance to review 
This may need to be revisited as tech debt, perhaps if/when components moved to be server-side rendered (and also if this is supported by `recharts`) 

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

