### PR TITLE
adds custom data spending comparison page

### DIFF
--- a/web/src/Web.App/Controllers/SchoolController.cs
+++ b/web/src/Web.App/Controllers/SchoolController.cs
@@ -134,11 +134,11 @@ public class SchoolController(
         {
             try
             {
-                //var userData = await userDataService.GetSchoolDataAsync(User.UserId(), urn);
-                //if (string.IsNullOrEmpty(userData.CustomData))
-                //{
-                //    return RedirectToAction("Index", "School", new { urn });
-                //}
+                var userData = await userDataService.GetSchoolDataAsync(User.UserId(), urn);
+                if (string.IsNullOrEmpty(userData.CustomData))
+                {
+                    return RedirectToAction("Index", "School", new { urn });
+                }
 
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.SchoolCustomData(urn);
 

--- a/web/src/Web.App/Controllers/SchoolSpendingComparisonController.cs
+++ b/web/src/Web.App/Controllers/SchoolSpendingComparisonController.cs
@@ -1,12 +1,13 @@
-﻿using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http.Extensions;
+﻿using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.FeatureManagement.Mvc;
 using Web.App.Attributes;
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Extensions;
+using Web.App.Services;
 using Web.App.ViewModels;
+using Web.App.Extensions;
 
 namespace Web.App.Controllers;
 
@@ -16,6 +17,8 @@ namespace Web.App.Controllers;
 [Route("school/{urn}/spending-comparison")]
 public class SchoolSpendingComparisonController(
     IEstablishmentApi establishmentApi,
+    IUserDataService userDataService,
+    IMetricRagRatingApi metricRagRatingApi,
     ILogger<SchoolSpendingComparisonController> logger)
     : Controller
 {
@@ -26,11 +29,19 @@ public class SchoolSpendingComparisonController(
         {
             try
             {
+                var userData = await userDataService.GetSchoolDataAsync(User.UserId(), urn);
+                if (string.IsNullOrEmpty(userData.CustomData))
+                {
+                    return RedirectToAction("Index", "School", new { urn });
+                }
+
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.SchoolSpendingComparison(urn);
 
                 var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
+                var originalRating = await metricRagRatingApi.GetDefaultAsync(new ApiQuery().AddIfNotNull("urns", urn)).GetResultOrThrow<RagRating[]>();
+                var customRating = await metricRagRatingApi.CustomAsync(userData.CustomData).GetResultOrThrow<RagRating[]>();
 
-                var viewModel = new SchoolSpendingComparisonViewModel(school);
+                var viewModel = new SchoolSpendingComparisonViewModel(school, originalRating, customRating);
 
                 return View(viewModel);
             }

--- a/web/src/Web.App/Controllers/SchoolSpendingController.cs
+++ b/web/src/Web.App/Controllers/SchoolSpendingController.cs
@@ -79,11 +79,11 @@ public class SchoolSpendingController(
         {
             try
             {
-                //var userData = await userDataService.GetSchoolDataAsync(User.UserId(), urn);
-                //if (string.IsNullOrEmpty(userData.CustomData))
-                //{
-                //    return RedirectToAction("Index", "School", new { urn });
-                //}
+                var userData = await userDataService.GetSchoolDataAsync(User.UserId(), urn);
+                if (string.IsNullOrEmpty(userData.CustomData))
+                {
+                    return RedirectToAction("Index", "School", new { urn });
+                }
 
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.SchoolCustomisedDataSpending(urn);
 

--- a/web/src/Web.App/ViewModels/SchoolSpendingComparisonViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolSpendingComparisonViewModel.cs
@@ -63,8 +63,8 @@ public class SchoolSpendingComparisonViewModel
 
     private (int OriginalCount, int CustomCount, string Change) GetHeadlineResults(string rag)
     {
-        var originalCount = _originalRating.Where(c => c.RAG == rag).Count();
-        var customCount = _customRating.Where(c => c.RAG == rag).Count();
+        var originalCount = _originalRating.Count(c => c.RAG == rag);
+        var customCount = _customRating.Count(c => c.RAG == rag);
         var change = originalCount > customCount
             ? ChangeSymbols.Decrease : originalCount < customCount ? ChangeSymbols.Increase
             : ChangeSymbols.NoChange;

--- a/web/src/Web.App/ViewModels/SchoolSpendingComparisonViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolSpendingComparisonViewModel.cs
@@ -2,8 +2,97 @@
 
 namespace Web.App.ViewModels;
 
-public class SchoolSpendingComparisonViewModel(School school)
+public class SchoolSpendingComparisonViewModel
 {
-    public string? Name => school.SchoolName;
-    public string? Urn => school.URN;
+    private readonly RagRating[] _originalRating;
+    private readonly RagRating[] _customRating;
+
+    public SchoolSpendingComparisonViewModel(School school, RagRating[] originalRating, RagRating[] customRating)
+
+    {
+        Name = school.SchoolName;
+        Urn = school.URN;
+        _originalRating = originalRating;
+        _customRating = customRating;
+        GroupedComparisonResultsNoChange = GetGroupedComparisonResults(true);
+        GroupedComparisonResultsChange = GetGroupedComparisonResults(false);
+        HighHeadline = GetHeadlineResults("red");
+        MediumHeadline = GetHeadlineResults("amber");
+        LowHeadline = GetHeadlineResults("green");
+    }
+    public string? Name { get; }
+    public string? Urn { get; }
+    public (int OriginalCount, int CustomCount, string Change) HighHeadline { get; }
+    public (int OriginalCount, int CustomCount, string Change) MediumHeadline { get; }
+    public (int OriginalCount, int CustomCount, string Change) LowHeadline { get; }
+    public List<ComparisonResult> GroupedComparisonResultsNoChange { get; }
+    public List<ComparisonResult> GroupedComparisonResultsChange { get; }
+
+    private List<ComparisonResult> GetGroupedComparisonResults(bool match)
+    {
+        var results = new List<ComparisonResult>();
+
+        foreach (var originalItem in _originalRating)
+        {
+            var customItem = _customRating.FirstOrDefault(c => c.Category == originalItem.Category);
+
+            bool isMatch = originalItem.PriorityTag == customItem?.PriorityTag;
+
+            if ((match && isMatch) || (!match && !isMatch))
+            {
+                var result = new ComparisonResult
+                {
+                    OriginalPriorityTag = originalItem.PriorityTag,
+                    CustomPriorityTag = customItem?.PriorityTag,
+                    OriginalValue = originalItem.Value,
+                    CustomValue = customItem?.Value,
+                    OriginalPercentile = originalItem.Percentile,
+                    CustomPercentile = customItem?.Percentile,
+                    OriginalRAG = originalItem.RAG,
+                    Category = originalItem.Category,
+                };
+
+                results.Add(result);
+            }
+        }
+
+        return results.OrderBy(r => Lookups.StatusOrderMap[r.OriginalRAG ?? string.Empty])
+            .ThenBy(r => r.OriginalValue)
+            .ToList();
+    }
+
+    private (int OriginalCount, int CustomCount, string Change) GetHeadlineResults(string rag)
+    {
+        var originalCount = _originalRating.Where(c => c.RAG == rag).Count();
+        var customCount = _customRating.Where(c => c.RAG == rag).Count();
+        var change = originalCount > customCount
+            ? ChangeSymbols.Decrease : originalCount < customCount ? ChangeSymbols.Increase
+            : ChangeSymbols.NoChange;
+
+        return (originalCount, customCount, change);
+    }
+}
+public class ComparisonResult
+{
+    public (TagColour Colour, string DisplayText, string Class)? OriginalPriorityTag { get; set; }
+    public (TagColour Colour, string DisplayText, string Class)? CustomPriorityTag { get; set; }
+    public decimal? OriginalValue { get; set; }
+    public decimal? CustomValue { get; set; }
+    public decimal? OriginalPercentile { get; set; }
+    public decimal? CustomPercentile { get; set; }
+    public string? OriginalRAG { get; set; }
+    public string? Category { get; set; }
+}
+
+public static class ChangeSymbols
+{
+    public const string Decrease = "▼";
+    public const string Increase = "▲";
+    public const string NoChange = "";
+}
+
+public class CategoryListSectionViewModel
+{
+    public string? Heading { get; init; }
+    public List<ComparisonResult> CategoryList { get; init; } = [];
 }

--- a/web/src/Web.App/ViewModels/SchoolSpendingComparisonViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolSpendingComparisonViewModel.cs
@@ -22,9 +22,9 @@ public class SchoolSpendingComparisonViewModel
     }
     public string? Name { get; }
     public string? Urn { get; }
-    public (int OriginalCount, int CustomCount, string Change) HighHeadline { get; }
-    public (int OriginalCount, int CustomCount, string Change) MediumHeadline { get; }
-    public (int OriginalCount, int CustomCount, string Change) LowHeadline { get; }
+    public (int OriginalCount, int CustomCount, string Change, string ChangeDescription) HighHeadline { get; }
+    public (int OriginalCount, int CustomCount, string Change, string ChangeDescription) MediumHeadline { get; }
+    public (int OriginalCount, int CustomCount, string Change, string ChangeDescription) LowHeadline { get; }
     public List<ComparisonResult> GroupedComparisonResultsNoChange { get; }
     public List<ComparisonResult> GroupedComparisonResultsChange { get; }
 
@@ -61,15 +61,18 @@ public class SchoolSpendingComparisonViewModel
             .ToList();
     }
 
-    private (int OriginalCount, int CustomCount, string Change) GetHeadlineResults(string rag)
+    private (int OriginalCount, int CustomCount, string Change, string changeDescription) GetHeadlineResults(string rag)
     {
         var originalCount = _originalRating.Count(c => c.RAG == rag);
         var customCount = _customRating.Count(c => c.RAG == rag);
         var change = originalCount > customCount
             ? ChangeSymbols.Decrease : originalCount < customCount ? ChangeSymbols.Increase
             : ChangeSymbols.NoChange;
+        var changeDescription = originalCount > customCount
+        ? ChangeSymbols.DecreaseText : originalCount < customCount ? ChangeSymbols.IncreaseText
+        : ChangeSymbols.NoChangeText;
 
-        return (originalCount, customCount, change);
+        return (originalCount, customCount, change, changeDescription);
     }
 }
 public class ComparisonResult
@@ -89,6 +92,9 @@ public static class ChangeSymbols
     public const string Decrease = "▼";
     public const string Increase = "▲";
     public const string NoChange = "";
+    public const string DecreaseText = "decreased";
+    public const string IncreaseText = "increased";
+    public const string NoChangeText = "no change";
 }
 
 public class CategoryListSectionViewModel

--- a/web/src/Web.App/Views/SchoolSpendingComparison/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolSpendingComparison/Index.cshtml
@@ -16,17 +16,47 @@
     <div class="govuk-grid-column-full">
         <ul class="app-headline app-headline-3 govuk-!-text-align-centre">
             <li class="app-headline-high">
-                <p class="govuk-body govuk-!-font-size-48 govuk-!-margin-bottom-1">@Model.HighHeadline.CustomCount @Model.HighHeadline.Change</p>
+                <p class="govuk-body govuk-!-font-size-48 govuk-!-margin-bottom-1">
+                    <span>
+                        @Model.HighHeadline.CustomCount
+                    </span> 
+                    <span aria-label="high priority change icon">
+                        @Model.HighHeadline.Change
+                        <span class="govuk-visually-hidden">
+                            @Model.HighHeadline.ChangeDescription
+                        </span>
+                    </span>
+                </p>
                 <p class="govuk-body govuk-!-margin-bottom-1">@($"(was {@Model.HighHeadline.OriginalCount})")</p>
                 <p class="govuk-body govuk-!-margin-bottom-1">High priority costs</p>
             </li>
             <li class="app-headline-medium">
-                <p class="govuk-body govuk-!-font-size-48 govuk-!-margin-bottom-1">@Model.MediumHeadline.CustomCount @Model.MediumHeadline.Change</p>
+                <p class="govuk-body govuk-!-font-size-48 govuk-!-margin-bottom-1">
+                    <span>
+                        @Model.MediumHeadline.CustomCount
+                    </span>
+                    <span aria-label="medium priority change icon">
+                        @Model.MediumHeadline.Change
+                        <span class="govuk-visually-hidden">
+                            @Model.MediumHeadline.ChangeDescription
+                        </span>
+                    </span>
+                </p>
                 <p class="govuk-body govuk-!-margin-bottom-1">@($"(was {@Model.MediumHeadline.OriginalCount})")</p>
                 <p class="govuk-body govuk-!-margin-bottom-1">Medium priority costs</p>
             </li>
             <li class="app-headline-low">
-                <p class="govuk-body govuk-!-font-size-48 govuk-!-margin-bottom-1">@Model.LowHeadline.CustomCount @Model.LowHeadline.Change</p>
+                <p class="govuk-body govuk-!-font-size-48 govuk-!-margin-bottom-1">
+                    <span>
+                        @Model.LowHeadline.CustomCount
+                    </span>
+                    <span aria-label="low priority change icon">
+                        @Model.LowHeadline.Change
+                        <span class="govuk-visually-hidden">
+                            @Model.LowHeadline.ChangeDescription
+                        </span>
+                    </span>
+                </p>
                 <p class="govuk-body govuk-!-margin-bottom-1">@($"(was {@Model.LowHeadline.OriginalCount})")</p>
                 <p class="govuk-body govuk-!-margin-bottom-1">Low priority costs</p>
             </li>

--- a/web/src/Web.App/Views/SchoolSpendingComparison/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolSpendingComparison/Index.cshtml
@@ -17,7 +17,7 @@
         <ul class="app-headline app-headline-3 govuk-!-text-align-centre">
             <li class="app-headline-high">
                 <p class="govuk-body govuk-!-font-size-48 govuk-!-margin-bottom-1">
-                    <span>
+                    <span aria-label="high priority customised category count">
                         @Model.HighHeadline.CustomCount
                     </span> 
                     <span aria-label="high priority change icon">
@@ -32,7 +32,7 @@
             </li>
             <li class="app-headline-medium">
                 <p class="govuk-body govuk-!-font-size-48 govuk-!-margin-bottom-1">
-                    <span>
+                    <span aria-label="medium priority customised category count">
                         @Model.MediumHeadline.CustomCount
                     </span>
                     <span aria-label="medium priority change icon">
@@ -47,7 +47,7 @@
             </li>
             <li class="app-headline-low">
                 <p class="govuk-body govuk-!-font-size-48 govuk-!-margin-bottom-1">
-                    <span>
+                    <span aria-label="low priority customised category count">
                         @Model.LowHeadline.CustomCount
                     </span>
                     <span aria-label="low priority change icon">

--- a/web/src/Web.App/Views/SchoolSpendingComparison/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolSpendingComparison/Index.cshtml
@@ -1,4 +1,5 @@
-﻿@model Web.App.ViewModels.SchoolSpendingComparisonViewModel
+﻿@using Web.App.ViewModels
+@model Web.App.ViewModels.SchoolSpendingComparisonViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.SchoolSpendingComparison;
 }
@@ -10,6 +11,35 @@
         id = Model.Urn,
         kind = OrganisationTypes.School
     })
+
+<div class="govuk-grid-row govuk-!-margin-bottom-5">
+    <div class="govuk-grid-column-full">
+        <ul class="app-headline app-headline-3 govuk-!-text-align-centre">
+            <li class="app-headline-high">
+                <p class="govuk-body govuk-!-font-size-48 govuk-!-margin-bottom-1">@Model.HighHeadline.CustomCount @Model.HighHeadline.Change</p>
+                <p class="govuk-body govuk-!-margin-bottom-1">@($"(was {@Model.HighHeadline.OriginalCount})")</p>
+                <p class="govuk-body govuk-!-margin-bottom-1">High priority costs</p>
+            </li>
+            <li class="app-headline-medium">
+                <p class="govuk-body govuk-!-font-size-48 govuk-!-margin-bottom-1">@Model.MediumHeadline.CustomCount @Model.MediumHeadline.Change</p>
+                <p class="govuk-body govuk-!-margin-bottom-1">@($"(was {@Model.MediumHeadline.OriginalCount})")</p>
+                <p class="govuk-body govuk-!-margin-bottom-1">Medium priority costs</p>
+            </li>
+            <li class="app-headline-low">
+                <p class="govuk-body govuk-!-font-size-48 govuk-!-margin-bottom-1">@Model.LowHeadline.CustomCount @Model.LowHeadline.Change</p>
+                <p class="govuk-body govuk-!-margin-bottom-1">@($"(was {@Model.LowHeadline.OriginalCount})")</p>
+                <p class="govuk-body govuk-!-margin-bottom-1">Low priority costs</p>
+            </li>
+        </ul>
+    </div>
+</div>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        @await Html.PartialAsync("_CategoryList", new CategoryListSectionViewModel { Heading = "Categories with changes to priority", CategoryList = Model.GroupedComparisonResultsChange })
+        @await Html.PartialAsync("_CategoryList", new CategoryListSectionViewModel { Heading = "Other categories", CategoryList = Model.GroupedComparisonResultsNoChange })
+    </div>
+</div>
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 

--- a/web/src/Web.App/Views/SchoolSpendingComparison/_CategoryList.cshtml
+++ b/web/src/Web.App/Views/SchoolSpendingComparison/_CategoryList.cshtml
@@ -1,0 +1,55 @@
+﻿@using Web.App.Extensions
+@using Web.App.ViewModels
+@model Web.App.ViewModels.CategoryListSectionViewModel
+
+<h2 class="govuk-heading-m">@Model.Heading</h2>
+<div class="top-categories">
+    @if (Model.CategoryList.Any())
+    {
+        @foreach (var category in Model.CategoryList)
+        {
+            <div>
+                <table class="govuk-table govuk govuk-!-margin-bottom-0">
+                    <caption class="govuk-table__caption govuk-table__caption--m">@category.Category</caption>
+                    <thead class="govuk-table__head">
+                        <tr class="govuk-table__row">
+                            <th scope="col" class="govuk-table__header"></th>
+                            <th scope="col" class="govuk-table__header">Priority</th>
+                            <th scope="col" class="govuk-table__header">Spend (per pupil)</th>
+                            <th scope="col" class="govuk-table__header">Percentage</th>
+                        </tr>
+                    </thead>
+                    <tbody class="govuk-table__body">
+                        <tr class="govuk-table__row">
+                            <th scope="row" class="govuk-table__header">Original Value</th>
+                            <td class="govuk-table__cell">
+                                @await Component.InvokeAsync("Tag", new
+                                    {
+                                        rating = new RatingViewModel(category.OriginalPriorityTag?.Colour, category.OriginalPriorityTag?.DisplayText)
+                                    })
+                            </td>
+                            <td class="govuk-table__cell">@category.OriginalValue.ToCurrency(0)</td>
+                            <td class="govuk-table__cell">@($"{category.OriginalPercentile.ToPercent()} of all benchmarked schools")</td>
+                        </tr>
+                        <tr class="govuk-table__row">
+                            <th scope="row" class="govuk-table__header">Custom Value</th>
+                            <td class="govuk-table__cell">
+                                @await Component.InvokeAsync("Tag", new
+                                    {
+                                        rating = new RatingViewModel(category.CustomPriorityTag?.Colour, category.CustomPriorityTag?.DisplayText)
+                                    })
+                            </td>
+                            <td class="govuk-table__cell">@category.CustomValue.ToCurrency(0)</td>
+                            <td class="govuk-table__cell">@($"{category.CustomPercentile.ToPercent()} of all benchmarked schools")</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        }
+    }
+    else
+    {
+        <p class="govuk-body">There are no categories to display of this type for this comparison</p>
+    }
+</div>
+

--- a/web/src/Web.App/Views/SchoolSpendingComparison/_CategoryList.cshtml
+++ b/web/src/Web.App/Views/SchoolSpendingComparison/_CategoryList.cshtml
@@ -13,10 +13,10 @@
                     <caption class="govuk-table__caption govuk-table__caption--m">@category.Category</caption>
                     <thead class="govuk-table__head">
                         <tr class="govuk-table__row">
-                            <th scope="col" class="govuk-table__header"></th>
-                            <th scope="col" class="govuk-table__header">Priority</th>
-                            <th scope="col" class="govuk-table__header">Spend (per pupil)</th>
-                            <th scope="col" class="govuk-table__header">Percentage</th>
+                            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter"></th>
+                            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Priority</th>
+                            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Spend (per pupil)</th>
+                            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Percentage</th>
                         </tr>
                     </thead>
                     <tbody class="govuk-table__body">

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -253,6 +253,16 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         return this;
     }
 
+    public BenchmarkingWebAppClient SetupMetricRagRatingIncCustom(string customData, IEnumerable<RagRating> customRatings, IEnumerable<RagRating>? originalRatings = null)
+    {
+        MetricRagRatingApi.Reset();
+
+        MetricRagRatingApi.Setup(api => api.GetDefaultAsync(It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(originalRatings ?? Array.Empty<RagRating>()));
+        MetricRagRatingApi.Setup(api => api.CustomAsync(customData)).ReturnsAsync(ApiResult.Ok(customRatings));
+
+        return this;
+    }
+
     public BenchmarkingWebAppClient SetupExpenditure(School school, SchoolExpenditure? expenditure = null)
     {
         ExpenditureApi.Reset();

--- a/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataSpendingComparison.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataSpendingComparison.cs
@@ -309,26 +309,26 @@ public class WhenViewingCustomDataSpendingComparison(SchoolBenchmarkingWebAppCli
         var expectedCustomCount = customRatings.Count(x => x.RAG == rag);
         var expectedOriginalCount = originalRatings.Count(x => x.RAG == rag);
 
-        var customCountText = elements[0].TextContent;
+        var customCountSection = elements[0].QuerySelectorAll("span").ToList();
 
-        var customCountTextAsList = customCountText.Split(" ");
+        var numericPart = customCountSection[0].TextContent.Trim();
 
-        var numericPart = customCountTextAsList[0];
-
-        var changeSymbol = customCountTextAsList[1];
+        var changeSymbol = customCountSection[1].TextContent.Trim();
 
         Assert.Equal(expectedCustomCount.ToString(), numericPart);
 
         switch (expectedCustomCount)
         {
             case var _ when expectedCustomCount > expectedOriginalCount:
-                Assert.Equal(ChangeSymbols.Increase, changeSymbol);
+                Assert.Contains(ChangeSymbols.Increase, changeSymbol);
+                Assert.Contains(ChangeSymbols.IncreaseText, changeSymbol);
                 break;
             case var _ when expectedCustomCount < expectedOriginalCount:
-                Assert.Equal(ChangeSymbols.Decrease, changeSymbol);
+                Assert.Contains(ChangeSymbols.Decrease, changeSymbol);
+                Assert.Contains(ChangeSymbols.DecreaseText, changeSymbol);
                 break;
             case var _ when expectedCustomCount == expectedOriginalCount:
-                Assert.Equal(ChangeSymbols.NoChange, changeSymbol);
+                Assert.Contains(ChangeSymbols.NoChangeText, changeSymbol);
                 break;
             default:
                 Assert.Fail("Error with comparison for changeSymbol assertion");
@@ -417,6 +417,9 @@ public class WhenViewingCustomDataSpendingComparison(SchoolBenchmarkingWebAppCli
         public const string Decrease = "▼";
         public const string Increase = "▲";
         public const string NoChange = "";
+        public const string DecreaseText = "decreased";
+        public const string IncreaseText = "increased";
+        public const string NoChangeText = "no change";
     }
 }
 

--- a/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataSpendingComparison.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataSpendingComparison.cs
@@ -1,0 +1,422 @@
+﻿using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using AngleSharp.XPath;
+using AutoFixture;
+using System.Net;
+using Web.App.Domain;
+using Xunit;
+
+namespace Web.Integration.Tests.Pages.Schools.CustomData;
+public class WhenViewingCustomDataSpendingComparison(SchoolBenchmarkingWebAppClient client)
+    : PageBase<SchoolBenchmarkingWebAppClient>(client)
+{
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(true, false, false)]
+    [InlineData(true, true, false)]
+    [InlineData(false, false, false)]
+    [InlineData(false, true, true)]
+    [InlineData(false, false, true)]
+    public async Task CanDisplay(bool withUserData, bool noCategoryChange, bool allCategoryChange)
+    {
+        var (page, school, originalRatings, customRatings) = await SetupNavigateInitPage(withUserData, noCategoryChange, allCategoryChange);
+
+        if (withUserData)
+        {
+            AssertPageLayout(page, school, originalRatings, customRatings);
+        }
+        else
+        {
+            DocumentAssert.AssertPageUrl(page, Paths.SchoolHome(school.URN).ToAbsolute());
+        }
+    }
+
+    [Fact]
+    public async Task CanNavigateToCompareYourCostsCustomData()
+    {
+        var (page, school, _, _) = await SetupNavigateInitPage(true, false, false);
+
+        var liElements = page.QuerySelectorAll("ul.app-links > li");
+        var anchor = liElements[0].QuerySelector("h3 > a");
+        Assert.NotNull(anchor);
+
+        var newPage = await Client.Follow(anchor);
+
+        DocumentAssert.AssertPageUrl(newPage, Paths.SchoolComparisonCustomData(school.URN).ToAbsolute());
+    }
+
+    [Fact]
+    public async Task CanNavigateToSpendingCustomData()
+    {
+        var (page, school, _, _) = await SetupNavigateInitPage(true);
+
+        var liElements = page.QuerySelectorAll("ul.app-links > li");
+        var anchor = liElements[1].QuerySelector("h3 > a");
+        Assert.NotNull(anchor);
+
+        var newPage = await Client.Follow(anchor);
+
+        DocumentAssert.AssertPageUrl(newPage, Paths.SchoolSpendingCustomData(school.URN).ToAbsolute());
+    }
+
+    [Fact]
+    public async Task CanNavigateToCensusCustomData()
+    {
+        var (page, school, _, _) = await SetupNavigateInitPage(true);
+
+        var liElements = page.QuerySelectorAll("ul.app-links > li");
+        var anchor = liElements[2].QuerySelector("h3 > a");
+        Assert.NotNull(anchor);
+
+        var newPage = await Client.Follow(anchor);
+
+        DocumentAssert.AssertPageUrl(newPage, Paths.SchoolCensusCustomData(school.URN).ToAbsolute());
+    }
+
+    [Fact]
+    public async Task CanDisplayNotFound()
+    {
+        var userData = new[]
+        {
+            new UserData
+            {
+                Type = "custom-data",
+                Id = "123"
+            }
+        };
+
+        const string urn = "12345";
+        var page = await Client.SetupEstablishmentWithNotFound()
+            .SetupUserData(userData)
+            .Navigate(Paths.SchoolSpendingComparison(urn));
+
+        PageAssert.IsNotFoundPage(page);
+        DocumentAssert.AssertPageUrl(page, Paths.SchoolSpendingComparison(urn).ToAbsolute(), HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task CanDisplayProblemWithService()
+    {
+        const string urn = "12345";
+        var page = await Client.SetupEstablishmentWithException()
+            .Navigate(Paths.SchoolSpendingComparison(urn));
+
+        PageAssert.IsProblemPage(page);
+        DocumentAssert.AssertPageUrl(page, Paths.SchoolSpendingComparison(urn).ToAbsolute(), HttpStatusCode.InternalServerError);
+    }
+
+    private async Task<(IHtmlDocument page, School school, RagRating[] originalRatings, RagRating[] customRatings)> SetupNavigateInitPage(bool withUserData, bool noCategoryChange = false, bool allCategoryChange = false)
+    {
+        var school = Fixture.Build<School>()
+            .With(x => x.URN, "12345")
+            .Create();
+
+        var customDataId = "123";
+
+        var userData = new[]
+        {
+            new UserData
+            {
+                Type = "custom-data",
+                Id = customDataId
+            }
+        };
+
+        Assert.NotNull(school.URN);
+
+        var originalRatings = CreateRagRatings(school.URN);
+        var customRatings = CreateRagRatings(school.URN);
+
+        if (noCategoryChange)
+        {
+            Array.ForEach(customRatings, r =>
+            {
+                var original = originalRatings.FirstOrDefault(orig => orig.Category == r.Category);
+                r.RAG = original?.RAG;
+            });
+        }
+
+        if (allCategoryChange)
+        {
+            var statusKeys = Lookups.StatusPriorityMap.Keys.ToList();
+            var random = new Random();
+
+            Array.ForEach(customRatings, r =>
+            {
+                var original = originalRatings.FirstOrDefault(orig => orig.Category == r.Category);
+                if (r.RAG == original?.RAG)
+                {
+                    string newValue;
+                    do
+                    {
+                        newValue = statusKeys[random.Next(statusKeys.Count)];
+                    } while (newValue == original?.RAG);
+
+                    r.RAG = newValue;
+                }
+            });
+        }
+
+        IHtmlDocument page;
+
+        if (withUserData)
+        {
+            page = await Client.SetupEstablishment(school)
+                .SetupUserData(userData)
+                .SetupMetricRagRatingIncCustom(customDataId, customRatings, originalRatings)
+                .Navigate(Paths.SchoolSpendingComparison(school.URN));
+        }
+        else
+        {
+            page = await Client.SetupEstablishment(school)
+                .SetupMetricRagRating()
+                .SetupInsights()
+                .SetupUserData()
+                .Navigate(Paths.SchoolSpendingComparison(school.URN));
+        }
+
+        return (page, school, originalRatings, customRatings);
+
+    }
+
+    private static void AssertPageLayout(IHtmlDocument page, School school, RagRating[] originalRatings, RagRating[] customRatings)
+    {
+        DocumentAssert.AssertPageUrl(page, Paths.SchoolSpendingComparison(school.URN).ToAbsolute());
+
+        var expectedBreadcrumbs = new[]
+        {
+            ("Home", Paths.ServiceHome.ToAbsolute()),
+            ("Your school", Paths.SchoolHome(school.URN).ToAbsolute()),
+            ("Customised data", Paths.SchoolCustomisedData(school.URN).ToAbsolute()),
+            ("Side-by-side comparison", Paths.SchoolSpendingComparison(school.URN).ToAbsolute()),
+        };
+
+        DocumentAssert.Breadcrumbs(page, expectedBreadcrumbs);
+
+        DocumentAssert.TitleAndH1(page, "Side-by-side comparison - Financial Benchmarking and Insights Tool - GOV.UK",
+            "Side-by-side comparison");
+
+        var headlinesSection = page.Body.SelectSingleNode("//main/div/div[2]");
+        Assert.NotNull(headlinesSection);
+
+        var highHeadline = headlinesSection.ChildNodes.QuerySelectorAll(".app-headline-high > p").ToList();
+        Assert.NotNull(highHeadline);
+        AssertHeadlines(highHeadline, "red", customRatings, originalRatings);
+
+        var mediumHeadline = headlinesSection.ChildNodes.QuerySelectorAll(".app-headline-medium > p").ToList();
+        Assert.NotNull(mediumHeadline);
+        AssertHeadlines(mediumHeadline, "amber", customRatings, originalRatings);
+
+        var lowHeadline = headlinesSection.ChildNodes.QuerySelectorAll(".app-headline-low > p").ToList();
+        Assert.NotNull(lowHeadline);
+        AssertHeadlines(lowHeadline, "green", customRatings, originalRatings);
+
+        var categorySections = page.QuerySelectorAll(".top-categories").ToList();
+        Assert.NotNull(categorySections);
+        Assert.Equal(2, categorySections.Count);
+
+        var changeCount = customRatings
+            .Join(originalRatings,
+                  custom => custom.Category,
+                  original => original.Category,
+                  (custom, original) => new { custom, original })
+            .Where(joined => joined.custom.RAG != joined.original.RAG)
+            .Count();
+
+        if (changeCount > 0)
+        {
+            var changeSection = categorySections[0].ChildNodes.QuerySelectorAll("div").ToList();
+            Assert.NotNull(changeSection);
+            Assert.Equal(changeCount, changeSection.Count);
+
+            foreach (var table in changeSection)
+            {
+                AssertTableContents(table, originalRatings, customRatings);
+            }
+        }
+        else
+        {
+            var changeSection = categorySections[0]?.ChildNodes.QuerySelector("p")?.TextContent;
+            Assert.NotNull(changeSection);
+            Assert.Contains("There are no categories to display of this type for this comparison", changeSection);
+        }
+
+        var noChangeCount = customRatings
+            .Join(originalRatings,
+                  custom => custom.Category,
+                  original => original.Category,
+                  (custom, original) => new { custom, original })
+            .Where(joined => joined.custom.RAG == joined.original.RAG)
+            .Count();
+
+        if (noChangeCount > 0)
+        {
+            var noChangeSection = categorySections[1].ChildNodes.QuerySelectorAll("div").ToList();
+            Assert.NotNull(noChangeSection);
+            Assert.Equal(noChangeCount, noChangeSection.Count);
+
+            foreach (var table in noChangeSection)
+            {
+                AssertTableContents(table, originalRatings, customRatings);
+            }
+        }
+        else
+        {
+            var noChangeSection = categorySections[1]?.ChildNodes.QuerySelector("p")?.TextContent;
+            Assert.NotNull(noChangeSection);
+            Assert.Contains("There are no categories to display of this type for this comparison", noChangeSection);
+        }
+
+        var toolsListSection = page.Body.SelectSingleNode("//main/div/div[4]");
+        DocumentAssert.Heading2(toolsListSection, "Custom data benchmarking tools");
+
+        var toolsLinks = toolsListSection.ChildNodes.QuerySelectorAll("ul> li > h3 > a").ToList();
+        Assert.Equal(3, toolsLinks.Count);
+
+        DocumentAssert.Link(toolsLinks[0], "Compare your costs",
+            Paths.SchoolComparisonCustomData(school.URN).ToAbsolute());
+        DocumentAssert.Link(toolsLinks[1], "Spending priorities for this school",
+            Paths.SchoolSpendingCustomData(school.URN).ToAbsolute());
+        DocumentAssert.Link(toolsLinks[2], "Benchmark pupil and workforce data",
+            Paths.SchoolCensusCustomData(school.URN).ToAbsolute());
+    }
+
+    private RagRating[] CreateRagRatings(string urn)
+    {
+        var random = new Random();
+
+        var statusKeys = Lookups.StatusPriorityMap.Keys.ToList();
+
+        var ratings = new List<RagRating>();
+
+        foreach (var category in AllCostCategories)
+        {
+            var rating = Fixture.Build<RagRating>()
+                                .With(x => x.Category, category)
+                                .With(r => r.RAG, () => statusKeys[random.Next(statusKeys.Count)])
+                                .With(r => r.URN, urn)
+                                .Create();
+            ratings.Add(rating);
+        }
+
+        return ratings.ToArray();
+    }
+
+    private static void AssertHeadlines(List<IElement> elements, string rag, RagRating[] customRatings, RagRating[] originalRatings)
+    {
+        Assert.Equal(3, elements.Count);
+
+        var expectedCustomCount = customRatings.Count(x => x.RAG == rag);
+        var expectedOriginalCount = originalRatings.Count(x => x.RAG == rag);
+
+        var customCountText = elements[0].TextContent;
+
+        var customCountTextAsList = customCountText.Split(" ");
+
+        var numericPart = customCountTextAsList[0];
+
+        var changeSymbol = customCountTextAsList[1];
+
+        Assert.Equal(expectedCustomCount.ToString(), numericPart);
+
+        switch (expectedCustomCount)
+        {
+            case var _ when expectedCustomCount > expectedOriginalCount:
+                Assert.Equal(ChangeSymbols.Increase, changeSymbol);
+                break;
+            case var _ when expectedCustomCount < expectedOriginalCount:
+                Assert.Equal(ChangeSymbols.Decrease, changeSymbol);
+                break;
+            case var _ when expectedCustomCount == expectedOriginalCount:
+                Assert.Equal(ChangeSymbols.NoChange, changeSymbol);
+                break;
+            default:
+                Assert.Fail("Error with comparison for changeSymbol assertion");
+                break;
+        }
+
+        var originalCountText = elements[1].TextContent.Replace("(was ", "").TrimEnd(')');
+        Assert.Equal(expectedOriginalCount.ToString(), originalCountText);
+    }
+
+    private static void AssertTableContents(IElement table, RagRating[] originalRatings, RagRating[] customRatings)
+    {
+        var heading = table.QuerySelector("caption")?.TextContent.Trim();
+        Assert.NotNull(heading);
+
+        var originalExpected = originalRatings.FirstOrDefault(x => x.Category == heading);
+        Assert.NotNull(originalExpected);
+
+        var customExpected = customRatings.FirstOrDefault(x => x.Category == heading);
+        Assert.NotNull(customExpected);
+
+        var rows = table.QuerySelectorAll("table.govuk-table tbody.govuk-table__body tr.govuk-table__row").ToList();
+        Assert.Equal(2, rows.Count);
+
+        var originalRow = rows[0];
+        var customRow = rows[1];
+
+        var originalPriorityCell = originalRow.QuerySelector("td:nth-child(2)")?.TextContent.Trim();
+        Assert.Equal(originalExpected.PriorityTag?.DisplayText, originalPriorityCell);
+
+        var originalSpendCell = originalRow.QuerySelector("td:nth-child(3)")?.TextContent.Replace("£", "").Trim();
+        Assert.Equal(originalExpected.Value.ToString(), originalSpendCell);
+
+        var originalPercentageCell = originalRow.QuerySelector("td:nth-child(4)")?.TextContent.Trim();
+        Assert.NotNull(originalPercentageCell);
+        var originalExpectedPercentage = originalExpected.Percentile.ToString();
+        Assert.NotNull(originalExpectedPercentage);
+        Assert.Contains(originalExpectedPercentage, originalPercentageCell);
+
+        var customPriorityCell = customRow.QuerySelector("td:nth-child(2)")?.TextContent.Trim();
+        Assert.Equal(customExpected.PriorityTag?.DisplayText, customPriorityCell);
+
+        var customSpendCell = customRow.QuerySelector("td:nth-child(3)")?.TextContent.Replace("£", "").Trim();
+        Assert.Equal(customExpected.Value.ToString(), customSpendCell);
+
+        var customPercentageCell = customRow.QuerySelector("td:nth-child(4)")?.TextContent.Trim();
+        Assert.NotNull(customPercentageCell);
+        var customExpectedPercentage = customExpected.Percentile.ToString();
+        Assert.NotNull(customExpectedPercentage);
+        Assert.Contains(customExpectedPercentage, customPercentageCell);
+    }
+
+    private static readonly List<string> AllCostCategories = new()
+    {
+        {
+            Category.TeachingStaff
+        },
+        {
+            Category.NonEducationalSupportStaff
+        },
+        {
+            Category.EducationalSupplies
+        },
+        {
+            Category.EducationalIct
+        },
+        {
+            Category.PremisesStaffServices
+        },
+        {
+            Category.Utilities
+        },
+        {
+            Category.AdministrativeSupplies
+        },
+        {
+            Category.CateringStaffServices
+        },
+        {
+            Category.Other
+        }
+    };
+
+    private static class ChangeSymbols
+    {
+        public const string Decrease = "▼";
+        public const string Increase = "▲";
+        public const string NoChange = "";
+    }
+}
+

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -16,6 +16,7 @@ public static class Paths
 
     public static string StatusError(int statusCode) => $"/error/{statusCode}";
     public static string SchoolHome(string? urn) => $"/school/{urn}";
+    public static string SchoolSpendingComparison(string? urn) => $"/school/{urn}/spending-comparison";
     public static string TrustHome(string? companyNumber) => $"/trust/{companyNumber}";
     public static string TrustDetails(string? companyNumber) => $"/trust/{companyNumber}/details";
     public static string TrustComparison(string? companyNumber) => $"/trust/{companyNumber}/comparison";
@@ -25,12 +26,16 @@ public static class Paths
     public static string SchoolComparatorSet(string? urn, string referrer) =>
         $"/school/{urn}/comparator-set?referrer={referrer}";
     public static string SchoolComparison(string? urn) => $"/school/{urn}/comparison";
+    public static string SchoolComparisonCustomData(string? urn) => $"/school/{urn}/comparison/custom-data";
     public static string SchoolCensus(string? urn) => $"/school/{urn}/census";
+    public static string SchoolCensusCustomData(string? urn) => $"/school/{urn}/census/custom-data";
+    public static string SchoolSpendingCustomData(string? urn) => $"/school/{urn}/spending-and-costs/custom-data";
     public static string SchoolInvestigation(string? urn) => $"/school/{urn}/investigation";
     public static string SchoolFinancialPlanning(string? urn) => $"/school/{urn}/financial-planning";
     public static string SchoolHistory(string? urn) => $"/school/{urn}/history";
     public static string SchoolDetails(string? urn) => $"/school/{urn}/details";
     public static string SchoolCustomData(string? urn) => $"/school/{urn}/custom-data";
+    public static string SchoolCustomisedData(string? urn) => $"/school/{urn}/customised-data";
 
     public static string SchoolFinancialPlanningStart(string? urn) => $"/school/{urn}/financial-planning/create/start";
     public static string SchoolFinancialPlanningSelectYear(string? urn) =>


### PR DESCRIPTION
### Context
[AB#192482](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/192482) - [AB#214247](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/214247) [AB#214250](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/214250)

### Change proposed in this pull request
adds spending comparison page for the custom page (side by side comparison original and custom rag rating)
adds integration tests for this page
also adds SchoolAuthorization to the pages in this story where missing.

### Guidance to review 
N/A

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

