### PR TITLE
Fix: view or change custom data link

### DIFF
--- a/web/src/Web.App/Views/School/CustomData.cshtml
+++ b/web/src/Web.App/Views/School/CustomData.cshtml
@@ -16,7 +16,7 @@
 <p class="govuk-body">Use your customised data with the benchmarking tools below.</p>
 
 <p class="govuk-body">
-    <a href=@Url.Action("Index", "SchoolCustomData", new { urn = Model.Urn }) class="govuk-link govuk-link--no-visited-state">
+    <a href=@Url.Action("FinancialData", "SchoolCustomDataChange", new { urn = Model.Urn }) class="govuk-link govuk-link--no-visited-state">
         View or change your custom data
     </a>
 </p>

--- a/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomisedData.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomisedData.cs
@@ -130,7 +130,7 @@ public class WhenViewingCustomisedData(SchoolBenchmarkingWebAppClient client)
             "Use your customised data");
 
         var viewCustomDataLink = page.Body.SelectSingleNode("//main/div/p[2]/a") as IElement;
-        DocumentAssert.Link(viewCustomDataLink, "View or change your custom data", Paths.SchoolCustomData(school.URN).ToAbsolute());
+        DocumentAssert.Link(viewCustomDataLink, "View or change your custom data", Paths.SchoolCustomDataFinancialData(school.URN).ToAbsolute());
 
         var viewOriginalDataLink = page.Body.SelectSingleNode("//main/div/p[3]/a") as IElement;
         DocumentAssert.Link(viewOriginalDataLink, $"View the original data for {school.SchoolName}", Paths.SchoolHome(school.URN).ToAbsolute());


### PR DESCRIPTION
### Context
[AB#192482](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/192482)
fix following QA feedback

### Change proposed in this pull request
View or change your custom data now directs to financial data input page in this journey not the start page of the journey
tests also updated to reflect this change

### Guidance to review 
N/A

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

