### PR TITLE
Include school phase breakdown in Trust Comparators table

### DIFF
--- a/core-infrastructure/src/db/Core.Database/Scripts/048-AlterSchoolPhasesCoveredByTrust.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/048-AlterSchoolPhasesCoveredByTrust.sql
@@ -1,0 +1,34 @@
+ALTER VIEW SchoolPhasesCoveredByTrust AS
+SELECT
+    CompanyNumber,
+    CONCAT(
+        '[',
+        STRING_AGG(
+            CONCAT(
+                '{"phase":"',
+                OverallPhase,
+                '","count":',
+                Count,
+                '}'
+            ),
+            ','
+        ),
+        ']'
+    ) 'PhasesCovered'
+FROM
+    (
+        SELECT
+            DISTINCT TrustCompanyNumber 'CompanyNumber',
+            OverallPhase,
+            COUNT(OverallPhase) 'Count'
+        FROM
+            School
+        WHERE
+            TrustCompanyNumber IS NOT NULL
+        GROUP BY
+            TrustCompanyNumber,
+            OverallPhase
+    ) t
+GROUP BY
+    t.CompanyNumber
+GO

--- a/platform/src/apis/Platform.Api.Insight/Trusts/TrustCharacteristic.cs
+++ b/platform/src/apis/Platform.Api.Insight/Trusts/TrustCharacteristic.cs
@@ -1,6 +1,8 @@
 ﻿using System;
-using Newtonsoft.Json;
+using System.Linq;
+using System.Text.Json.Serialization;
 using Platform.Functions.Extensions;
+// ReSharper disable PropertyCanBeMadeInitOnly.Global
 
 namespace Platform.Api.Insight.Trusts;
 
@@ -18,6 +20,18 @@ public record TrustCharacteristic
 
     [JsonIgnore]
     public string? PhasesCovered { get; set; }
-    public string[] Phases => PhasesCovered == null ? Array.Empty<string>() : PhasesCovered.FromJson<string[]>();
+    public TrustPhase[] Phases => PhasesCovered == null
+        ? []
+        : PhasesCovered.Contains("count")
+            ? PhasesCovered.FromJson<TrustPhase[]>()
+            : PhasesCovered.FromJson<string[]>().Select(p => new TrustPhase
+            {
+                Phase = p
+            }).ToArray();
+}
 
+public record TrustPhase
+{
+    public string? Phase { get; set; }
+    public int? Count { get; set; }
 }

--- a/platform/src/apis/Platform.Api.Insight/Trusts/TrustsFunctions.cs
+++ b/platform/src/apis/Platform.Api.Insight/Trusts/TrustsFunctions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
@@ -12,7 +11,6 @@ using Platform.Functions.Extensions;
 using Platform.Functions.OpenApi;
 namespace Platform.Api.Insight.Trusts;
 
-[ApiExplorerSettings(GroupName = "Trusts")]
 public class TrustsFunctions(ILogger<TrustsFunctions> logger, ITrustsService service)
 {
     [Function(nameof(QueryTrustsCharacteristicsAsync))]

--- a/platform/tests/Platform.ApiTests/Features/InsightTrusts.feature
+++ b/platform/tests/Platform.ApiTests/Features/InsightTrusts.feature
@@ -1,14 +1,25 @@
 ﻿Feature: Insights trusts endpoints
-        
+
     Scenario: Sending valid trust characteristics requests
         Given a valid trust characteristics request with company numbers:
-           | CompanyNumber |
-           | 10020683      |
-           | 10038640      |
-           | 10050238      |
+          | CompanyNumber |
+          | 10020683      |
+          | 10038640      |
+          | 10050238      |
+          | 10749662      |
+          | 10499174      |
         When I submit the insight trusts request
         Then the trust characteristics results should be ok and contain:
-          | CompanyNumber | TrustName               | TotalIncome | TotalPupils | SchoolsInTrust | OpenDate             | PercentFreeSchoolMeals | PercentSpecialEducationNeeds | TotalInternalFloorArea | 
-          | 10020683      | Test Company/Trust  244 |             | 128.0       | 1.0            | 9/1/2021 12:00:00 AM | 6.0                    | 0.0                          | 3710.0                 |        
-          | 10038640      | Test Company/Trust  334 |             | 292.0       | 1.0            | 6/1/2016 12:00:00 AM | 14.0                   | 0.0                          | 25572.0                |        
-          | 10050238      | Test Company/Trust  388 |             | 139.0       | 1.0            | 9/1/2017 12:00:00 AM | 7.0                    | 0.0                          | 17322.0                |         
+          | CompanyNumber | TrustName               | TotalIncome | TotalPupils | SchoolsInTrust | OpenDate             | PercentFreeSchoolMeals | PercentSpecialEducationNeeds | TotalInternalFloorArea |
+          | 10020683      | Test Company/Trust  244 |             | 128.0       | 1.0            | 9/1/2021 12:00:00 AM | 6.0                    | 0.0                          | 3710.0                 |
+          | 10038640      | Test Company/Trust  334 |             | 292.0       | 1.0            | 6/1/2016 12:00:00 AM | 14.0                   | 0.0                          | 25572.0                |
+          | 10050238      | Test Company/Trust  388 |             | 139.0       | 1.0            | 9/1/2017 12:00:00 AM | 7.0                    | 0.0                          | 17322.0                |
+          | 10499174      | Heart of Mercia         |             | 747         | 3              | 3/1/2017 12:00:00 AM | 9.666666               | 0                            | 7255                   |
+          | 10749662      | Hamwic Education Trust  |             | 694         | 3              | 3/1/2014 12:00:00 AM | 10.333333              | 0                            | 6686                   |
+        And the phases should contain:
+          | CompanyNumber | Phases                             |
+          | 10020683      | Special: 1                         |
+          | 10038640      | Pupil referral unit: 1             |
+          | 10050238      | All-through: 1                     |
+          | 10499174      | 16 plus: 3                         |
+          | 10749662      | Primary: 2, Pupil referral unit: 1 |

--- a/platform/tests/Platform.ApiTests/Steps/InsightTrustsSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/InsightTrustsSteps.cs
@@ -4,7 +4,6 @@ using Platform.Api.Insight.Trusts;
 using Platform.ApiTests.Drivers;
 using Platform.Functions.Extensions;
 using TechTalk.SpecFlow.Assist;
-
 namespace Platform.ApiTests.Steps;
 
 [Binding]
@@ -40,6 +39,19 @@ public class InsightTrustsSteps(InsightApiDriver api)
         var content = await response.Content.ReadAsByteArrayAsync();
         var results = content.FromJson<TrustCharacteristic[]>();
         table.CompareToSet(results);
+    }
+
+    [Then("the phases should contain:")]
+    public async Task ThenThePhasesShouldContain(Table table)
+    {
+        var response = api[InsightTrustsKey].Response;
+        var content = await response.Content.ReadAsByteArrayAsync();
+        var results = content.FromJson<TrustCharacteristic[]>();
+        table.CompareToSet(results.Select(r => new
+        {
+            r.CompanyNumber,
+            Phases = string.Join(", ", r.Phases.Select(p => $"{p.Phase}: {(p.Count.HasValue ? p.Count.ToString() : "?")}"))
+        }));
     }
 
     private static IEnumerable<string> GetFirstColumnsFromTableRowsAsString(Table table)

--- a/web/src/Web.App/Domain/Insight/TrustCharacteristic.cs
+++ b/web/src/Web.App/Domain/Insight/TrustCharacteristic.cs
@@ -11,7 +11,7 @@ public record TrustCharacteristic
     public decimal? PercentFreeSchoolMeals { get; set; }
     public decimal? PercentSpecialEducationNeeds { get; set; }
     public decimal? TotalInternalFloorArea { get; set; }
-    public string[] Phases { get; set; } = [];
+    public TrustPhase[] Phases { get; set; } = [];
 }
 
 public record TrustCharacteristicUserDefined
@@ -21,4 +21,11 @@ public record TrustCharacteristicUserDefined
     public decimal? TotalIncome { get; set; }
     public decimal? TotalPupils { get; set; }
     public decimal? SchoolsInTrust { get; set; }
+    public TrustPhase[] Phases { get; set; } = [];
+}
+
+public record TrustPhase
+{
+    public string? Phase { get; set; }
+    public int? Count { get; set; }
 }

