### PR TITLE
Redefined `dbo.BudgetForecastReturn` table and managed mapping to expected API response in code

### DIFF
--- a/core-infrastructure/src/db/Core.Database/Scripts/045-CreateBudgetForecastTable.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/045-CreateBudgetForecastTable.sql
@@ -1,0 +1,24 @@
+IF EXISTS (SELECT *
+           FROM INFORMATION_SCHEMA.TABLES
+           WHERE table_name = 'BudgetForecastReturn')
+    BEGIN
+        DROP TABLE dbo.BudgetForecastReturn;
+    END;
+
+IF NOT EXISTS(SELECT *
+              FROM INFORMATION_SCHEMA.TABLES
+              WHERE table_name = 'BudgetForecastReturn')
+    BEGIN
+        CREATE TABLE dbo.BudgetForecastReturn
+        (
+            RunType         nvarchar(50)   NOT NULL,
+            RunId           nvarchar(50)   NOT NULL,
+            Year            int            NOT NULL,
+            CompanyNumber   nvarchar(8)    NOT NULL,
+            Category        nvarchar(50)   NOT NULL,
+            Value           decimal(16, 2) NULL,
+            TotalPupils     decimal(16, 2) NULL,
+
+            CONSTRAINT PK_BudgetForecastReturn PRIMARY KEY (RunType, RunId, CompanyNumber, Year, Category)
+        );
+    END;  

--- a/platform/src/apis/Platform.Api.Insight/BudgetForecast/BudgetForecastFunctions.cs
+++ b/platform/src/apis/Platform.Api.Insight/BudgetForecast/BudgetForecastFunctions.cs
@@ -48,12 +48,12 @@ public class BudgetForecastFunctions
         {
             try
             {
-                var result = await _service.GetBudgetForecastReturnsAsync(
+                var results = await _service.GetBudgetForecastReturnsAsync(
                     companyNumber,
                     queryParams.RunType,
                     queryParams.Category,
                     queryParams.RunId);
-                return new JsonContentResult(result.Select(BudgetForecastReturnsResponseFactory.Create));
+                return new JsonContentResult(BudgetForecastReturnsResponseFactory.CreateForDefaultRunType(results));
             }
             catch (Exception e)
             {
@@ -81,7 +81,7 @@ public class BudgetForecastFunctions
         {
             try
             {
-                var result = await _service.GetBudgetForecastReturnMetricsAsync(companyNumber);
+                var result = await _service.GetBudgetForecastReturnMetricsAsync(companyNumber, "default");
                 return new JsonContentResult(result.Select(BudgetForecastReturnsResponseFactory.Create));
             }
             catch (Exception e)

--- a/platform/src/apis/Platform.Api.Insight/BudgetForecast/BudgetForecastModel.cs
+++ b/platform/src/apis/Platform.Api.Insight/BudgetForecast/BudgetForecastModel.cs
@@ -7,12 +7,8 @@ public record BudgetForecastReturnModel
     public int? Year { get; set; }
     public string? CompanyNumber { get; set; }
     public string? Category { get; set; }
-    public decimal? Forecast { get; set; }
-    public decimal? Actual { get; set; }
+    public decimal? Value { get; set; }
     public decimal? TotalPupils { get; set; }
-    public decimal? Slope { get; set; }
-    public decimal? Variance { get; set; }
-    public decimal? PercentVariance { get; set; }
 }
 
 public record BudgetForecastReturnMetricModel

--- a/platform/src/apis/Platform.Api.Insight/BudgetForecast/BudgetForecastService.cs
+++ b/platform/src/apis/Platform.Api.Insight/BudgetForecast/BudgetForecastService.cs
@@ -11,7 +11,9 @@ public interface IBudgetForecastService
         string runType,
         string category,
         string? runId = null);
-    Task<IEnumerable<BudgetForecastReturnMetricModel>> GetBudgetForecastReturnMetricsAsync(string companyNumber);
+    Task<IEnumerable<BudgetForecastReturnMetricModel>> GetBudgetForecastReturnMetricsAsync(
+        string companyNumber,
+        string runType);
 }
 
 public class BudgetForecastService : IBudgetForecastService
@@ -23,7 +25,11 @@ public class BudgetForecastService : IBudgetForecastService
         _dbFactory = dbFactory;
     }
 
-    public async Task<IEnumerable<BudgetForecastReturnModel>> GetBudgetForecastReturnsAsync(string companyNumber, string runType, string category, string? runId = null)
+    public async Task<IEnumerable<BudgetForecastReturnModel>> GetBudgetForecastReturnsAsync(
+        string companyNumber,
+        string runType,
+        string category,
+        string? runId = null)
     {
         var builder = new SqlBuilder();
         var template = builder.AddTemplate("SELECT * from BudgetForecastReturn /**where**/");
@@ -47,10 +53,16 @@ public class BudgetForecastService : IBudgetForecastService
         return await conn.QueryAsync<BudgetForecastReturnModel>(template.RawSql, template.Parameters);
     }
 
-    public async Task<IEnumerable<BudgetForecastReturnMetricModel>> GetBudgetForecastReturnMetricsAsync(string companyNumber)
+    public async Task<IEnumerable<BudgetForecastReturnMetricModel>> GetBudgetForecastReturnMetricsAsync(
+        string companyNumber,
+        string runType)
     {
-        const string sql = "SELECT * from BudgetForecastReturnMetric where CompanyNumber = @CompanyNumber";
-        var parameters = new { CompanyNumber = companyNumber };
+        const string sql = "SELECT * from BudgetForecastReturnMetric where CompanyNumber = @CompanyNumber and RunType = @RunType";
+        var parameters = new
+        {
+            CompanyNumber = companyNumber,
+            RunType = runType
+        };
 
         using var conn = await _dbFactory.GetConnection();
         return await conn.QueryAsync<BudgetForecastReturnMetricModel>(sql, parameters);

--- a/platform/tests/Platform.Tests/Insight/BudgetForecast/WhenBudgetForecastReturnsResponseFactoryCreatesResponse.cs
+++ b/platform/tests/Platform.Tests/Insight/BudgetForecast/WhenBudgetForecastReturnsResponseFactoryCreatesResponse.cs
@@ -1,0 +1,277 @@
+﻿using Platform.Api.Insight.BudgetForecast;
+using Xunit;
+namespace Platform.Tests.Insight.BudgetForecast;
+
+public class WhenBudgetForecastReturnsResponseFactoryCreatesResponse
+{
+    /// <summary>
+    /// Sample source input:
+    /// 
+    /// | RunId | Year | Value |
+    /// | ----- | ---- | ----- |
+    /// | 2020  | 2018 | 1_001 |
+    /// | 2020  | 2019 | 1_002 |
+    /// | 2020  | 2020 | 1_003 |
+    /// | 2020  | 2021 | 1_004 |
+    /// | 2020  | 2022 | 1_005 |
+    /// | 2020  | 2023 | 1_006 |
+    /// | 2021  | 2019 | 1_002 |
+    /// | 2021  | 2020 | 1_003 |
+    /// | 2021  | 2021 | 1_007 |
+    /// | 2021  | 2022 | 1_008 |
+    /// | 2021  | 2023 | 1_009 |
+    /// | 2021  | 2024 | 1_010 |
+    /// | 2022  | 2020 | 1_003 |
+    /// | 2022  | 2021 | 1_007 |
+    /// | 2022  | 2022 | 1_011 |
+    /// | 2022  | 2023 | 1_012 |
+    /// | 2022  | 2024 | 1_013 |
+    /// | 2022  | 2025 | 1_014 |
+    ///
+    /// Expected output:
+    /// 
+    /// | Year | Actual | Forecast |
+    /// | ---- | ------ | -------- |
+    /// | 2018 | 1_001  |          |
+    /// | 2019 | 1_002  |          |
+    /// | 2020 | 1_003  |          |
+    /// | 2021 | 1_007  | 1_004    |
+    /// | 2022 | 1_011  | 1_008    |
+    /// | 2023 |        | 1_012    |
+    /// | 2024 |        | 1_013    |
+    /// | 2025 |        | 1_014    |
+    /// </summary>
+    [Fact]
+    public void ShouldBuildResponseModelForDefaultRunType()
+    {
+        // arrange
+        var models = new BudgetForecastReturnModel[]
+        {
+            new()
+            {
+                RunType = "default",
+                RunId = "2020",
+                Year = 2018,
+                Value = 1_001,
+                TotalPupils = 2_001
+            },
+            new()
+            {
+                RunType = "default",
+                RunId = "2020",
+                Year = 2019,
+                Value = 1_002,
+                TotalPupils = 2_002
+            },
+            new()
+            {
+                RunType = "default",
+                RunId = "2020",
+                Year = 2020,
+                Value = 1_003,
+                TotalPupils = 2_003
+            },
+            new()
+            {
+                RunType = "default",
+                RunId = "2020",
+                Year = 2021,
+                Value = 1_004,
+                TotalPupils = 2_004
+            },
+            new()
+            {
+                RunType = "default",
+                RunId = "2020",
+                Year = 2022,
+                Value = 1_005,
+                TotalPupils = 2_005
+            },
+            new()
+            {
+                RunType = "default",
+                RunId = "2020",
+                Year = 2023,
+                Value = 1_006,
+                TotalPupils = 2_006
+            },
+            new()
+            {
+                RunType = "default",
+                RunId = "2021",
+                Year = 2019,
+                Value = 1_002,
+                TotalPupils = 2_002
+            },
+            new()
+            {
+                RunType = "default",
+                RunId = "2021",
+                Year = 2020,
+                Value = 1_003,
+                TotalPupils = 2_003
+            },
+            new()
+            {
+                RunType = "default",
+                RunId = "2021",
+                Year = 2021,
+                Value = 1_007,
+                TotalPupils = 2_007
+            },
+            new()
+            {
+                RunType = "default",
+                RunId = "2021",
+                Year = 2022,
+                Value = 1_008,
+                TotalPupils = 2_008
+            },
+            new()
+            {
+                RunType = "default",
+                RunId = "2021",
+                Year = 2023,
+                Value = 1_009,
+                TotalPupils = 2_009
+            },
+            new()
+            {
+                RunType = "default",
+                RunId = "2021",
+                Year = 2024,
+                Value = 1_010,
+                TotalPupils = 2_010
+            },
+            new()
+            {
+                RunType = "default",
+                RunId = "2022",
+                Year = 2020,
+                Value = 1_002,
+                TotalPupils = 2_002
+            },
+            new()
+            {
+                RunType = "default",
+                RunId = "2022",
+                Year = 2021,
+                Value = 1_003,
+                TotalPupils = 2_003
+            },
+            new()
+            {
+                RunType = "default",
+                RunId = "2022",
+                Year = 2022,
+                Value = 1_011,
+                TotalPupils = 2_011
+            },
+            new()
+            {
+                RunType = "default",
+                RunId = "2022",
+                Year = 2023,
+                Value = 1_012,
+                TotalPupils = 2_012
+            },
+            new()
+            {
+                RunType = "default",
+                RunId = "2022",
+                Year = 2024,
+                Value = 1_013,
+                TotalPupils = 2_013
+            },
+            new()
+            {
+                RunType = "default",
+                RunId = "2022",
+                Year = 2025,
+                Value = 1_014,
+                TotalPupils = 2_014
+            }
+        };
+
+        // act
+        var actual = BudgetForecastReturnsResponseFactory.CreateForDefaultRunType(models);
+
+        // assert
+        var year2018 = actual.ElementAt(0);
+        Assert.Equal(2018, year2018.Year);
+        Assert.Equal(1_001, year2018.Actual);
+        Assert.Null(year2018.Forecast);
+        Assert.Null(year2018.Variance);
+        Assert.Null(year2018.PercentVariance);
+
+        var year2019 = actual.ElementAt(1);
+        Assert.Equal(2019, year2019.Year);
+        Assert.Equal(1_002, year2019.Actual);
+        Assert.Null(year2019.Forecast);
+        Assert.Null(year2019.Variance);
+        Assert.Null(year2019.PercentVariance);
+
+        var year2020 = actual.ElementAt(2);
+        Assert.Equal(2020, year2020.Year);
+        Assert.Equal(1_003, year2020.Actual);
+        Assert.Null(year2020.Forecast);
+        Assert.Null(year2020.Variance);
+        Assert.Null(year2020.PercentVariance);
+
+        var year2021 = actual.ElementAt(3);
+        Assert.Equal(2021, year2021.Year);
+        Assert.Equal(1_007, year2021.Actual);
+        Assert.Equal(1_004, year2021.Forecast);
+        Assert.Equal(3, year2021.Variance);
+        Assert.Equal("0.298", year2021.PercentVariance.GetValueOrDefault().ToString("0.000"));
+
+        var year2022 = actual.ElementAt(4);
+        Assert.Equal(2022, year2022.Year);
+        Assert.Equal(1_011, year2022.Actual);
+        Assert.Equal(1_008, year2022.Forecast);
+        Assert.Equal(3, year2022.Variance);
+        Assert.Equal("0.297", year2022.PercentVariance.GetValueOrDefault().ToString("0.000"));
+
+        var year2023 = actual.ElementAt(5);
+        Assert.Equal(2023, year2023.Year);
+        Assert.Null(year2023.Actual);
+        Assert.Equal(1_012, year2023.Forecast);
+        Assert.Null(year2023.Variance);
+        Assert.Null(year2023.PercentVariance);
+
+        var year2024 = actual.ElementAt(6);
+        Assert.Equal(2024, year2024.Year);
+        Assert.Null(year2024.Actual);
+        Assert.Equal(1_013, year2024.Forecast);
+        Assert.Null(year2024.Variance);
+        Assert.Null(year2024.PercentVariance);
+
+        var year2025 = actual.ElementAt(7);
+        Assert.Equal(2025, year2025.Year);
+        Assert.Null(year2025.Actual);
+        Assert.Equal(1_014, year2025.Forecast);
+        Assert.Null(year2025.Variance);
+        Assert.Null(year2025.PercentVariance);
+    }
+    [Fact]
+    public void ShouldThrowExceptionForMalformedDefaultRunType()
+    {
+        // arrange
+        var models = new BudgetForecastReturnModel[]
+        {
+            new()
+            {
+                RunType = "default",
+                RunId = "runId",
+                Year = 2018,
+                Value = 1_001
+            }
+        };
+
+        // act
+        var actual = Assert.Throws<ArithmeticException>(() => BudgetForecastReturnsResponseFactory.CreateForDefaultRunType(models));
+
+        // assert
+        Assert.Equal("Expected RunId to be of type int for RunType default but found 'runId'", actual.Message);
+    }
+}


### PR DESCRIPTION
### Context
[AB#215136](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/215136) [AB#188391](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/188391)

### Change proposed in this pull request
Calculated actual and forecast RR and pupil count based on agreed logic (see below). Re-defined table schema for source data based on what will be outputted from data pipeline.

![image](https://github.com/DFE-Digital/education-benchmarking-and-insights/assets/3224486/28823dce-eeed-4b7a-be7e-b07825a0ef7b)

### Guidance to review 
Unit tests should all pass to cover the new functionality. Downstream consumers will need to be updated at a future date but nothing will break due to stubs still being in use.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

