### PR TITLE
feat: adds comparator page for workforce only

### DIFF
--- a/web/src/Web.App/ViewComponents/ComparatorSetDetailsViewComponent.cs
+++ b/web/src/Web.App/ViewComponents/ComparatorSetDetailsViewComponent.cs
@@ -5,8 +5,8 @@ namespace Web.App.ViewComponents;
 
 public class ComparatorSetDetailsViewComponent : ViewComponent
 {
-    public IViewComponentResult Invoke(string identifier, bool hasUserDefinedSet, bool hasCustomData)
+    public IViewComponentResult Invoke(string identifier, bool hasUserDefinedSet, bool hasCustomData, ComparatorSetType type = ComparatorSetType.Costs)
     {
-        return View(new ComparatorSetDetailsViewModel(identifier, hasUserDefinedSet, hasCustomData));
+        return View(new ComparatorSetDetailsViewModel(identifier, hasUserDefinedSet, hasCustomData, type));
     }
 }

--- a/web/src/Web.App/ViewModels/Components/ComparatorSetDetailsViewModel.cs
+++ b/web/src/Web.App/ViewModels/Components/ComparatorSetDetailsViewModel.cs
@@ -1,8 +1,16 @@
 ﻿namespace Web.App.ViewModels.Components;
 
-public class ComparatorSetDetailsViewModel(string identifier, bool hasUserDefinedSet, bool hasCustomData)
+public class ComparatorSetDetailsViewModel(string identifier, bool hasUserDefinedSet, bool hasCustomData, ComparatorSetType type)
 {
     public string Identifier => identifier;
     public bool HasUserDefinedSet => hasUserDefinedSet;
     public bool HasCustomData => hasCustomData;
+    public ComparatorSetType Type => type;
 }
+
+public enum ComparatorSetType
+{
+    Costs,
+    Workforce
+}
+

--- a/web/src/Web.App/Views/SchoolCensus/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolCensus/Index.cshtml
@@ -1,4 +1,5 @@
-﻿@model Web.App.ViewModels.SchoolCensusViewModel
+﻿@using Web.App.ViewModels.Components
+@model Web.App.ViewModels.SchoolCensusViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.Census;
 }
@@ -22,7 +23,8 @@
 {
     identifier = Model.Urn, 
     hasUserDefinedSet = !string.IsNullOrEmpty(Model.UserDefinedSetId), 
-    hasCustomData = !string.IsNullOrEmpty(Model.CustomDataId)
+    hasCustomData = !string.IsNullOrEmpty(Model.CustomDataId),
+    type = ComparatorSetType.Workforce
 })
 
 <div id="compare-your-census" data-type="@OrganisationTypes.School" data-id="@Model.Urn"></div>

