### PR TITLE
When no categories chosen on Trust spending priorities order by Status first, then by category

### DIFF
--- a/web/src/Web.App/Views/TrustSpending/Index.cshtml
+++ b/web/src/Web.App/Views/TrustSpending/Index.cshtml
@@ -63,52 +63,44 @@
         </form>
     </aside>
     <div class="govuk-grid-column-three-quarters">
-        @foreach (var rating in Model.Ratings)
+        @if (Model.CostCategories.Length > 0)
         {
-            <h2 class="govuk-heading-m" id="@rating.CostCategory?.ToSlug()">@rating.CostCategory</h2>
-
-            @foreach (var status in rating.Statuses)
+            @foreach (var rating in Model.RatingsByCategory)
             {
-                <h3 class="govuk-heading-s">@status.PriorityTag?.DisplayText</h3>
+                <h2 class="govuk-heading-m" id="@rating.CostCategory?.ToSlug()">@rating.CostCategory</h2>
 
-                <div class="top-categories">
-                    <div>
-                        <p class="priority @status.PriorityTag?.Class govuk-body">
-                            @await Component.InvokeAsync("Tag", new
-                            {
-                                rating = new RatingViewModel(status.PriorityTag?.Colour, status.PriorityTag?.DisplayText)
-                            })
-                            @status.Schools.Count() out of @Model.NumberSchools school@(Model.NumberSchools == 1 ? string.Empty : "s")
-                            in the @status.PriorityTag?.DisplayText.ToLower() range
-                        </p>
-                    </div>
-                </div>
-
-                <table class="govuk-table table-trust-spending-and-costs" id="govuk-trust-spending-and-costs-@rating.CostCategory?.ToSlug()-@status.Status?.ToSlug()">
-                    <thead class="govuk-table__head">
-                    <tr class="govuk-table__row">
-                        <th scope="col" class="govuk-table__header">Rank</th>
-                        <th scope="col" class="govuk-table__header">School</th>
-                        <th scope="col" class="govuk-table__header">Expenditure</th>
-                    </tr>
-                    </thead>
-                    <tbody class="govuk-table__body">
-                    @for (var i = 0; i < status.Schools.Count(); i++)
+                @foreach (var status in rating.Statuses)
+                {
+                    <h3 class="govuk-heading-s">@status.PriorityTag?.DisplayText</h3>
+                    @await Html.PartialAsync("_PriorityStatus", new TrustSpendingPriorityStatusViewModel(status.PriorityTag, status.Schools.Count(), Model.NumberSchools))
+                    @await Html.PartialAsync("_PriorityTable", status.Schools, new ViewDataDictionary(ViewData)
                     {
-                        var school = status.Schools.ElementAt(i);
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">@(i + 1)</td>
-                            <td class="govuk-table__cell">
-                                <a class="govuk-link govuk-link--no-visited-state" href="@Url.Action("Index", "SchoolSpending", new { urn = school.Urn })">@school.Name</a>
-                            </td>
-                            <td class="govuk-table__cell">@school.Value.ToCurrency(0) per pupil</td>
-                        </tr>
-                    }
-                    </tbody>
-                </table>
+                        {
+                            "Id", $"govuk-trust-spending-and-costs-{rating.CostCategory?.ToSlug()}-{status.Status?.ToSlug()}"
+                        }
+                    })
+                }
             }
         }
+        else
+        {
+            @foreach (var rating in Model.RatingsByPriority)
+            {
+                <h2 class="govuk-heading-m" id="@rating.PriorityTag?.DisplayText.ToSlug()">@rating.PriorityTag?.DisplayText</h2>
 
+                @foreach (var category in rating.Categories)
+                {
+                    <h3 class="govuk-heading-s">@category.Category</h3>
+                    @await Html.PartialAsync("_PriorityStatus", new TrustSpendingPriorityStatusViewModel(rating.PriorityTag, category.Schools.Count(), Model.NumberSchools))
+                    @await Html.PartialAsync("_PriorityTable", category.Schools, new ViewDataDictionary(ViewData)
+                    {
+                        {
+                            "Id", $"govuk-trust-spending-and-costs-{category.Category?.ToSlug()}-{rating.Status?.ToSlug()}"
+                        }
+                    })
+                }
+            }
+        }
     </div>
 </div>
 

--- a/web/src/Web.App/Views/TrustSpending/_PriorityStatus.cshtml
+++ b/web/src/Web.App/Views/TrustSpending/_PriorityStatus.cshtml
@@ -1,0 +1,15 @@
+@using Web.App.ViewModels
+@model Web.App.ViewModels.TrustSpendingPriorityStatusViewModel
+
+<div class="top-categories">
+    <div>
+        <p class="priority @Model.PriorityTag?.Class govuk-body">
+            @await Component.InvokeAsync("Tag", new
+            {
+                rating = new RatingViewModel(Model.PriorityTag?.Colour, Model.PriorityTag?.DisplayText)
+            })
+            @Model.SchoolsInStatus out of @Model.TotalSchools school@(Model.TotalSchools == 1 ? string.Empty : "s")
+            in the @Model.PriorityTag?.DisplayText.ToLower() range
+        </p>
+    </div>
+</div>

--- a/web/src/Web.App/Views/TrustSpending/_PriorityTable.cshtml
+++ b/web/src/Web.App/Views/TrustSpending/_PriorityTable.cshtml
@@ -1,0 +1,28 @@
+@using Web.App.Extensions
+@model IEnumerable<Web.App.ViewModels.RagSchoolSpendingSchoolViewModel>
+@{
+    var id = ViewData["Id"] as string;
+}
+
+<table class="govuk-table table-trust-spending-and-costs" id="@id">
+    <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Rank</th>
+        <th scope="col" class="govuk-table__header">School</th>
+        <th scope="col" class="govuk-table__header">Expenditure</th>
+    </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    @for (var i = 0; i < Model.Count(); i++)
+    {
+        var school = Model.ElementAt(i);
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell">@(i + 1)</td>
+            <td class="govuk-table__cell">
+                <a class="govuk-link govuk-link--no-visited-state" href="@Url.Action("Index", "SchoolSpending", new { urn = school.Urn })">@school.Name</a>
+            </td>
+            <td class="govuk-table__cell">@school.Value.ToCurrency(0) per pupil</td>
+        </tr>
+    }
+    </tbody>
+</table>


### PR DESCRIPTION
### Context
[AB#216436](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/216436) [AB#192288](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/192288)

### Change proposed in this pull request
Otherwise stick to original behaviour and order by selected Category/ies first, then by Status.

### Guidance to review 
Switch between all categories or specific one(s) using the drop down on the left of the Trust spending-and-costs page to observe the different result grouping. New ticket added for the missing integration tests here.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