--- a/web/src/Web.App/Views/TrustComparatorsCreateBy/Characteristic.cshtml
+++ b/web/src/Web.App/Views/TrustComparatorsCreateBy/Characteristic.cshtml
@@ -5,7 +5,7 @@
 @model Web.App.ViewModels.TrustComparatorsByCharacteristicViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.TrustComparatorsCreateByCharacteristic;
-    var phases = Model.Characteristic?.Phases ?? [];
+    var phases = Model.Characteristic?.Phases.Select(p => p.Phase).OfType<string>().ToArray() ?? [];
 }
 
 @await Component.InvokeAsync("EstablishmentHeading", new

--- a/web/src/Web.App/Views/TrustComparatorsCreateBy/Preview.cshtml
+++ b/web/src/Web.App/Views/TrustComparatorsCreateBy/Preview.cshtml
@@ -60,7 +60,7 @@
                 <tbody class="govuk-table__body">
                 @foreach (var characteristic in Model.Characteristics)
                 {
-                    var phases = characteristic.Phases;
+                    var phases = characteristic.Phases.Select(p => p.Phase).OfType<string>().ToArray();
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">
                             <span class="govuk-body govuk-!-font-weight-bold">@characteristic.TrustName</span><br>

--- a/web/src/Web.App/Views/TrustComparatorsCreateBy/_ChosenTrusts.cshtml
+++ b/web/src/Web.App/Views/TrustComparatorsCreateBy/_ChosenTrusts.cshtml
@@ -33,7 +33,17 @@
                     <br/>
                     <span class="govuk-hint">@trust.CompanyNumber</span>
                 </td>
-                <td class="govuk-table__cell">@trust.SchoolsInTrust.GetValueOrDefault().ToSimpleDisplay()</td>
+                <td class="govuk-table__cell">
+                    @trust.SchoolsInTrust.GetValueOrDefault().ToSimpleDisplay()
+                    @($"school{(trust.SchoolsInTrust == 1 ? string.Empty : "s")}")
+                    <p class="govuk-hint govuk-!-margin-top-1 govuk-!-font-size-16">
+                        @foreach (var phase in trust.Phases.Where(p => p.Count.HasValue))
+                        {
+                            <span>@phase.Count @phase.Phase?.ToLower()</span>
+                            <br/>
+                        }
+                    </p>
+                </td>
                 <td class="govuk-table__cell">@trust.TotalPupils.GetValueOrDefault().ToNumberSeparator()</td>
                 <td class="govuk-table__cell">@trust.TotalIncome?.ToCurrency(0)</td>
                 <td class="govuk-table__cell">

--- a/web/tests/Web.A11yTests/Pages/Trust/Comparators/WhenViewingComparatorsByName.cs
+++ b/web/tests/Web.A11yTests/Pages/Trust/Comparators/WhenViewingComparatorsByName.cs
@@ -31,7 +31,7 @@ public class WhenViewingComparatorsByName(ITestOutputHelper testOutputHelper, We
     public async Task ValidationErrorThenThereAreNoAccessibilityIssues()
     {
         await GoToPage();
-        await Page.Locator("button[type='submit']").ClickAsync();
+        await Page.Locator("main button[type='submit']").ClickAsync();
         await EvaluatePage(_context);
     }
 
@@ -43,7 +43,7 @@ public class WhenViewingComparatorsByName(ITestOutputHelper testOutputHelper, We
         await Page.Locator("#trust-input__listbox.autocomplete__menu--visible").WaitForAsync();
         await Page.Keyboard.DownAsync("ArrowDown");
         await Page.Keyboard.DownAsync("Enter");
-        await Page.Locator("button[type='submit']").ClickAsync();
+        await Page.Locator("main button[type='submit']").ClickAsync();
         await EvaluatePage(_context);
     }
 }


### PR DESCRIPTION
### Context
[AB#220506](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/220506) [AB#217226](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/217226)

### Change proposed in this pull request
Modified view and bound type to parse trust school phase count as well as name.

### Guidance to review 
The figures will only show up on environment(s) where the database migration script has been executed to include the phase counts. 

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

