### PR TITLE
Use `xlink:href` instead of `href` in `<a>` within `<svg>` elements

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -93,14 +93,14 @@
       <button type="submit">Submit</button>
     </form>-->
     <!--<div id="compare-your-trust" data-id="07465701"></div>-->
-    <!--<div id="compare-your-costs" data-type="school" data-id="140565"></div>-->
+    <div id="compare-your-costs" data-type="school" data-id="140565"></div>
     <!--<div id="historic-data" data-type="school" data-id="140565"></div>-->
     <!--<div
       id="compare-your-costs"
       data-type="local-authority"
       data-id="383"
     ></div>-->
-    <div id="budget-forecast-returns" data-id="07465701"></div>
+    <!--<div id="budget-forecast-returns" data-id="07465701"></div>-->
     <script type="module" src="/src/main.tsx"></script>
     <script
       type="module"

--- a/front-end-components/src/components/charts/chart-link/component.tsx
+++ b/front-end-components/src/components/charts/chart-link/component.tsx
@@ -1,0 +1,12 @@
+import { ChartLinkProps } from "./types";
+
+export function ChartLink({ href, children, ...props }: ChartLinkProps) {
+  const attributes = {
+    xlinkHref: href,
+  };
+  return (
+    <a {...props} {...attributes}>
+      {children}
+    </a>
+  );
+}

--- a/front-end-components/src/components/charts/chart-link/index.tsx
+++ b/front-end-components/src/components/charts/chart-link/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/components/charts/chart-link/types";
+export * from "src/components/charts/chart-link/component";

--- a/front-end-components/src/components/charts/chart-link/types.tsx
+++ b/front-end-components/src/components/charts/chart-link/types.tsx
@@ -1,0 +1,10 @@
+export interface ChartLinkProps
+  extends Omit<
+    React.DetailedHTMLProps<
+      React.AnchorHTMLAttributes<HTMLAnchorElement>,
+      HTMLAnchorElement
+    >,
+    "href"
+  > {
+  href: string;
+}

--- a/front-end-components/src/components/charts/establishment-tick/component.tsx
+++ b/front-end-components/src/components/charts/establishment-tick/component.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Text } from "recharts";
 import { EstablishmentTickProps } from "src/components/charts/establishment-tick";
+import { ChartLink } from "../chart-link";
 
 export function EstablishmentTick(props: EstablishmentTickProps) {
   const {
@@ -44,7 +45,7 @@ export function EstablishmentTick(props: EstablishmentTickProps) {
         className="recharts-text establishment-tick"
         {...rest}
       >
-        <a
+        <ChartLink
           href={href(urn)}
           className="govuk-link govuk-link--no-visited-state"
           aria-label={name}
@@ -56,7 +57,7 @@ export function EstablishmentTick(props: EstablishmentTickProps) {
               <tspan key={i}>{(i > 0 ? " " : "") + s}</tspan>
             ))}
           {name.length > truncateAt && "…"}
-        </a>
+        </ChartLink>
       </text>
     </>
   );

--- a/web/src/Web.App/Views/Shared/Components/RagStack/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/RagStack/Default.cshtml
@@ -15,7 +15,7 @@ else
         {
             if (!string.IsNullOrWhiteSpace(Model.RedHref))
             {
-                @:<a href="@Model.RedHref" aria-label="@Model.Red high priority">
+                @:<a xlink:href="@Model.RedHref" aria-label="@Model.Red high priority" role="link">
             }
             <rect
                 role="presentation"
@@ -34,7 +34,7 @@ else
         {
             if (!string.IsNullOrWhiteSpace(Model.AmberHref))
             {
-                @:<a href="@Model.AmberHref" aria-label="@Model.Amber medium priority">
+                @:<a xlink:href="@Model.AmberHref" aria-label="@Model.Amber medium priority" role="link">
             }
             <rect
                 role="presentation"
@@ -53,7 +53,7 @@ else
         {
             if (!string.IsNullOrWhiteSpace(Model.GreenHref))
             {
-                @:<a href="@Model.GreenHref" aria-label="@Model.Green low priority">
+                @:<a xlink:href="@Model.GreenHref" aria-label="@Model.Green low priority" role="link">
             }
             <rect
                 role="presentation"

--- a/web/src/Web.App/package-lock.json
+++ b/web/src/Web.App/package-lock.json
@@ -1164,9 +1164,9 @@
       }
     },
     "node_modules/front-end": {
-      "version": "0.2.34",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-0.2.34.tgz",
-      "integrity": "sha1-j6+7tDSUf8S/+pDd1xAE93FKKQI=",
+      "version": "0.2.41",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-0.2.41.tgz",
+      "integrity": "sha1-2BmNBEdLeJhUBBFSt/Uw2D/bnfw=",
       "dependencies": {
         "accessible-autocomplete": "^3.0.0",
         "classnames": "^2.5.1",

--- a/web/tests/Web.A11yTests/Pages/Trust/Comparators/WhenViewingComparators.cs
+++ b/web/tests/Web.A11yTests/Pages/Trust/Comparators/WhenViewingComparators.cs
@@ -9,7 +9,7 @@ public class WhenViewingComparators(ITestOutputHelper testOutputHelper, WebDrive
     protected override string PageUrl => $"/trust/{TestConfiguration.Trust}/comparators/create/by/name";
 
     [Fact]
-    public async Task ThenThereAreNoAccessibilityIssues()
+    public async Task ShowAllSectionsThenThereAreNoAccessibilityIssues()
     {
         await GoToPage();
         await Page.Locator("#trust-input").FillAsync("trust");
@@ -20,7 +20,8 @@ public class WhenViewingComparators(ITestOutputHelper testOutputHelper, WebDrive
         await Page.Locator("#create-set").WaitForAsync();
         await Page.Locator("#create-set").ClickAsync();
         await Page.WaitForURLAsync("**/comparators?comparator-generated=true");
-        await Page.Locator("#tab_balance").WaitForAsync();
+        await Page.Locator("#spending-mode-chart").ClickAsync();
+        await Page.Locator(".govuk-accordion__show-all").ClickAsync();
         await EvaluatePage();
     }
 }

--- a/web/tests/Web.A11yTests/Pages/Trust/WhenViewingHome.cs
+++ b/web/tests/Web.A11yTests/Pages/Trust/WhenViewingHome.cs
@@ -1,4 +1,3 @@
-using Deque.AxeCore.Commons;
 using Web.A11yTests.Drivers;
 using Xunit;
 using Xunit.Abstractions;
@@ -9,22 +8,12 @@ public class WhenViewingHome(
     WebDriver webDriver)
     : PageBase(testOutputHelper, webDriver)
 {
-    private readonly AxeRunContext _context = new()
-    {
-        // known issues
-        Exclude =
-        [
-            // Interactive controls must not be nested
-            new AxeSelector("svg.rag-stack")
-        ]
-    };
-
     protected override string PageUrl => $"/trust/{TestConfiguration.Trust}";
 
     [Fact]
     public async Task ThenThereAreNoAccessibilityIssues()
     {
         await GoToPage();
-        await EvaluatePage(_context);
+        await EvaluatePage();
     }
 }


### PR DESCRIPTION
### Context
[AB#215031](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/215031) [AB#214915](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/214915)

### Change proposed in this pull request
Fixes to some `<a>` elements when children of `<svg>` for accessibility tests.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

