### PR TITLE
Assigned app service system defined identity to Cosmos account with read/write role

### DIFF
--- a/web/Directory.Packages.props
+++ b/web/Directory.Packages.props
@@ -5,6 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="AngleSharp.Js" Version="0.15.0" />
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
+    <PackageVersion Include="Azure.Identity" Version="1.12.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.20.0" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageVersion Include="IdentityModel" Version="7.0.0" />

--- a/web/src/Web.App/Infrastructure/Cosmos/ClientFactory.cs
+++ b/web/src/Web.App/Infrastructure/Cosmos/ClientFactory.cs
@@ -1,6 +1,8 @@
+using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
+using Azure;
+using Azure.Identity;
 using Microsoft.Azure.Cosmos;
-
 namespace Web.App.Infrastructure.Cosmos;
 
 [ExcludeFromCodeCoverage]
@@ -9,10 +11,40 @@ public static class ClientFactory
     public static CosmosClient Create(Settings settings)
     {
         ArgumentNullException.ThrowIfNull(settings.ConnectionString);
-
-        return new CosmosClient(settings.ConnectionString, new CosmosClientOptions
+        var options = new CosmosClientOptions
         {
             ConnectionMode = settings.IsDirect ? ConnectionMode.Direct : ConnectionMode.Gateway
-        });
+        };
+
+        var key = GetAccountKey(settings.ConnectionString);
+        var endpoint = GetAccountEndpoint(settings.ConnectionString);
+        return string.IsNullOrWhiteSpace(key)
+            ? new CosmosClient(endpoint, new DefaultAzureCredential(), options)
+            : new CosmosClient(endpoint, new AzureKeyCredential(key), options);
+    }
+
+    // from CosmosClientOptions.cs
+    private static string? GetAccountEndpoint(string connectionString) => GetValueFromConnectionString(connectionString, "AccountEndpoint");
+
+    private static string? GetAccountKey(string connectionString) => GetValueFromConnectionString(connectionString, "AccountKey");
+
+    private static string? GetValueFromConnectionString(string connectionString, string keyName)
+    {
+        var builder = new DbConnectionStringBuilder
+        {
+            ConnectionString = connectionString
+        };
+        if (!builder.TryGetValue(keyName, out var value))
+        {
+            return null;
+        }
+
+        var keyNameValue = value as string;
+        if (!string.IsNullOrEmpty(keyNameValue))
+        {
+            return keyNameValue;
+        }
+
+        throw new ArgumentException("The connection string is missing a required property: " + keyName);
     }
 }

--- a/web/src/Web.App/Web.App.csproj
+++ b/web/src/Web.App/Web.App.csproj
@@ -12,6 +12,7 @@
         <NoWarn>1701;1702;CS1591</NoWarn>
     </PropertyGroup>
     <ItemGroup>
+        <PackageReference Include="Azure.Identity"/>
         <PackageReference Include="Azure.Storage.Blobs"/>
         <PackageReference Include="CorrelationId"/>
         <PackageReference Include="FluentValidation"/>

