### PR TITLE
Set units to 'square metre' for utilities and premises costs

### DIFF
--- a/web/src/Web.App/Views/TrustSpending/Index.cshtml
+++ b/web/src/Web.App/Views/TrustSpending/Index.cshtml
@@ -77,7 +77,10 @@
                         @await Html.PartialAsync("_PriorityTable", status.Schools, new ViewDataDictionary(ViewData)
                         {
                             {
-                                "Id", $"govuk-trust-spending-and-costs-{rating.CostCategory?.ToSlug()}-{status.Status?.ToSlug()}"
+                                "Category", rating.CostCategory
+                            },
+                            {
+                                "Status", status.Status
                             }
                         })
                     }
@@ -98,7 +101,10 @@
                         @await Html.PartialAsync("_PriorityTable", category.Schools, new ViewDataDictionary(ViewData)
                         {
                             {
-                                "Id", $"govuk-trust-spending-and-costs-{category.Category?.ToSlug()}-{rating.Status?.ToSlug()}"
+                                "Category", category.Category
+                            },
+                            {
+                                "Status", rating.Status
                             }
                         })
                     </div>

--- a/web/src/Web.App/Views/TrustSpending/_PriorityTable.cshtml
+++ b/web/src/Web.App/Views/TrustSpending/_PriorityTable.cshtml
@@ -1,10 +1,12 @@
+@using Web.App.Domain
 @using Web.App.Extensions
 @model IEnumerable<Web.App.ViewModels.RagSchoolSpendingSchoolViewModel>
 @{
-    var id = ViewData["Id"] as string;
+    var category = ViewData["Category"] as string;
+    var status = ViewData["Status"] as string;
 }
 
-<table class="govuk-table table-trust-spending-and-costs" id="@id">
+<table class="govuk-table table-trust-spending-and-costs" id="govuk-trust-spending-and-costs-@category?.ToSlug()-@status?.ToSlug()">
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header">Rank</th>
@@ -16,12 +18,13 @@
     @for (var i = 0; i < Model.Count(); i++)
     {
         var school = Model.ElementAt(i);
+        var unit = category is Category.Utilities or Category.PremisesStaffServices ? "square metre" : "pupil";
         <tr class="govuk-table__row">
             <td class="govuk-table__cell">@(i + 1)</td>
             <td class="govuk-table__cell">
                 <a class="govuk-link govuk-link--no-visited-state" href="@Url.Action("Index", "SchoolSpending", new { urn = school.Urn })">@school.Name</a>
             </td>
-            <td class="govuk-table__cell">@school.Value.ToCurrency(0) per pupil</td>
+            <td class="govuk-table__cell">@school.Value.ToCurrency(0) per @unit</td>
         </tr>
     }
     </tbody>

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingSpending.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingSpending.cs
@@ -187,15 +187,16 @@ public partial class WhenViewingSpending(SchoolBenchmarkingWebAppClient client) 
             foreach (var row in rows)
             {
                 var cols = row.QuerySelectorAll("td");
-                var rank = int.Parse(cols.ElementAt(0).GetInnerText().Trim());
                 var name = cols.ElementAt(1).GetInnerText().Trim();
                 var expenditure = cols.ElementAt(2).GetInnerText().Trim();
                 var value = decimal.Parse(DecimalRegex().Match(expenditure).Value);
+                var units = UnitsRegex().Matches(expenditure)[0].Groups[1].Value;
 
                 Assert.Contains(name, schools.Select(s => s.SchoolName));
                 var school = schools.Single(s => s.SchoolName == name);
                 var rating = ratings.Where(r => r.URN == school.URN);
                 Assert.Contains(value, rating.Select(r => r.Value));
+                Assert.Contains(units, new[] { "per pupil", "per square metre" });
 
                 rowCount++;
             }
@@ -206,4 +207,7 @@ public partial class WhenViewingSpending(SchoolBenchmarkingWebAppClient client) 
 
     [GeneratedRegex(@"[\d\.]+")]
     private static partial Regex DecimalRegex();
+
+    [GeneratedRegex(@"£[\d\.]+\s([\w\s]+)")]
+    private static partial Regex UnitsRegex();
 }


### PR DESCRIPTION
### Context
[AB#216588](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/216588) [AB#192288](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/192288)

### Change proposed in this pull request
For these two cost categories only, display spending as 'per square metre' instead of 'per pupil'.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

