### PR TITLE
adds custom data banner, updates census and comparison pages

### DIFF
--- a/web/src/Web.App/Controllers/SchoolCensusController.cs
+++ b/web/src/Web.App/Controllers/SchoolCensusController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement.Mvc;
 using Web.App.Attributes;
 using Web.App.Domain;
 using Web.App.Extensions;
@@ -44,23 +45,24 @@ public class SchoolCensusController(
     [HttpGet]
     [Route("custom-data")]
     //[SchoolAuthorization]
+    [FeatureGate(FeatureFlags.CustomData)]
     public async Task<IActionResult> CustomData(string urn)
     {
         using (logger.BeginScope(new { urn }))
         {
             try
             {
-                //var userData = await userDataService.GetSchoolDataAsync(User.UserId(), urn);
-                //if (string.IsNullOrEmpty(userData.CustomData))
-                //{
-                //    return RedirectToAction("Index", "School", new { urn });
-                //}
+                var userData = await userDataService.GetSchoolDataAsync(User.UserId(), urn);
+                if (string.IsNullOrEmpty(userData.CustomData))
+                {
+                    return RedirectToAction("Index", "School", new { urn });
+                }
 
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.SchoolCustomisedDataCensus(urn);
 
                 var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
 
-                var viewModel = new SchoolCensusViewModel(school);
+                var viewModel = new SchoolCensusViewModel(school, customDataId: userData.CustomData);
 
                 return View(viewModel);
             }

--- a/web/src/Web.App/Controllers/SchoolComparisonController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparisonController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement.Mvc;
 using Web.App.Attributes;
 using Web.App.Domain;
 using Web.App.Extensions;
@@ -44,23 +45,24 @@ public class SchoolComparisonController(
     [HttpGet]
     [Route("custom-data")]
     //[SchoolAuthorization]
+    [FeatureGate(FeatureFlags.CustomData)]
     public async Task<IActionResult> CustomData(string urn)
     {
         using (logger.BeginScope(new { urn }))
         {
             try
             {
-                //var userData = await userDataService.GetSchoolDataAsync(User.UserId(), urn);
-                //if (string.IsNullOrEmpty(userData.CustomData))
-                //{
-                //    return RedirectToAction("Index", "School", new { urn });
-                //}
+                var userData = await userDataService.GetSchoolDataAsync(User.UserId(), urn);
+                if (string.IsNullOrEmpty(userData.CustomData))
+                {
+                    return RedirectToAction("Index", "School", new { urn });
+                }
 
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.SchoolCustomisedDataComparison(urn);
 
                 var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
 
-                var viewModel = new SchoolComparisonViewModel(school);
+                var viewModel = new SchoolComparisonViewModel(school, customDataId : userData.CustomData);
 
                 return View(viewModel);
             }

--- a/web/src/Web.App/Controllers/SchoolComparisonController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparisonController.cs
@@ -62,7 +62,7 @@ public class SchoolComparisonController(
 
                 var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
 
-                var viewModel = new SchoolComparisonViewModel(school, customDataId : userData.CustomData);
+                var viewModel = new SchoolComparisonViewModel(school, customDataId: userData.CustomData);
 
                 return View(viewModel);
             }

--- a/web/src/Web.App/ViewComponents/CustomDataBannerViewComponent.cs
+++ b/web/src/Web.App/ViewComponents/CustomDataBannerViewComponent.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Web.App.ViewModels.Components;
+
+namespace Web.App.ViewComponents;
+
+public class CustomDataBannerViewComponent : ViewComponent
+{
+    public IViewComponentResult Invoke(string name, string id)
+    {
+        var vm = new CustomDataBannerViewModel(name, id);
+
+        return View(vm);
+    }
+}

--- a/web/src/Web.App/ViewModels/Components/CustomDataBannerViewModel.cs
+++ b/web/src/Web.App/ViewModels/Components/CustomDataBannerViewModel.cs
@@ -1,7 +1,7 @@
-﻿namespace Web.App.ViewModels.Components; 
+﻿namespace Web.App.ViewModels.Components;
 
 public class CustomDataBannerViewModel(string name, string urn)
 {
     public string? Name => name;
     public string? Id => urn;
-    }
+}

--- a/web/src/Web.App/ViewModels/Components/CustomDataBannerViewModel.cs
+++ b/web/src/Web.App/ViewModels/Components/CustomDataBannerViewModel.cs
@@ -1,0 +1,7 @@
+﻿namespace Web.App.ViewModels.Components; 
+
+public class CustomDataBannerViewModel(string name, string urn)
+{
+    public string? Name => name;
+    public string? Id => urn;
+    }

--- a/web/src/Web.App/Views/SchoolCensus/CustomData.cshtml
+++ b/web/src/Web.App/Views/SchoolCensus/CustomData.cshtml
@@ -11,7 +11,13 @@
         kind = OrganisationTypes.School
     })
 
-<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+@await Component.InvokeAsync("CustomDataBanner", new
+    {
+        name = Model.Name,
+        id = Model.Urn,
+    })
+
+<div id="compare-your-census" data-type="@OrganisationTypes.School" data-id="@Model.Urn" data-custom-data-id="@Model.CustomDataId"/>
 
 @await Component.InvokeAsync("CustomDataFinanceTools", new
     {

--- a/web/src/Web.App/Views/SchoolComparison/CustomData.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/CustomData.cshtml
@@ -11,7 +11,13 @@
         kind = OrganisationTypes.School
     })
 
-<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+@await Component.InvokeAsync("CustomDataBanner", new
+    {
+        name = Model.Name,
+        id = Model.Urn,
+    })
+
+<div id="compare-your-costs" data-type="@OrganisationTypes.School" data-id="@Model.Urn" data-custom-data-id="@Model.CustomDataId"/>
 
 @await Component.InvokeAsync("CustomDataFinanceTools", new
     {

--- a/web/src/Web.App/Views/Shared/Components/CustomDataBanner/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/CustomDataBanner/Default.cshtml
@@ -1,0 +1,20 @@
+﻿@model Web.App.ViewModels.Components.CustomDataBannerViewModel
+
+<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            Important
+        </h2>
+    </div>
+    <div class="govuk-notification-banner__content">
+        <h3 class="govuk-notification-banner__heading">
+            This is your custom data for this school, not the original data
+        </h3>
+        <p>
+            <a class="govuk-notification-banner__link"
+               href="@Url.Action("Index", "School", new { urn = Model.Id })">
+                View the original data for @Model.Name
+            </a>
+        </p>
+    </div>
+</div>


### PR DESCRIPTION

### Context
[AB#192482](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/192482) - [AB#214243](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/214243)

### Change proposed in this pull request
This PR updates the custom data comparison and benchmark workforce pages to use the front end component to display the respective charts and pass the custom data id in the dataset. In a future PR front end components will be updated to use this to pass to the proxy api end points so the actual custom data can be used for these charts.

### Guidance to review 
Include any useful information needed to review this change. Include any dependencies that are required for this change. 

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

