### PR TITLE
fix: use gias_all_links for Trust info.

### DIFF
--- a/data-pipeline/src/pipeline/database.py
+++ b/data-pipeline/src/pipeline/database.py
@@ -161,19 +161,19 @@ def insert_schools_and_trusts_and_local_authorities(
     logger.info(f"Wrote {len(write_frame)} rows to school {run_type} - {year}")
 
     trust_projections = {
-        "Trust Name": "TrustName",
+        "Group Name": "TrustName",
         "Group UID": "UID",
         "CFO name": "CFOName",
         "CFO email": "CFOEmail",
         "OpenDate": "OpenDate",
-        "Company Registration Number": "CompanyNumber",
+        "Companies House Number": "CompanyNumber",
     }
 
     trusts = (
-        df[~df["Company Registration Number"].isna()]
+        df[~df["Companies House Number"].isna()]
         .reset_index()
-        .sort_values(by=["Company Registration Number", "OpenDate"], ascending=False)
-        .groupby(["Company Registration Number"])
+        .sort_values(by=["Companies House Number", "OpenDate"], ascending=False)
+        .groupby(["Companies House Number"])
         .first()
         .reset_index()
         .rename(columns=trust_projections)[[*trust_projections.values()]]

--- a/data-pipeline/src/pipeline/database.py
+++ b/data-pipeline/src/pipeline/database.py
@@ -127,7 +127,7 @@ def insert_schools_and_trusts_and_local_authorities(
         "URN": "URN",
         "EstablishmentName": "SchoolName",
         "Company Registration Number": "TrustCompanyNumber",
-        "Trust Name": "TrustName",
+        "Group Name": "TrustName",
         "Federation Lead School URN": "FederationLeadURN",
         "Federation Name": "FederationLeadName",
         "LA Code": "LACode",

--- a/data-pipeline/src/pipeline/pre_processing.py
+++ b/data-pipeline/src/pipeline/pre_processing.py
@@ -738,7 +738,7 @@ def build_academy_data(
         index_col=input_schemas.groups_index_col,
         usecols=input_schemas.groups.keys(),
         dtype=input_schemas.groups,
-    )[["Group Type", "Group UID"]]
+    )[["Group Type", "Group UID", "Group Name", "Companies House Number"]]
 
     group_links = group_links[
         group_links["Group Type"].isin(

--- a/data-pipeline/src/pipeline/pre_processing.py
+++ b/data-pipeline/src/pipeline/pre_processing.py
@@ -1611,12 +1611,8 @@ def _post_process_custom(
         if column.startswith(category) and column.endswith(("_Per Unit", "_Total"))
     ]
     zero_column_indices = [target_data.columns.get_loc(c) for c in zero_columns]
-    target_data.iloc[
-        0,
-        zero_column_indices,
-    ] = [
-        0.0
-    ] * len(zero_column_indices)
+    zero_column_values = [0.0] * len(zero_column_indices)
+    target_data.iloc[0, zero_column_indices] = zero_column_values
 
     # TODO: `_Net Costs` need to be recalculated as per line 1152.
     catering_net_costs = target_data["Catering staff and supplies_Net Costs"].copy()


### PR DESCRIPTION
### Context

there is an inconsistency between the  Trust information in    `academy_master_list` and `gias_all_links`: rely on the latter for    Trust-related data.

[AB#218046](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/218046)
[AB#218339](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/218339)

### Change proposed in this pull request

change the data used for the `TrustName` column from `Trust Name` (from the `academy_master_list` file) to `Group Name` (from the `gias_all_links` file) for consistency with `Group UID`.

### Guidance to review 

…

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally

