### PR TITLE
Display remaining priority status/guidance on BFR

### DIFF
--- a/front-end-components/src/services/types.tsx
+++ b/front-end-components/src/services/types.tsx
@@ -376,4 +376,5 @@ export type BudgetForecastReturn = {
   actualTotalPupils?: number;
   variance?: number;
   percentVariance?: number;
+  varianceStatus?: string;
 };

--- a/front-end-components/src/views/budget-forecast-returns/partials/bfr-table.tsx
+++ b/front-end-components/src/views/budget-forecast-returns/partials/bfr-table.tsx
@@ -34,7 +34,8 @@ export const BfrTable = ({ data }: BfrTableProps) => {
             The thresholds for the variance between AR and BFR are:
           </p>
           <ul className="govuk-list">
-            <li>Below -5%: AR below forecast</li>
+            <li>Below -10%: AR significantly below forecast</li>
+            <li>Between -10% and -5%: AR below forecast</li>
             <li>Between -5% and 5%: stable forecast</li>
             <li>Between 5% and 10%: AR above forecast</li>
             <li>Above 10%: AR significantly above forecast</li>

--- a/front-end-components/src/views/budget-forecast-returns/partials/bfr-table.tsx
+++ b/front-end-components/src/views/budget-forecast-returns/partials/bfr-table.tsx
@@ -55,21 +55,6 @@ export const BfrTable = ({ data }: BfrTableProps) => {
           </thead>
           <tbody className="govuk-table__body">
             {data.map((item) => {
-              let status = "";
-              if (item.percentVariance !== undefined) {
-                if (item.percentVariance < -5) {
-                  status = "AR below forecast";
-                }
-                if (item.percentVariance >= -5 && item.percentVariance < 5) {
-                  status = "Stable forecast";
-                }
-                if (item.percentVariance >= 5 && item.percentVariance < 10) {
-                  status = "AR above forecast";
-                }
-                if (item.percentVariance >= 10) {
-                  status = "AR significantly above forecast";
-                }
-              }
               return (
                 <tr className="govuk-table__row">
                   <td className="govuk-table__cell">
@@ -99,7 +84,7 @@ export const BfrTable = ({ data }: BfrTableProps) => {
                         valueUnit: "%",
                       })}
                   </td>
-                  <td className="govuk-table__cell">{status}</td>
+                  <td className="govuk-table__cell">{item.varianceStatus}</td>
                 </tr>
               );
             })}

--- a/platform/src/apis/Platform.Api.Insight/BudgetForecast/BudgetForecastResponse.cs
+++ b/platform/src/apis/Platform.Api.Insight/BudgetForecast/BudgetForecastResponse.cs
@@ -83,6 +83,15 @@ public record BudgetForecastReturnResponse
 
     public decimal? Variance => Forecast.HasValue && Actual.HasValue ? Actual - Forecast : null;
     public decimal? PercentVariance => Forecast.HasValue && Actual.HasValue ? 100 - Forecast / Actual * 100 : null;
+    public string? VarianceStatus => PercentVariance switch
+    {
+        < -10 => "AR significantly below forecast",
+        < -5 and -10 => "AR below forecast",
+        >= -5 and < 5 => "Stable forecast",
+        >= 5 and < 10 => "AR above forecast",
+        >= 10 => "AR significantly above forecast",
+        _ => null
+    };
 }
 
 public record BudgetForecastReturnMetricResponse

