### PR TITLE
Reinstated 'live' expenditure calculation on Custom Data Financials page

### DIFF
--- a/web/src/Web.App/ViewModels/SchoolCustomDataChangeViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolCustomDataChangeViewModel.cs
@@ -292,8 +292,8 @@ public class SchoolCustomDataChangeViewModel(
             Title = SchoolCustomDataViewModelTitles.TotalExpenditure,
             Name = nameof(SchoolCustomDataViewModel.TotalExpenditure),
             Current = CurrentValues.TotalExpenditure,
-            Custom = CustomInput.TotalExpenditure,
-            Hidden = true
+            Custom = CustomInput.TotalExpenditure ?? CurrentValues.TotalExpenditure,
+            ReadOnly = true
         },
         new SchoolCustomDataValueViewModel
         {
@@ -358,7 +358,8 @@ public class SchoolCustomDataChangeViewModel(
             Current = CurrentValues.TeachersFte,
             Custom = CustomInput.TeachersFte,
             Units = SchoolCustomDataValueUnits.Actual
-        }, new SchoolCustomDataValueViewModel
+        },
+        new SchoolCustomDataValueViewModel
         {
             Title = SchoolCustomDataViewModelTitles.QualifiedTeacherPercent,
             Name = nameof(SchoolCustomDataViewModel.QualifiedTeacherPercent),

--- a/web/src/Web.App/Views/SchoolCustomDataChange/FinancialData.cshtml
+++ b/web/src/Web.App/Views/SchoolCustomDataChange/FinancialData.cshtml
@@ -96,5 +96,78 @@
     <script type="module" add-nonce="true">
         import { initAll } from '/js/govuk-frontend.min.js';
         initAll();
+
+        const currentTotalExpenditureElement = document.getElementById("current-TotalExpenditure");
+        const customTotalExpenditureElement = document.getElementById("custom-TotalExpenditure");
+        const customTotalExpenditureInputElement = document.getElementById("TotalExpenditure");
+        const form = document.getElementById("form-custom-data-financial");
+        const inputs = form.getElementsByTagName("input");
+        const currencyFormatter = new Intl.NumberFormat("en-GB", { style: "currency", currency: "GBP", maximumFractionDigits: 0 });
+
+        // get the current totals to help obtain the base figures to use with custom values
+        const currentTotalExpenditure = parseFloat(currentTotalExpenditureElement.dataset.value);
+        console.debug("Current total expenditure", currentTotalExpenditure);
+        let baseExpenditure = 0;
+
+        const recalculateAndSetTotals = function() {
+            console.debug("--- Recalculate ---");
+            let customExpenditure = 0;
+
+            // for every <form>'s <input> that is not `type=hidden`:
+            //   1. parse the corresponding 'current' value
+            //   2. attempt to parse the 'custom' value in the <input>
+            //   3. add 'custom' value, if valid, otherwise 'current' value to 'custom' expenditure totals
+            for (let input of inputs) {
+                const currentValueElement = document.getElementById(`current-${input.id}`);
+                if (!currentValueElement 
+                    || input.type === "hidden" 
+                    || input.id === "TotalIncome" 
+                    || input.id === "RevenueReserve") {
+                    continue;
+                }
+
+                const currentValue = parseFloat(currentValueElement.dataset.value);
+                const value = input.value === "" ? currentValue : parseFloat(input.value);
+                if (isNaN(value)) {
+                    continue;
+                }
+
+                customExpenditure += value;
+                console.debug("Adding", value, "for", input.id, "totalling", customExpenditure);
+            }
+
+            // then calculate the new totals based on the base values calculated earlier
+            const customTotalExpenditure = customExpenditure + baseExpenditure;
+            console.debug("New custom total expenditure", customTotalExpenditure, "=", customExpenditure, "+", baseExpenditure);
+
+            // and set appropriately in the DOM
+            customTotalExpenditureElement.setAttribute("data-value", customTotalExpenditure.toString());
+            customTotalExpenditureElement.innerText = currencyFormatter.format(customTotalExpenditure);
+            customTotalExpenditureInputElement.value = customTotalExpenditure.toString();
+        }
+
+        // for every <form>'s <input> that is not `type=hidden`:
+        //   1. attach an event listener when the field is blurred
+        //   2. add corresponding 'current' value to 'current' expenditure totals
+        let currentExpenditure = 0;
+        for (let input of inputs) {
+            const currentValueElement = document.getElementById(`current-${input.id}`);
+            if (!currentValueElement 
+                || input.type === "hidden" 
+                || input.id === "TotalIncome" 
+                || input.id === "RevenueReserve") {
+                continue;
+            }
+
+            input.addEventListener("blur", recalculateAndSetTotals);
+            
+            const value = parseFloat(currentValueElement.dataset.value);
+            currentExpenditure += value;
+            console.debug("Adding", value, "for", input.id, "totalling", currentExpenditure);
+        }
+
+        // then calculate the base income/expenditure values to use when calculating the 'custom' values 
+        baseExpenditure = currentTotalExpenditure - currentExpenditure;
+        console.debug("New base expenditure", baseExpenditure, "=", currentTotalExpenditure, "-", currentExpenditure);
     </script>
 }

--- a/web/src/Web.App/Views/SchoolCustomDataChange/_CustomDataEntryTableRow.cshtml
+++ b/web/src/Web.App/Views/SchoolCustomDataChange/_CustomDataEntryTableRow.cshtml
@@ -48,7 +48,7 @@
             <span id="custom-@Model.Name" data-value="@Model.Custom">
                 @if (Model.Custom > 0)
                 {
-                    @Model.Custom.ToCurrency(Model.Custom > 1_000 ? 0 : 2)
+                    @Model.Custom.ToCurrency(0)
                 }
             </span>
             <input id="@Model.Name" name="@Model.Name" type="hidden" value="@Model.Custom"/>


### PR DESCRIPTION
### Context
[AB#216378](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/216378) [AB#198080](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/198080)

### Change proposed in this pull request
This behaviour [existed previously](https://github.com/DFE-Digital/education-benchmarking-and-insights/commit/c515f6077e972a4abb2b05cea1726198d2359d0a#diff-81473a4a2985639913c2161343efe07ad5b6853d08f07a7b49304fd890e7ab1e), before Income/RR was editable.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

