### PR TITLE
fix: remove extraneous break

### DIFF
--- a/data-pipeline/src/pipeline/comparator_sets.py
+++ b/data-pipeline/src/pipeline/comparator_sets.py
@@ -397,8 +397,6 @@ def compute_distances(
 
                 pupils.loc[urn] = top_pupil_set_urns
                 buildings.loc[urn] = top_building_set_urns
-
-                break
             except Exception as error:
                 logger.exception(
                     f"An exception occurred {type(error).__name__} processing {urn}:",


### PR DESCRIPTION
This was causing all but the first of each phase type to be skipped when generating comparator-sets.

The resulting `'float' object has no attribute 'tolist'` error was the result of trying to apply `.tolist()` to a column for which a comparator-set hadn't been generated (i.e. once processed, it's an `array`; unprocessed, it's a `float`).