--- a/platform/src/apis/Platform.Api.Insight/BudgetForecast/BudgetForecastResponse.cs
+++ b/platform/src/apis/Platform.Api.Insight/BudgetForecast/BudgetForecastResponse.cs
@@ -86,7 +86,7 @@ public record BudgetForecastReturnResponse
     public string? VarianceStatus => PercentVariance switch
     {
         < -10 => "AR significantly below forecast",
-        < -5 and -10 => "AR below forecast",
+        >= -10 and < -5 => "AR below forecast",
         >= -5 and < 5 => "Stable forecast",
         >= 5 and < 10 => "AR above forecast",
         >= 10 => "AR significantly above forecast",

--- a/web/src/Web.App/Controllers/TrustForecastController.cs
+++ b/web/src/Web.App/Controllers/TrustForecastController.cs
@@ -6,8 +6,8 @@ using Web.App.Attributes.RequestTelemetry;
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.Establishment;
-using Web.App.Infrastructure.Apis.Insight;
 using Web.App.Infrastructure.Extensions;
+using Web.App.TagHelpers;
 using Web.App.ViewModels;
 namespace Web.App.Controllers;
 
@@ -32,7 +32,11 @@ public class TrustForecastController(
         {
             try
             {
-                ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.TrustForecast(companyNumber);
+                ViewData[ViewDataKeys.Backlink] = new BacklinkInfo(Url.Action("Index", "Trust", new
+                {
+                    companyNumber
+                }));
+
                 var trust = await establishmentApi.GetTrust(companyNumber).GetResultOrThrow<Trust>();
                 var metrics = await GetBudgetForecastReturnMetrics(companyNumber);
                 var bfrYear = await budgetForecastApi.GetCurrentBudgetForecastYear(companyNumber).GetResultOrDefault(Constants.CurrentYear - 1);

--- a/web/src/Web.App/Domain/Insight/Balance.cs
+++ b/web/src/Web.App/Domain/Insight/Balance.cs
@@ -56,4 +56,21 @@ public record BudgetForecastReturnMetric
     public string? CompanyNumber { get; set; }
     public string? Metric { get; set; }
     public decimal? Value { get; set; }
+
+    public BudgetForecastReturnMetricType MetricType => new(Metric);
+}
+
+public class BudgetForecastReturnMetricType(string? metric)
+{
+    public const string ExpenditureAsPercentageOfIncome = "Expenditure as percentage of income";
+    public const string GrantFundingAsPercentageOfIncome = "Grant funding as percentage of income";
+    public const string RevenueReserveAsPercentageOfIncome = "Revenue reserve as percentage of income";
+    public const string SelfGeneratedIncomeAsPercentageOfIncome = "Self generated income as percentage of income";
+    public const string Slope = "Slope";
+    public const string SlopeFlag = "Slope flag";
+    public const string StaffCostsAsPercentageOfIncome = "Staff costs as percentage of income";
+
+    public bool IsSlope() => string.Equals(metric, Slope);
+
+    public bool IsSlopeFlag() => string.Equals(metric, SlopeFlag);
 }

--- a/web/src/Web.App/Domain/Insight/Balance.cs
+++ b/web/src/Web.App/Domain/Insight/Balance.cs
@@ -46,6 +46,7 @@ public record BudgetForecastReturn
 
     public decimal? Variance { get; set; }
     public decimal? PercentVariance { get; set; }
+    public string? VarianceStatus { get; set; }
 }
 
 public record BudgetForecastReturnMetric
@@ -71,6 +72,15 @@ public class BudgetForecastReturnMetricType(string? metric)
     public const string StaffCostsAsPercentageOfIncome = "Staff costs as percentage of income";
 
     public bool IsSlope() => string.Equals(metric, Slope);
-
     public bool IsSlopeFlag() => string.Equals(metric, SlopeFlag);
+    public bool IsStaffCosts() => string.Equals(metric, StaffCostsAsPercentageOfIncome);
+}
+
+public class BudgetForecastVarianceStatusType
+{
+    public const string ArSignificantlyBelowForecast = "AR significantly below forecast";
+    public const string ArBelowForecast = "AR below forecast";
+    public const string StableForecast = "Stable forecast";
+    public const string ArAboveForecast = "AR above forecast";
+    public const string ArSignificantlyAboveForecast = "AR significantly above forecast";
 }

--- a/web/src/Web.App/ViewModels/TrustForecastMetricsViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustForecastMetricsViewModel.cs
@@ -4,5 +4,9 @@ namespace Web.App.ViewModels;
 public class TrustForecastMetricsViewModel(int? year, BudgetForecastReturnMetric[] metrics)
 {
     public int? Year => year;
-    public BudgetForecastReturnMetric[] Metrics => metrics;
+    public BudgetForecastReturnMetric[] Metrics => metrics
+        .Where(m => !m.MetricType.IsSlope())
+        .Where(m => !m.MetricType.IsSlopeFlag())
+        .Select(m => m)
+        .ToArray();
 }

--- a/web/src/Web.App/ViewModels/TrustForecastViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustForecastViewModel.cs
@@ -10,28 +10,63 @@ public class TrustForecastViewModel(
     public string? CompanyNumber => trust.CompanyNumber;
     public string? Name => trust.TrustName;
 
-    // red
+    // Figure for the current financial year end (Y1P2) revenue reserves balances is negative
     public bool BalancesInDeficit => currentReturns.Any(r => r.Year == bfrYear && r.Actual < 0);
+
+    // Figure for the next financial year end (Y2P2) revenue reserves balances is negative.
     public bool BalancesForecastingDeficit => currentReturns.Any(r => r.Year == bfrYear + 1 && r.Forecast < 0);
-    public bool SteepDeclineInBalances => false;
-    public bool SteepDeclineInBalancesAndHighProportionStaffCosts => false;
+
+    // 1) The slope of the graph determined using slope analysis is negative and among the top 10% of negative slopes (the most negative).
+    // 2) The most frequent status of volatility analysis for previous years is not “AR above forecast”.
+    // 3) Staff costs as percentage of total income is less than 80%
+    public bool SteepDeclineInBalances => SlopeAnalysisNegativeAndAmongTheMostNegative
+                                          && MostFrequentStatusOfVolatilityAnalyses.All(b => b.VarianceStatus != BudgetForecastVarianceStatusType.ArAboveForecast)
+                                          && metrics.Any(m => m.MetricType.IsStaffCosts() && m.Value < 80);
+
+    // 1) The slope of the graph determined using slope analysis is negative and among the top 10% of negative slopes (the most negative).
+    // 2) The most frequent status of volatility analysis for previous years is not “AR above forecast”.
+    // 3) Staff costs as percentage of total income is more or equal to 80%
+    public bool SteepDeclineInBalancesAndHighProportionStaffCosts => SlopeAnalysisNegativeAndAmongTheMostNegative
+                                                                     && MostFrequentStatusOfVolatilityAnalyses.All(b => b.VarianceStatus != BudgetForecastVarianceStatusType.ArAboveForecast)
+                                                                     && metrics.Any(m => m.MetricType.IsStaffCosts() && m.Value >= 80);
     public bool IsRed => BalancesInDeficit
                          || BalancesForecastingDeficit
                          || SteepDeclineInBalancesAndHighProportionStaffCosts
                          || SteepDeclineInBalances;
 
-    // amber
-    public bool DeclineInBalancesButNoForecastDecline => false;
-    public bool DeclineInBalancesButAboveForecastHistory => false;
-    public bool SteepInclineInBalancesForecastButBelowForecastHistory => false;
+    // The slope of the graph determined using slope analysis is negative and not among the top 10% of negative slopes (the most negative).
+    public bool DeclineInBalancesButNoForecastDecline => SlopeAnalysisNegativeAndNotAmongTheMostNegative;
+
+    // 1) The slope of the graph determined using slope analysis is negative and among the top 10% of negative slopes (the most negative).
+    // 2) The most frequent status of volatility analysis for previous years is “AR above forecast”.
+    public bool DeclineInBalancesButAboveForecastHistory => SlopeAnalysisNegativeAndAmongTheMostNegative
+                                                            && MostFrequentStatusOfVolatilityAnalyses.Any(b => b.VarianceStatus == BudgetForecastVarianceStatusType.ArAboveForecast);
+
+    // 1) The slope of the graph determined using slope analysis is positive and is among the top 10% of positive slopes
+    // 2) The most frequent status of volatility analysis for previous years is “AR significantly below forecast”.
+    public bool SteepInclineInBalancesForecastButBelowForecastHistory => SlopeAnalysisPositiveAndAmongTheMostPositive
+                                                                         && MostFrequentStatusOfVolatilityAnalyses.Any(b => b.VarianceStatus == BudgetForecastVarianceStatusType.ArSignificantlyBelowForecast);
+
     public bool IsAmber => DeclineInBalancesButNoForecastDecline
                            || DeclineInBalancesButAboveForecastHistory
                            || SteepInclineInBalancesForecastButBelowForecastHistory;
 
-    // green
-    public bool BalancesStableAndPositive => false;
-    public bool BalancesIncreasingSteadily => false;
-    public bool BalancesIncreasingSteeply => false;
+    // Trust has positive balances, and year-on-year change is less or equal to 10% 
+    public bool BalancesStableAndPositive => !BalancesForecastingDeficit
+                                             && currentReturns.Any(r => r.Year == bfrYear - 1 && r.Actual > 0)
+                                             && currentReturns.Any(r => r.Year == bfrYear && r.Actual > 0)
+                                             && (currentReturns.Where(r => r.Year == bfrYear).Select(r => r.Actual.GetValueOrDefault()).FirstOrDefault() -
+                                                 currentReturns.Where(r => r.Year == bfrYear - 1).Select(r => r.Actual.GetValueOrDefault()).FirstOrDefault())
+                                             / currentReturns.Where(r => r.Year == bfrYear - 1).Select(r => r.Actual.GetValueOrDefault()).FirstOrDefault() <= 0.1m;
+
+    // The slope of the graph determined in slope analysis is positive and not among the top 10% of positive slopes.
+    public bool BalancesIncreasingSteadily => SlopeAnalysisPositiveAndNotAmongTheMostPositive;
+
+    // 1) The slope of the graph determined in slope analysis is positive and is among the top 10% of positive slopes.
+    // 2) The most frequent status of volatility analysis for previous years is not “AR significantly below forecast”.
+    public bool BalancesIncreasingSteeply => SlopeAnalysisPositiveAndAmongTheMostPositive
+                                             && MostFrequentStatusOfVolatilityAnalyses.All(b => b.VarianceStatus != BudgetForecastVarianceStatusType.ArSignificantlyBelowForecast);
+
     public bool IsGreen => BalancesStableAndPositive
                            || BalancesIncreasingSteadily
                            || BalancesIncreasingSteeply;
@@ -48,4 +83,28 @@ public class TrustForecastViewModel(
         .ToArray();
 
     public bool HasMetrics => MetricsYear != null;
+
+    private IOrderedEnumerable<(string VarianceStatus, BudgetForecastReturn[] Statuses, int Count)> OrderedVarianceStatusFrequency => currentReturns
+        .GroupBy(r => r.VarianceStatus)
+        .Select(g => (VarianceStatus: g.Key!, Statuses: g.ToArray(), Count: g.Count()))
+        .OrderByDescending(x => x.Count);
+
+    private IEnumerable<BudgetForecastReturn> MostFrequentStatusOfVolatilityAnalyses =>
+        OrderedVarianceStatusFrequency.GroupBy(x => x.Count)
+            .Select(x => x.Key)
+            .Take(1)
+            .Join(OrderedVarianceStatusFrequency, x => x, y => y.Count, (_, s) => s.Statuses)
+            .SelectMany(x => x);
+
+    private bool SlopeAnalysisNegativeAndAmongTheMostNegative => metrics.Any(m => m.MetricType.IsSlope() && m.Value < 0)
+                                                                 && metrics.Any(m => m.MetricType.IsSlopeFlag() && m.Value == -1);
+
+    private bool SlopeAnalysisNegativeAndNotAmongTheMostNegative => metrics.Any(m => m.MetricType.IsSlope() && m.Value < 0)
+                                                                 && metrics.Any(m => m.MetricType.IsSlopeFlag() && m.Value != -1);
+
+    private bool SlopeAnalysisPositiveAndAmongTheMostPositive => metrics.Any(m => m.MetricType.IsSlope() && m.Value > 0)
+                                                                 && metrics.Any(m => m.MetricType.IsSlopeFlag() && m.Value == 1);
+
+    private bool SlopeAnalysisPositiveAndNotAmongTheMostPositive => metrics.Any(m => m.MetricType.IsSlope() && m.Value > 0)
+                                                                    && metrics.Any(m => m.MetricType.IsSlopeFlag() && m.Value != 1);
 }

--- a/web/src/Web.App/Views/TrustForecast/_Metrics.cshtml
+++ b/web/src/Web.App/Views/TrustForecast/_Metrics.cshtml
@@ -1,10 +1,11 @@
-﻿@using Web.App.Extensions
+﻿@using Web.App.Domain
+@using Web.App.Extensions
 @model Web.App.ViewModels.TrustForecastMetricsViewModel
 
 @if (Model.Year != null && Model.Metrics.Any())
 {
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-one-half-from-desktop">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
             <table class="govuk-table" id="bfr-metrics">
                 <caption class="govuk-table__caption govuk-table__caption--m">Budget forecast return metrics</caption>
                 <thead class="govuk-table__head">
@@ -14,11 +15,27 @@
                 </tr>
                 </thead>
                 <tbody class="govuk-table__body">
-                @foreach (var metric in Model.Metrics)
+                @foreach (var metric in Model.Metrics.Where(m => m.Metric != BudgetForecastReturnMetricType.GrantFundingAsPercentageOfIncome))
                 {
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">@metric.Metric</td>
-                        <td class="govuk-table__cell">@metric.Value.ToPercent()</td>
+                        <td class="govuk-table__cell">
+                            @if (metric.Metric == BudgetForecastReturnMetricType.SelfGeneratedIncomeAsPercentageOfIncome)
+                            {
+                                @:Self-generated income vs grant funding 
+                            }
+                            else
+                            {
+                                @metric.Metric
+                            }
+                        </td>
+                        <td class="govuk-table__cell">
+                            @metric.Value.ToPercent()
+                            @if (metric.Metric == BudgetForecastReturnMetricType.SelfGeneratedIncomeAsPercentageOfIncome)
+                            {
+                                @:/
+                                @Model.Metrics.SingleOrDefault(m => m.Metric == BudgetForecastReturnMetricType.GrantFundingAsPercentageOfIncome)?.Value.ToPercent()
+                            }
+                        </td>
                     </tr>
                 }
                 </tbody>

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingForecast.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingForecast.cs
@@ -72,15 +72,8 @@ public class WhenViewingForecast(SchoolBenchmarkingWebAppClient client) : PageBa
 
     private static void AssertPageLayout(IHtmlDocument page, Trust trust, BudgetForecastReturnMetric[] metrics)
     {
-        var expectedBreadcrumbs = new[]
-        {
-            ("Home", Paths.ServiceHome.ToAbsolute()),
-            ("Your trust", Paths.TrustHome(trust.CompanyNumber).ToAbsolute()),
-            ("Forecast and risks", Paths.TrustForecast(trust.CompanyNumber).ToAbsolute())
-        };
-
         DocumentAssert.AssertPageUrl(page, Paths.TrustForecast(trust.CompanyNumber).ToAbsolute());
-        DocumentAssert.Breadcrumbs(page, expectedBreadcrumbs);
+        DocumentAssert.BackLink(page, "Back", Paths.TrustHome(trust.CompanyNumber).ToAbsolute());
         DocumentAssert.TitleAndH1(page, "Forecast and risks - Financial Benchmarking and Insights Tool - GOV.UK", "Forecast and risks");
 
         var metricsTable = page.QuerySelector("#bfr-metrics tbody");

--- a/web/tests/Web.Tests/ViewModels/GivenATrustForecastViewModel.cs
+++ b/web/tests/Web.Tests/ViewModels/GivenATrustForecastViewModel.cs
@@ -1,0 +1,352 @@
+using AutoFixture;
+using Web.App.Domain;
+using Web.App.ViewModels;
+using Xunit;
+namespace Web.Tests.ViewModels;
+
+public class GivenATrustForecastViewModel
+{
+    private const int Year = 2023;
+    private readonly Fixture _fixture = new();
+    private readonly Trust _trust;
+
+    public GivenATrustForecastViewModel()
+    {
+        _trust = _fixture.Create<Trust>();
+    }
+
+    [Fact]
+    public void WhenBalanceInDeficit()
+    {
+        var metrics = Array.Empty<BudgetForecastReturnMetric>();
+        var returns = new[]
+        {
+            new BudgetForecastReturn
+            {
+                Year = Year,
+                Actual = -1_000_000m
+            }
+        };
+
+        var vm = new TrustForecastViewModel(_trust, metrics, returns, Year);
+
+        Assert.True(vm.BalancesInDeficit);
+        Assert.True(vm.IsRed);
+        Assert.False(vm.IsAmber);
+        Assert.False(vm.IsGreen);
+    }
+
+    [Fact]
+    public void WhenBalancesForecastingDeficit()
+    {
+        var metrics = Array.Empty<BudgetForecastReturnMetric>();
+        var returns = new[]
+        {
+            new BudgetForecastReturn
+            {
+                Year = Year,
+                Actual = 1_000_000m
+            },
+            new BudgetForecastReturn
+            {
+                Year = Year + 1,
+                Forecast = -1_000_000m
+            }
+        };
+
+        var vm = new TrustForecastViewModel(_trust, metrics, returns, Year);
+
+        Assert.True(vm.BalancesForecastingDeficit);
+        Assert.True(vm.IsRed);
+        Assert.False(vm.IsAmber);
+        Assert.False(vm.IsGreen);
+    }
+
+    [Fact]
+    public void WhenSteepDeclineInBalances()
+    {
+        var metrics = new[]
+        {
+            new BudgetForecastReturnMetric
+            {
+                Metric = "Slope",
+                Value = -1.23m
+            },
+            new BudgetForecastReturnMetric
+            {
+                Metric = "Slope flag",
+                Value = -1
+            },
+            new BudgetForecastReturnMetric
+            {
+                Metric = "Staff costs as percentage of income",
+                Value = 50
+            }
+        };
+        var returns = new[]
+        {
+            new BudgetForecastReturn
+            {
+                VarianceStatus = "AR above forecast"
+            },
+            new BudgetForecastReturn
+            {
+                VarianceStatus = "Stable forecast"
+            },
+            new BudgetForecastReturn
+            {
+                VarianceStatus = "Stable forecast"
+            }
+        };
+
+        var vm = new TrustForecastViewModel(_trust, metrics, returns, Year);
+
+        Assert.True(vm.SteepDeclineInBalances);
+        Assert.True(vm.IsRed);
+        Assert.False(vm.IsAmber);
+        Assert.False(vm.IsGreen);
+    }
+
+    [Fact]
+    public void WhenSteepDeclineInBalancesAndHighProportionStaffCosts()
+    {
+        var metrics = new[]
+        {
+            new BudgetForecastReturnMetric
+            {
+                Metric = "Slope",
+                Value = -1.23m
+            },
+            new BudgetForecastReturnMetric
+            {
+                Metric = "Slope flag",
+                Value = -1
+            },
+            new BudgetForecastReturnMetric
+            {
+                Metric = "Staff costs as percentage of income",
+                Value = 80
+            }
+        };
+        var returns = new[]
+        {
+            new BudgetForecastReturn
+            {
+                VarianceStatus = "AR above forecast"
+            },
+            new BudgetForecastReturn
+            {
+                VarianceStatus = "Stable forecast"
+            },
+            new BudgetForecastReturn
+            {
+                VarianceStatus = "Stable forecast"
+            }
+        };
+
+        var vm = new TrustForecastViewModel(_trust, metrics, returns, Year);
+
+        Assert.True(vm.SteepDeclineInBalancesAndHighProportionStaffCosts);
+        Assert.True(vm.IsRed);
+        Assert.False(vm.IsAmber);
+        Assert.False(vm.IsGreen);
+    }
+
+    [Fact]
+    public void WhenDeclineInBalancesButNoForecastDecline()
+    {
+        var metrics = new[]
+        {
+            new BudgetForecastReturnMetric
+            {
+                Metric = "Slope",
+                Value = -1.23m
+            },
+            new BudgetForecastReturnMetric
+            {
+                Metric = "Slope flag",
+                Value = 0
+            }
+        };
+        var returns = Array.Empty<BudgetForecastReturn>();
+
+        var vm = new TrustForecastViewModel(_trust, metrics, returns, Year);
+
+        Assert.True(vm.DeclineInBalancesButNoForecastDecline);
+        Assert.False(vm.IsRed);
+        Assert.True(vm.IsAmber);
+        Assert.False(vm.IsGreen);
+    }
+
+    [Fact]
+    public void WhenDeclineInBalancesButAboveForecastHistory()
+    {
+        var metrics = new[]
+        {
+            new BudgetForecastReturnMetric
+            {
+                Metric = "Slope",
+                Value = -1.23m
+            },
+            new BudgetForecastReturnMetric
+            {
+                Metric = "Slope flag",
+                Value = -1
+            }
+        };
+        var returns = new[]
+        {
+            new BudgetForecastReturn
+            {
+                VarianceStatus = "AR above forecast"
+            },
+            new BudgetForecastReturn
+            {
+                VarianceStatus = "Stable forecast"
+            },
+            new BudgetForecastReturn
+            {
+                VarianceStatus = "AR above forecast"
+            }
+        };
+
+        var vm = new TrustForecastViewModel(_trust, metrics, returns, Year);
+
+        Assert.True(vm.DeclineInBalancesButAboveForecastHistory);
+        Assert.False(vm.IsRed);
+        Assert.True(vm.IsAmber);
+        Assert.False(vm.IsGreen);
+    }
+
+    [Fact]
+    public void WhenSteepInclineInBalancesForecastButBelowForecastHistory()
+    {
+        var metrics = new[]
+        {
+            new BudgetForecastReturnMetric
+            {
+                Metric = "Slope",
+                Value = 1.23m
+            },
+            new BudgetForecastReturnMetric
+            {
+                Metric = "Slope flag",
+                Value = 1
+            }
+        };
+        var returns = new[]
+        {
+            new BudgetForecastReturn
+            {
+                VarianceStatus = "AR significantly below forecast"
+            },
+            new BudgetForecastReturn
+            {
+                VarianceStatus = "Stable forecast"
+            },
+            new BudgetForecastReturn
+            {
+                VarianceStatus = "AR significantly below forecast"
+            }
+        };
+
+        var vm = new TrustForecastViewModel(_trust, metrics, returns, Year);
+
+        Assert.True(vm.SteepInclineInBalancesForecastButBelowForecastHistory);
+        Assert.False(vm.IsRed);
+        Assert.True(vm.IsAmber);
+        Assert.False(vm.IsGreen);
+    }
+
+    [Fact]
+    public void WhenBalancesStableAndPositive()
+    {
+        var metrics = Array.Empty<BudgetForecastReturnMetric>();
+        var returns = new[]
+        {
+            new BudgetForecastReturn
+            {
+               Year = Year - 1,
+               Actual = 1_000_000
+            },
+            new BudgetForecastReturn
+            {
+                Year = Year,
+                Actual = 1_100_000
+            }
+        };
+
+        var vm = new TrustForecastViewModel(_trust, metrics, returns, Year);
+
+        Assert.True(vm.BalancesStableAndPositive);
+        Assert.False(vm.IsRed);
+        Assert.False(vm.IsAmber);
+        Assert.True(vm.IsGreen);
+    }
+
+    [Fact]
+    public void WhenBalancesIncreasingSteadily()
+    {
+        var metrics = new[]
+        {
+            new BudgetForecastReturnMetric
+            {
+                Metric = "Slope",
+                Value = 1.23m
+            },
+            new BudgetForecastReturnMetric
+            {
+                Metric = "Slope flag",
+                Value = 0
+            }
+        };
+        var returns = Array.Empty<BudgetForecastReturn>();
+
+        var vm = new TrustForecastViewModel(_trust, metrics, returns, Year);
+
+        Assert.True(vm.BalancesIncreasingSteadily);
+        Assert.False(vm.IsRed);
+        Assert.False(vm.IsAmber);
+        Assert.True(vm.IsGreen);
+    }
+
+    [Fact]
+    public void WhenBalancesIncreasingSteeply()
+    {
+        var metrics = new[]
+        {
+            new BudgetForecastReturnMetric
+            {
+                Metric = "Slope",
+                Value = 1.23m
+            },
+            new BudgetForecastReturnMetric
+            {
+                Metric = "Slope flag",
+                Value = 1
+            }
+        };
+        var returns = new[]
+        {
+            new BudgetForecastReturn
+            {
+                VarianceStatus = "AR significantly below forecast"
+            },
+            new BudgetForecastReturn
+            {
+                VarianceStatus = "Stable forecast"
+            },
+            new BudgetForecastReturn
+            {
+                VarianceStatus = "Stable forecast"
+            }
+        };
+
+        var vm = new TrustForecastViewModel(_trust, metrics, returns, Year);
+
+        Assert.True(vm.BalancesIncreasingSteeply);
+        Assert.False(vm.IsRed);
+        Assert.False(vm.IsAmber);
+        Assert.True(vm.IsGreen);
+    }
+}


### PR DESCRIPTION
### Context
[AB#214547](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/214547) [AB#188391](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/188391)

### Change proposed in this pull request
Rules from Word document from user story attachments used to implement logic for remaining statuses. Test coverage to validate each use case. May need to be tweaked based on feedback from client.

### Guidance to review 
`SELECT` from the `BudgetForecastReturn` table to find trusts at varying status levels to validate the expected logic.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

