### PR TITLE
Add release annotation to App Insights post deployment

### DIFF
--- a/pipelines/common/scripts/CreateReleaseAnnotation.ps1
+++ b/pipelines/common/scripts/CreateReleaseAnnotation.ps1
@@ -1,0 +1,60 @@
+# Based on: https://learn.microsoft.com/en-gb/azure/azure-monitor/app/release-and-work-item-insights?tabs=release-annotations#create-release-annotations-with-the-azure-cli
+param(
+    [parameter(Mandatory = $true)][string]$appInsightsResourceName,
+    [parameter(Mandatory = $true)][string]$releaseName,
+    [parameter(Mandatory = $false)]$releaseProperties = @()
+)
+
+# Function to ensure all Unicode characters in a JSON string are properly escaped
+function Convert-UnicodeToEscapeHex {
+    param (
+        [parameter(Mandatory = $true)][string]$JsonString
+    )
+    $JsonObject = ConvertFrom-Json -InputObject $JsonString
+    foreach ($property in $JsonObject.PSObject.Properties) {
+        $name = $property.Name
+        $value = $property.Value
+        if ($value -is [string]) {
+            $value = [regex]::Unescape($value)
+            $OutputString = ""
+            foreach ($char in $value.ToCharArray()) {
+                $dec = [int]$char
+                if ($dec -gt 127) {
+                    $hex = [convert]::ToString($dec, 16)
+                    $hex = $hex.PadLeft(4, '0')
+                    $OutputString += "\u$hex"
+                }
+                else {
+                    $OutputString += $char
+                }
+            }
+            $JsonObject.$name = $OutputString
+        }
+    }
+    return ConvertTo-Json -InputObject $JsonObject -Compress
+}
+
+$annotation = @{
+    Id             = [GUID]::NewGuid();
+    AnnotationName = $releaseName;
+    EventTime      = (Get-Date).ToUniversalTime().GetDateTimeFormats("s")[0];
+    Category       = "Deployment"; #Application Insights only displays annotations from the "Deployment" Category
+    Properties     = ConvertTo-Json $releaseProperties -Compress
+}
+
+Write-Host "App Insights resource name:" $appInsightsResourceName
+
+$appInsightsResourceId = az resource list --query "[?ends_with(name, '$appInsightsResourceName')].[id]" --output tsv
+$appInsightsResourceExists = $appInsightsResourceId.Length -gt 0
+if (!$appInsightsResourceExists) {
+    Write-Error "Application Insights resource '$appInsightsResourceName' does not exist. Release annotation will not be created."
+    exit
+}
+
+Write-Host "App Insights resource ID:" $appInsightsResourceId
+
+$body = ConvertTo-Json $annotation -Compress
+$body = Convert-UnicodeToEscapeHex -JsonString $body
+Write-Host "PUT body: $body"
+
+az rest --method put --uri "$($appInsightsResourceId)/Annotations?api-version=2015-05-01" --body "$($body)"

--- a/pipelines/platform/deployment.yaml
+++ b/pipelines/platform/deployment.yaml
@@ -127,3 +127,34 @@ jobs:
                 slotName: production
                 appSettings: '-WEBSITE_RUN_FROM_PACKAGE 1'
                 DeploymentType: 'runFromZip'
+
+  - deployment: ReleaseAnnotation
+    displayName: 'Platform : Release Annotation'
+    dependsOn: [ PlatformDeployment ]
+    pool:
+      vmImage: ubuntu-latest
+    environment: ${{ parameters.environment }}
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+            - checkout: self
+
+            - task: AzureCLI@2
+              displayName: 'Add release annotation to Application Insights'
+              continueOnError: true
+              inputs:
+                azureSubscription: ${{ parameters.subscription }}
+                scriptType: pscore
+                scriptLocation: scriptPath
+                scriptPath: "$(Agent.BuildDirectory)/s/pipelines/common/scripts/CreateReleaseAnnotation.ps1"
+                arguments: '
+                  -appInsightsResourceName ${{ parameters.environmentPrefix }}-ebis-ai `
+                  -releaseName "$(Build.Repository.Name) - $(Build.BuildNumber)" `
+                  -releaseProperties @{
+                  "BuildNumber"="$(Build.BuildNumber)";
+                  "BuildRepositoryName"="$(Build.Repository.Name)";
+                  "BuildRepositoryProvider"="$(Build.Repository.Provider)";
+                  "ReleaseDefinitionName"="$(Build.DefinitionName)";
+                  "ReleaseDescription"="Triggered by $(Build.DefinitionName) $(Build.BuildNumber)";
+                  "SourceBranch"="$(Build.SourceBranch)" }'

--- a/pipelines/web/deployment.yaml
+++ b/pipelines/web/deployment.yaml
@@ -53,3 +53,34 @@ jobs:
                 packageForLinux: '${{ parameters.workspaceDir }}/web/Web.App.zip'
                 enableCustomDeployment: true
                 DeploymentType: 'zipDeploy'
+
+  - deployment: ReleaseAnnotation
+    displayName: 'Web : Release Annotation'
+    dependsOn: [ WebDeployment ]
+    pool:
+      vmImage: ubuntu-latest
+    environment: ${{ parameters.environment }}
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+            - checkout: self
+
+            - task: AzureCLI@2
+              displayName: 'Add release annotation to Application Insights'
+              continueOnError: true
+              inputs:
+                azureSubscription: ${{ parameters.subscription }}
+                scriptType: pscore
+                scriptLocation: scriptPath
+                scriptPath: "$(Agent.BuildDirectory)/s/pipelines/common/scripts/CreateReleaseAnnotation.ps1"
+                arguments: '
+                  -appInsightsResourceName ${{ parameters.environmentPrefix }}-ebis-ai `
+                  -releaseName "$(Build.Repository.Name) - $(Build.BuildNumber)" `
+                  -releaseProperties @{
+                  "BuildNumber"="$(Build.BuildNumber)";
+                  "BuildRepositoryName"="$(Build.Repository.Name)";
+                  "BuildRepositoryProvider"="$(Build.Repository.Provider)";
+                  "ReleaseDefinitionName"="$(Build.DefinitionName)";
+                  "ReleaseDescription"="Triggered by $(Build.DefinitionName) $(Build.BuildNumber)";
+                  "SourceBranch"="$(Build.SourceBranch)" }'


### PR DESCRIPTION
### Context
[AB#214348](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/214348) [AB#214347](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/214347)

### Change proposed in this pull request
Modified deployment pipelines for Web and Platform to annotate App Insights post-release.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~~Your code builds clean without any errors or warnings~~
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

