### PR TITLE
chore: add apportionment for missing values

### DIFF
--- a/data-pipeline/src/pipeline/pre_processing.py
+++ b/data-pipeline/src/pipeline/pre_processing.py
@@ -984,6 +984,43 @@ def build_academy_data(
             academies[target_income_col] + academies[income_col]
         )
 
+
+    academies["In year balance_CS"] = academies["In year balance_CS"] * (
+        academies["Number of pupils"].astype(float)
+        / academies["Total pupils in trust"].astype(float)
+    )
+
+    academies["In year balance_CS"] = (
+        academies["In year balance"] + academies["In year balance_CS"]
+    )
+
+    academies["Revenue reserve_CS"] = academies["Revenue reserve_CS"] * (
+        academies["Number of pupils"].astype(float)
+        / academies["Total pupils in trust"].astype(float)
+    )
+
+    academies["Revenue reserve"] = (
+        academies["Revenue reserve"] + academies["Revenue reserve_CS"]
+    )
+
+    academies["Total Income_CS"] = academies["Total Income_CS"] * (
+        academies["Number of pupils"].astype(float)
+        / academies["Total pupils in trust"].astype(float)
+    )
+
+    academies["Total Income"] = (
+        academies["Total Income"] + academies["Total Income_CS"]
+    )
+
+    academies["Total Expenditure_CS"] = academies["Total Expenditure_CS"] * (
+        academies["Number of pupils"].astype(float)
+        / academies["Total pupils in trust"].astype(float)
+    )
+
+    academies["Total Expenditure"] = (
+        academies["Total Expenditure"] + academies["Total Expenditure_CS"]
+    )
+
     academies["Catering staff and supplies_Net Costs"] = (
         academies["Income_Catering services"]
         + academies["Catering staff and supplies_Total"]
@@ -1006,10 +1043,6 @@ def build_academy_data(
     )
 
     academies = academies.merge(trust_revenue_reserve, on="Trust UPIN", how="left")
-
-    academies["Trust Revenue reserve"] = (
-        academies["Revenue reserve_CS"] + academies["Trust Revenue reserve"]
-    )
 
     academies["Company Registration Number"] = academies[
         "Company Registration Number"


### PR DESCRIPTION
### Context
[AB#218640](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/218640)

### Change proposed in this pull request
Adds apportionment calculation for revenue reserve, in-year balance, total income and total expenditure.

Currently just sorting the whole CS value for all schools

![image](https://github.com/user-attachments/assets/5694050f-a149-438c-b2fb-7b708bbeeea1)


### Guidance to review 
N/A

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

