### PR TITLE
chore: updates guard clauses for customised data pages

### DIFF
--- a/web/src/Web.App/Controllers/SchoolCensusController.cs
+++ b/web/src/Web.App/Controllers/SchoolCensusController.cs
@@ -61,7 +61,17 @@ public class SchoolCensusController(
             try
             {
                 var userData = await userDataService.GetSchoolDataAsync(User.UserId(), urn);
-                if (string.IsNullOrEmpty(userData.CustomData))
+                var customDataId = userData.CustomData;
+                if (string.IsNullOrEmpty(customDataId))
+                {
+                    return RedirectToAction("Index", "School", new
+                    {
+                        urn
+                    });
+                }
+
+                var userCustomData = await userDataService.GetCustomDataAsync(User.UserId(), customDataId, urn);
+                if (userCustomData?.Status != "complete")
                 {
                     return RedirectToAction("Index", "School", new
                     {
@@ -73,7 +83,7 @@ public class SchoolCensusController(
 
                 var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
 
-                var viewModel = new SchoolCensusViewModel(school, customDataId: userData.CustomData);
+                var viewModel = new SchoolCensusViewModel(school, customDataId: customDataId);
 
                 return View(viewModel);
             }

--- a/web/src/Web.App/Controllers/SchoolComparisonController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparisonController.cs
@@ -61,7 +61,17 @@ public class SchoolComparisonController(
             try
             {
                 var userData = await userDataService.GetSchoolDataAsync(User.UserId(), urn);
-                if (string.IsNullOrEmpty(userData.CustomData))
+                var customDataId = userData.CustomData;
+                if (string.IsNullOrEmpty(customDataId))
+                {
+                    return RedirectToAction("Index", "School", new
+                    {
+                        urn
+                    });
+                }
+
+                var userCustomData = await userDataService.GetCustomDataAsync(User.UserId(), customDataId, urn);
+                if (userCustomData?.Status != "complete")
                 {
                     return RedirectToAction("Index", "School", new
                     {
@@ -73,7 +83,7 @@ public class SchoolComparisonController(
 
                 var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
 
-                var viewModel = new SchoolComparisonViewModel(school, customDataId: userData.CustomData);
+                var viewModel = new SchoolComparisonViewModel(school, customDataId: customDataId);
 
                 return View(viewModel);
             }

--- a/web/src/Web.App/Controllers/SchoolController.cs
+++ b/web/src/Web.App/Controllers/SchoolController.cs
@@ -154,7 +154,17 @@ public class SchoolController(
             try
             {
                 var userData = await userDataService.GetSchoolDataAsync(User.UserId(), urn);
-                if (string.IsNullOrEmpty(userData.CustomData))
+                var customDataId = userData.CustomData;
+                if (string.IsNullOrEmpty(customDataId))
+                {
+                    return RedirectToAction("Index", "School", new
+                    {
+                        urn
+                    });
+                }
+
+                var userCustomData = await userDataService.GetCustomDataAsync(User.UserId(), customDataId, urn);
+                if (userCustomData?.Status != "complete")
                 {
                     return RedirectToAction("Index", "School", new
                     {

--- a/web/src/Web.App/Controllers/SchoolSpendingComparisonController.cs
+++ b/web/src/Web.App/Controllers/SchoolSpendingComparisonController.cs
@@ -34,7 +34,17 @@ public class SchoolSpendingComparisonController(
             try
             {
                 var userData = await userDataService.GetSchoolDataAsync(User.UserId(), urn);
-                if (string.IsNullOrEmpty(userData.CustomData))
+                var customDataId = userData.CustomData;
+                if (string.IsNullOrEmpty(customDataId))
+                {
+                    return RedirectToAction("Index", "School", new
+                    {
+                        urn
+                    });
+                }
+
+                var userCustomData = await userDataService.GetCustomDataAsync(User.UserId(), customDataId, urn);
+                if (userCustomData?.Status != "complete")
                 {
                     return RedirectToAction("Index", "School", new
                     {
@@ -46,7 +56,7 @@ public class SchoolSpendingComparisonController(
 
                 var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
                 var originalRating = await metricRagRatingApi.GetDefaultAsync(new ApiQuery().AddIfNotNull("urns", urn)).GetResultOrThrow<RagRating[]>();
-                var customRating = await metricRagRatingApi.CustomAsync(userData.CustomData).GetResultOrThrow<RagRating[]>();
+                var customRating = await metricRagRatingApi.CustomAsync(customDataId).GetResultOrThrow<RagRating[]>();
 
                 var viewModel = new SchoolSpendingComparisonViewModel(school, originalRating, customRating);
 

--- a/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataSpendingComparison.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataSpendingComparison.cs
@@ -82,7 +82,8 @@ public class WhenViewingCustomDataSpendingComparison(SchoolBenchmarkingWebAppCli
             new UserData
             {
                 Type = "custom-data",
-                Id = "123"
+                Id = "123",
+                Status = "complete"
             }
         };
 
@@ -98,8 +99,19 @@ public class WhenViewingCustomDataSpendingComparison(SchoolBenchmarkingWebAppCli
     [Fact]
     public async Task CanDisplayProblemWithService()
     {
+        var userData = new[]
+        {
+            new UserData
+            {
+                Type = "custom-data",
+                Id = "123",
+                Status = "complete"
+            }
+        };
+
         const string urn = "12345";
         var page = await Client.SetupEstablishmentWithException()
+            .SetupUserData(userData)
             .Navigate(Paths.SchoolSpendingComparison(urn));
 
         PageAssert.IsProblemPage(page);
@@ -119,7 +131,8 @@ public class WhenViewingCustomDataSpendingComparison(SchoolBenchmarkingWebAppCli
             new UserData
             {
                 Type = "custom-data",
-                Id = customDataId
+                Id = customDataId,
+                Status = "complete"
             }
         };
 


### PR DESCRIPTION
### Context
[AB#192482](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/192482) - [AB#215862](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/215862)

### Change proposed in this pull request
Adds guard clauses for all customised data pages to also also check the status of UserData not just the custom data id
Updates setup in integration tests for `WhenViewingCustomDataSpendingComparison` to include the status.

### Guidance to review 
N/A

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

