### PR TITLE
Avoid unecessary processing for custom-data

### DIFF
--- a/data-pipeline/src/pipeline/comparator_sets.py
+++ b/data-pipeline/src/pipeline/comparator_sets.py
@@ -425,7 +425,8 @@ def compute_comparator_set(
     Perform comparator-set derivation, restricted by "phase".
 
     If `data` is "custom" data, the resulting output will be restricted
-    to just the `target_urn`.
+    to just the `target_urn`. Equally, if the target is not present, an
+    empty DataFrame will be returned.
 
     :param data: data for which to determine the comparator-sets
     :param target_urn: optional identifier for custom data
@@ -455,6 +456,9 @@ def compute_comparator_set(
             "Percentage Primary Need OTH",
         ]
     ].copy()
+
+    if target_urn and target_urn not in copy.index:
+        return pd.DataFrame(columns=copy.columns)
 
     classes = copy.reset_index().groupby(["SchoolPhaseType"]).agg(list)
 

--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -738,7 +738,7 @@ def run_user_defined_rag(
     insert_metric_rag(
         run_type=run_type,
         set_type=set_type,
-        year=run_id,
+        run_id=run_id,
         df=df,
     )
 

--- a/data-pipeline/src/pipeline/pre_processing.py
+++ b/data-pipeline/src/pipeline/pre_processing.py
@@ -1246,13 +1246,18 @@ def update_custom_data(
 
     Note: only a subset of the custom fields may be present in the
     inbound message; only a subset of mapped columns may be present in
-    the existing data.
+    the existing data. Equally, the data will only be updated if the
+    target is present in the existing data.
 
     :param existing_data: existing, pre-processed data
     :param custom_data: custom financial information
     :param target_urn: specific row to update
     :return: updated data
     """
+
+    if target_urn not in existing_data.index:
+        return existing_data
+
     custom_to_columns = {
         "administrativeSuppliesNonEducationalCosts": "Administrative supplies_Administrative supplies (non educational)",
         "cateringStaffCosts": "Catering staff and supplies_Catering staff",

--- a/data-pipeline/src/pipeline/rag.py
+++ b/data-pipeline/src/pipeline/rag.py
@@ -177,7 +177,11 @@ def get_category_cols_predicates(category_name, data):
     return category_cols, sub_categories
 
 
-def compute_rag(data, comparators):
+def compute_rag(
+    data,
+    comparators,
+    target_urn: str | None = None,
+):
     keys = rag_category_settings.keys()
 
     # reduce to only used columns so that extraction routines are more efficient
@@ -197,6 +201,9 @@ def compute_rag(data, comparators):
             for indx in indices:
                 target = df.iloc[indx]
                 urn = target.name
+                if target_urn and urn != target_urn:
+                    continue
+
                 try:
                     pupil_urns = comparators["Pupil"][urn]
                     building_urns = comparators["Building"][urn]

--- a/data-pipeline/tests/unit/pre_processing/test_custom_data.py
+++ b/data-pipeline/tests/unit/pre_processing/test_custom_data.py
@@ -223,3 +223,22 @@ def test_update_custom_data_missing_columns():
     )
 
     assert "Total Internal Floor Area" not in result.columns
+
+
+def test_update_custom_data_missing_target():
+    """
+    If `target_urn` is absent, the data are unaltered.
+    """
+    df = pd.DataFrame(_default_existing_data, index=[0, 1, 2, 3])
+    custom_data = _default_custom_data | {
+        "totalInternalFloorArea": 2.0,
+        "workforceFTE": 3.0,
+    }
+
+    result = update_custom_data(
+        existing_data=df,
+        custom_data=custom_data,
+        target_urn=4,
+    )
+
+    assert 4 not in result.index


### PR DESCRIPTION
For custom-data processing:

1. when overlaying the custom data, skip processing of datasets where the target URN isn't present (previously this was effectively _adding_ this as a new row).
2. don't produce comparator-sets for datasets where the target URN isn't present (but produce an empty DataFrame with the right columns for downstream processing).
3. skip RAG calculations for all but the target URN (the comparators will be reduced as per the above but the input data is still there in its entirety; all rows need to be there for the RAG calculation but the final dataset reduced to just the relevant row).
    - skip RAG calculations entirely for datasets where the target URN isn't present (again, producing an empty, consistent DataFrame for downstream processing).