--- a/web/src/Web.App/Views/SchoolComparators/Workforce.cshtml
+++ b/web/src/Web.App/Views/SchoolComparators/Workforce.cshtml
@@ -1,0 +1,93 @@
+﻿@using Microsoft.FeatureManagement.Mvc.TagHelpers
+@using Web.App.Extensions
+@using Web.App.TagHelpers
+@model Web.App.ViewModels.SchoolComparatorsViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.SchoolComparators;
+}
+
+@await Component.InvokeAsync("EstablishmentHeading", new
+    {
+        title = ViewData[ViewDataKeys.Title],
+        name = Model.Name,
+        id = Model.Urn,
+        kind = OrganisationTypes.School
+    })
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <p class="govuk-body">This is the set of similar schools we've chosen to benchmark this school's pupil and workforce data against.</p>
+
+        <feature name="@FeatureFlags.UserDefinedComparators">
+            @if (!Model.HasCustomData)
+            {
+                <p class="govuk-body">
+                    <a class="govuk-link govuk-link--no-visited-state"
+                       href="@Url.Action("Index", "SchoolComparatorsCreate", new { urn = Model.Urn })">
+                        Choose your own set of schools
+                    </a>
+                </p>
+            }
+        </feature>
+    </div>
+</div>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <p class="govuk-body">We've chosen @Model.PupilSchools.Count(x => x.URN != Model.Urn) similar schools to benchmark this school against running cost categories, which includes all staffing (excluding premises staff), ICT, consultancy and catering.</p>
+        <h2 class="govuk-heading-m">How we chose these schools</h2>
+        <p class="govuk-body">We chose these schools based on:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>school phase or type</li>
+            <li>region</li>
+            <li>number of pupils</li>
+            <li>pupils eligible for free school meals (FSM)</li>
+            <li>pupils with special educational needs (SEN)</li>
+        </ul>
+        <table class="govuk-table">
+            <caption class="govuk-table__caption govuk-table__caption--m">Schools we've chosen</caption>
+            <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                    <th scope="col" class="govuk-table__header">School</th>
+                    <th scope="col" class="govuk-table__header">Type</th>
+                    <th scope="col" class="govuk-table__header">Number of pupils</th>
+                    <th scope="col" class="govuk-table__header">Pupils with special educational needs</th>
+                    <th scope="col" class="govuk-table__header">Pupils eligible for free school meals</th>
+                </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+
+                @foreach (var school in Model.PupilSchools.Where(x => x.URN != Model.Urn))
+                {
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell">
+                            <strong>@school.SchoolName</strong>
+                            <br />
+                            <span class="govuk-hint">@school.Address</span>
+                        </td>
+                        <td class="govuk-table__cell">
+                            @school.OverallPhase
+                        </td>
+                        <td class="govuk-table__cell">
+                            @school.TotalPupils.GetValueOrDefault().ToNumberSeparator()
+                        </td>
+                        <td class="govuk-table__cell">
+                            @school.PercentSpecialEducationNeeds.ToPercent()
+                        </td>
+                        <td class="govuk-table__cell">
+                            @school.PercentFreeSchoolMeals.ToPercent()
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+</div>
+
+@section scripts
+{
+    <script type="module" add-nonce="true">
+        import { initAll } from '/js/govuk-frontend.min.js'
+        initAll()
+    </script>
+}

--- a/web/src/Web.App/Views/Shared/Components/ComparatorSetDetails/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/ComparatorSetDetails/Default.cshtml
@@ -1,4 +1,5 @@
 ﻿@using Microsoft.FeatureManagement.Mvc.TagHelpers
+@using Web.App.ViewModels.Components
 @model Web.App.ViewModels.Components.ComparatorSetDetailsViewModel
 
 <div class="govuk-grid-row govuk-!-margin-bottom-3">
@@ -38,34 +39,64 @@
                     View custom data set
                 </a>
             </p>
-        </feature>
+            </feature>
         }
         else
         {
-        <p class="govuk-body">
-            <a class="govuk-link govuk-link--no-visited-state"
-               href="@Url.Action("Index", "SchoolComparators", new { urn = Model.Identifier })">
-                We've chosen 2 sets of similar schools
-            </a> to benchmark this school's spending against.
-        </p>
+            if (Model.Type == ComparatorSetType.Workforce)
+            {
+                <p class="govuk-body">
+                    <a class="govuk-link govuk-link--no-visited-state"
+                       href="@Url.Action("Workforce", "SchoolComparators", new { urn = Model.Identifier })">
+                        We've chosen this set of similar schools
+                    </a> to benchmark this school's pupil and workforce data against.
+                </p>
 
-        <feature name="@FeatureFlags.UserDefinedComparators">
-            <p class="govuk-body">
-                <a class="govuk-link govuk-link--no-visited-state"
-                   href="@Url.Action("Index", "SchoolComparatorsCreate", new { urn = Model.Identifier })">
-                    Choose a new or saved set of your own schools
-                </a>
-            </p>
-        </feature>
-        <feature name="@FeatureFlags.CustomData">
-            <p class="govuk-body govuk-!-margin-bottom-0">
-                <a class="govuk-link govuk-link--no-visited-state"
-                   id="custom-data-link"
-                   href="@Url.Action("Index", "SchoolCustomData", new { urn = Model.Identifier })">
-                    Change the data for this school
-                </a>
-            </p>
-        </feature>
+                <feature name="@FeatureFlags.UserDefinedComparators">
+                    <p class="govuk-body">
+                        <a class="govuk-link govuk-link--no-visited-state"
+                           href="@Url.Action("Index", "SchoolComparatorsCreate", new { urn = Model.Identifier })">
+                            Choose a new or saved set of your own schools
+                        </a>
+                    </p>
+                </feature>
+                <feature name="@FeatureFlags.CustomData">
+                    <p class="govuk-body govuk-!-margin-bottom-0">
+                        <a class="govuk-link govuk-link--no-visited-state"
+                           id="custom-data-link"
+                           href="@Url.Action("Index", "SchoolCustomData", new { urn = Model.Identifier })">
+                            Change the data for this school
+                        </a>
+                    </p>
+                </feature>
+            }
+            else
+            {
+                <p class="govuk-body">
+                    <a class="govuk-link govuk-link--no-visited-state"
+                       href="@Url.Action("Index", "SchoolComparators", new { urn = Model.Identifier })">
+                        We've chosen 2 sets of similar schools
+                    </a> to benchmark this school's spending against.
+                </p>
+
+                <feature name="@FeatureFlags.UserDefinedComparators">
+                    <p class="govuk-body">
+                        <a class="govuk-link govuk-link--no-visited-state"
+                           href="@Url.Action("Index", "SchoolComparatorsCreate", new { urn = Model.Identifier })">
+                            Choose a new or saved set of your own schools
+                        </a>
+                    </p>
+                </feature>
+                <feature name="@FeatureFlags.CustomData">
+                    <p class="govuk-body govuk-!-margin-bottom-0">
+                        <a class="govuk-link govuk-link--no-visited-state"
+                           id="custom-data-link"
+                           href="@Url.Action("Index", "SchoolCustomData", new { urn = Model.Identifier })">
+                            Change the data for this school
+                        </a>
+                    </p>
+                </feature>
+            }
         }
     </div>
 </div>

--- a/web/tests/Web.E2ETests/Pages/School/BenchmarkCensusPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/BenchmarkCensusPage.cs
@@ -37,7 +37,7 @@ public class BenchmarkCensusPage(IPage page)
 
     private ILocator ComparatorSetDetails =>
         page.Locator(Selectors.GovLink,
-            new PageLocatorOptions { HasText = "We've chosen 2 sets of similar schools" });
+            new PageLocatorOptions { HasText = "We've chosen this set of similar schools" });
 
     private ILocator CustomComparatorLink => page.Locator(Selectors.GovLink,
         new PageLocatorOptions { HasText = "Choose a new or saved set of your own schools" });


### PR DESCRIPTION
### Context
following discussion with design and product agreed a page is required for displaying comparator set for only pupil which is relevant when viewing workforce benchmarking

### Change proposed in this pull request
Adds this page
updates e2e tests following changes

### Guidance to review 
Include any useful information needed to review this change. Include any dependencies that are required for this change. 

### Checklist
- ~[ ] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)~
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

