### PR TITLE
fix: always inclue comparator-set columns

### DIFF
--- a/data-pipeline/src/pipeline/comparator_sets.py
+++ b/data-pipeline/src/pipeline/comparator_sets.py
@@ -426,7 +426,8 @@ def compute_comparator_set(
 
     If `data` is "custom" data, the resulting output will be restricted
     to just the `target_urn`. Equally, if the target is not present, an
-    empty DataFrame will be returned.
+    empty DataFrame will be returned (though with additional, related
+    columns).
 
     :param data: data for which to determine the comparator-sets
     :param target_urn: optional identifier for custom data
@@ -458,7 +459,7 @@ def compute_comparator_set(
     ].copy()
 
     if target_urn and target_urn not in copy.index:
-        return pd.DataFrame(columns=copy.columns)
+        return pd.DataFrame(columns=list(copy.columns) + ["Pupil", "Building"])
 
     classes = copy.reset_index().groupby(["SchoolPhaseType"]).agg(list)
 


### PR DESCRIPTION
make certain that `Pupil` and `Building` are _always_ added as columns, even if no comparator sets are generated.