### PR TITLE
Fixed flaky integration test

### DIFF
--- a/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingHome.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingHome.cs
@@ -81,9 +81,22 @@ public class WhenViewingHome(SchoolBenchmarkingWebAppClient client) : PageBase<S
             .With(x => x.TrustCompanyNumber, trust.CompanyNumber)
             .CreateMany(20).ToArray();
 
+        var values = AllCostCategories.Where(k => k.Key != 9).Select(c => c.Value);
+        var queue = new Queue<string>();
         var ratings = Fixture.Build<RagRating>()
             .OmitAutoProperties()
-            .With(x => x.Category, () => AllCostCategories.Values.ElementAt(random.Next(0, AllCostCategories.Keys.Count - 1)))
+            .With(x => x.Category, () =>
+            {
+                if (queue.Count == 0)
+                {
+                    foreach (var value in values)
+                    {
+                        queue.Enqueue(value);
+                    }
+                }
+
+                return queue.Dequeue();
+            })
             .With(x => x.RAG, () => Lookups.StatusPriorityMap.Keys.ElementAt(random.Next(0, Lookups.StatusPriorityMap.Keys.Count - 1)))
             .CreateMany(50).ToArray();
 


### PR DESCRIPTION
### Context
AB#218028 AB#220562

### Change proposed in this pull request
Fixed flaky test by ensuring that all cost categories are evenly assigned to ratings rather than using `Random`

### Guidance to review 
Run the `WhenViewingHome` integration tests a few times. The failure should never occur after this fix.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

