### PR TITLE
Define database automatic tuning using `azapi` provider

### DIFF
--- a/core-infrastructure/terraform/README.md
+++ b/core-infrastructure/terraform/README.md
@@ -4,14 +4,16 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | 1.13.1 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.87 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.98.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.6.1 |
+| <a name="provider_azapi"></a> [azapi](#provider\_azapi) | 1.13.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.87 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 
@@ -21,6 +23,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [azapi_resource_action.sql-server-auto-tuning](https://registry.terraform.io/providers/azure/azapi/1.13.1/docs/resources/resource_action) | resource |
 | [azurerm_application_insights.application-insights](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights) | resource |
 | [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry) | resource |
 | [azurerm_key_vault.key-vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault) | resource |

--- a/core-infrastructure/terraform/databases.tf
+++ b/core-infrastructure/terraform/databases.tf
@@ -204,3 +204,22 @@ resource "azurerm_storage_container" "sql-vulnerability-container" {
   storage_account_name  = azurerm_storage_account.sql-log-storage.name
   container_access_type = "private"
 }
+
+# https://learn.microsoft.com/en-us/rest/api/sql/server-automatic-tuning/update?view=rest-sql-2021-11-01
+resource "azapi_resource_action" "sql-server-auto-tuning" {
+  resource_id = "${azurerm_mssql_server.sql-server.id}/automaticTuning/current"
+  type        = "Microsoft.Sql/servers/automaticTuning@2021-11-01"
+  method      = "PATCH"
+  body = jsonencode({
+    properties = {
+      desiredState = "Auto"
+      options = {
+        # Valid desiredState options = "Default","On","Off"
+        forceLastGoodPlan = { desiredState = "Default" }
+        createIndex       = { desiredState = "On" }
+        dropIndex         = { desiredState = "On" }
+      }
+    }
+  })
+  depends_on = [azurerm_mssql_database.sql-db]
+}

--- a/core-infrastructure/terraform/provider.tf
+++ b/core-infrastructure/terraform/provider.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.87"
     }
+    azapi = {
+      source  = "azure/azapi"
+      version = "1.13.1"
+    }
   }
   backend "azurerm" {}
 }
@@ -17,4 +21,7 @@ provider "azurerm" {
       recover_soft_deleted_key_vaults = true
     }
   }
+}
+
+provider "azapi" {
 }

--- a/pipelines/feature/release.yaml
+++ b/pipelines/feature/release.yaml
@@ -85,13 +85,21 @@ stages:
               TerraformFolder: '$(System.DefaultWorkingDirectory)/$(WorkingDir.Core)/terraform'
               Module: 'core'
 
+      - job: BuildCore
+        displayName: 'Core : Build'
+        steps:
+          - template: ../core-infrastructure/steps/build.yaml
+            parameters:
+              BuildVersion: $(Version.BuildVersion)
+              BuildNumber: $(Version.BuildNumber)
+
       - template: ../core-infrastructure/deployment.yaml
         parameters:
           subscription: $(Subscription)
           environmentPrefix: $(environmentPrefix)
           environment: $(Pipeline.Environment)
           cipEnvironment: 'Dev'
-          dependsOn: [ ZipStaticCoreArtifacts ]
+          dependsOn: [ ZipStaticCoreArtifacts, BuildCore ]
           disablePurgeProtection: 'true'
 
   - stage: BuildDataPipeline


### PR DESCRIPTION
### Context
[AB#216465](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/216465) [AB#186287](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/186287)

### Change proposed in this pull request
There isn't `azurerm` support for this feature, so `azapi` needs to be [used](https://github.com/hashicorp/terraform-provider-azurerm/issues/7665#issuecomment-1854459160) instead. Incentive to configure automatic tuning is to try and resolve performance issues with the E2E tests.

### Guidance to review 
Validated by pushing out to the `d14` feature environment.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~~Your code builds clean without any errors or warnings~~
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

