### PR TITLE
fix: correct percentile calculation

### DIFF
--- a/data-pipeline/src/pipeline/rag.py
+++ b/data-pipeline/src/pipeline/rag.py
@@ -109,7 +109,7 @@ def find_percentile(d, value):
     sorted_series = np.sort(d, axis=0, kind="stable")
     rank = np.searchsorted(sorted_series, value, side="right")
     pc = rank / len(d) * 100
-    return pc - 1
+    return pc
 
 
 def category_stats(urn, category_name, data, ofsted_rating, rag_mapping, close_count):

--- a/data-pipeline/tests/unit/rag/test_percentile.py
+++ b/data-pipeline/tests/unit/rag/test_percentile.py
@@ -1,0 +1,33 @@
+import pandas
+import pytest
+
+from src.pipeline.rag import find_percentile
+
+
+@pytest.mark.parametrize(
+    "score,expected",
+    [
+        (2, 9),
+        (4, 18),
+        (6, 27),
+        (8, 36),
+        (13, 45),
+        (16, 54),
+        (22, 63),
+        (35, 72),
+        (40, 81),
+        (42, 90),
+        (48, 100),
+    ],
+)
+def test_simple_range(score: int, expected: int):
+    """
+    Note: expected values derived from
+    `scipy.stats.percentileofscore(kind="rank")`.
+
+    :param score: to determine percentile of
+    :param expected: expected percentile
+    """
+    scores = pandas.Series([2, 4, 6, 8, 13, 16, 22, 35, 40, 42, 48])
+
+    assert int(find_percentile(scores, score)) == expected


### PR DESCRIPTION
### Context

As per [AB#216667](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/216667), percentile calculations are off by one.

### Change proposed in this pull request

1. Adding tests to validate the expected values.
2. Removing the decrement of the calculated percentile.

### Guidance to review 

I've used [`scipy.stats.percentilofscore()`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.percentileofscore.html) to calculate the expected values, which tally with the expectations as per the ticket.

Note: `scipy` recognises various "percentile" calculations, as per the `kind` parameter:

* `rank` is the variant used for the above and matches the client expectations, as per the ticket.
* `strict` is one variant which includes values _strictly less_ than the score—this may have been the intention but the final percentile was decremented, whereas it should possibly have been the rank).

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

