### PR TITLE
Wired up Web to Budget Forecast API

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -100,7 +100,7 @@
       data-type="local-authority"
       data-id="383"
     ></div>-->
-    <div id="budget-forecast-returns" data-id="07465701"></div>
+    <div id="budget-forecast-returns" data-id="01532445"></div>
     <script type="module" src="/src/main.tsx"></script>
     <script
       type="module"

--- a/front-end-components/src/index.css
+++ b/front-end-components/src/index.css
@@ -146,6 +146,10 @@
   margin: 0;
 }
 
+#budget-forecast-returns .recharts-wrapper .recharts-legend-wrapper {
+  top: 0 !important;
+}
+
 .chart-stat abbr.summary {
   text-decoration: underline;
   text-decoration-style: dotted;

--- a/platform/src/apis/Platform.Api.Insight/BudgetForecast/BudgetForecastResponse.cs
+++ b/platform/src/apis/Platform.Api.Insight/BudgetForecast/BudgetForecastResponse.cs
@@ -35,6 +35,11 @@ public static class BudgetForecastReturnsResponseFactory
                 response.Forecast = model.Value;
                 response.ForecastTotalPupils = model.TotalPupils;
             }
+            else if (model.Value == 0)
+            {
+                // historical zero values should be skipped
+                continue;
+            }
             else if (response.Actual == null)
             {
                 // sanity check that the first actual values are not overwritten by a subsequent RunId year's values

--- a/platform/tests/Platform.Tests/Insight/BudgetForecast/WhenBudgetForecastReturnsResponseFactoryCreatesResponse.cs
+++ b/platform/tests/Platform.Tests/Insight/BudgetForecast/WhenBudgetForecastReturnsResponseFactoryCreatesResponse.cs
@@ -9,7 +9,7 @@ public class WhenBudgetForecastReturnsResponseFactoryCreatesResponse
     /// 
     /// | RunId | Year | Value |
     /// | ----- | ---- | ----- |
-    /// | 2020  | 2018 | 1_001 |
+    /// | 2020  | 2018 | 0     |
     /// | 2020  | 2019 | 1_002 |
     /// | 2020  | 2020 | 1_003 |
     /// | 2020  | 2021 | 1_004 |
@@ -32,7 +32,6 @@ public class WhenBudgetForecastReturnsResponseFactoryCreatesResponse
     /// 
     /// | Year | Actual | Forecast |
     /// | ---- | ------ | -------- |
-    /// | 2018 | 1_001  |          |
     /// | 2019 | 1_002  |          |
     /// | 2020 | 1_003  |          |
     /// | 2021 | 1_007  | 1_004    |
@@ -52,8 +51,8 @@ public class WhenBudgetForecastReturnsResponseFactoryCreatesResponse
                 RunType = "default",
                 RunId = "2020",
                 Year = 2018,
-                Value = 1_001,
-                TotalPupils = 2_001
+                Value = 0,
+                TotalPupils = 0
             },
             new()
             {
@@ -197,56 +196,49 @@ public class WhenBudgetForecastReturnsResponseFactoryCreatesResponse
         var actual = BudgetForecastReturnsResponseFactory.CreateForDefaultRunType(models);
 
         // assert
-        var year2018 = actual.ElementAt(0);
-        Assert.Equal(2018, year2018.Year);
-        Assert.Equal(1_001, year2018.Actual);
-        Assert.Null(year2018.Forecast);
-        Assert.Null(year2018.Variance);
-        Assert.Null(year2018.PercentVariance);
-
-        var year2019 = actual.ElementAt(1);
+        var year2019 = actual.ElementAt(0);
         Assert.Equal(2019, year2019.Year);
         Assert.Equal(1_002, year2019.Actual);
         Assert.Null(year2019.Forecast);
         Assert.Null(year2019.Variance);
         Assert.Null(year2019.PercentVariance);
 
-        var year2020 = actual.ElementAt(2);
+        var year2020 = actual.ElementAt(1);
         Assert.Equal(2020, year2020.Year);
         Assert.Equal(1_003, year2020.Actual);
         Assert.Null(year2020.Forecast);
         Assert.Null(year2020.Variance);
         Assert.Null(year2020.PercentVariance);
 
-        var year2021 = actual.ElementAt(3);
+        var year2021 = actual.ElementAt(2);
         Assert.Equal(2021, year2021.Year);
         Assert.Equal(1_007, year2021.Actual);
         Assert.Equal(1_004, year2021.Forecast);
         Assert.Equal(3, year2021.Variance);
         Assert.Equal("0.298", year2021.PercentVariance.GetValueOrDefault().ToString("0.000"));
 
-        var year2022 = actual.ElementAt(4);
+        var year2022 = actual.ElementAt(3);
         Assert.Equal(2022, year2022.Year);
         Assert.Equal(1_011, year2022.Actual);
         Assert.Equal(1_008, year2022.Forecast);
         Assert.Equal(3, year2022.Variance);
         Assert.Equal("0.297", year2022.PercentVariance.GetValueOrDefault().ToString("0.000"));
 
-        var year2023 = actual.ElementAt(5);
+        var year2023 = actual.ElementAt(4);
         Assert.Equal(2023, year2023.Year);
         Assert.Null(year2023.Actual);
         Assert.Equal(1_012, year2023.Forecast);
         Assert.Null(year2023.Variance);
         Assert.Null(year2023.PercentVariance);
 
-        var year2024 = actual.ElementAt(6);
+        var year2024 = actual.ElementAt(5);
         Assert.Equal(2024, year2024.Year);
         Assert.Null(year2024.Actual);
         Assert.Equal(1_013, year2024.Forecast);
         Assert.Null(year2024.Variance);
         Assert.Null(year2024.PercentVariance);
 
-        var year2025 = actual.ElementAt(7);
+        var year2025 = actual.ElementAt(6);
         Assert.Equal(2025, year2025.Year);
         Assert.Null(year2025.Actual);
         Assert.Equal(1_014, year2025.Forecast);

--- a/web/src/Web.App/Infrastructure/Apis/Insight/BudgetForecastApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Insight/BudgetForecastApi.cs
@@ -1,6 +1,4 @@
-﻿using Web.App.Domain;
-
-namespace Web.App.Infrastructure.Apis.Insight;
+﻿namespace Web.App.Infrastructure.Apis;
 
 public interface IBudgetForecastApi
 {
@@ -11,97 +9,12 @@ public interface IBudgetForecastApi
 
 public class BudgetForecastApi(HttpClient httpClient, string? key = default) : ApiBase(httpClient, key), IBudgetForecastApi
 {
-    // todo: replace stub with actual API call
-    // e.g. await GetAsync($"api/budget-forecast/{companyNo}{query?.ToQueryString()}");
-    public Task<ApiResult> BudgetForecastReturns(string? companyNo, ApiQuery? query = null) => Task.FromResult(ApiResult.Ok(new[]
-    {
-        new BudgetForecastReturn
-        {
-            Year = 2020,
-            Forecast = 211_000_000,
-            Actual = 219_000_000,
-            ForecastTotalPupils = 11_000,
-            ActualTotalPupils = 11_100,
-            Variance = 8_000_000,
-            PercentVariance = 3.65296804m
-        },
-        new BudgetForecastReturn
-        {
-            Year = 2021,
-            Forecast = 277_000_000,
-            Actual = 412_000_000,
-            ForecastTotalPupils = 12_200,
-            ActualTotalPupils = 12_100,
-            Variance = 135_000_000,
-            PercentVariance = 32.76699029m
-        },
-        new BudgetForecastReturn
-        {
-            Year = 2022,
-            Forecast = 487_000_000,
-            Actual = 457_000_000,
-            ForecastTotalPupils = 13_300,
-            ActualTotalPupils = 14_000,
-            Variance = -30_000_000,
-            PercentVariance = -6.16014643m
-        },
-        new BudgetForecastReturn
-        {
-            Year = 2023,
-            Forecast = -25_000_000,
-            ForecastTotalPupils = 14_400
-        },
-        new BudgetForecastReturn
-        {
-            Year = 2024,
-            Forecast = 264_000_000,
-            ForecastTotalPupils = 15_500
-        },
-        new BudgetForecastReturn
-        {
-            Year = 2025,
-            Forecast = 286_000_000,
-            ForecastTotalPupils = 16_600
-        }
-    }));
+    public async Task<ApiResult> BudgetForecastReturns(string? companyNo, ApiQuery? query = null) =>
+        await GetAsync($"api/budget-forecast/{companyNo}{query?.ToQueryString()}");
 
-    // todo: replace stub with actual API call
-    // e.g. await GetAsync($"api/budget-forecast/{companyNo}/metrics{query?.ToQueryString()}");
-    public Task<ApiResult> BudgetForecastReturnsMetrics(string? companyNo, ApiQuery? query = null) => Task.FromResult(ApiResult.Ok(new[]
-    {
-        new BudgetForecastReturnMetric
-        {
-            Year = 2022,
-            Metric = "Revenue reserve as percentage of income",
-            Value = 1.2m
-        },
-        new BudgetForecastReturnMetric
-        {
-            Year = 2022,
-            Metric = "Staff costs as percentage of income",
-            Value = 2.3m
-        },
-        new BudgetForecastReturnMetric
-        {
-            Year = 2022,
-            Metric = "Expenditure as percentage of income",
-            Value = 3.4m
-        },
-        new BudgetForecastReturnMetric
-        {
-            Year = 2022,
-            Metric = "Self-generated funding as percentage of income",
-            Value = 4.5m
-        },
-        new BudgetForecastReturnMetric
-        {
-            Year = 2022,
-            Metric = "Grant funding as percentage of income",
-            Value = 5.6m
-        }
-    }));
+    public async Task<ApiResult> BudgetForecastReturnsMetrics(string? companyNo, ApiQuery? query = null) =>
+        await GetAsync($"api/budget-forecast/{companyNo}/metrics{query?.ToQueryString()}");
 
-    // todo: replace stub with actual API call
-    // e.g. await GetAsync($"api/budget-forecast/{companyNo}/current-year{query?.ToQueryString()}");
-    public Task<ApiResult> GetCurrentBudgetForecastYear(string? companyNo, ApiQuery? query = null) => Task.FromResult(ApiResult.Ok(2022));
+    public async Task<ApiResult> GetCurrentBudgetForecastYear(string? companyNo, ApiQuery? query = null) =>
+        await GetAsync($"api/budget-forecast/{companyNo}/current-year{query?.ToQueryString()}");
 }


### PR DESCRIPTION
### Context
[AB#215312](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/215312) [AB#188391](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/188391)

### Change proposed in this pull request
Wire up to API to get data feeding through from the now-populated source tables. Sample populated content is below:

![image](https://github.com/DFE-Digital/education-benchmarking-and-insights/assets/3224486/9089f0be-97fe-4283-baf7-b749fae9919d)

Additional wiring up of the metric categories will also be required once these have been properly defined.

### Guidance to review 
View a Trust Forecast page.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

