### PR TITLE
fix: exclude catering net costs for custom-data

### DIFF
--- a/data-pipeline/src/pipeline/pre_processing.py
+++ b/data-pipeline/src/pipeline/pre_processing.py
@@ -1618,6 +1618,10 @@ def _post_process_custom(
         0.0
     ] * len(zero_column_indices)
 
+    # TODO: `_Net Costs` need to be recalculated as per line 1152.
+    catering_net_costs = target_data["Catering staff and supplies_Net Costs"].copy()
+    target_data["Catering staff and supplies_Net Costs"] = 0.0
+
     for category, settings in config.rag_category_settings.items():
         basis_data = target_data[
             (
@@ -1627,5 +1631,7 @@ def _post_process_custom(
             )
         ]
         target_data = mappings.map_cost_series(category, target_data, basis_data)
+
+    target_data["Catering staff and supplies_Net Costs"] = catering_net_costs
 
     return target_data


### PR DESCRIPTION
- `Catering staff and supplies_Net Costs` are normally calculated _after_ other fields;
- for custom-data, this field must be excluded from `_Total` calculations;
- for now, temporarily set this to zero to allow the existing logic to be re-used, before setting the value back to its original.
