### PR TITLE
Remove previous custom data for a school when creating new set

### DIFF
--- a/web/src/Web.App/Controllers/SchoolCustomDataChangeController.cs
+++ b/web/src/Web.App/Controllers/SchoolCustomDataChangeController.cs
@@ -199,6 +199,13 @@ public class SchoolCustomDataChangeController(
 
                 customDataService.MergeCustomDataIntoSession(urn, viewModel);
 
+                // remove previous set of custom data before submitting new
+                var userData = await userDataService.GetSchoolDataAsync(User.UserId(), urn);
+                if (userData.CustomData != null)
+                {
+                    await customDataService.RemoveCustomData(urn, userData.CustomData);
+                }
+
                 await customDataService.CreateCustomData(urn, User.UserId());
 
                 customDataService.ClearCustomDataFromSession(urn);
@@ -249,10 +256,10 @@ public class SchoolCustomDataChangeController(
         // attempt to load in custom data from previous submission if not already in the middle of a new submission
         if (customInput == null)
         {
-            var (customData, _) = await userDataService.GetSchoolDataAsync(User.UserId(), urn);
-            if (!string.IsNullOrWhiteSpace(customData))
+            var userData = await userDataService.GetSchoolDataAsync(User.UserId(), urn);
+            if (userData.CustomData != null)
             {
-                customInput = await customDataService.GetCustomDataById(urn, customData);
+                customInput = await customDataService.GetCustomDataById(urn, userData.CustomData);
             }
 
             // set session to match view model to sync continue/back CTAs in UI

--- a/web/src/Web.App/Controllers/SchoolCustomDataController.cs
+++ b/web/src/Web.App/Controllers/SchoolCustomDataController.cs
@@ -19,7 +19,6 @@ public class SchoolCustomDataController(
     IEstablishmentApi establishmentApi,
     IUserDataService userDataService,
     ICustomDataService customDataService,
-    ICustomDataApi customDataApi,
     ILogger<SchoolCustomDataController> logger)
     : Controller
 {
@@ -94,7 +93,7 @@ public class SchoolCustomDataController(
                 var userData = await userDataService.GetSchoolDataAsync(User.UserId(), urn);
                 if (userData.CustomData != null)
                 {
-                    await customDataApi.RemoveSchoolAsync(urn, userData.CustomData).EnsureSuccess();
+                    await customDataService.RemoveCustomData(urn, userData.CustomData);
                     customDataService.ClearCustomDataFromSession(urn);
                 }
 

--- a/web/src/Web.App/Services/CustomDataService.cs
+++ b/web/src/Web.App/Services/CustomDataService.cs
@@ -14,6 +14,7 @@ public interface ICustomDataService
     void ClearCustomDataFromSession(string urn);
     Task CreateCustomData(string urn, string userId);
     Task<CustomData?> GetCustomDataById(string urn, string identifier);
+    Task RemoveCustomData(string urn, string identifier);
 }
 
 public class CustomDataService(
@@ -102,6 +103,9 @@ public class CustomDataService(
         var parsed = customDataSchool.Data.FromJson<PutCustomDataRequest>();
         return parsed == null ? null : CreateCustomData(parsed);
     }
+
+    public async Task RemoveCustomData(string urn, string identifier) =>
+        await customDataApi.RemoveSchoolAsync(urn, identifier).EnsureSuccess();
 
     private static PutCustomDataRequest CreateRequest(CustomData data) => new()
     {


### PR DESCRIPTION
### Context
AB#216321 [AB#192482](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/192482)

### Change proposed in this pull request
Call API to delete previous custom data when saving new so that there is only ever one active instance per user per school.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

