### PR TITLE
Added priority guidance panel to Trust forecast and risks page, pending data to set various states

### DIFF
--- a/web/Web.sln.DotSettings
+++ b/web/Web.sln.DotSettings
@@ -15,4 +15,6 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SLD/@EntryIndexedValue">SLD</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SPLD/@EntryIndexedValue">SPLD</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=VI/@EntryIndexedValue">VI</s:String>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=govuk/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=esfa/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=govuk/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=icfp/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -77,10 +77,21 @@ p.priority .govuk-tag {
   border-left: none !important;
 }
 
-.top-categories div {
+.top-categories div,
+.priority-guidance div {
   background-color: #EEEFEF;
   padding: 20px;
   margin-bottom: 20px;
+}
+
+.priority-guidance .priority {
+  display: flex;
+  align-items: center;
+
+  > .govuk-tag {
+    flex-basis: 200px;
+    align-self: stretch;
+  }
 }
 
 .govuk-caption-l a {

--- a/web/src/Web.App/Controllers/TrustForecastController.cs
+++ b/web/src/Web.App/Controllers/TrustForecastController.cs
@@ -14,6 +14,7 @@ namespace Web.App.Controllers;
 [Route("trust/{companyNumber}/forecast-risks")]
 public class TrustForecastController(
     IEstablishmentApi establishmentApi,
+    IBalanceApi balanceApi,
     ILogger<TrustForecastController> logger)
     : Controller
 {
@@ -29,7 +30,8 @@ public class TrustForecastController(
             {
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.TrustForecast(companyNumber);
                 var trust = await establishmentApi.GetTrust(companyNumber).GetResultOrThrow<Trust>();
-                var viewModel = new TrustForecastViewModel(trust);
+                var balance = await balanceApi.Trust(companyNumber).GetResultOrThrow<TrustBalance>();
+                var viewModel = new TrustForecastViewModel(trust, balance);
                 return View(viewModel);
             }
             catch (Exception e)

--- a/web/src/Web.App/ViewModels/TrustForecastViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustForecastViewModel.cs
@@ -1,8 +1,36 @@
 ﻿using Web.App.Domain;
 namespace Web.App.ViewModels;
 
-public class TrustForecastViewModel(Trust trust)
+public class TrustForecastViewModel(Trust trust, TrustBalance balance)
 {
     public string? CompanyNumber => trust.CompanyNumber;
     public string? Name => trust.TrustName;
+
+    // red
+    public bool BalancesInDeficit => balance.InYearBalance < 0;
+    public bool BalancesInDeficitOrForecastingDeficit => false;
+    public bool SteepDeclineInBalances => false;
+    public bool SteepDeclineInBalancesAndHighProportionStaffCosts => false;
+    public bool IsRed => BalancesInDeficit
+                         || BalancesInDeficitOrForecastingDeficit
+                         || SteepDeclineInBalancesAndHighProportionStaffCosts
+                         || SteepDeclineInBalances;
+
+    // amber
+    public bool DeclineInBalancesButNoForecastDecline => false;
+    public bool DeclineInBalancesButAboveForecastHistory => false;
+    public bool SteepInclineInBalancesForecastButBelowForecastHistory => false;
+    public bool IsAmber => DeclineInBalancesButNoForecastDecline
+                           || DeclineInBalancesButAboveForecastHistory
+                           || SteepInclineInBalancesForecastButBelowForecastHistory;
+
+    // green
+    public bool BalancesStableAndPositive => false;
+    public bool BalancesIncreasingSteadily => false;
+    public bool BalancesIncreasingSteeply => false;
+    public bool IsGreen => BalancesStableAndPositive
+                           || BalancesIncreasingSteadily
+                           || BalancesIncreasingSteeply;
+
+    public bool HasGuidance => IsRed || IsAmber || IsGreen;
 }

--- a/web/src/Web.App/Views/TrustForecast/Index.cshtml
+++ b/web/src/Web.App/Views/TrustForecast/Index.cshtml
@@ -1,4 +1,6 @@
-﻿@model Web.App.ViewModels.TrustForecastViewModel
+﻿@using Web.App.Domain
+@using Web.App.ViewModels
+@model Web.App.ViewModels.TrustForecastViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.ForecastAndRisks;
 }
@@ -10,3 +12,85 @@
     id = Model.CompanyNumber,
     kind = OrganisationTypes.Trust
 })
+
+@if (Model.HasGuidance)
+{
+    <div class="priority-guidance">
+        <div>
+            @{ var rating = Lookups.StatusPriorityMap[Model.IsGreen
+                   ? "green"
+                   : Model.IsAmber
+                       ? "amber"
+                       : "red"]; }
+            <p class="priority @rating.Class govuk-body">
+                @await Component.InvokeAsync("Tag", new
+                {
+                    rating = new RatingViewModel(rating.Colour, rating.DisplayText)
+                })
+
+                <span>
+                    @if (Model.BalancesInDeficit || Model.BalancesInDeficitOrForecastingDeficit)
+                    {
+                        @:Your trust balances indicate that you are in deficit
+                        if (Model.BalancesInDeficitOrForecastingDeficit)
+                        {
+                            @:or forecasting a deficit within the next year
+                        }
+                    }
+
+                    @if (Model.SteepDeclineInBalances || Model.SteepDeclineInBalancesAndHighProportionStaffCosts)
+                    {
+                        @:Using your latest AR and BFR submissions, your trust is forecasting a steep decline in balances
+                        if (Model.SteepDeclineInBalancesAndHighProportionStaffCosts)
+                        {
+                            @:and has a high proportion of staff costs
+                        }
+                    }
+
+                    @if (Model.DeclineInBalancesButAboveForecastHistory)
+                    {
+                        @:Using your latest AR and BFR submissions, your trust is forecasting a decline in balances but has a history of your AR balances being above forecast
+                    }
+
+                    @if (Model.DeclineInBalancesButNoForecastDecline)
+                    {
+                        @:Using your latest AR and BFR submissions, your trust is not forecasting a deficit but your balances are in decline
+                    }
+
+                    @if (Model.SteepInclineInBalancesForecastButBelowForecastHistory)
+                    {
+                        @:Your trust is forecasting a steep incline in balances but has a history of AR balances being significantly below forecast
+                    }
+
+                    @if (Model.BalancesStableAndPositive)
+                    {
+                        @:Your trust balances are stable and positive
+                    }
+
+                    @if (Model.BalancesIncreasingSteadily)
+                    {
+                        @:Your trust balances are increasing steadily
+                    }
+
+                    @if (Model.BalancesIncreasingSteeply)
+                    {
+                        @:Your trust balances are increasing sharply and there is no history of AR balances being significantly below forecast
+                    }
+                </span>
+            </p>
+
+            @if (Model.IsRed || Model.IsAmber)
+            {
+                <p class="govuk-body">
+                    If you are not already engaging with ESFA on your finances, you may wish to consider reviewing
+                    @if (Model.SteepDeclineInBalancesAndHighProportionStaffCosts)
+                    {
+                        <a href="https://www.gov.uk/guidance/integrated-curriculum-and-financial-planning-icfp" class="govuk-link">ICFP guidance</a>
+                        @:and the
+                    }
+                    <a href="https://www.gov.uk/government/collections/schools-financial-health-and-efficiency" class="govuk-link">school resources management guidance</a>
+                </p>
+            }
+        </div>
+    </div>
+}

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingForecast.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingForecast.cs
@@ -53,7 +53,10 @@ public class WhenViewingForecast(SchoolBenchmarkingWebAppClient client) : PageBa
             .With(t => t.CompanyNumber, "54321")
             .Create();
 
+        var trustBalance = Fixture.Build<TrustBalance>().Create();
+
         var page = await Client.SetupEstablishment(trust)
+            .SetupBalance(trust, trustBalance)
             .Navigate(Paths.TrustForecast(trust.CompanyNumber));
 
         return (page, trust);


### PR DESCRIPTION
### Context
[AB#214517](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/214517) [AB#188391](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/188391)

### Change proposed in this pull request
Top-most priority banner on Trust forecast page depending on state of incoming data (pending).

### Guidance to review 
To test the different states, `TrustForecastViewModel` may be manually modified to set each of the r/a/g props to `true`.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally



