### PR TITLE
Added API stubs for BFR and BFR metrics endpoints

### DIFF
--- a/web/Web.sln.DotSettings
+++ b/web/Web.sln.DotSettings
@@ -17,4 +17,5 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=VI/@EntryIndexedValue">VI</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=esfa/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=govuk/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=icfp/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=icfp/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=upin/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/web/src/Web.App/Controllers/Api/ForecastProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/ForecastProxyController.cs
@@ -11,7 +11,6 @@ namespace Web.App.Controllers.Api;
 [Route("api/forecast")]
 public class ForecastProxyController(ILogger<ForecastProxyController> logger, IBalanceApi balanceApi) : Controller
 {
-    // todo: deprecate if not required to be called from client
     /// <param name="companyNumber" example="07465701"></param>
     [HttpGet]
     [Produces("application/json")]
@@ -29,35 +28,6 @@ public class ForecastProxyController(ILogger<ForecastProxyController> logger, IB
                 var result = await balanceApi
                     .BudgetForecastReturns(companyNumber)
                     .GetResultOrDefault<BudgetForecastReturn[]>();
-
-                return new JsonResult(result);
-            }
-            catch (Exception e)
-            {
-                logger.LogError(e, "An error getting forecast data: {DisplayUrl}", Request.GetDisplayUrl());
-                return StatusCode(500);
-            }
-        }
-    }
-
-    /// <param name="companyNumber" example="07465701"></param>
-    [HttpGet]
-    [Produces("application/json")]
-    [ProducesResponseType<BudgetForecastReturnMetric[]>(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    [Route("metrics")]
-    public async Task<IActionResult> Metrics([FromQuery] string companyNumber)
-    {
-        using (logger.BeginScope(new
-        {
-            companyNumber
-        }))
-        {
-            try
-            {
-                var result = await balanceApi
-                    .BudgetForecastReturnsMetrics(companyNumber)
-                    .GetResultOrDefault<BudgetForecastReturnMetric[]>();
 
                 return new JsonResult(result);
             }

--- a/web/src/Web.App/Controllers/TrustForecastController.cs
+++ b/web/src/Web.App/Controllers/TrustForecastController.cs
@@ -11,7 +11,7 @@ namespace Web.App.Controllers;
 [Controller]
 [TrustAuthorization]
 [FeatureGate(FeatureFlags.Trusts)]
-[Route("trust/{companyNumber}/forecast-risks")]
+[Route("trust/{companyNumber}/forecast")]
 public class TrustForecastController(
     IEstablishmentApi establishmentApi,
     IBalanceApi balanceApi,
@@ -31,7 +31,8 @@ public class TrustForecastController(
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.TrustForecast(companyNumber);
                 var trust = await establishmentApi.GetTrust(companyNumber).GetResultOrThrow<Trust>();
                 var balance = await balanceApi.Trust(companyNumber).GetResultOrThrow<TrustBalance>();
-                var viewModel = new TrustForecastViewModel(trust, balance);
+                var metrics = await GetBudgetForecastReturnMetrics(companyNumber);
+                var viewModel = new TrustForecastViewModel(trust, balance, metrics);
                 return View(viewModel);
             }
             catch (Exception e)
@@ -42,4 +43,8 @@ public class TrustForecastController(
             }
         }
     }
+
+    private async Task<BudgetForecastReturnMetric[]> GetBudgetForecastReturnMetrics(string companyNumber) => await balanceApi
+        .BudgetForecastReturnsMetrics(companyNumber)
+        .GetResultOrDefault<BudgetForecastReturnMetric[]>() ?? [];
 }

--- a/web/src/Web.App/Domain/Establishment/Trust.cs
+++ b/web/src/Web.App/Domain/Establishment/Trust.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-
 namespace Web.App.Domain;
 
 [ExcludeFromCodeCoverage]
@@ -11,4 +10,5 @@ public record Trust
     public string? CFOName { get; set; }
     public string? CFOEmail { get; set; }
     public DateTime? OpenDate { get; set; }
+    public string? TrustUPIN { get; set; }
 }

--- a/web/src/Web.App/Domain/Establishment/Trust.cs
+++ b/web/src/Web.App/Domain/Establishment/Trust.cs
@@ -10,5 +10,4 @@ public record Trust
     public string? CFOName { get; set; }
     public string? CFOEmail { get; set; }
     public DateTime? OpenDate { get; set; }
-    public string? TrustUPIN { get; set; }
 }

--- a/web/src/Web.App/Domain/Insight/Balance.cs
+++ b/web/src/Web.App/Domain/Insight/Balance.cs
@@ -31,3 +31,28 @@ public record BalanceHistory : BalanceBase
     public int? Year { get; set; }
     public string? Term { get; set; }
 }
+
+public record BudgetForecastReturn
+{
+    public string? RunType { get; set; }
+    public string? RunId { get; set; }
+    public int? Year { get; set; }
+    public string? CompanyNumber { get; set; }
+    public string? Category { get; set; }
+    public decimal? Forecast { get; set; }
+    public decimal? Actual { get; set; }
+    public decimal? TotalPupils { get; set; }
+    public decimal? Slope { get; set; }
+    public decimal? Variance { get; set; }
+    public decimal? PercentVariance { get; set; }
+}
+
+public record BudgetForecastReturnMetric
+{
+    public string? RunType { get; set; }
+    public string? RunId { get; set; }
+    public int? Year { get; set; }
+    public string? CompanyNumber { get; set; }
+    public string? Metric { get; set; }
+    public decimal? Value { get; set; }
+}

--- a/web/src/Web.App/Extensions/WebApplicationBuilderExtensions.cs
+++ b/web/src/Web.App/Extensions/WebApplicationBuilderExtensions.cs
@@ -69,12 +69,12 @@ public static class WebApplicationBuilderExtensions
                     // lazy hack to add sign in/out links to UI
                     Contact = new OpenApiContact
                     {
-                        Name = "Sign in",
+                        Name = "🔒 Sign in",
                         Url = new Uri("/sign-in", UriKind.Relative)
                     },
                     License = new OpenApiLicense
                     {
-                        Name = "Sign out",
+                        Name = "🔓 Sign out",
                         Url = new Uri("/sign-out", UriKind.Relative)
                     }
                 });

--- a/web/src/Web.App/Infrastructure/Apis/Insight/BalanceApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Insight/BalanceApi.cs
@@ -8,8 +8,8 @@ public interface IBalanceApi
     Task<ApiResult> SchoolHistory(string? urn, ApiQuery? query = null);
     Task<ApiResult> TrustHistory(string? companyNo, ApiQuery? query = null);
     Task<ApiResult> QueryTrusts(ApiQuery? query = null);
-    Task<ApiResult> BudgetForecastReturns(string? companyNo);
-    Task<ApiResult> BudgetForecastReturnsMetrics(string? companyNo);
+    Task<ApiResult> BudgetForecastReturns(string? companyNo, ApiQuery? query = null);
+    Task<ApiResult> BudgetForecastReturnsMetrics(string? companyNo, ApiQuery? query = null);
 }
 
 public class BalanceApi(HttpClient httpClient, string? key = default) : ApiBase(httpClient, key), IBalanceApi
@@ -25,11 +25,11 @@ public class BalanceApi(HttpClient httpClient, string? key = default) : ApiBase(
     public async Task<ApiResult> QueryTrusts(ApiQuery? query = null) => await GetAsync($"api/balance/trusts{query?.ToQueryString()}");
 
     // todo: replace stub with actual API call
-    public Task<ApiResult> BudgetForecastReturns(string? companyNo) => Task.FromResult(ApiResult.Ok(new[]
+    public Task<ApiResult> BudgetForecastReturns(string? companyNo, ApiQuery? query = null) => Task.FromResult(ApiResult.Ok(new[]
     {
         new BudgetForecastReturn
         {
-            Year = 2023,
+            Year = 2020,
             Forecast = 211_000_000,
             Actual = 219_000_000
         },
@@ -63,7 +63,7 @@ public class BalanceApi(HttpClient httpClient, string? key = default) : ApiBase(
     }));
 
     // todo: replace stub with actual API call
-    public Task<ApiResult> BudgetForecastReturnsMetrics(string? companyNo) => Task.FromResult(ApiResult.Ok(new[]
+    public Task<ApiResult> BudgetForecastReturnsMetrics(string? companyNo, ApiQuery? query = null) => Task.FromResult(ApiResult.Ok(new[]
     {
         new BudgetForecastReturnMetric
         {

--- a/web/src/Web.App/Infrastructure/Apis/Insight/BalanceApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Insight/BalanceApi.cs
@@ -1,4 +1,5 @@
-﻿namespace Web.App.Infrastructure.Apis;
+﻿using Web.App.Domain;
+namespace Web.App.Infrastructure.Apis;
 
 public interface IBalanceApi
 {
@@ -7,6 +8,8 @@ public interface IBalanceApi
     Task<ApiResult> SchoolHistory(string? urn, ApiQuery? query = null);
     Task<ApiResult> TrustHistory(string? companyNo, ApiQuery? query = null);
     Task<ApiResult> QueryTrusts(ApiQuery? query = null);
+    Task<ApiResult> BudgetForecastReturns(string? companyNo);
+    Task<ApiResult> BudgetForecastReturnsMetrics(string? companyNo);
 }
 
 public class BalanceApi(HttpClient httpClient, string? key = default) : ApiBase(httpClient, key), IBalanceApi
@@ -20,4 +23,77 @@ public class BalanceApi(HttpClient httpClient, string? key = default) : ApiBase(
     public async Task<ApiResult> TrustHistory(string? companyNo, ApiQuery? query = null) => await GetAsync($"api/balance/trust/{companyNo}/history{query?.ToQueryString()}");
 
     public async Task<ApiResult> QueryTrusts(ApiQuery? query = null) => await GetAsync($"api/balance/trusts{query?.ToQueryString()}");
+
+    // todo: replace stub with actual API call
+    public Task<ApiResult> BudgetForecastReturns(string? companyNo) => Task.FromResult(ApiResult.Ok(new[]
+    {
+        new BudgetForecastReturn
+        {
+            Year = 2023,
+            Forecast = 211_000_000,
+            Actual = 219_000_000
+        },
+        new BudgetForecastReturn
+        {
+            Year = 2021,
+            Forecast = 277_000_000,
+            Actual = 412_000_000
+        },
+        new BudgetForecastReturn
+        {
+            Year = 2022,
+            Forecast = 487_000_000,
+            Actual = 609_000_000
+        },
+        new BudgetForecastReturn
+        {
+            Year = 2023,
+            Forecast = 265_000_000
+        },
+        new BudgetForecastReturn
+        {
+            Year = 2024,
+            Forecast = 264_000_000
+        },
+        new BudgetForecastReturn
+        {
+            Year = 2025,
+            Forecast = 286_000_000
+        }
+    }));
+
+    // todo: replace stub with actual API call
+    public Task<ApiResult> BudgetForecastReturnsMetrics(string? companyNo) => Task.FromResult(ApiResult.Ok(new[]
+    {
+        new BudgetForecastReturnMetric
+        {
+            Year = 2022,
+            Metric = "Revenue reserve as percentage of income",
+            Value = 1.2m
+        },
+        new BudgetForecastReturnMetric
+        {
+            Year = 2022,
+            Metric = "Staff costs as percentage of income",
+            Value = 2.3m
+        },
+        new BudgetForecastReturnMetric
+        {
+            Year = 2022,
+            Metric = "Expenditure as percentage of income",
+            Value = 3.4m
+        },
+        new BudgetForecastReturnMetric
+        {
+            Year = 2022,
+            Metric = "Self-generated funding as percentage of income",
+            Value = 4.5m
+        },
+        new BudgetForecastReturnMetric
+        {
+            Year = 2022,
+            Metric = "Grant funding as percentage of income",
+            Value = 5.6m
+        }
+    }));
 }

--- a/web/src/Web.App/ViewModels/TrustForecastViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustForecastViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using Web.App.Domain;
 namespace Web.App.ViewModels;
 
-public class TrustForecastViewModel(Trust trust, TrustBalance balance)
+public class TrustForecastViewModel(Trust trust, TrustBalance balance, BudgetForecastReturnMetric[] metrics)
 {
     public string? CompanyNumber => trust.CompanyNumber;
     public string? Name => trust.TrustName;
@@ -33,4 +33,7 @@ public class TrustForecastViewModel(Trust trust, TrustBalance balance)
                            || BalancesIncreasingSteeply;
 
     public bool HasGuidance => IsRed || IsAmber || IsGreen;
+
+    // todo: return latest year only
+    public BudgetForecastReturnMetric[] Metrics => metrics;
 }

--- a/web/tests/Web.A11yTests/Pages/Trust/WhenViewingForecast.cs
+++ b/web/tests/Web.A11yTests/Pages/Trust/WhenViewingForecast.cs
@@ -8,7 +8,7 @@ public class WhenViewingForecast(
     WebDriver webDriver)
     : AuthPageBase(testOutputHelper, webDriver)
 {
-    protected override string PageUrl => $"/trust/{TestConfiguration.Trust}/forecast-risks";
+    protected override string PageUrl => $"/trust/{TestConfiguration.Trust}/forecast";
 
     [Fact]
     public async Task ThenThereAreNoAccessibilityIssues()

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -206,10 +206,11 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         return this;
     }
 
-    public BenchmarkingWebAppClient SetupBalance(Trust trust, TrustBalance? balance = null)
+    public BenchmarkingWebAppClient SetupBalance(Trust trust, TrustBalance? balance = null, BudgetForecastReturnMetric[]? metrics = null)
     {
         BalanceApi.Reset();
         BalanceApi.Setup(api => api.Trust(trust.CompanyNumber, It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(balance ?? new TrustBalance()));
+        BalanceApi.Setup(api => api.BudgetForecastReturnsMetrics(trust.CompanyNumber, It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(metrics ?? []));
         return this;
     }
 

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -21,7 +21,7 @@ public static class Paths
     public static string TrustComparison(string? companyNumber) => $"/trust/{companyNumber}/comparison";
     public static string TrustCensus(string? companyNumber) => $"/trust/{companyNumber}/census";
     public static string TrustFinancialPlanning(string? companyNumber) => $"/trust/{companyNumber}/financial-planning";
-    public static string TrustForecast(string? companyNumber) => $"/trust/{companyNumber}/forecast-risks";
+    public static string TrustForecast(string? companyNumber) => $"/trust/{companyNumber}/forecast";
     public static string SchoolComparatorSet(string? urn, string referrer) =>
         $"/school/{urn}/comparator-set?referrer={referrer}";
     public static string SchoolComparison(string? urn) => $"/school/{urn}/comparison";


### PR DESCRIPTION
### Context
[AB#214181](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/214181) AB#188397

### Change proposed in this pull request
Stubbed API calls to BFR and BFR metrics based on the latest database schema. To be wired up properly as part of future tickets. BFR endpoint called via client for rendering chart/table. BFR metric endpoint called from Forecast controller.

### Guidance to review 
This will be tweaked when the BFR schema is stable, but for now these models will suffice to continue with the front end build.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

