### PR TITLE
Pre-populated previous Custom Data values when defining new set of data for school

### DIFF
--- a/platform/src/abstractions/Platform.Functions/PipelineMessage.cs
+++ b/platform/src/abstractions/Platform.Functions/PipelineMessage.cs
@@ -79,7 +79,7 @@ public record CustomDataPayload : Payload
     public decimal? TotalPupils { get; set; }
     public decimal? PercentFreeSchoolMeals { get; set; }
     public decimal? PercentSpecialEducationNeeds { get; set; }
-    public int? TotalInternalFloorArea { get; set; }
+    public decimal? TotalInternalFloorArea { get; set; }
     public decimal? WorkforceFTE { get; set; }
     public decimal? TeachersFTE { get; set; }
     public decimal? PercentTeacherWithQualifiedStatus { get; set; }

--- a/platform/src/apis/Platform.Api.Benchmark/CustomData/CustomDataRequest.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/CustomData/CustomDataRequest.cs
@@ -42,7 +42,7 @@ public record CustomDataRequest
     public decimal? TotalPupils { get; set; }
     public decimal? PercentFreeSchoolMeals { get; set; }
     public decimal? PercentSpecialEducationNeeds { get; set; }
-    public int? TotalInternalFloorArea { get; set; }
+    public decimal? TotalInternalFloorArea { get; set; }
     public decimal? WorkforceFTE { get; set; }
     public decimal? TeachersFTE { get; set; }
     public decimal? PercentTeacherWithQualifiedStatus { get; set; }

--- a/platform/src/apis/Platform.Api.Benchmark/CustomData/CustomDataService.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/CustomData/CustomDataService.cs
@@ -54,7 +54,7 @@ public class CustomDataService : ICustomDataService
     public async Task<CustomDataSchool?> CustomDataSchoolAsync(string urn, string identifier)
     {
         const string sql = "SELECT * from CustomDataSchool where URN = @URN AND Id = @Id";
-        var parameters = new { URN = urn, RunId = identifier };
+        var parameters = new { URN = urn, Id = identifier };
 
         using var conn = await _dbFactory.GetConnection();
         return await conn.QueryFirstOrDefaultAsync<CustomDataSchool>(sql, parameters);

--- a/web/Web.sln.DotSettings
+++ b/web/Web.sln.DotSettings
@@ -15,6 +15,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SLCN/@EntryIndexedValue">SLCN</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SLD/@EntryIndexedValue">SLD</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SPLD/@EntryIndexedValue">SPLD</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=URN/@EntryIndexedValue">URN</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=VI/@EntryIndexedValue">VI</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=esfa/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=govuk/@EntryIndexedValue">True</s:Boolean>

--- a/web/src/Web.App/Controllers/SchoolCustomDataChangeController.cs
+++ b/web/src/Web.App/Controllers/SchoolCustomDataChangeController.cs
@@ -229,6 +229,12 @@ public class SchoolCustomDataChangeController(
             {
                 customInput = await customDataService.GetCustomDataById(urn, customData);
             }
+
+            // set session to match view model to sync continue/back CTAs in UI
+            if (customInput != null)
+            {
+                customDataService.SetCustomDataInSession(urn, customInput);
+            }
         }
 
         return new SchoolCustomDataChangeViewModel(school, currentValues, customInput ?? new CustomData());

--- a/web/src/Web.App/Domain/Benchmark/CustomDataSchool.cs
+++ b/web/src/Web.App/Domain/Benchmark/CustomDataSchool.cs
@@ -1,0 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
+// ReSharper disable ClassNeverInstantiated.Global
+namespace Web.App.Domain;
+
+[ExcludeFromCodeCoverage]
+public record CustomDataSchool
+{
+    public string? Id { get; set; }
+    public string? URN { get; set; }
+    public string? Data { get; set; }
+}

--- a/web/src/Web.App/Services/CustomDataService.cs
+++ b/web/src/Web.App/Services/CustomDataService.cs
@@ -9,6 +9,7 @@ public interface ICustomDataService
 {
     Task<CustomData> GetCurrentData(string urn);
     CustomData? GetCustomDataFromSession(string urn);
+    void SetCustomDataInSession(string urn, CustomData data);
     void MergeCustomDataIntoSession(string urn, ICustomDataViewModel data);
     void ClearCustomDataFromSession(string urn);
     Task CreateCustomData(string urn, string userId);
@@ -47,6 +48,15 @@ public class CustomDataService(
         return data;
     }
 
+    public void SetCustomDataInSession(string urn, CustomData data)
+    {
+        var key = SessionKeys.CustomData(urn);
+        var context = httpContextAccessor.HttpContext;
+        context?.Session.Set(key, data);
+
+        logger.LogDebug("Set {CustomData} for {Key} in session", data.ToJson(), urn);
+    }
+
     public async Task CreateCustomData(string urn, string userId)
     {
         var key = SessionKeys.CustomData(urn);
@@ -76,7 +86,7 @@ public class CustomDataService(
         logger.LogDebug("Got {CustomData} for {Key} from session", data.ToJson(), urn);
 
         data.Merge(viewModel);
-        context?.Session.Set(key, data);
+        SetCustomDataInSession(urn, data);
         logger.LogDebug("Merged {ViewModel} and set {CustomData} for {Key} in session", viewModel.ToJson(),
             data.ToJson(), urn);
     }

--- a/web/src/Web.App/Services/CustomDataService.cs
+++ b/web/src/Web.App/Services/CustomDataService.cs
@@ -3,16 +3,16 @@ using Web.App.Extensions;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Extensions;
 using Web.App.ViewModels;
-
 namespace Web.App.Services;
 
 public interface ICustomDataService
 {
     Task<CustomData> GetCurrentData(string urn);
-    CustomData GetCustomDataFromSession(string urn);
+    CustomData? GetCustomDataFromSession(string urn);
     void MergeCustomDataIntoSession(string urn, ICustomDataViewModel data);
     void ClearCustomDataFromSession(string urn);
     Task CreateCustomData(string urn, string userId);
+    Task<CustomData?> GetCustomDataById(string urn, string identifier);
 }
 
 public class CustomDataService(
@@ -28,8 +28,6 @@ public class CustomDataService(
 {
     public async Task<CustomData> GetCurrentData(string urn)
     {
-        // todo: lookup and return current, potentially customised figures
-
         var income = await incomeApi.School(urn).GetResultOrThrow<SchoolIncome>();
         var expenditure = await expenditureApi.School(urn).GetResultOrThrow<SchoolExpenditure>();
         var census = await censusApi.Get(urn).GetResultOrThrow<Census>();
@@ -39,11 +37,11 @@ public class CustomDataService(
         return CustomDataFactory.Create(income, expenditure, census, characteristics, balance);
     }
 
-    public CustomData GetCustomDataFromSession(string urn)
+    public CustomData? GetCustomDataFromSession(string urn)
     {
         var key = SessionKeys.CustomData(urn);
         var context = httpContextAccessor.HttpContext;
-        var data = context?.Session.Get<CustomData>(key) ?? new CustomData();
+        var data = context?.Session.Get<CustomData>(key);
 
         logger.LogDebug("Got {CustomData} for {Key} from session", data.ToJson(), urn);
         return data;
@@ -83,55 +81,113 @@ public class CustomDataService(
             data.ToJson(), urn);
     }
 
-    private static PutCustomDataRequest CreateRequest(CustomData data)
+    public async Task<CustomData?> GetCustomDataById(string urn, string identifier)
     {
-        return new PutCustomDataRequest
+        var customDataSchool = await customDataApi.GetSchoolAsync(urn, identifier).GetResultOrDefault<CustomDataSchool>();
+        if (customDataSchool?.Data == null)
         {
-            AdministrativeSuppliesNonEducationalCosts = data.AdministrativeSuppliesCosts,
-            CateringStaffCosts = data.CateringStaffCosts,
-            CateringSuppliesCosts = data.CateringSuppliesCosts,
-            IncomeCateringServices = data.CateringIncome,
-            ExaminationFeesCosts = data.ExaminationFeesCosts,
-            LearningResourcesNonIctCosts = data.LearningResourcesNonIctCosts,
-            LearningResourcesIctCosts = data.LearningResourcesIctCosts,
-            AdministrativeClericalStaffCosts = data.AdministrativeClericalStaffCosts,
-            AuditorsCosts = data.AuditorsCosts,
-            OtherStaffCosts = data.OtherStaffCosts,
-            ProfessionalServicesNonCurriculumCosts = data.ProfessionalServicesNonCurriculumCosts,
-            CleaningCaretakingCosts = data.CleaningCaretakingCosts,
-            MaintenancePremisesCosts = data.MaintenancePremisesCosts,
-            OtherOccupationCosts = data.OtherOccupationCosts,
-            PremisesStaffCosts = data.PremisesStaffCosts,
-            AgencySupplyTeachingStaffCosts = data.AgencySupplyTeachingStaffCosts,
-            EducationSupportStaffCosts = data.EducationSupportStaffCosts,
-            EducationalConsultancyCosts = data.EducationalConsultancyCosts,
-            SupplyTeachingStaffCosts = data.SupplyTeachingStaffCosts,
-            TeachingStaffCosts = data.TeachingStaffCosts,
-            EnergyCosts = data.EnergyCosts,
-            WaterSewerageCosts = data.WaterSewerageCosts,
-            DirectRevenueFinancingCosts = data.DirectRevenueFinancingCosts,
-            GroundsMaintenanceCosts = data.GroundsMaintenanceCosts,
-            IndirectEmployeeExpenses = data.IndirectEmployeeExpenses,
-            InterestChargesLoanBank = data.InterestChargesLoanBank,
-            OtherInsurancePremiumsCosts = data.OtherInsurancePremiumsCosts,
-            PrivateFinanceInitiativeCharges = data.PrivateFinanceInitiativeCharges,
-            RentRatesCosts = data.RentRatesCosts,
-            SpecialFacilitiesCosts = data.SpecialFacilitiesCosts,
-            StaffDevelopmentTrainingCosts = data.StaffDevelopmentTrainingCosts,
-            StaffRelatedInsuranceCosts = data.StaffRelatedInsuranceCosts,
-            SupplyTeacherInsurableCosts = data.SupplyTeacherInsurableCosts,
-            TotalPupils = data.NumberOfPupilsFte,
-            PercentFreeSchoolMeals = data.FreeSchoolMealPercent,
-            PercentSpecialEducationNeeds = data.SpecialEducationalNeedsPercent,
-            TotalInternalFloorArea = data.FloorArea,
-            WorkforceFTE = data.WorkforceFte,
-            TeachersFTE = data.TeachersFte,
-            PercentTeacherWithQualifiedStatus = data.QualifiedTeacherPercent,
-            SeniorLeadershipFTE = data.SeniorLeadershipFte,
-            TeachingAssistantFTE = data.TeachingAssistantsFte,
-            NonClassroomSupportStaffFTE = data.NonClassroomSupportStaffFte,
-            AuxiliaryStaffFTE = data.AuxiliaryStaffFte,
-            WorkforceHeadcount = data.WorkforceHeadcount
-        };
+            return null;
+        }
+
+        var parsed = customDataSchool.Data.FromJson<PutCustomDataRequest>();
+        return parsed == null ? null : CreateCustomData(parsed);
     }
+
+    private static PutCustomDataRequest CreateRequest(CustomData data) => new()
+    {
+        AdministrativeSuppliesNonEducationalCosts = data.AdministrativeSuppliesCosts,
+        CateringStaffCosts = data.CateringStaffCosts,
+        CateringSuppliesCosts = data.CateringSuppliesCosts,
+        IncomeCateringServices = data.CateringIncome,
+        ExaminationFeesCosts = data.ExaminationFeesCosts,
+        LearningResourcesNonIctCosts = data.LearningResourcesNonIctCosts,
+        LearningResourcesIctCosts = data.LearningResourcesIctCosts,
+        AdministrativeClericalStaffCosts = data.AdministrativeClericalStaffCosts,
+        AuditorsCosts = data.AuditorsCosts,
+        OtherStaffCosts = data.OtherStaffCosts,
+        ProfessionalServicesNonCurriculumCosts = data.ProfessionalServicesNonCurriculumCosts,
+        CleaningCaretakingCosts = data.CleaningCaretakingCosts,
+        MaintenancePremisesCosts = data.MaintenancePremisesCosts,
+        OtherOccupationCosts = data.OtherOccupationCosts,
+        PremisesStaffCosts = data.PremisesStaffCosts,
+        AgencySupplyTeachingStaffCosts = data.AgencySupplyTeachingStaffCosts,
+        EducationSupportStaffCosts = data.EducationSupportStaffCosts,
+        EducationalConsultancyCosts = data.EducationalConsultancyCosts,
+        SupplyTeachingStaffCosts = data.SupplyTeachingStaffCosts,
+        TeachingStaffCosts = data.TeachingStaffCosts,
+        EnergyCosts = data.EnergyCosts,
+        WaterSewerageCosts = data.WaterSewerageCosts,
+        DirectRevenueFinancingCosts = data.DirectRevenueFinancingCosts,
+        GroundsMaintenanceCosts = data.GroundsMaintenanceCosts,
+        IndirectEmployeeExpenses = data.IndirectEmployeeExpenses,
+        InterestChargesLoanBank = data.InterestChargesLoanBank,
+        OtherInsurancePremiumsCosts = data.OtherInsurancePremiumsCosts,
+        PrivateFinanceInitiativeCharges = data.PrivateFinanceInitiativeCharges,
+        RentRatesCosts = data.RentRatesCosts,
+        SpecialFacilitiesCosts = data.SpecialFacilitiesCosts,
+        StaffDevelopmentTrainingCosts = data.StaffDevelopmentTrainingCosts,
+        StaffRelatedInsuranceCosts = data.StaffRelatedInsuranceCosts,
+        SupplyTeacherInsurableCosts = data.SupplyTeacherInsurableCosts,
+        TotalPupils = data.NumberOfPupilsFte,
+        PercentFreeSchoolMeals = data.FreeSchoolMealPercent,
+        PercentSpecialEducationNeeds = data.SpecialEducationalNeedsPercent,
+        TotalInternalFloorArea = data.FloorArea,
+        WorkforceFTE = data.WorkforceFte,
+        TeachersFTE = data.TeachersFte,
+        PercentTeacherWithQualifiedStatus = data.QualifiedTeacherPercent,
+        SeniorLeadershipFTE = data.SeniorLeadershipFte,
+        TeachingAssistantFTE = data.TeachingAssistantsFte,
+        NonClassroomSupportStaffFTE = data.NonClassroomSupportStaffFte,
+        AuxiliaryStaffFTE = data.AuxiliaryStaffFte,
+        WorkforceHeadcount = data.WorkforceHeadcount
+    };
+
+    private static CustomData CreateCustomData(PutCustomDataRequest data) => new()
+    {
+        AdministrativeSuppliesCosts = data.AdministrativeSuppliesNonEducationalCosts,
+        CateringStaffCosts = data.CateringStaffCosts,
+        CateringSuppliesCosts = data.CateringSuppliesCosts,
+        CateringIncome = data.IncomeCateringServices,
+        ExaminationFeesCosts = data.ExaminationFeesCosts,
+        LearningResourcesNonIctCosts = data.LearningResourcesNonIctCosts,
+        LearningResourcesIctCosts = data.LearningResourcesIctCosts,
+        AdministrativeClericalStaffCosts = data.AdministrativeClericalStaffCosts,
+        AuditorsCosts = data.AuditorsCosts,
+        OtherStaffCosts = data.OtherStaffCosts,
+        ProfessionalServicesNonCurriculumCosts = data.ProfessionalServicesNonCurriculumCosts,
+        CleaningCaretakingCosts = data.CleaningCaretakingCosts,
+        MaintenancePremisesCosts = data.MaintenancePremisesCosts,
+        OtherOccupationCosts = data.OtherOccupationCosts,
+        PremisesStaffCosts = data.PremisesStaffCosts,
+        AgencySupplyTeachingStaffCosts = data.AgencySupplyTeachingStaffCosts,
+        EducationSupportStaffCosts = data.EducationSupportStaffCosts,
+        EducationalConsultancyCosts = data.EducationalConsultancyCosts,
+        SupplyTeachingStaffCosts = data.SupplyTeachingStaffCosts,
+        TeachingStaffCosts = data.TeachingStaffCosts,
+        EnergyCosts = data.EnergyCosts,
+        WaterSewerageCosts = data.WaterSewerageCosts,
+        DirectRevenueFinancingCosts = data.DirectRevenueFinancingCosts,
+        GroundsMaintenanceCosts = data.GroundsMaintenanceCosts,
+        IndirectEmployeeExpenses = data.IndirectEmployeeExpenses,
+        InterestChargesLoanBank = data.InterestChargesLoanBank,
+        OtherInsurancePremiumsCosts = data.OtherInsurancePremiumsCosts,
+        PrivateFinanceInitiativeCharges = data.PrivateFinanceInitiativeCharges,
+        RentRatesCosts = data.RentRatesCosts,
+        SpecialFacilitiesCosts = data.SpecialFacilitiesCosts,
+        StaffDevelopmentTrainingCosts = data.StaffDevelopmentTrainingCosts,
+        StaffRelatedInsuranceCosts = data.StaffRelatedInsuranceCosts,
+        SupplyTeacherInsurableCosts = data.SupplyTeacherInsurableCosts,
+        NumberOfPupilsFte = data.TotalPupils,
+        FreeSchoolMealPercent = data.PercentFreeSchoolMeals,
+        SpecialEducationalNeedsPercent = data.PercentSpecialEducationNeeds,
+        FloorArea = data.TotalInternalFloorArea,
+        WorkforceFte = data.WorkforceFTE,
+        TeachersFte = data.TeachersFTE,
+        QualifiedTeacherPercent = data.PercentTeacherWithQualifiedStatus,
+        SeniorLeadershipFte = data.SeniorLeadershipFTE,
+        TeachingAssistantsFte = data.TeachingAssistantFTE,
+        NonClassroomSupportStaffFte = data.NonClassroomSupportStaffFTE,
+        AuxiliaryStaffFte = data.AuxiliaryStaffFTE,
+        WorkforceHeadcount = data.WorkforceHeadcount
+    };
 }

--- a/web/src/Web.App/ViewModels/SchoolCustomDataChangeViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolCustomDataChangeViewModel.cs
@@ -1,5 +1,4 @@
 using Web.App.Domain;
-
 namespace Web.App.ViewModels;
 
 public class SchoolCustomDataChangeViewModel(
@@ -14,6 +13,7 @@ public class SchoolCustomDataChangeViewModel(
 
     public SchoolCustomDataSectionViewModel AdministrativeSuppliesSection => new(
         "Administrative supplies",
+        "Cost",
         new SchoolCustomDataValueViewModel
         {
             Title = SchoolCustomDataViewModelTitles.AdministrativeSuppliesCosts,
@@ -25,6 +25,7 @@ public class SchoolCustomDataChangeViewModel(
 
     public SchoolCustomDataSectionViewModel CateringSection => new(
         "Catering",
+        "Cost",
         new SchoolCustomDataValueViewModel
         {
             Title = SchoolCustomDataViewModelTitles.CateringStaffCosts,
@@ -50,6 +51,7 @@ public class SchoolCustomDataChangeViewModel(
 
     public SchoolCustomDataSectionViewModel EducationalSuppliesSection => new(
         "Educational supplies",
+        "Cost",
         new SchoolCustomDataValueViewModel
         {
             Title = SchoolCustomDataViewModelTitles.ExaminationFeesCosts,
@@ -68,6 +70,7 @@ public class SchoolCustomDataChangeViewModel(
 
     public SchoolCustomDataSectionViewModel ITSection => new(
         "IT",
+        "Cost",
         new SchoolCustomDataValueViewModel
         {
             Title = SchoolCustomDataViewModelTitles.LearningResourcesIctCosts,
@@ -79,6 +82,7 @@ public class SchoolCustomDataChangeViewModel(
 
     public SchoolCustomDataSectionViewModel NonEducationalSupportStaffSection => new(
         "Non-educational support staff",
+        "Cost",
         new SchoolCustomDataValueViewModel
         {
             Title = SchoolCustomDataViewModelTitles.AdministrativeClericalStaffCosts,
@@ -111,6 +115,7 @@ public class SchoolCustomDataChangeViewModel(
 
     public SchoolCustomDataSectionViewModel PremisesAndServicesSection => new(
         "Premises and services",
+        "Cost",
         new SchoolCustomDataValueViewModel
         {
             Title = SchoolCustomDataViewModelTitles.CleaningCaretakingCosts,
@@ -143,6 +148,7 @@ public class SchoolCustomDataChangeViewModel(
 
     public SchoolCustomDataSectionViewModel TeachingAndTeachingSupportSection => new(
         "Teaching and teaching support",
+        "Cost",
         new SchoolCustomDataValueViewModel
         {
             Title = SchoolCustomDataViewModelTitles.AgencySupplyTeachingStaffCosts,
@@ -181,6 +187,7 @@ public class SchoolCustomDataChangeViewModel(
 
     public SchoolCustomDataSectionViewModel UtilitiesSection => new(
         "Utilities",
+        "Cost",
         new SchoolCustomDataValueViewModel
         {
             Title = SchoolCustomDataViewModelTitles.EnergyCosts,
@@ -198,6 +205,7 @@ public class SchoolCustomDataChangeViewModel(
 
     public SchoolCustomDataSectionViewModel OtherCostsSection => new(
         "Other costs",
+        "Cost",
         new SchoolCustomDataValueViewModel
         {
             Title = SchoolCustomDataViewModelTitles.DirectRevenueFinancingCosts,
@@ -278,6 +286,7 @@ public class SchoolCustomDataChangeViewModel(
 
     public SchoolCustomDataSectionViewModel TotalsSection => new(
         "Totals",
+        "Cost",
         new SchoolCustomDataValueViewModel
         {
             Title = SchoolCustomDataViewModelTitles.TotalIncome,
@@ -305,6 +314,7 @@ public class SchoolCustomDataChangeViewModel(
 
     public SchoolCustomDataSectionViewModel NonFinancialDataSection => new(
         "Non-financial figures",
+        "Item",
         new SchoolCustomDataValueViewModel
         {
             Title = SchoolCustomDataViewModelTitles.NumberOfPupilsFte,
@@ -341,6 +351,7 @@ public class SchoolCustomDataChangeViewModel(
 
     public SchoolCustomDataSectionViewModel WorkforceDataSection => new(
         "Workforce figures",
+        "Item",
         new SchoolCustomDataValueViewModel
         {
             Title = SchoolCustomDataViewModelTitles.WorkforceFte,
@@ -409,13 +420,15 @@ public class SchoolCustomDataChangeViewModel(
 
 public record SchoolCustomDataSectionViewModel
 {
-    public SchoolCustomDataSectionViewModel(string title, params SchoolCustomDataValueViewModel[] values)
+    public SchoolCustomDataSectionViewModel(string title, string metricHeading, params SchoolCustomDataValueViewModel[] values)
     {
         Title = title;
+        MetricHeading = metricHeading;
         Values = values;
     }
 
     public string Title { get; init; }
+    public string MetricHeading { get; init; }
     public IEnumerable<SchoolCustomDataValueViewModel> Values { get; init; }
 }
 

--- a/web/src/Web.App/Views/SchoolCustomDataChange/_CustomDataEntryTable.cshtml
+++ b/web/src/Web.App/Views/SchoolCustomDataChange/_CustomDataEntryTable.cshtml
@@ -5,11 +5,11 @@
 }
 
 <table class="govuk-table table-custom-data" id="govuk-table-custom-data-@id">
-    <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden">@Model.Title costs</caption>
+    <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden">@Model.Title @(Model.MetricHeading)s</caption>
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header govuk-!-width-one-half">Cost</th>
-        <th scope="col" class="govuk-table__header">Current data</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-half">@Model.MetricHeading</th>
+        <th scope="col" class="govuk-table__header">Original data</th>
         <th scope="col" class="govuk-table__header">Custom data</th>
     </tr>
     </thead>

--- a/web/src/Web.App/Views/SchoolCustomDataChange/_CustomDataEntryTableRow.cshtml
+++ b/web/src/Web.App/Views/SchoolCustomDataChange/_CustomDataEntryTableRow.cshtml
@@ -4,7 +4,7 @@
 @model Web.App.ViewModels.SchoolCustomDataValueViewModel
 @{
     var id = Model.Title.ToSlug();
-    var customValueFormatted = ViewData.ModelState.GetAttemptedValueOrDefault(Model.Name, Model.Custom.HasValue ? Model.Custom.ToString() : string.Empty);
+    var customValueFormatted = ViewData.ModelState.GetAttemptedValueOrDefault(Model.Name, Model.Custom.HasValue ? Model.Name.Contains("Percent") ? Model.Custom.ToPercent().TrimEnd('%') : Model.Custom.ToSimpleDisplay() : string.Empty);
     var currentValue = Model.Current.GetValueOrDefault();
     var currentValueFormatted = currentValue.ToString(CultureInfo.InvariantCulture);
     var hasError = ViewData.ModelState.HasError(Model.Name);

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -282,10 +282,11 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         return this;
     }
 
-    public BenchmarkingWebAppClient SetUpCustomData()
+    public BenchmarkingWebAppClient SetUpCustomData(CustomDataSchool? customData = null)
     {
         CustomDataApi.Reset();
         CustomDataApi.Setup(api => api.UpsertSchoolAsync(It.IsAny<string>(), It.IsAny<PutCustomDataRequest>())).ReturnsAsync(ApiResult.Ok());
+        CustomDataApi.Setup(api => api.GetSchoolAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(ApiResult.Ok(customData));
         return this;
     }
 

--- a/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataNonFinancialData.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataNonFinancialData.cs
@@ -3,6 +3,7 @@ using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using AutoFixture;
 using Web.App.Domain;
+using Web.App.Extensions;
 using Web.App.ViewModels;
 using Xunit;
 namespace Web.Integration.Tests.Pages.Schools.CustomData;
@@ -11,7 +12,6 @@ public class WhenViewingCustomDataNonFinancialData : PageBase<SchoolBenchmarking
 {
     private readonly Census _census;
     private readonly Census _customCensus;
-    private readonly SchoolExpenditure _customExpenditure;
     private readonly SchoolCharacteristic _customFloorAreaMetric;
     private readonly SchoolExpenditure _expenditure;
     private readonly SchoolCharacteristic _floorAreaMetric;
@@ -21,9 +21,6 @@ public class WhenViewingCustomDataNonFinancialData : PageBase<SchoolBenchmarking
     public WhenViewingCustomDataNonFinancialData(SchoolBenchmarkingWebAppClient client) : base(client)
     {
         _expenditure = Fixture.Build<SchoolExpenditure>()
-            .Create();
-
-        _customExpenditure = Fixture.Build<SchoolExpenditure>()
             .Create();
 
         _income = Fixture.Build<SchoolIncome>()
@@ -127,10 +124,11 @@ public class WhenViewingCustomDataNonFinancialData : PageBase<SchoolBenchmarking
             var field = customValue.Id ?? string.Empty;
             var expected = field switch
             {
-                nameof(NonFinancialDataCustomDataViewModel.NumberOfPupilsFte) => $"{_customCensus.TotalPupils:#.0}",
-                nameof(NonFinancialDataCustomDataViewModel.FreeSchoolMealPercent) => $"{_customFloorAreaMetric.PercentFreeSchoolMeals:#.0}",
-                nameof(NonFinancialDataCustomDataViewModel.SpecialEducationalNeedsPercent) => $"{_customFloorAreaMetric.PercentSpecialEducationNeeds:#.0}",
-                _ => $"{_customFloorAreaMetric.TotalInternalFloorArea:#.0}"
+                nameof(NonFinancialDataCustomDataViewModel.NumberOfPupilsFte) => _customCensus.TotalPupils.ToSimpleDisplay(),
+                nameof(NonFinancialDataCustomDataViewModel.FreeSchoolMealPercent) => _customFloorAreaMetric.PercentFreeSchoolMeals.ToPercent().TrimEnd('%'),
+                nameof(NonFinancialDataCustomDataViewModel.SpecialEducationalNeedsPercent) => _customFloorAreaMetric.PercentSpecialEducationNeeds.ToPercent().TrimEnd('%'),
+                nameof(NonFinancialDataCustomDataViewModel.FloorArea) => _customFloorAreaMetric.TotalInternalFloorArea.ToSimpleDisplay(),
+                _ => throw new ArgumentOutOfRangeException()
             };
 
             Assert.True(expected.Equals(actual), $"{field} expected to be {expected} but found {actual}");


### PR DESCRIPTION
### Context
[AB#215864](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/215864) [AB#192482](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/192482)

### Change proposed in this pull request
Allow user to 'edit' previously submitted custom data for a school.

### Guidance to review 
Submit custom data for a school, then go back and attempt to submit again to see the previous values pre-populated until the new journey is started.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

