### PR TITLE
fix: remove link when no rag is available

### DIFF
--- a/web/src/Web.App/ViewModels/RagViewModel.cs
+++ b/web/src/Web.App/ViewModels/RagViewModel.cs
@@ -7,7 +7,7 @@ public abstract class RagViewModel(int red, int amber, int green)
     public int Green => green;
     public decimal RedRatio => Total > 0 ? red / Total : 0;
     public decimal AmberRatio => Total > 0 ? amber / Total : 0;
-    private decimal Total => red + amber + green;
+    public decimal Total => red + amber + green;
 }
 
 public class RagCostCategoryViewModel(string? category, int red, int amber, int green) : RagViewModel(red, amber, green)

--- a/web/src/Web.App/Views/Trust/_SchoolsSection.cshtml
+++ b/web/src/Web.App/Views/Trust/_SchoolsSection.cshtml
@@ -16,7 +16,14 @@
         {
             <tr class="govuk-table__row">
                 <td class="govuk-body-s">
-                    <a class="govuk-link govuk-link--no-visited-state" href="@Url.Action("Index", "SchoolSpending", new { urn = school.Urn })">@school.Name</a>
+                    @if (school.Total <= 0)
+                    {
+                        @school.Name
+                    }
+                    else
+                    {
+                        <a class="govuk-link govuk-link--no-visited-state" href="@Url.Action("Index", "SchoolSpending", new { urn = school.Urn })">@school.Name</a>    
+                    }
                 </td>
                 <td>
                     @await Component.InvokeAsync("RagStack", new


### PR DESCRIPTION
### Context
AB#217937 AB#218005

### Change proposed in this pull request
Removes link when no rag is available. thus not sending the user to a potential 404.

### Guidance to review 
N/A

### Checklist
- [ ] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally

