### PR TITLE
Use distinct models for add/remove school/trust comparators to separate validation rules

### DIFF
--- a/web/src/Web.App/Controllers/SchoolComparatorsCreateByController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparatorsCreateByController.cs
@@ -132,7 +132,7 @@ public class SchoolComparatorsCreateByController(
     [HttpPost]
     [Route("by/name")]
     [ExportModelState]
-    public IActionResult Name([FromRoute] string urn, [FromForm] SchoolComparatorsUrnViewModel viewModel)
+    public IActionResult Name([FromRoute] string urn, [FromForm] SchoolComparatorAddViewModel viewModel)
     {
         if (!ModelState.IsValid)
         {
@@ -145,7 +145,7 @@ public class SchoolComparatorsCreateByController(
             var countOthers = userDefinedSet.Set.Count(s => s != urn);
             if (countOthers >= 29)
             {
-                ModelState.AddModelError(nameof(SchoolComparatorsUrnViewModel.Urn), "Maximum number of comparison schools reached");
+                ModelState.AddModelError(nameof(SchoolComparatorAddViewModel.Urn), "Maximum number of comparison schools reached");
                 return RedirectToAction("Name");
             }
 
@@ -161,7 +161,7 @@ public class SchoolComparatorsCreateByController(
 
     [HttpPost]
     [Route("remove")]
-    public IActionResult Remove([FromRoute] string urn, [FromForm] SchoolComparatorsUrnViewModel viewModel)
+    public IActionResult Remove([FromRoute] string urn, [FromForm] SchoolComparatorRemoveViewModel viewModel)
     {
         if (!ModelState.IsValid)
         {

--- a/web/src/Web.App/Controllers/TrustComparatorsCreateByController.cs
+++ b/web/src/Web.App/Controllers/TrustComparatorsCreateByController.cs
@@ -132,7 +132,7 @@ public class TrustComparatorsCreateByController(
     [HttpPost]
     [Route("by/name")]
     [ExportModelState]
-    public IActionResult Name([FromRoute] string companyNumber, [FromForm] TrustComparatorsCompanyNumberViewModel viewModel)
+    public IActionResult Name([FromRoute] string companyNumber, [FromForm] TrustComparatorAddViewModel viewModel)
     {
         if (!ModelState.IsValid)
         {
@@ -145,7 +145,7 @@ public class TrustComparatorsCreateByController(
             var countOthers = userDefinedSet.Set.Count(s => s != companyNumber);
             if (countOthers >= 9)
             {
-                ModelState.AddModelError(nameof(TrustComparatorsCompanyNumberViewModel.CompanyNumber), "Maximum number of comparison trusts reached");
+                ModelState.AddModelError(nameof(TrustComparatorAddViewModel.CompanyNumber), "Maximum number of comparison trusts reached");
                 return RedirectToAction("Name");
             }
 
@@ -161,7 +161,7 @@ public class TrustComparatorsCreateByController(
 
     [HttpPost]
     [Route("remove")]
-    public IActionResult Remove([FromRoute] string companyNumber, [FromForm] TrustComparatorsCompanyNumberViewModel viewModel)
+    public IActionResult Remove([FromRoute] string companyNumber, [FromForm] TrustComparatorRemoveViewModel viewModel)
     {
         if (!ModelState.IsValid)
         {

--- a/web/src/Web.App/ViewModels/SchoolComparatorsByNameViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolComparatorsByNameViewModel.cs
@@ -14,7 +14,13 @@ public class SchoolComparatorsByNameViewModel(School school, SchoolCharacteristi
         .ToArray();
 }
 
-public record SchoolComparatorsUrnViewModel : IValidatableObject
+public record SchoolComparatorRemoveViewModel
+{
+    [Required(ErrorMessage = "Select a school to remove")]
+    public string? Urn { get; init; }
+}
+
+public record SchoolComparatorAddViewModel : IValidatableObject
 {
     public string? SchoolInput { get; init; }
     public string? Urn { get; init; }

--- a/web/src/Web.App/ViewModels/TrustComparatorsByNameViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustComparatorsByNameViewModel.cs
@@ -15,7 +15,13 @@ public class TrustComparatorsByNameViewModel(Trust trust, TrustCharacteristicUse
         .ToArray();
 }
 
-public record TrustComparatorsCompanyNumberViewModel : IValidatableObject
+public record TrustComparatorRemoveViewModel
+{
+    [Required(ErrorMessage = "Select a trust to remove")]
+    public string? CompanyNumber { get; init; }
+}
+
+public record TrustComparatorAddViewModel : IValidatableObject
 {
     public string? TrustInput { get; init; }
     public string? CompanyNumber { get; init; }


### PR DESCRIPTION
### Context
[AB#217431](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/217431) [AB#217429](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/217429)

### Change proposed in this pull request
Bug fix on school and trust manual add/remove comparators pages introduced after validation rules changed during content review.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

