### PR TITLE
Only output sourcemaps for dev Vite.js builds

### DIFF
--- a/front-end-components/copy-js.ps1
+++ b/front-end-components/copy-js.ps1
@@ -1,6 +1,6 @@
 npm run lint
 npm test
-npm run build
+npm run build:dev
 
 Copy-Item dist/front-end.js* ../web/src/Web.App/wwwroot/js -Verbose
 Copy-Item dist/front-end.css ../web/src/Web.App/wwwroot/css -Verbose

--- a/front-end-components/copy-js.sh
+++ b/front-end-components/copy-js.sh
@@ -2,7 +2,7 @@
 
 npm run lint
 npm test
-npm run build
+npm run build:dev
 
 mkdir -p ../web/src/Web.App/wwwroot/js
 mkdir -p ../web/src/Web.App/wwwroot/css

--- a/front-end-components/package.json
+++ b/front-end-components/package.json
@@ -9,6 +9,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --config vite.config-dev.js",
+    "build:dev": "tsc && vite build --sourcemap true",
     "build": "tsc && vite build",
     "test": "jest",
     "lint": "eslint . --ext ts,tsx,cjs --report-unused-disable-directives --max-warnings 0",

--- a/front-end-components/vite.config.ts
+++ b/front-end-components/vite.config.ts
@@ -17,7 +17,6 @@ export default defineConfig({
         assetFileNames: "front-end.[ext]",
       },
     },
-    sourcemap: true,
   },
   define: { "process.env.NODE_ENV": '"production"' },
   resolve: {

--- a/web/src/Web.App/gulpfile.js
+++ b/web/src/Web.App/gulpfile.js
@@ -14,6 +14,7 @@ const buildSass = () => gulp.src("AssetSrc/scss/*.scss")
 const copyStaticAssets = () => gulp.src(["node_modules/govuk-frontend/dist/govuk/assets/**/*"], {encoding: false}).pipe(gulp.dest("wwwroot/assets")).on("end", () =>
     gulp.src(["node_modules/govuk-frontend/dist/govuk/assets/images/favicon.ico"], {encoding: false}).pipe(gulp.dest("wwwroot/"))).on("end", () =>
     gulp.src(["node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js"]).pipe(gulp.dest("wwwroot/js/"))).on("end", () =>
+    gulp.src(["node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js.map"]).pipe(gulp.dest("wwwroot/js/"))).on("end", () =>
     gulp.src(["node_modules/front-end/dist/front-end.js"]).pipe(gulp.dest("wwwroot/js/"))).on("end", () =>
     gulp.src(["node_modules/front-end/dist/front-end.css"]).pipe(gulp.dest("wwwroot/css/"))).on("end", () =>
     gulp.src(["AssetSrc/images/*"], {encoding: false}).pipe(gulp.dest("wwwroot/assets/images")));


### PR DESCRIPTION
### Context
[AB#217989](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/217989) [AB#217950](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/217950)

### Change proposed in this pull request
JS source maps were being generated for all Vite builds. Config updated to not produce these by default rather use [CLI argument](https://vitejs.dev/guide/cli#build) instead. Also include `govuk-frontend.min.js.map` in Web `wwwroot` as per [GDS instructions](https://frontend.design-system.service.gov.uk/install-using-precompiled-files/#copy-and-install-the-precompiled-files) (at least for the time being).

### Guidance to review 
CI build should not produce the source maps, so once deployed to `d01` there should no longer be `404`s reported trying to resolve this missing asset. For local dev purposes, the `copy-js.XXX` commands should still produce the source maps for debug support.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~~Your code builds clean without any errors or warnings~~
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

