### PR TITLE
Revert "reenable a11y tests in pipeline"

### DIFF
--- a/pipelines/web/build.yaml
+++ b/pipelines/web/build.yaml
@@ -137,15 +137,15 @@ stages:
             parameters:
               workspaceDir: '$(Pipeline.Workspace)'
 
-      - job: RunA11YTests
-        dependsOn: [ WebDeployment ]
-        displayName: 'Run automated a11y tests'
-        steps:
-          - template: steps\run-a11y-tests.yaml
-            parameters:
-              workspaceDir: '$(Pipeline.Workspace)'
-              subscription: 's198d.azdo-deployment'
-              environmentPrefix: 's198d02'
+#      - job: RunA11YTests
+#        dependsOn: [ WebDeployment ]
+#        displayName: 'Run automated a11y tests'
+#        steps:
+#          - template: steps\run-a11y-tests.yaml
+#            parameters:
+#              workspaceDir: '$(Pipeline.Workspace)'
+#              subscription: 's198d.azdo-deployment'
+#              environmentPrefix: 's198d02'
 
   - stage: DeployTest
     dependsOn: [ DeployAutomatedTest ]


### PR DESCRIPTION
need to fix a11y tests to not leave any data and more observation for stable e2e tests run
Reverts DFE-Digital/education-benchmarking-and-insights#1033