### PR TITLE
Set minimum app contanier replicas to `1` for production only

### DIFF
--- a/data-pipeline/terraform/container_apps.tf
+++ b/data-pipeline/terraform/container_apps.tf
@@ -7,7 +7,7 @@ resource "azurerm_container_app_environment" "main" {
   workload_profile {
     name                  = "Pipeline"
     workload_profile_type = "D4"
-    minimum_count         = 0
+    minimum_count         = var.environment == "production" ? 3 : 0
     maximum_count         = 10
   }
 
@@ -64,7 +64,7 @@ resource "azurerm_container_app" "data-pipeline" {
   }
 
   template {
-    min_replicas    = 0
+    min_replicas    = var.environment == "production" ? 1 : 0
     max_replicas    = var.environment == "development" ? 1 : 10
     revision_suffix = replace(split(":", var.image-name)[1], ".", "-")
     container {


### PR DESCRIPTION
### Context
[AB#217528](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/217528) [AB#217527](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/217527)

### Change proposed in this pull request
Also set app container environment workload minimum count to `3` for production only

### Guidance to review 
Deployed to `d12` feature environment to validate Terraform, but impact will not be seen until pushed to production.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~~Your code builds clean without any errors or warnings~~
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

