### PR TITLE
pass customDataId as param to proxy end points

### DIFF
--- a/front-end-components/src/contexts/contexts.tsx
+++ b/front-end-components/src/contexts/contexts.tsx
@@ -33,3 +33,5 @@ export interface CentralServicesBreakdownContextValue {
 export const CentralServicesBreakdownContext = createContext<
   CentralServicesBreakdownContextValue | undefined
 >(undefined);
+
+export const CustomDataContext = createContext<string | undefined>(undefined);

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -95,14 +95,19 @@ if (findOrganisationElement) {
 const compareCostsElement = document.getElementById(CompareCostsElementId);
 
 if (compareCostsElement) {
-  const { type, id, phases } = compareCostsElement.dataset;
+  const { type, id, phases, customDataId } = compareCostsElement.dataset;
   if (type && id) {
     const root = ReactDOM.createRoot(compareCostsElement);
     const phasesParsed = phases ? (JSON.parse(phases) as string[]) : null;
 
     root.render(
       <React.StrictMode>
-        <CompareYourCosts type={type} id={id} phases={phasesParsed} />
+        <CompareYourCosts
+          type={type}
+          id={id}
+          phases={phasesParsed}
+          customDataId={customDataId}
+        />
       </React.StrictMode>
     );
   }
@@ -126,13 +131,18 @@ if (compareCostsTrustElement) {
 const compareCensusElement = document.getElementById(CompareCensusElementId);
 
 if (compareCensusElement) {
-  const { type, id, phases } = compareCensusElement.dataset;
+  const { type, id, phases, customDataId } = compareCensusElement.dataset;
   if (type && id) {
     const root = ReactDOM.createRoot(compareCensusElement);
     const phasesParsed = phases ? (JSON.parse(phases) as string[]) : null;
     root.render(
       <React.StrictMode>
-        <CompareYourCensus type={type} id={id} phases={phasesParsed} />
+        <CompareYourCensus
+          type={type}
+          id={id}
+          phases={phasesParsed}
+          customDataId={customDataId}
+        />
       </React.StrictMode>
     );
   }

--- a/front-end-components/src/services/census-api.tsx
+++ b/front-end-components/src/services/census-api.tsx
@@ -33,7 +33,8 @@ export class CensusApi {
     id: string,
     dimension: string,
     category: string,
-    phase?: string
+    phase?: string,
+    customDataId?: string
   ): Promise<Census[]> {
     const params = new URLSearchParams({
       type: type,
@@ -44,6 +45,10 @@ export class CensusApi {
 
     if (phase) {
       params.append("phase", phase);
+    }
+
+    if (customDataId) {
+      params.append("customDataId", customDataId);
     }
 
     return fetch("/api/census?" + params, {

--- a/front-end-components/src/services/expenditure-api.tsx
+++ b/front-end-components/src/services/expenditure-api.tsx
@@ -47,7 +47,8 @@ export class ExpenditureApi {
     id: string,
     dimension: string,
     category: string,
-    phase?: string
+    phase?: string,
+    customDataId?: string
   ): Promise<T[]> {
     const params = new URLSearchParams({
       type: type,
@@ -58,6 +59,10 @@ export class ExpenditureApi {
 
     if (phase) {
       params.append("phase", phase);
+    }
+
+    if (customDataId) {
+      params.append("customDataId", customDataId);
     }
 
     return fetch("/api/expenditure?" + params, {

--- a/front-end-components/src/views/compare-your-census/partials/auxiliary-staff.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/auxiliary-staff.tsx
@@ -14,6 +14,7 @@ import {
   ChartDimensionContext,
   HasIncompleteDataContext,
   PhaseContext,
+  CustomDataContext,
 } from "src/contexts";
 import { AuxiliaryStaffData } from "src/views/compare-your-census/partials";
 import {
@@ -27,6 +28,7 @@ export const AuxiliaryStaff: React.FC<{ type: string; id: string }> = ({
   id,
 }) => {
   const phase = useContext(PhaseContext);
+  const customDataId = useContext(CustomDataContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
   const [data, setData] = useState<Census[] | null>();
   const getData = useCallback(async () => {
@@ -36,9 +38,10 @@ export const AuxiliaryStaff: React.FC<{ type: string; id: string }> = ({
       id,
       dimension.value,
       "AuxiliaryStaffFte",
-      phase
+      phase,
+      customDataId
     );
-  }, [id, dimension, type, phase]);
+  }, [id, dimension, type, phase, customDataId]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-census/partials/headcount.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/headcount.tsx
@@ -16,6 +16,7 @@ import {
   ChartDimensionContext,
   HasIncompleteDataContext,
   PhaseContext,
+  CustomDataContext,
 } from "src/contexts";
 import { HeadcountData } from "src/views/compare-your-census/partials";
 import {
@@ -29,6 +30,7 @@ export const Headcount: React.FC<{ type: string; id: string }> = ({
   id,
 }) => {
   const phase = useContext(PhaseContext);
+  const customDataId = useContext(CustomDataContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
   const [data, setData] = useState<Census[] | null>();
   const getData = useCallback(async () => {
@@ -38,9 +40,10 @@ export const Headcount: React.FC<{ type: string; id: string }> = ({
       id,
       dimension.value,
       "WorkforceHeadcount",
-      phase
+      phase,
+      customDataId
     );
-  }, [id, dimension, type, phase]);
+  }, [id, dimension, type, phase, customDataId]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-census/partials/non-classroom-support.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/non-classroom-support.tsx
@@ -14,6 +14,7 @@ import {
   ChartDimensionContext,
   HasIncompleteDataContext,
   PhaseContext,
+  CustomDataContext,
 } from "src/contexts";
 import { NonClassroomSupportData } from "src/views/compare-your-census/partials";
 import {
@@ -27,6 +28,7 @@ export const NonClassroomSupport: React.FC<{ type: string; id: string }> = ({
   id,
 }) => {
   const phase = useContext(PhaseContext);
+  const customDataId = useContext(CustomDataContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
   const [data, setData] = useState<Census[] | null>();
   const getData = useCallback(async () => {
@@ -36,9 +38,10 @@ export const NonClassroomSupport: React.FC<{ type: string; id: string }> = ({
       id,
       dimension.value,
       "NonClassroomSupportStaffFte",
-      phase
+      phase,
+      customDataId
     );
-  }, [id, dimension, type, phase]);
+  }, [id, dimension, type, phase, customDataId]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-census/partials/school-workforce.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/school-workforce.tsx
@@ -15,6 +15,7 @@ import {
   ChartDimensionContext,
   HasIncompleteDataContext,
   PhaseContext,
+  CustomDataContext,
 } from "src/contexts";
 import { SchoolCensusData } from "src/views/compare-your-census/partials";
 import {
@@ -28,6 +29,7 @@ export const SchoolWorkforce: React.FC<{ type: string; id: string }> = ({
   id,
 }) => {
   const phase = useContext(PhaseContext);
+  const customDataId = useContext(CustomDataContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
   const [data, setData] = useState<Census[] | null>();
   const getData = useCallback(async () => {
@@ -37,9 +39,10 @@ export const SchoolWorkforce: React.FC<{ type: string; id: string }> = ({
       id,
       dimension.value,
       "WorkforceFte",
-      phase
+      phase,
+      customDataId
     );
-  }, [id, dimension, type, phase]);
+  }, [id, dimension, type, phase, customDataId]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-census/partials/senior-leadership.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/senior-leadership.tsx
@@ -14,6 +14,7 @@ import {
   ChartDimensionContext,
   HasIncompleteDataContext,
   PhaseContext,
+  CustomDataContext,
 } from "src/contexts";
 import { SeniorLeadershipData } from "src/views/compare-your-census/partials";
 import {
@@ -27,6 +28,7 @@ export const SeniorLeadership: React.FC<{ type: string; id: string }> = ({
   id,
 }) => {
   const phase = useContext(PhaseContext);
+  const customDataId = useContext(CustomDataContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
   const [data, setData] = useState<Census[] | null>();
   const getData = useCallback(async () => {
@@ -36,9 +38,10 @@ export const SeniorLeadership: React.FC<{ type: string; id: string }> = ({
       id,
       dimension.value,
       "SeniorLeadershipFte",
-      phase
+      phase,
+      customDataId
     );
-  }, [id, dimension, type, phase]);
+  }, [id, dimension, type, phase, customDataId]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-census/partials/teaching-assistants.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/teaching-assistants.tsx
@@ -14,6 +14,7 @@ import {
   ChartDimensionContext,
   HasIncompleteDataContext,
   PhaseContext,
+  CustomDataContext,
 } from "src/contexts";
 import { TeachingAssistantsData } from "src/views/compare-your-census/partials";
 import {
@@ -27,6 +28,7 @@ export const TeachingAssistants: React.FC<{ type: string; id: string }> = ({
   id,
 }) => {
   const phase = useContext(PhaseContext);
+  const customDataId = useContext(CustomDataContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
   const [data, setData] = useState<Census[] | null>();
   const getData = useCallback(async () => {
@@ -36,9 +38,10 @@ export const TeachingAssistants: React.FC<{ type: string; id: string }> = ({
       id,
       dimension.value,
       "TeachingAssistantsFte",
-      phase
+      phase,
+      customDataId
     );
-  }, [id, dimension, type, phase]);
+  }, [id, dimension, type, phase, customDataId]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-census/partials/total-teachers-qualified.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/total-teachers-qualified.tsx
@@ -13,6 +13,7 @@ import {
   ChartDimensionContext,
   HasIncompleteDataContext,
   PhaseContext,
+  CustomDataContext,
 } from "src/contexts";
 import { TotalTeachersQualifiedData } from "src/views/compare-your-census/partials";
 import { Percent } from "src/components";
@@ -23,11 +24,19 @@ export const TotalTeachersQualified: React.FC<{ type: string; id: string }> = ({
   id,
 }) => {
   const phase = useContext(PhaseContext);
+  const customDataId = useContext(CustomDataContext);
   const [data, setData] = useState<Census[] | null>();
   const getData = useCallback(async () => {
     setData(null);
-    return await CensusApi.query(type, id, "Total", "TeachersQualified", phase);
-  }, [id, type, phase]);
+    return await CensusApi.query(
+      type,
+      id,
+      "Total",
+      "TeachersQualified",
+      phase,
+      customDataId
+    );
+  }, [id, type, phase, customDataId]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-census/partials/total-teachers.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/total-teachers.tsx
@@ -14,6 +14,7 @@ import {
   ChartDimensionContext,
   HasIncompleteDataContext,
   PhaseContext,
+  CustomDataContext,
 } from "src/contexts";
 import { TotalTeachersData } from "src/views/compare-your-census/partials";
 import {
@@ -27,6 +28,7 @@ export const TotalTeachers: React.FC<{ type: string; id: string }> = ({
   id,
 }) => {
   const phase = useContext(PhaseContext);
+  const customDataId = useContext(CustomDataContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
   const [data, setData] = useState<Census[] | null>();
   const getData = useCallback(async () => {
@@ -36,9 +38,10 @@ export const TotalTeachers: React.FC<{ type: string; id: string }> = ({
       id,
       dimension.value,
       "TeachersFte",
-      phase
+      phase,
+      customDataId
     );
-  }, [id, dimension, type, phase]);
+  }, [id, dimension, type, phase, customDataId]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-census/types.tsx
+++ b/front-end-components/src/views/compare-your-census/types.tsx
@@ -2,4 +2,5 @@ export type CompareYourCensusViewProps = {
   type: string;
   id: string;
   phases: string[] | null;
+  customDataId: string | undefined;
 };

--- a/front-end-components/src/views/compare-your-census/view.tsx
+++ b/front-end-components/src/views/compare-your-census/view.tsx
@@ -5,6 +5,7 @@ import {
   SelectedEstablishmentContext,
   PhaseContext,
   ChartModeProvider,
+  CustomDataContext,
 } from "src/contexts";
 import {
   AuxiliaryStaff,
@@ -21,7 +22,7 @@ import { ChartOptionsPhaseMode } from "src/components/chart-options-phase-mode";
 export const CompareYourCensus: React.FC<CompareYourCensusViewProps> = (
   props
 ) => {
-  const { type, id, phases } = props;
+  const { type, id, phases, customDataId } = props;
   const [phase, setPhase] = useState<string | undefined>(
     phases ? phases[0] : undefined
   );
@@ -29,17 +30,22 @@ export const CompareYourCensus: React.FC<CompareYourCensusViewProps> = (
   return (
     <SelectedEstablishmentContext.Provider value={id}>
       <PhaseContext.Provider value={phase}>
-        <ChartModeProvider initialValue={ChartModeChart}>
-          <ChartOptionsPhaseMode phases={phases} handlePhaseChange={setPhase} />
-          <SchoolWorkforce id={id} type={type} />
-          <TotalTeachers id={id} type={type} />
-          <TotalTeachersQualified id={id} type={type} />
-          <SeniorLeadership id={id} type={type} />
-          <TeachingAssistants id={id} type={type} />
-          <NonClassroomSupport id={id} type={type} />
-          <AuxiliaryStaff id={id} type={type} />
-          <Headcount id={id} type={type} />
-        </ChartModeProvider>
+        <CustomDataContext.Provider value={customDataId}>
+          <ChartModeProvider initialValue={ChartModeChart}>
+            <ChartOptionsPhaseMode
+              phases={phases}
+              handlePhaseChange={setPhase}
+            />
+            <SchoolWorkforce id={id} type={type} />
+            <TotalTeachers id={id} type={type} />
+            <TotalTeachersQualified id={id} type={type} />
+            <SeniorLeadership id={id} type={type} />
+            <TeachingAssistants id={id} type={type} />
+            <NonClassroomSupport id={id} type={type} />
+            <AuxiliaryStaff id={id} type={type} />
+            <Headcount id={id} type={type} />
+          </ChartModeProvider>
+        </CustomDataContext.Provider>
       </PhaseContext.Provider>
     </SelectedEstablishmentContext.Provider>
   );

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/administrative-supplies.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/administrative-supplies.tsx
@@ -11,7 +11,11 @@ import {
   PoundsPerPupil,
   ChartDimensions,
 } from "src/components";
-import { ChartDimensionContext, PhaseContext } from "src/contexts";
+import {
+  ChartDimensionContext,
+  PhaseContext,
+  CustomDataContext,
+} from "src/contexts";
 import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
@@ -29,6 +33,7 @@ export const AdministrativeSupplies: React.FC<{
 }> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const phase = useContext(PhaseContext);
+  const customDataId = useContext(CustomDataContext);
   const [data, setData] = useState<
     AdministrativeSuppliesExpenditure[] | null
   >();
@@ -39,9 +44,10 @@ export const AdministrativeSupplies: React.FC<{
       id,
       dimension.value,
       "AdministrationSupplies",
-      phase
+      phase,
+      customDataId
     );
-  }, [id, dimension, type, phase]);
+  }, [id, dimension, type, phase, customDataId]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
@@ -11,7 +11,11 @@ import {
   PoundsPerPupil,
   ChartDimensions,
 } from "src/components";
-import { ChartDimensionContext, PhaseContext } from "src/contexts";
+import {
+  ChartDimensionContext,
+  CustomDataContext,
+  PhaseContext,
+} from "src/contexts";
 import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
@@ -26,6 +30,7 @@ export const CateringStaffServices: React.FC<{
 }> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const phase = useContext(PhaseContext);
+  const customDataId = useContext(CustomDataContext);
   const [data, setData] = useState<CateringStaffServicesExpenditure[] | null>();
   const getData = useCallback(async () => {
     setData(null);
@@ -34,9 +39,10 @@ export const CateringStaffServices: React.FC<{
       id,
       dimension.value,
       "CateringStaffServices",
-      phase
+      phase,
+      customDataId
     );
-  }, [id, dimension, type, phase]);
+  }, [id, dimension, type, phase, customDataId]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-ict.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-ict.tsx
@@ -11,7 +11,11 @@ import {
   PoundsPerPupil,
   ChartDimensions,
 } from "src/components";
-import { ChartDimensionContext, PhaseContext } from "src/contexts";
+import {
+  ChartDimensionContext,
+  PhaseContext,
+  CustomDataContext,
+} from "src/contexts";
 import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
@@ -26,6 +30,7 @@ export const EducationalIct: React.FC<{
 }> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const phase = useContext(PhaseContext);
+  const customDataId = useContext(CustomDataContext);
   const [data, setData] = useState<EducationalIctExpenditure[] | null>();
   const getData = useCallback(async () => {
     setData(null);
@@ -34,9 +39,10 @@ export const EducationalIct: React.FC<{
       id,
       dimension.value,
       "EducationalIct",
-      phase
+      phase,
+      customDataId
     );
-  }, [id, dimension, type, phase]);
+  }, [id, dimension, type, phase, customDataId]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-supplies.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-supplies.tsx
@@ -11,7 +11,11 @@ import {
   PoundsPerPupil,
   ChartDimensions,
 } from "src/components";
-import { ChartDimensionContext, PhaseContext } from "src/contexts";
+import {
+  ChartDimensionContext,
+  CustomDataContext,
+  PhaseContext,
+} from "src/contexts";
 import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
@@ -26,6 +30,7 @@ export const EducationalSupplies: React.FC<{
 }> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const phase = useContext(PhaseContext);
+  const customDataId = useContext(CustomDataContext);
   const [data, setData] = useState<EducationalSuppliesExpenditure[] | null>();
   const getData = useCallback(async () => {
     setData(null);
@@ -34,9 +39,10 @@ export const EducationalSupplies: React.FC<{
       id,
       dimension.value,
       "EducationalSupplies",
-      phase
+      phase,
+      customDataId
     );
-  }, [id, dimension, type, phase]);
+  }, [id, dimension, type, phase, customDataId]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/non-educational-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/non-educational-support-staff.tsx
@@ -11,7 +11,11 @@ import {
   PoundsPerPupil,
   ChartDimensions,
 } from "src/components";
-import { ChartDimensionContext, PhaseContext } from "src/contexts";
+import {
+  ChartDimensionContext,
+  PhaseContext,
+  CustomDataContext,
+} from "src/contexts";
 import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
@@ -29,6 +33,7 @@ export const NonEducationalSupportStaff: React.FC<{
 }> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const phase = useContext(PhaseContext);
+  const customDataId = useContext(CustomDataContext);
   const [data, setData] = useState<
     NonEducationalSupportStaffExpenditure[] | null
   >();
@@ -39,9 +44,10 @@ export const NonEducationalSupportStaff: React.FC<{
       id,
       dimension.value,
       "NonEducationalSupportStaff",
-      phase
+      phase,
+      customDataId
     );
-  }, [id, dimension, type, phase]);
+  }, [id, dimension, type, phase, customDataId]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/other-costs.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/other-costs.tsx
@@ -11,7 +11,11 @@ import {
   PoundsPerPupil,
   ChartDimensions,
 } from "src/components";
-import { ChartDimensionContext, PhaseContext } from "src/contexts";
+import {
+  ChartDimensionContext,
+  PhaseContext,
+  CustomDataContext,
+} from "src/contexts";
 import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
@@ -26,6 +30,7 @@ export const OtherCosts: React.FC<{
 }> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const phase = useContext(PhaseContext);
+  const customDataId = useContext(CustomDataContext);
   const [data, setData] = useState<OtherCostsDataExpenditure[] | null>();
   const getData = useCallback(async () => {
     setData(null);
@@ -34,9 +39,10 @@ export const OtherCosts: React.FC<{
       id,
       dimension.value,
       "Other",
-      phase
+      phase,
+      customDataId
     );
-  }, [id, dimension, type, phase]);
+  }, [id, dimension, type, phase, customDataId]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
@@ -11,7 +11,11 @@ import {
   PremisesCategories,
   ChartDimensions,
 } from "src/components";
-import { ChartDimensionContext, PhaseContext } from "src/contexts";
+import {
+  ChartDimensionContext,
+  PhaseContext,
+  CustomDataContext,
+} from "src/contexts";
 import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
@@ -26,6 +30,7 @@ export const PremisesStaffServices: React.FC<{
 }> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerMetreSq);
   const phase = useContext(PhaseContext);
+  const customDataId = useContext(CustomDataContext);
   const [data, setData] = useState<PremisesStaffServicesExpenditure[] | null>();
   const getData = useCallback(async () => {
     setData(null);
@@ -34,9 +39,10 @@ export const PremisesStaffServices: React.FC<{
       id,
       dimension.value,
       "PremisesStaffServices",
-      phase
+      phase,
+      customDataId
     );
-  }, [id, dimension, type, phase]);
+  }, [id, dimension, type, phase, customDataId]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/teaching-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/teaching-support-staff.tsx
@@ -11,7 +11,11 @@ import {
   PoundsPerPupil,
   ChartDimensions,
 } from "src/components";
-import { ChartDimensionContext, PhaseContext } from "src/contexts";
+import {
+  ChartDimensionContext,
+  PhaseContext,
+  CustomDataContext,
+} from "src/contexts";
 import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
@@ -26,6 +30,7 @@ export const TeachingSupportStaff: React.FC<{ type: string; id: string }> = ({
 }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const phase = useContext(PhaseContext);
+  const customDataId = useContext(CustomDataContext);
   const [data, setData] = useState<TeachingSupportStaffExpenditure[] | null>();
   const getData = useCallback(async () => {
     setData(null);
@@ -34,9 +39,10 @@ export const TeachingSupportStaff: React.FC<{ type: string; id: string }> = ({
       id,
       dimension.value,
       "TeachingTeachingSupportStaff",
-      phase
+      phase,
+      customDataId
     );
-  }, [id, dimension, type, phase]);
+  }, [id, dimension, type, phase, customDataId]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/utilities.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/utilities.tsx
@@ -11,7 +11,11 @@ import {
   PremisesCategories,
   ChartDimensions,
 } from "src/components";
-import { ChartDimensionContext, PhaseContext } from "src/contexts";
+import {
+  ChartDimensionContext,
+  PhaseContext,
+  CustomDataContext,
+} from "src/contexts";
 import {
   HorizontalBarChartWrapper,
   HorizontalBarChartWrapperData,
@@ -26,6 +30,7 @@ export const Utilities: React.FC<{
 }> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerMetreSq);
   const phase = useContext(PhaseContext);
+  const customDataId = useContext(CustomDataContext);
   const [data, setData] = useState<UtilitiesExpenditure[] | null>();
   const getData = useCallback(async () => {
     setData(null);
@@ -34,9 +39,10 @@ export const Utilities: React.FC<{
       id,
       dimension.value,
       "Utilities",
-      phase
+      phase,
+      customDataId
     );
-  }, [id, dimension, type, phase]);
+  }, [id, dimension, type, phase, customDataId]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/compare-your-costs/types.tsx
+++ b/front-end-components/src/views/compare-your-costs/types.tsx
@@ -2,4 +2,5 @@ export type CompareYourCostsViewProps = {
   type: string;
   id: string;
   phases: string[] | null;
+  customDataId: string | undefined;
 };

--- a/front-end-components/src/views/compare-your-costs/view.tsx
+++ b/front-end-components/src/views/compare-your-costs/view.tsx
@@ -9,6 +9,7 @@ import {
   SelectedEstablishmentContext,
   //HasIncompleteDataContext,
   PhaseContext,
+  CustomDataContext,
   ChartModeProvider,
 } from "src/contexts";
 import { useGovUk } from "src/hooks/useGovUk";
@@ -17,7 +18,7 @@ import { ChartOptionsPhaseMode } from "src/components/chart-options-phase-mode";
 export const CompareYourCosts: React.FC<CompareYourCostsViewProps> = (
   props
 ) => {
-  const { type, id, phases } = props;
+  const { type, id, phases, customDataId } = props;
   const [phase, setPhase] = useState<string | undefined>(
     phases ? phases[0] : undefined
   );
@@ -27,15 +28,20 @@ export const CompareYourCosts: React.FC<CompareYourCostsViewProps> = (
   return (
     <SelectedEstablishmentContext.Provider value={id}>
       <PhaseContext.Provider value={phase}>
-        <ChartModeProvider initialValue={ChartModeChart}>
-          <ChartOptionsPhaseMode phases={phases} handlePhaseChange={setPhase} />
-          {/*<HasIncompleteDataContext.Provider*/}
-          {/*  value={{ hasIncompleteData, hasNoData }}*/}
-          {/*>*/}
-          <TotalExpenditure id={id} type={type} />
-          <ExpenditureAccordion id={id} type={type} />
-          {/*</HasIncompleteDataContext.Provider>*/}
-        </ChartModeProvider>
+        <CustomDataContext.Provider value={customDataId}>
+          <ChartModeProvider initialValue={ChartModeChart}>
+            <ChartOptionsPhaseMode
+              phases={phases}
+              handlePhaseChange={setPhase}
+            />
+            {/*<HasIncompleteDataContext.Provider*/}
+            {/*  value={{ hasIncompleteData, hasNoData }}*/}
+            {/*>*/}
+            <TotalExpenditure id={id} type={type} />
+            <ExpenditureAccordion id={id} type={type} />
+            {/*</HasIncompleteDataContext.Provider>*/}
+          </ChartModeProvider>
+        </CustomDataContext.Provider>
       </PhaseContext.Provider>
     </SelectedEstablishmentContext.Provider>
   );


### PR DESCRIPTION
### Context
[AB#192482](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/192482) - [AB#214246](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/214246)

### Change proposed in this pull request
Updates to front-end components so that the customDataId prop is passed to the proxy api end points, expenditure and census. A future update will use this to generate the custom data for the charts for these components

### Guidance to review 
N/A

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~You have run all unit/integration tests and they pass~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

