### PR TITLE
filter other costs for school homepage only

### DIFF
--- a/web/src/Web.App/ViewModels/SchoolViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolViewModel.cs
@@ -40,7 +40,7 @@ public class SchoolViewModel(School school)
 
         HasMetricRag = ratingsArray.Length != 0;
         Ratings = ratingsArray
-            .Where(x => x.RAG is "red" or "amber" && x.Category is not Category.Other)
+            .Where(x => x.RAG is "red" or "amber")
             .OrderBy(x => Lookups.StatusOrderMap[x.RAG ?? string.Empty])
             .ThenByDescending(x => x.Decile)
             .ThenByDescending(x => x.Value);


### PR DESCRIPTION
### Context
[AB#218546](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/218546) - [AB#220226](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/220226)

### Change proposed in this pull request
Correct filtering of Ratings on SchoolViewModel to now only filter for school homepage. Not find ways to spend less page as introduced by #1130 

### Guidance to review 
Using the example in the story can confirm locally school homepage no longer displays Other costs as a priority but on the find ways to spend less page other costs is still included in the recommended section.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

