### PR TITLE
feat: filter other costs from ratings

### DIFF
--- a/web/src/Web.App/ViewModels/SchoolViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolViewModel.cs
@@ -24,7 +24,7 @@ public class SchoolViewModel(School school)
 
         HasMetricRag = ratingsArray.Length != 0;
         Ratings = ratingsArray
-            .Where(x => x.RAG is "red" or "amber")
+            .Where(x => x.RAG is "red" or "amber" && x.Category is not Category.Other)
             .OrderBy(x => Lookups.StatusOrderMap[x.RAG ?? string.Empty])
             .ThenByDescending(x => x.Decile)
             .ThenByDescending(x => x.Value)
@@ -40,7 +40,7 @@ public class SchoolViewModel(School school)
 
         HasMetricRag = ratingsArray.Length != 0;
         Ratings = ratingsArray
-            .Where(x => x.RAG is "red" or "amber")
+            .Where(x => x.RAG is "red" or "amber" && x.Category is not Category.Other)
             .OrderBy(x => Lookups.StatusOrderMap[x.RAG ?? string.Empty])
             .ThenByDescending(x => x.Decile)
             .ThenByDescending(x => x.Value);


### PR DESCRIPTION
### Context
[AB#218546](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/218546) - [AB#220130](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/220130)

### Change proposed in this pull request
Excludes category "Other costs" from Ratings property so this is not displayed in the Top spending priorities on the school homepage.

### Guidance to review 
To confirm run locally with the example provided in the story where this occurs to confirm the change.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

