### PR TITLE
Typo in `HistoricChart` for Investment Income

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -100,7 +100,8 @@
       data-type="local-authority"
       data-id="383"
     ></div>-->
-    <div id="budget-forecast-returns" data-id="01532445"></div>
+    <!--<div id="budget-forecast-returns" data-id="01532445"></div>-->
+    <div id="historic-data" data-type="trust" data-id="10377760"></div>
     <script type="module" src="/src/main.tsx"></script>
     <script
       type="module"

--- a/front-end-components/src/components/charts/utils.ts
+++ b/front-end-components/src/components/charts/utils.ts
@@ -80,7 +80,7 @@ export function fullValueFormatter(
   options?: Partial<ValueFormatterOptions>
 ): string {
   if (typeof value !== "number") {
-    return String(value) || "";
+    return value ? String(value) : "";
   }
 
   return new Intl.NumberFormat("en-GB", {

--- a/front-end-components/src/views/historic-data/partials/income-section-self-generated.tsx
+++ b/front-end-components/src/views/historic-data/partials/income-section-self-generated.tsx
@@ -237,7 +237,7 @@ export const IncomeSectionSelfGenerated: React.FC<{
             chartName="Investment income"
             data={data}
             seriesConfig={{
-              directRevenueFinancing: {
+              investmentIncome: {
                 label: "Investment income",
                 visible: true,
               },


### PR DESCRIPTION
### Context
[AB#218017](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/218017) [AB#217960](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/217960)

### Change proposed in this pull request
Fixed typo - the wrong value was attempting to be rendered in the historical chart. Use empty string instead of `undefined` in tables where values are missing.

### Guidance to review 
Run Vite dev server in `front-end-components` to load Trust that was previously experiencing this issue, but now renders correctly.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

