### PR TITLE
fix: custom data fixes

### DIFF
--- a/web/src/Web.App/Controllers/SchoolController.cs
+++ b/web/src/Web.App/Controllers/SchoolController.cs
@@ -175,7 +175,7 @@ public class SchoolController(
                     });
                 }
 
-                ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.SchoolCustomData(urn);
+                ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.SchoolCustomisedData(urn);
 
                 var school = await School(urn);
                 var viewModel = new SchoolViewModel(school, customDataGenerated);

--- a/web/src/Web.App/Controllers/SchoolController.cs
+++ b/web/src/Web.App/Controllers/SchoolController.cs
@@ -146,7 +146,7 @@ public class SchoolController(
     [SchoolAuthorization]
     [FeatureGate(FeatureFlags.CustomData)]
     [SchoolRequestTelemetry(TrackedRequestFeature.CustomisedData)]
-    public async Task<IActionResult> CustomData(string urn)
+    public async Task<IActionResult> CustomData(string urn, [FromQuery(Name = "custom-data-generated")] bool? customDataGenerated)
     {
         using (logger.BeginScope(new
         {
@@ -178,7 +178,7 @@ public class SchoolController(
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.SchoolCustomData(urn);
 
                 var school = await School(urn);
-                var viewModel = new SchoolViewModel(school);
+                var viewModel = new SchoolViewModel(school, customDataGenerated);
 
                 return View(viewModel);
             }

--- a/web/src/Web.App/ViewModels/SchoolViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolViewModel.cs
@@ -45,6 +45,14 @@ public class SchoolViewModel(School school)
             .ThenByDescending(x => x.Value);
     }
 
+    public SchoolViewModel(
+        School school,
+        bool? customDataGenerated = false)
+        : this(school)
+    {
+        CustomDataGenerated = customDataGenerated;
+    }
+
     public string? Name => school.SchoolName;
     public string? Urn => school.URN;
     public string? OverallPhase => school.OverallPhase;
@@ -78,4 +86,5 @@ public class SchoolViewModel(School school)
     public bool HasMetricRag { get; }
     public IEnumerable<RagRating> Ratings { get; } = [];
     public bool? ComparatorGenerated { get; }
+    public bool? CustomDataGenerated { get; }
 }

--- a/web/src/Web.App/Views/School/CustomData.cshtml
+++ b/web/src/Web.App/Views/School/CustomData.cshtml
@@ -15,7 +15,6 @@
 
 <p class="govuk-body">Use your customised data with the benchmarking tools below.</p>
 
-@* TODO: update href once path is decided when journey is complete *@
 <p class="govuk-body">
     <a href=@Url.Action("Index", "SchoolCustomData", new { urn = Model.Urn }) class="govuk-link govuk-link--no-visited-state">
         View or change your custom data
@@ -24,7 +23,7 @@
 
 <p class="govuk-body">
     <a href="@Url.Action("Index", "School" , new { urn=Model.Urn})" class="govuk-link govuk-link--no-visited-state">
-        Return to the spending overview for @Model.Name
+        View the original data for @Model.Name
     </a>
 </p>
 

--- a/web/src/Web.App/Views/School/CustomData.cshtml
+++ b/web/src/Web.App/Views/School/CustomData.cshtml
@@ -17,7 +17,7 @@
 
 @* TODO: update href once path is decided when journey is complete *@
 <p class="govuk-body">
-    <a href="" class="govuk-link govuk-link--no-visited-state">
+    <a href=@Url.Action("Index", "SchoolCustomData", new { urn = Model.Urn }) class="govuk-link govuk-link--no-visited-state">
         View or change your custom data
     </a>
 </p>

--- a/web/src/Web.App/Views/School/_Banners.cshtml
+++ b/web/src/Web.App/Views/School/_Banners.cshtml
@@ -19,7 +19,7 @@
                 </p>
                 <p>
                     <a class="govuk-notification-banner__link"
-                       href="">
+                       href="@Url.Action("CustomData", "School", new { urn = Model.Urn })">
                         View custom data set
                     </a>
                 </p>

--- a/web/src/Web.App/Views/School/_CustomDataBanner.cshtml
+++ b/web/src/Web.App/Views/School/_CustomDataBanner.cshtml
@@ -1,13 +1,18 @@
-﻿<div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-    <div class="govuk-notification-banner__header">
-        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-            Success
-        </h2>
+﻿@model Web.App.ViewModels.SchoolViewModel
+
+@if(Model.CustomDataGenerated.HasValue)
+{
+    <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                Success
+            </h2>
+        </div>
+        <div class="govuk-notification-banner__content">
+            <h3 class="govuk-notification-banner__heading">
+                You've updated your custom data
+            </h3>
+            <p class="govuk-body">Some of the data you entered means we've updated <a class="govuk-notification-banner__link" href="@Url.Action("Index", "SchoolComparators", new { urn = Model.Urn })">the similar schools</a> we chose to benchmark this school against.</p>
+        </div>
     </div>
-    <div class="govuk-notification-banner__content">
-        <h3 class="govuk-notification-banner__heading">
-            You've updated your custom data
-        </h3>
-        <p class="govuk-body">Some of the data you entered means we've updated <a class="govuk-notification-banner__link" href="@Url.Action("Index", "SchoolComparators", new { urn = Model.Urn })">the similar schools</a> we chose to benchmark this school against.</p>
-    </div>
-</div>
+}

--- a/web/src/Web.App/Views/SchoolCensus/CustomData.cshtml
+++ b/web/src/Web.App/Views/SchoolCensus/CustomData.cshtml
@@ -17,7 +17,7 @@
         id = Model.Urn,
     })
 
-<div id="compare-your-census" data-type="@OrganisationTypes.School" data-id="@Model.Urn" data-custom-data-id="@Model.CustomDataId"/>
+<div id="compare-your-census" data-type="@OrganisationTypes.School" data-id="@Model.Urn" data-custom-data-id="@Model.CustomDataId"></div>
 
 @await Component.InvokeAsync("CustomDataFinanceTools", new
     {

--- a/web/src/Web.App/Views/SchoolComparison/CustomData.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/CustomData.cshtml
@@ -17,7 +17,7 @@
         id = Model.Urn,
     })
 
-<div id="compare-your-costs" data-type="@OrganisationTypes.School" data-id="@Model.Urn" data-custom-data-id="@Model.CustomDataId"/>
+<div id="compare-your-costs" data-type="@OrganisationTypes.School" data-id="@Model.Urn" data-custom-data-id="@Model.CustomDataId"></div>
 
 @await Component.InvokeAsync("CustomDataFinanceTools", new
     {

--- a/web/src/Web.App/Views/SchoolCustomDataChange/Submit.cshtml
+++ b/web/src/Web.App/Views/SchoolCustomDataChange/Submit.cshtml
@@ -23,7 +23,7 @@
         function statusCheck() {
             if (done || failed) {
                 clearInterval(interval);
-                window.location.href = `/school/@Model.Urn/customised-data`;
+                window.location.href = `/school/@Model.Urn/customised-data?custom-data-generated=${!failed}`;
                 return;
             }
 

--- a/web/src/Web.App/Views/Shared/Components/ComparatorSetDetails/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/ComparatorSetDetails/Default.cshtml
@@ -34,7 +34,7 @@
             <p class="govuk-body govuk-!-margin-bottom-0">
                 <a class="govuk-link govuk-link--no-visited-state"
                    id="custom-data-link"
-                   href="">
+                       href="@Url.Action("CustomData", "School", new { urn = Model.Identifier })">
                     View custom data set
                 </a>
             </p>


### PR DESCRIPTION
### Context
[AB#192482](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/192482)

fixes and updates to the pages in this story to match ACs (and correct errors I missed last week!)

### Change proposed in this pull request
- closes div correctly for census and comparison pages of the custom data journey so that the custom data finance tools section shows correctly.
- success banner on customised data page (dashboard) only shows when directed from creating/editing custom data
- correct breadcrumbs on customised data page 
- "view your custom data set" from elsewhere in the service updated to direct to the customised data page 
- "view or change your custom data set" link from the customised data page now directs to the start of the create custom data journey
- updates wording to match with the latest designs

### Guidance to review 
N/A - note endpoints for this journey are not functional yet

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