--- a/web/src/Web.App/packages.lock.json
+++ b/web/src/Web.App/packages.lock.json
@@ -2,6 +2,21 @@
   "version": 2,
   "dependencies": {
     "net8.0": {
+      "Azure.Identity": {
+        "type": "Direct",
+        "requested": "[1.12.0, )",
+        "resolved": "1.12.0",
+        "contentHash": "OBIM3aPz8n9oEO5fdnee+Vsc5Nl4W3FeslPpESyDiyByntQI5BAa76KD60eFXm9ulevnwxGZP9YXL8Y+paI5Uw==",
+        "dependencies": {
+          "Azure.Core": "1.40.0",
+          "Microsoft.Identity.Client": "4.61.3",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
+          "System.Memory": "4.5.4",
+          "System.Security.Cryptography.ProtectedData": "4.7.0",
+          "System.Text.Json": "4.7.2",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "Azure.Storage.Blobs": {
         "type": "Direct",
         "requested": "[12.20.0, )",
@@ -233,8 +248,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.39.0",
-        "contentHash": "9vaV4ZICtVQp+2wjOKrIAjEjMzBkUohaBbKGqqcTW993MRfHA0N4L1BszQjWynS7lRvlYQLxaFK4wh9ewNm4HQ==",
+        "resolved": "1.40.0",
+        "contentHash": "eOx6wk3kQ3SCnoAj7IytAu/d99l07PdarmUc+RmMkVOTkcQ3s+UQEaGzMyEqC2Ua4SKnOW4Xw/klLeB5V2PiSA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.1.1",
           "System.ClientModel": "1.0.0",
@@ -658,6 +673,24 @@
           "Microsoft.Extensions.Caching.Memory": "2.1.23",
           "Microsoft.Extensions.Configuration.Binder": "2.1.10",
           "Microsoft.Extensions.Logging": "2.1.1"
+        }
+      },
+      "Microsoft.Identity.Client": {
+        "type": "Transitive",
+        "resolved": "4.61.3",
+        "contentHash": "naJo/Qm35Caaoxp5utcw+R8eU8ZtLz2ALh8S+gkekOYQ1oazfCQMWVT4NJ/FnHzdIJlm8dMz0oMpMGCabx5odA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "6.35.0",
+          "System.Diagnostics.DiagnosticSource": "6.0.1"
+        }
+      },
+      "Microsoft.Identity.Client.Extensions.Msal": {
+        "type": "Transitive",
+        "resolved": "4.61.3",
+        "contentHash": "PWnJcznrSGr25MN8ajlc2XIDW4zCFu0U6FkpaNLEWLgd1NgFCp5uDY3mqLDgM8zCN8hqj8yo5wHYfLB2HjcdGw==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.61.3",
+          "System.Security.Cryptography.ProtectedData": "4.5.0"
         }
       },
       "Microsoft.IdentityModel.Abstractions": {

--- a/web/terraform/README.md
+++ b/web/terraform/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.98.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.110.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.6.2 |
 
 ## Modules
@@ -34,6 +34,7 @@ No modules.
 | [azurerm_cosmosdb_account.session-cache-account](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_account) | resource |
 | [azurerm_cosmosdb_sql_container.session-cache-container](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_sql_container) | resource |
 | [azurerm_cosmosdb_sql_database.session-cache-database](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_sql_database) | resource |
+| [azurerm_cosmosdb_sql_role_assignment.app-service-cache](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_sql_role_assignment) | resource |
 | [azurerm_monitor_diagnostic_setting.front-door-analytics](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_resource_group.resource-group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_service_plan.education-benchmarking-asp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_plan) | resource |

--- a/web/terraform/app-service.tf
+++ b/web/terraform/app-service.tf
@@ -91,7 +91,7 @@ resource "azurerm_windows_web_app" "education-benchmarking-as" {
     "DFESignInSettings__SignOutUri"                    = var.dfe-signin.sign-out-uri
     "DFESignInSettings__SignInUri"                     = var.dfe-signin.sign-in-uri
     "SessionData__Using"                               = "Cosmos"
-    "SessionData__Settings__ConnectionString"          = azurerm_cosmosdb_account.session-cache-account.primary_sql_connection_string
+    "SessionData__Settings__ConnectionString"          = "AccountEndpoint=${azurerm_cosmosdb_account.session-cache-account.endpoint}"
     "SessionData__Settings__ContainerName"             = azurerm_cosmosdb_sql_container.session-cache-container.name
     "SessionData__Settings__DatabaseName"              = azurerm_cosmosdb_sql_database.session-cache-database.name
     "Storage__ConnectionString"                        = azurerm_storage_account.data-source-storage.primary_connection_string

--- a/web/terraform/cache.tf
+++ b/web/terraform/cache.tf
@@ -44,3 +44,13 @@ resource "azurerm_cosmosdb_sql_container" "session-cache-container" {
   partition_key_path    = "/id"
   partition_key_version = 1
 }
+
+resource "azurerm_cosmosdb_sql_role_assignment" "app-service-cache" {
+  resource_group_name = azurerm_resource_group.resource-group.name
+  account_name        = azurerm_cosmosdb_account.session-cache-account.name
+  scope               = azurerm_cosmosdb_account.session-cache-account.id
+  principal_id        = azurerm_windows_web_app.education-benchmarking-as.identity[0].principal_id
+
+  # see https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-setup-rbac#built-in-role-definitions
+  role_definition_id = "${azurerm_cosmosdb_account.session-cache-account.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
+}

--- a/web/tests/Web.Integration.Tests/packages.lock.json
+++ b/web/tests/Web.Integration.Tests/packages.lock.json
@@ -148,8 +148,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.39.0",
-        "contentHash": "9vaV4ZICtVQp+2wjOKrIAjEjMzBkUohaBbKGqqcTW993MRfHA0N4L1BszQjWynS7lRvlYQLxaFK4wh9ewNm4HQ==",
+        "resolved": "1.40.0",
+        "contentHash": "eOx6wk3kQ3SCnoAj7IytAu/d99l07PdarmUc+RmMkVOTkcQ3s+UQEaGzMyEqC2Ua4SKnOW4Xw/klLeB5V2PiSA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.1.1",
           "System.ClientModel": "1.0.0",
@@ -726,6 +726,24 @@
           "Microsoft.Extensions.Caching.Memory": "2.1.23",
           "Microsoft.Extensions.Configuration.Binder": "2.1.10",
           "Microsoft.Extensions.Logging": "2.1.1"
+        }
+      },
+      "Microsoft.Identity.Client": {
+        "type": "Transitive",
+        "resolved": "4.61.3",
+        "contentHash": "naJo/Qm35Caaoxp5utcw+R8eU8ZtLz2ALh8S+gkekOYQ1oazfCQMWVT4NJ/FnHzdIJlm8dMz0oMpMGCabx5odA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "6.35.0",
+          "System.Diagnostics.DiagnosticSource": "6.0.1"
+        }
+      },
+      "Microsoft.Identity.Client.Extensions.Msal": {
+        "type": "Transitive",
+        "resolved": "4.61.3",
+        "contentHash": "PWnJcznrSGr25MN8ajlc2XIDW4zCFu0U6FkpaNLEWLgd1NgFCp5uDY3mqLDgM8zCN8hqj8yo5wHYfLB2HjcdGw==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.61.3",
+          "System.Security.Cryptography.ProtectedData": "4.5.0"
         }
       },
       "Microsoft.IdentityModel.Abstractions": {
@@ -2062,6 +2080,7 @@
       "web.app": {
         "type": "Project",
         "dependencies": {
+          "Azure.Identity": "[1.12.0, )",
           "Azure.Storage.Blobs": "[12.20.0, )",
           "CorrelationId": "[3.0.1, )",
           "FluentValidation": "[11.9.2, )",
@@ -2084,6 +2103,21 @@
           "Serilog.Sinks.ApplicationInsights": "[4.0.0, )",
           "SmartBreadcrumbs": "[3.6.1, )",
           "Swashbuckle.AspNetCore": "[6.6.2, )"
+        }
+      },
+      "Azure.Identity": {
+        "type": "CentralTransitive",
+        "requested": "[1.12.0, )",
+        "resolved": "1.12.0",
+        "contentHash": "OBIM3aPz8n9oEO5fdnee+Vsc5Nl4W3FeslPpESyDiyByntQI5BAa76KD60eFXm9ulevnwxGZP9YXL8Y+paI5Uw==",
+        "dependencies": {
+          "Azure.Core": "1.40.0",
+          "Microsoft.Identity.Client": "4.61.3",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
+          "System.Memory": "4.5.4",
+          "System.Security.Cryptography.ProtectedData": "4.7.0",
+          "System.Text.Json": "4.7.2",
+          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "Azure.Storage.Blobs": {

--- a/web/tests/Web.Tests/packages.lock.json
+++ b/web/tests/Web.Tests/packages.lock.json
@@ -77,8 +77,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.39.0",
-        "contentHash": "9vaV4ZICtVQp+2wjOKrIAjEjMzBkUohaBbKGqqcTW993MRfHA0N4L1BszQjWynS7lRvlYQLxaFK4wh9ewNm4HQ==",
+        "resolved": "1.40.0",
+        "contentHash": "eOx6wk3kQ3SCnoAj7IytAu/d99l07PdarmUc+RmMkVOTkcQ3s+UQEaGzMyEqC2Ua4SKnOW4Xw/klLeB5V2PiSA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.1.1",
           "System.ClientModel": "1.0.0",
@@ -523,6 +523,24 @@
           "Microsoft.Extensions.Caching.Memory": "2.1.23",
           "Microsoft.Extensions.Configuration.Binder": "2.1.10",
           "Microsoft.Extensions.Logging": "2.1.1"
+        }
+      },
+      "Microsoft.Identity.Client": {
+        "type": "Transitive",
+        "resolved": "4.61.3",
+        "contentHash": "naJo/Qm35Caaoxp5utcw+R8eU8ZtLz2ALh8S+gkekOYQ1oazfCQMWVT4NJ/FnHzdIJlm8dMz0oMpMGCabx5odA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "6.35.0",
+          "System.Diagnostics.DiagnosticSource": "6.0.1"
+        }
+      },
+      "Microsoft.Identity.Client.Extensions.Msal": {
+        "type": "Transitive",
+        "resolved": "4.61.3",
+        "contentHash": "PWnJcznrSGr25MN8ajlc2XIDW4zCFu0U6FkpaNLEWLgd1NgFCp5uDY3mqLDgM8zCN8hqj8yo5wHYfLB2HjcdGw==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.61.3",
+          "System.Security.Cryptography.ProtectedData": "4.5.0"
         }
       },
       "Microsoft.IdentityModel.Abstractions": {
@@ -1824,6 +1842,7 @@
       "web.app": {
         "type": "Project",
         "dependencies": {
+          "Azure.Identity": "[1.12.0, )",
           "Azure.Storage.Blobs": "[12.20.0, )",
           "CorrelationId": "[3.0.1, )",
           "FluentValidation": "[11.9.2, )",
@@ -1846,6 +1865,21 @@
           "Serilog.Sinks.ApplicationInsights": "[4.0.0, )",
           "SmartBreadcrumbs": "[3.6.1, )",
           "Swashbuckle.AspNetCore": "[6.6.2, )"
+        }
+      },
+      "Azure.Identity": {
+        "type": "CentralTransitive",
+        "requested": "[1.12.0, )",
+        "resolved": "1.12.0",
+        "contentHash": "OBIM3aPz8n9oEO5fdnee+Vsc5Nl4W3FeslPpESyDiyByntQI5BAa76KD60eFXm9ulevnwxGZP9YXL8Y+paI5Uw==",
+        "dependencies": {
+          "Azure.Core": "1.40.0",
+          "Microsoft.Identity.Client": "4.61.3",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
+          "System.Memory": "4.5.4",
+          "System.Security.Cryptography.ProtectedData": "4.7.0",
+          "System.Text.Json": "4.7.2",
+          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "Azure.Storage.Blobs": {


### PR DESCRIPTION
### Context
[AB#217518](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/217518) [AB#216189](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/216189)

### Change proposed in this pull request
Also updated app service Cosmos connection string to remove `AccountKey` in order for `DefaultAzureCredential` to be used instead of `AzureKeyCredential` as per the modified `ClientFactory`. Local development may continue to use the key from .NET secrets but deployments should honour the SQL RBAC.

### Guidance to review 

Deployed to `d16` feature environment for validation, but due to lack of data the underlying Cosmos connection is yet to be validated.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~~Your code builds clean without any errors or warnings~~
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

