### PR TITLE
feat: adds custom data end point for metric rag

### DIFF
--- a/platform/src/apis/Platform.Api.Insight/MetricRagRatings/MetricRagRatingParameters.cs
+++ b/platform/src/apis/Platform.Api.Insight/MetricRagRatings/MetricRagRatingParameters.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Http;
+using Platform.Functions;
+using Platform.Functions.Extensions;
+
+namespace Platform.Api.Insight.MetricRagRatings;
+
+public record MetricRagRatingParameters : QueryParameters
+{
+    public string DataContext { get; set; } = "default";
+
+    public override void SetValues(IQueryCollection query)
+    {
+        DataContext = query.ToBool("useCustomData") ? "custom" : "default";
+    }
+}

--- a/platform/src/apis/Platform.Api.Insight/MetricRagRatings/MetricRagRatingsFunctions.cs
+++ b/platform/src/apis/Platform.Api.Insight/MetricRagRatings/MetricRagRatingsFunctions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using AzureFunctions.Extensions.Swashbuckle.Attribute;
@@ -29,11 +28,14 @@ public class MetricRagRatingsFunctions
     [FunctionName(nameof(UserDefinedAsync))]
     [ProducesResponseType(typeof(MetricRagRating[]), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.InternalServerError)]
+    [QueryStringParameter("useCustomData", "Sets whether or not to use custom data context", DataType = typeof(bool), Required = false)]
+
     public async Task<IActionResult> UserDefinedAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "get", Route = "metric-rag/{identifier}")] HttpRequest req,
         string identifier)
     {
         var correlationId = req.GetCorrelationId();
+        var queryParams = req.GetParameters<MetricRagRatingParameters>();
 
         using (_logger.BeginScope(new Dictionary<string, object>
                {
@@ -44,7 +46,7 @@ public class MetricRagRatingsFunctions
         {
             try
             {
-                var result = await _service.UserDefinedAsync(identifier);
+                var result = await _service.UserDefinedAsync(identifier, queryParams.DataContext);
 
                 return new JsonContentResult(result);
             }

--- a/web/src/Web.App/Infrastructure/Apis/Insight/MetricRagRatingApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Insight/MetricRagRatingApi.cs
@@ -11,10 +11,17 @@ public class MetricRagRatingApi(HttpClient httpClient, string? key = default) : 
     {
         return await GetAsync($"api/metric-rag/{identifier}");
     }
+
+    public async Task<ApiResult> CustomAsync(string identifier)
+    {
+        var query = new ApiQuery().AddIfNotNull("useCustomData", true);
+        return await GetAsync($"api/metric-rag/{identifier}{query.ToQueryString()}");
+    }
 }
 
 public interface IMetricRagRatingApi
 {
     Task<ApiResult> GetDefaultAsync(ApiQuery? query = null);
     Task<ApiResult> UserDefinedAsync(string identifier);
+    Task<ApiResult> CustomAsync(string identifier);
 }


### PR DESCRIPTION
### Context
[AB#192482](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/192482) ([AB#214351](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/214351))

### Change proposed in this pull request
Adds end-point for custom RAG data

### Guidance to review 
N/A

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

