### PR TITLE
feat: adds loading submit page to create custom data journey

### DIFF
--- a/web/src/Web.App/Constants/PageTitles.cs
+++ b/web/src/Web.App/Constants/PageTitles.cs
@@ -51,6 +51,7 @@ public static class PageTitles
     public const string SchoolChangeDataFinancialData = "Change financial data";
     public const string SchoolChangeDataNonFinancialData = "Change non-financial data";
     public const string SchoolChangeDataWorkforceData = "Change workforce data";
+    public const string SchoolChangeDataSubmit = "Generating custom data";
     public const string SchoolCustomisedData = "Use your customised data";
     public const string SchoolSpendingComparison = "Side-by-side comparison";
     public const string LocalAuthorityHome = "Your local authority";

--- a/web/src/Web.App/Controllers/Api/UserDataProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/UserDataProxyController.cs
@@ -68,4 +68,35 @@ public class UserDataProxyController(ILogger<UserDataProxyController> logger, IU
             }
         }
     }
+
+    [HttpGet]
+    [Route("school/custom-data/{urn}/{identifier}")]
+    [Produces("application/json")]
+    [ProducesResponseType<UserData>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> SchoolCustomDataUserData(string urn, string identifier)
+    {
+        using (logger.BeginScope(new
+        {
+            identifier
+        }))
+        {
+            try
+            {
+                var userData = await userDataService.GetCustomDataAsync(User.UserId(), identifier, urn);
+                if (userData == null)
+                {
+                    return new NotFoundResult();
+                }
+
+                return new JsonResult(userData);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "An error getting school custom data user data {Id} for {User}", identifier, User.UserId());
+                return StatusCode(500);
+            }
+        }
+    }
 }

--- a/web/src/Web.App/ViewModels/SchoolCustomDataSubmittedViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolCustomDataSubmittedViewModel.cs
@@ -1,0 +1,11 @@
+﻿using Web.App.Domain;
+using Web.App.Infrastructure.Apis;
+
+namespace Web.App.ViewModels;
+
+public class SchoolCustomDataSubmittedViewModel(School school, string customData)
+{
+    public string? Urn => school.URN;
+    public string? Name => school.SchoolName;
+    public string Identifier => customData;
+}

--- a/web/src/Web.App/Views/SchoolCustomDataChange/Submit.cshtml
+++ b/web/src/Web.App/Views/SchoolCustomDataChange/Submit.cshtml
@@ -1,0 +1,51 @@
+﻿@model Web.App.ViewModels.SchoolCustomDataSubmittedViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.SchoolChangeDataSubmit;
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full loading">
+        <h1 class="govuk-heading-l">
+            @ViewData[ViewDataKeys.Title]
+        </h1>
+        <div class="spinner"></div>
+        <p class="govuk-hint">This may take a minute or two.</p>
+    </div>
+</div>
+
+@section scripts
+{
+    <script type="module" add-nonce="true">
+        // todo: refactor entire view its own partial/component for re-use by other async processes such as custom data submission
+        let done, failed = false;
+        const interval = setInterval(statusCheck, 5000);
+        function statusCheck() {
+            if (done || failed) {
+                clearInterval(interval);
+                window.location.href = `/school/@Model.Urn/customised-data`;
+                return;
+            }
+
+            fetch(
+                "/api/user-data/school/custom-data/@Model.Urn/@Model.Identifier",
+                {
+                    method: "GET",
+                    credentials: "include"
+                })
+                .then(response => response.json())
+                .then(json => {
+                    if (json) {
+                        if (json.status === "complete") {
+                            done = true;
+                        } else if (json.status !== "pending") {
+                            throw new Error("Unexpected response returned from API call");
+                        }
+                    }
+                })
+                .catch(err => {
+                    console.error(err);
+                    failed = true;
+                });
+        }
+    </script>
+}

--- a/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataWorkforceData.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataWorkforceData.cs
@@ -89,7 +89,7 @@ public class WhenViewingCustomDataWorkforceData : PageBase<SchoolBenchmarkingWeb
             f.SetFormValues(_formValues.ToDictionary(k => k.Key, v => v.Value?.ToString() ?? string.Empty));
         });
 
-        DocumentAssert.AssertPageUrl(page, Paths.SchoolCustomData(school.URN).ToAbsolute());
+        DocumentAssert.AssertPageUrl(page, Paths.SchoolCustomDataSubmit(school.URN).ToAbsolute());
     }
 
     [Fact]
@@ -102,7 +102,7 @@ public class WhenViewingCustomDataWorkforceData : PageBase<SchoolBenchmarkingWeb
 
         page = await Client.SubmitForm(page.Forms[0], action);
 
-        DocumentAssert.AssertPageUrl(page, Paths.SchoolCustomData(school.URN).ToAbsolute());
+        DocumentAssert.AssertPageUrl(page, Paths.SchoolCustomDataSubmit(school.URN).ToAbsolute());
     }
 
     [Fact]
@@ -171,13 +171,31 @@ public class WhenViewingCustomDataWorkforceData : PageBase<SchoolBenchmarkingWeb
             .With(x => x.URN, "12345")
             .Create();
 
+        var customDataId = "123";
+
+        var userData = new[]
+        {
+            new UserData
+            {
+                Type = "custom-data",
+                Id = customDataId
+            }
+        };
+
+        var customData = new CustomDataSchool
+        {
+            Id = customDataId,
+            URN = school.URN,
+        };
+
         var page = await Client.SetupEstablishment(school)
+            .SetupUserData(userData)
             .SetupIncome(school, _income)
             .SetupCensus(school, _census)
             .SetupBalance(school)
             .SetupExpenditure(school, _expenditure)
             .SetupSchoolInsight(school, _floorAreaMetric)
-            .SetUpCustomData()
+            .SetUpCustomData(customData)
             .SetupHttpContextAccessor()
             .Navigate(Paths.SchoolCustomDataWorkforceData(school.URN));
 

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -69,7 +69,7 @@ public static class Paths
     public static string SchoolCustomDataFinancialData(string? urn) => $"/school/{urn}/custom-data/financial-data";
     public static string SchoolCustomDataNonFinancialData(string? urn) => $"/school/{urn}/custom-data/school-characteristics";
     public static string SchoolCustomDataWorkforceData(string? urn) => $"/school/{urn}/custom-data/workforce";
-
+    public static string SchoolCustomDataSubmit(string? urn) => $"/school/{urn}/custom-data/submit";
     public static string SchoolComparators(string? urn) => $"/school/{urn}/comparators";
     public static string SchoolComparatorsCreate(string? urn) => $"/school/{urn}/comparators/create";
     public static string SchoolComparatorsCreateBy(string? urn) => $"/school/{urn}/comparators/create/by";


### PR DESCRIPTION
### Context
[AB#192482](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/192482)- [AB#215344](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/215344)

### Change proposed in this pull request
Adds a submit page to the end of the create custom data journey. 
Adds new proxy end point to return UserData which this page will poll until a status other than pending is received.
Updates integration tests for submit form for the previous page to mock UserData CustomDataSchool

### Guidance to review 
Guard clauses on customised data page will be updated to also check this status rather than just the existence of a custom data id in a following PR and the orchestrator will also be updated in a future PR to return a status of failed rather than complete on any errors while the pipeline creates this custom data.
Integration tests to follow on a separate PR

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

