### PR TITLE
Remove Trust History tab

### DIFF
--- a/web/src/Web.App/Views/Trust/Details.cshtml
+++ b/web/src/Web.App/Views/Trust/Details.cshtml
@@ -1,22 +1,27 @@
 ﻿@using Web.App.Extensions
-@using Web.App.TagHelpers
 @model Web.App.ViewModels.TrustViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.TrustContactDetails;
 }
 
-@await Component.InvokeAsync("EstablishmentHeading", new { title = ViewData[ViewDataKeys.Title], name = Model.Name, id = Model.CompanyNumber, kind = OrganisationTypes.Trust })
+@await Component.InvokeAsync("EstablishmentHeading", new
+{
+    title = ViewData[ViewDataKeys.Title],
+    name = Model.Name,
+    id = Model.CompanyNumber,
+    kind = OrganisationTypes.Trust
+})
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <p class="govuk-body">
             @Html.TrackedAnchor(
-                     TrackedLinks.SchoolDetails,
-                     Constants.GiasTrustUrl(Model.Uid),
-                     "Get more information about this trust",
-                     "Opens in a new window",
-                     "_blank",
-                     ["noopener", "noreferrer", "external"])
+                TrackedLinks.SchoolDetails,
+                Constants.GiasTrustUrl(Model.Uid),
+                "Get more information about this trust",
+                "Opens in a new window",
+                "_blank",
+                ["noopener", "noreferrer", "external"])
 
         </p>
         <dl class="govuk-summary-list">
@@ -41,7 +46,7 @@
                     {
                         <strong class="app-tag-login govuk-!-text-align-centre govuk-!-font-weight-bold">
                             Log in to view contact information
-                        </strong>    
+                        </strong>
                     }
                 </dd>
             </div>
@@ -52,42 +57,13 @@
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
 <h2 class="govuk-heading-m">Schools currently in this trust</h2>
-
-<div class="govuk-tabs" data-module="govuk-tabs">
-    <h2 class="govuk-tabs__title">
-        Contents
-    </h2>
-    <ul class="govuk-tabs__list" role="tablist">
-        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected" role="presentation">
-            <a class="govuk-tabs__tab" href="#current" id="tab_current" role="tab" aria-controls="current" aria-selected="true" tabindex="0">
-                Schools currently in trust
-            </a>
-        </li>
-        <li class="govuk-tabs__list-item" role="presentation">
-            <a class="govuk-tabs__tab" href="#history" id="tab_history" role="tab" aria-controls="history" aria-selected="false" tabindex="-1">
-                Trust history
-            </a>
-        </li>
+<div id="current">
+    <ul class="govuk-list">
+        @foreach (var school in Model.Schools)
+        {
+            <li>
+                <a class="govuk-link govuk-link--no-visited-state" href="@Url.Action("Index", "School", new { urn = school.URN })">@school.SchoolName</a>
+            </li>
+        }
     </ul>
-    <div class="govuk-tabs__panel" id="current" role="tabpanel" aria-labelledby="tab_current">
-        <h2 class="govuk-heading-s">Schools currently in trust</h2>
-        <ul class="govuk-list">
-            @foreach (var school in Model.Schools)
-            {
-                <li>
-                    <a class="govuk-link govuk-link--no-visited-state" href="@Url.Action("Index", "School", new {urn = school.URN})">@school.SchoolName</a>
-                </li>
-            }
-        </ul>
-    </div>
-    <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="history" role="tabpanel" aria-labelledby="tab_history">
-    </div>
 </div>
-
-@section scripts
-                {
-    <script type="module" add-nonce="true">
-        import { initAll } from '/js/govuk-frontend.min.js'
-        initAll()
-    </script>
-}


### PR DESCRIPTION
### Context
[AB#218036](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/218036) [AB#218015](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/218015)

### Change proposed in this pull request
The Trust History feature is not yet production ready and so has been removed from the UI.

### Guidance to review 
View any Trust Details page to ensure that there is no mention of Trust History.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

