### PR TITLE
removed saving of auth state

### DIFF
--- a/web/tests/Web.A11yTests/AuthPageBase.cs
+++ b/web/tests/Web.A11yTests/AuthPageBase.cs
@@ -18,21 +18,6 @@ public abstract partial class AuthPageBase(ITestOutputHelper testOutputHelper, W
         await page.Locator("#organisation").Locator("input[type='radio']").First.ClickAsync();
         await page.GetByText("Continue").ClickAsync();
         await page.WaitForURLAsync($"{ServiceUrl.TrimEnd('/')}/");
-
-        // Save storage state into the file.
-        // Tests are executed in <TestProject>\bin\Debug\netX.0\ therefore relative
-        // path is used to reference playwright/.auth created in project root.
-        const string statePath = "../../../playwright/.auth/state.json";
-        if (!File.Exists(statePath))
-        {
-            await File.Create(statePath).DisposeAsync();
-        }
-
-        await page.Context.StorageStateAsync(new BrowserContextStorageStateOptions
-        {
-            Path = statePath
-        });
-
         await base.GoToPage(statusCode, page);
     }
 


### PR DESCRIPTION
### Context
removing saving of auth state

### Change proposed in this pull request
a11y tests were saving auth state which was not helpful. removing it for now. 

### Guidance to review 
Include any useful information needed to review this change. Include any dependencies that are required for this change. 

### Checklist
~~- [ ] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)~~
~~- [ ] Your code builds clean without any errors or warnings~~
~~- [ ] You have run all unit/integration tests and they pass~~
~~- [ ] Your branch has been rebased onto main~~
~~- [ ] You have tested by running locally~~

