### PR TITLE
adds clickable bar chart for trust home school list

### DIFF
--- a/front-end-components/src/index.css
+++ b/front-end-components/src/index.css
@@ -211,7 +211,7 @@
 }
 
 .composed-container {
-  min-height: 200px;
+  min-height: 335px;
 }
 
 .composed-chart-wrapper {

--- a/front-end-components/src/index.css
+++ b/front-end-components/src/index.css
@@ -210,6 +210,10 @@
   color: inherit;
 }
 
+.composed-container {
+  min-height: 200px;
+}
+
 .composed-chart-wrapper {
   height: 100%;
 }

--- a/web/src/Web.App/ViewModels/SchoolSpendingViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolSpendingViewModel.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using Web.App.Domain;
 
 namespace Web.App.ViewModels;
@@ -19,8 +20,14 @@ public class SchoolSpendingViewModel(
 
     public string? CustomDataId => customDataId;
 
-    public IEnumerable<CostCategory> PriorityCosts => _categories
-        .Where(x => x.Rating.RAG is "red" or "amber")
+    public IEnumerable<CostCategory> HighPriorityCosts => _categories
+        .Where(x => x.Rating.RAG is "red")
+        .OrderBy(x => Lookups.StatusOrderMap[x.Rating.RAG ?? string.Empty])
+        .ThenByDescending(x => x.Rating.Decile)
+        .ThenByDescending(x => x.Rating.Value);
+    
+    public IEnumerable<CostCategory> MediumPriorityCosts => _categories
+        .Where(x => x.Rating.RAG is "amber")
         .OrderBy(x => Lookups.StatusOrderMap[x.Rating.RAG ?? string.Empty])
         .ThenByDescending(x => x.Rating.Decile)
         .ThenByDescending(x => x.Rating.Value);
@@ -50,4 +57,12 @@ public class ChartStatsViewModel
     public decimal? Difference { get; set; }
     public decimal? PercentDifference { get; set; }
 
+}
+
+public class CostsViewModel
+{
+    public IEnumerable<CostCategory> Costs { get; init; } = Array.Empty<CostCategory>();
+    public string? Id { get; init; }
+    public string? Urn { get; init; }
+    public bool HasIncompleteData { get; init; }
 }

--- a/web/src/Web.App/ViewModels/SchoolSpendingViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolSpendingViewModel.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using Web.App.Domain;
 
 namespace Web.App.ViewModels;
@@ -25,7 +24,7 @@ public class SchoolSpendingViewModel(
         .OrderBy(x => Lookups.StatusOrderMap[x.Rating.RAG ?? string.Empty])
         .ThenByDescending(x => x.Rating.Decile)
         .ThenByDescending(x => x.Rating.Value);
-    
+
     public IEnumerable<CostCategory> MediumPriorityCosts => _categories
         .Where(x => x.Rating.RAG is "amber")
         .OrderBy(x => Lookups.StatusOrderMap[x.Rating.RAG ?? string.Empty])

--- a/web/src/Web.App/Views/SchoolSpending/CustomData.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/CustomData.cshtml
@@ -1,6 +1,4 @@
-﻿@using Web.App.Extensions
-@using Newtonsoft.Json
-@using Web.App.ViewModels
+﻿@using Web.App.ViewModels
 @model Web.App.ViewModels.SchoolSpendingViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.Spending;
@@ -20,7 +18,7 @@
         id = Model.Urn,
     })
 
-@if (Model.PriorityCosts.Any())
+@if (Model.HighPriorityCosts.Any() || Model.MediumPriorityCosts.Any())
 {
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
@@ -28,31 +26,22 @@
             <p class="govuk-body">This shows where spending is different to similar schools.</p>
         </div>
     </div>
-
-    @foreach (var category in Model.PriorityCosts)
+    
+    @await Html.PartialAsync("_Costs", new CostsViewModel
     {
-        <div class="govuk-grid-row govuk-!-margin-bottom-4">
-            <div class="govuk-grid-column-two-thirds">
-                <h3 class="govuk-heading-s govuk-!-font-size-27">@category.Rating.Category</h3>
-                <p class="priority @category.Rating.PriorityTag?.Class govuk-body govuk-!-margin-bottom-0">
-                    @await Component.InvokeAsync("Tag", new { rating = new RatingViewModel(category.Rating.PriorityTag?.Colour, category.Rating.PriorityTag?.DisplayText) })
-                    Spends more than <strong>@category.Rating.Percentile.ToPercent()</strong> of similar schools.
-                </p>
-                <div class="govuk-!-margin-bottom-2"
-                     data-spending-and-costs-composed
-                     data-json="@category.Values.Select(x => new { urn = x.Key, amount = x.Value.Value }).ToArray().ToJson(Formatting.None)"
-                     data-highlight="@Model.Urn"
-                     data-suffix="@category.Rating.Unit"
-                     data-sort-direction="asc"
-                     data-stats="@SchoolSpendingViewModel.Stats(category.Rating).ToJson(Formatting.None)"
-                     data-has-incomplete-data="@Model.HasIncompleteData">
-                </div>
-                <p class="govuk-body">
-                    <a href="@Url.Action("CustomData", "SchoolComparison", new { urn = Model.Urn })#@category.Rating.CostCategoryAnchorId" class="govuk-link govuk-link--no-visited-state">View all @category.Rating.Category?.ToLower() costs</a>
-                </p>
-            </div>
-        </div>
-    }
+        Costs = Model.HighPriorityCosts,
+        Id = "high-priority",
+        Urn = Model.Urn,
+        HasIncompleteData = Model.HasIncompleteData
+    })
+    
+    @await Html.PartialAsync("_Costs", new CostsViewModel
+    {
+        Costs = Model.MediumPriorityCosts,
+        Id = "medium-priority",
+        Urn = Model.Urn,
+        HasIncompleteData = Model.HasIncompleteData
+    })
 }
 
 @if (Model.LowPriorityCosts.Any())
@@ -63,31 +52,14 @@
             <p class="govuk-body">This shows where spending is close to similar schools.</p>
         </div>
     </div>
-
-    @foreach (var category in Model.LowPriorityCosts)
+    
+    @await Html.PartialAsync("_Costs", new CostsViewModel
     {
-        <div class="govuk-grid-row govuk-!-margin-bottom-4">
-            <div class="govuk-grid-column-two-thirds">
-                <h3 class="govuk-heading-s govuk-!-font-size-27">@category.Rating.Category</h3>
-                <p class="priority @category.Rating.PriorityTag?.Class govuk-body">
-                    @await Component.InvokeAsync("Tag", new { rating = new RatingViewModel(category.Rating.PriorityTag?.Colour, category.Rating.PriorityTag?.DisplayText) })
-                    Spends more than <strong>@category.Rating.Percentile.ToPercent()</strong> of similar schools.
-                </p>
-                <div class="govuk-!-margin-bottom-2"
-                     data-spending-and-costs-composed
-                     data-json="@category.Values.Select(x => new { urn = x.Key, amount = x.Value.Value }).ToArray().ToJson(Formatting.None)"
-                     data-highlight="@Model.Urn"
-                     data-suffix="@category.Rating.Unit"
-                     data-sort-direction="asc"
-                     data-stats="@SchoolSpendingViewModel.Stats(category.Rating).ToJson(Formatting.None)"
-                     data-has-incomplete-data="@Model.HasIncompleteData">
-                </div>
-                <p class="govuk-body">
-                    <a href="@Url.Action("CustomData", "SchoolComparison", new { urn = Model.Urn })#@category.Rating.CostCategoryAnchorId" class="govuk-link govuk-link--no-visited-state">View all @category.Rating.Category?.ToLower() costs</a>
-                </p>
-            </div>
-        </div>
-    }
+        Costs = Model.LowPriorityCosts,
+        Id = "low-priority",
+        Urn = Model.Urn,
+        HasIncompleteData = Model.HasIncompleteData
+    })
 }
 
 @await Component.InvokeAsync("CustomDataFinanceTools", new

--- a/web/src/Web.App/Views/SchoolSpending/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/Index.cshtml
@@ -1,7 +1,4 @@
-﻿@using Web.App.Extensions
-@using Newtonsoft.Json
-@using Web.App.ViewModels
-@using Web.App.Domain
+﻿@using Web.App.ViewModels
 
 @model Web.App.ViewModels.SchoolSpendingViewModel
 @{
@@ -29,7 +26,7 @@
     hasCustomData = !string.IsNullOrEmpty(Model.CustomDataId)
 })
 
-@if (Model.PriorityCosts.Any())
+@if (Model.HighPriorityCosts.Any() || Model.MediumPriorityCosts.Any())
 {
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
@@ -37,41 +34,22 @@
             <p class="govuk-body">This shows where spending is different to similar schools.</p>
         </div>
     </div>
-
-    @foreach (var category in Model.PriorityCosts)
+    
+    @await Html.PartialAsync("_Costs", new CostsViewModel
     {
-        var categoryToLower = @category.Rating.Category == Category.Other
-            ? "other"
-            : @category.Rating.Category == Category.EducationalIct
-            ? "Educational ICT"
-            : @category.Rating.Category?.ToLower();
-
-        var categoryHeading = @category.Rating.Category == Category.NonEducationalSupportStaff
-            ? "Non-educational support staff"
-            : @category.Rating.Category;
-
-        <div class="govuk-grid-row govuk-!-margin-bottom-4">
-            <div class="govuk-grid-column-two-thirds">
-                <h3 class="govuk-heading-s govuk-!-font-size-27">@categoryHeading</h3>
-                <p class="priority @category.Rating.PriorityTag?.Class govuk-body govuk-!-margin-bottom-0">
-                    @await Component.InvokeAsync("Tag", new { rating = new RatingViewModel(category.Rating.PriorityTag?.Colour, category.Rating.PriorityTag?.DisplayText) })
-                    Spending is higher than <strong>@category.Rating.Percentile.ToPercent()</strong> of similar schools.
-                </p>
-                <div class="govuk-!-margin-bottom-2"
-                     data-spending-and-costs-composed
-                     data-json="@category.Values.Select(x => new { urn = x.Key, amount = x.Value.Value }).ToArray().ToJson(Formatting.None)"
-                     data-highlight="@Model.Urn"
-                     data-suffix="@category.Rating.Unit"
-                     data-sort-direction="asc"
-                     data-stats="@SchoolSpendingViewModel.Stats(category.Rating).ToJson(Formatting.None)"
-                     data-has-incomplete-data="@Model.HasIncompleteData">
-                </div>
-                <p class="govuk-body">
-                        <a href="comparison#@category.Rating.CostCategoryAnchorId" class="govuk-link govuk-link--no-visited-state">View all @categoryToLower costs</a>
-                </p>
-            </div>
-        </div>
-    }
+        Costs = Model.HighPriorityCosts,
+        Id = "high-priority",
+        Urn = Model.Urn,
+        HasIncompleteData = Model.HasIncompleteData
+    })
+    
+    @await Html.PartialAsync("_Costs", new CostsViewModel
+    {
+        Costs = Model.MediumPriorityCosts,
+        Id = "medium-priority",
+        Urn = Model.Urn,
+        HasIncompleteData = Model.HasIncompleteData
+    })    
 }
 
 @if (Model.LowPriorityCosts.Any())
@@ -82,39 +60,12 @@
             <p class="govuk-body">This shows where spending is close to similar schools.</p>
         </div>
     </div>
-
-    @foreach (var category in Model.LowPriorityCosts)
+    
+    @await Html.PartialAsync("_Costs", new CostsViewModel
     {
-        var categoryToLower = @category.Rating.Category == Category.Other
-            ? "other"
-            : @category.Rating.Category == Category.EducationalIct
-            ? "Educational ICT"
-            : @category.Rating.Category?.ToLower();
-
-        var categoryHeading = @category.Rating.Category == Category.NonEducationalSupportStaff
-            ? "Non-educational support staff"
-            : @category.Rating.Category;
-
-        <div class="govuk-grid-row govuk-!-margin-bottom-4">
-            <div class="govuk-grid-column-two-thirds">
-                <h3 class="govuk-heading-s govuk-!-font-size-27">@categoryHeading</h3>
-                <p class="priority @category.Rating.PriorityTag?.Class govuk-body">
-                    @await Component.InvokeAsync("Tag", new { rating = new RatingViewModel(category.Rating.PriorityTag?.Colour, category.Rating.PriorityTag?.DisplayText) })
-                    Spends more than <strong>@category.Rating.Percentile.ToPercent()</strong> of similar schools.
-                </p>
-                <div class="govuk-!-margin-bottom-2"
-                     data-spending-and-costs-composed
-                     data-json="@category.Values.Select(x => new { urn = x.Key, amount = x.Value.Value }).ToArray().ToJson(Formatting.None)"
-                     data-highlight="@Model.Urn"
-                     data-suffix="@category.Rating.Unit"
-                     data-sort-direction="asc"
-                     data-stats="@SchoolSpendingViewModel.Stats(category.Rating).ToJson(Formatting.None)"
-                     data-has-incomplete-data="@Model.HasIncompleteData">
-                </div>
-                <p class="govuk-body">
-                    <a href="comparison#@category.Rating.CostCategoryAnchorId" class="govuk-link govuk-link--no-visited-state">View all @categoryToLower costs</a>
-                </p>
-            </div>
-        </div>
-    }
+        Costs = Model.LowPriorityCosts,
+        Id = "low-priority",
+        Urn = Model.Urn,
+        HasIncompleteData = Model.HasIncompleteData
+    }) 
 }

--- a/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
@@ -27,7 +27,7 @@
                         @await Component.InvokeAsync("Tag", new { rating = new RatingViewModel(category.Rating.PriorityTag?.Colour, category.Rating.PriorityTag?.DisplayText) })
                         Spending is higher than <strong>@category.Rating.Percentile.ToPercent()</strong> of similar schools.
                     </p>
-                    <div class="govuk-!-margin-bottom-2"
+                    <div class="govuk-!-margin-bottom-2 composed-container"
                          data-spending-and-costs-composed
                          data-json="@category.Values.Select(x => new { urn = x.Key, amount = x.Value.Value }).ToArray().ToJson(Formatting.None)"
                          data-highlight="@Model.Urn"

--- a/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
@@ -1,0 +1,45 @@
+@using Web.App.Extensions
+@using Newtonsoft.Json
+@using Web.App.ViewModels
+@using Web.App.Domain
+
+@model CostsViewModel
+
+@if (Model.Costs.Any())
+    {
+        <a id=@Model.Id></a>
+        @foreach (var category in Model.Costs)
+        {
+            var categoryToLower = @category.Rating.Category == Category.Other
+                ? "other"
+                : @category.Rating.Category == Category.EducationalIct
+                    ? "Educational ICT"
+                    : @category.Rating.Category?.ToLower();
+
+            var categoryHeading = @category.Rating.Category == Category.NonEducationalSupportStaff
+                ? "Non-educational support staff"
+                : @category.Rating.Category;
+
+            <div class="govuk-grid-row govuk-!-margin-bottom-4">
+                <div class="govuk-grid-column-two-thirds">
+                    <h3 class="govuk-heading-s govuk-!-font-size-27">@categoryHeading</h3>
+                    <p class="priority @category.Rating.PriorityTag?.Class govuk-body govuk-!-margin-bottom-0">
+                        @await Component.InvokeAsync("Tag", new { rating = new RatingViewModel(category.Rating.PriorityTag?.Colour, category.Rating.PriorityTag?.DisplayText) })
+                        Spending is higher than <strong>@category.Rating.Percentile.ToPercent()</strong> of similar schools.
+                    </p>
+                    <div class="govuk-!-margin-bottom-2"
+                         data-spending-and-costs-composed
+                         data-json="@category.Values.Select(x => new { urn = x.Key, amount = x.Value.Value }).ToArray().ToJson(Formatting.None)"
+                         data-highlight="@Model.Urn"
+                         data-suffix="@category.Rating.Unit"
+                         data-sort-direction="asc"
+                         data-stats="@SchoolSpendingViewModel.Stats(category.Rating).ToJson(Formatting.None)"
+                         data-has-incomplete-data="@Model.HasIncompleteData">
+                    </div>
+                    <p class="govuk-body">
+                        <a href="comparison#@category.Rating.CostCategoryAnchorId" class="govuk-link govuk-link--no-visited-state">View all @categoryToLower costs</a>
+                    </p>
+                </div>
+            </div>
+        }
+    }

--- a/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
@@ -6,40 +6,44 @@
 @model CostsViewModel
 
 @if (Model.Costs.Any())
+{
+    var costs = Model.Costs.ToList();
+        
+    @for (var i = 0; i < costs.Count; i++)
     {
-        <a id=@Model.Id></a>
-        @foreach (var category in Model.Costs)
-        {
-            var categoryToLower = @category.Rating.Category == Category.Other
-                ? "other"
-                : @category.Rating.Category == Category.EducationalIct
-                    ? "Educational ICT"
-                    : @category.Rating.Category?.ToLower();
+        var category = costs[i];
+        
+        var categoryToLower = @category.Rating.Category == Category.Other
+            ? "other"
+            : @category.Rating.Category == Category.EducationalIct
+                ? "Educational ICT"
+                : @category.Rating.Category?.ToLower();
 
-            var categoryHeading = @category.Rating.Category == Category.NonEducationalSupportStaff
-                ? "Non-educational support staff"
-                : @category.Rating.Category;
+        var categoryHeading = @category.Rating.Category == Category.NonEducationalSupportStaff
+            ? "Non-educational support staff"
+            : @category.Rating.Category;
 
-            <div class="govuk-grid-row govuk-!-margin-bottom-4">
-                <div class="govuk-grid-column-two-thirds">
-                    <h3 class="govuk-heading-s govuk-!-font-size-27">@categoryHeading</h3>
-                    <p class="priority @category.Rating.PriorityTag?.Class govuk-body govuk-!-margin-bottom-0">
-                        @await Component.InvokeAsync("Tag", new { rating = new RatingViewModel(category.Rating.PriorityTag?.Colour, category.Rating.PriorityTag?.DisplayText) })
-                        Spending is higher than <strong>@category.Rating.Percentile.ToPercent()</strong> of similar schools.
-                    </p>
-                    <div class="govuk-!-margin-bottom-2 composed-container"
-                         data-spending-and-costs-composed
-                         data-json="@category.Values.Select(x => new { urn = x.Key, amount = x.Value.Value }).ToArray().ToJson(Formatting.None)"
-                         data-highlight="@Model.Urn"
-                         data-suffix="@category.Rating.Unit"
-                         data-sort-direction="asc"
-                         data-stats="@SchoolSpendingViewModel.Stats(category.Rating).ToJson(Formatting.None)"
-                         data-has-incomplete-data="@Model.HasIncompleteData">
-                    </div>
-                    <p class="govuk-body">
-                        <a href="comparison#@category.Rating.CostCategoryAnchorId" class="govuk-link govuk-link--no-visited-state">View all @categoryToLower costs</a>
-                    </p>
+        <div class="govuk-grid-row govuk-!-margin-bottom-4"
+             @(i == 0 ? $"id={Model.Id}" : "")>
+            <div class="govuk-grid-column-two-thirds">
+                <h3 class="govuk-heading-s govuk-!-font-size-27">@categoryHeading</h3>
+                <p class="priority @category.Rating.PriorityTag?.Class govuk-body govuk-!-margin-bottom-0">
+                    @await Component.InvokeAsync("Tag", new { rating = new RatingViewModel(category.Rating.PriorityTag?.Colour, category.Rating.PriorityTag?.DisplayText) })
+                    Spending is higher than <strong>@category.Rating.Percentile.ToPercent()</strong> of similar schools.
+                </p>
+                <div class="govuk-!-margin-bottom-2 composed-container"
+                     data-spending-and-costs-composed
+                     data-json="@category.Values.Select(x => new { urn = x.Key, amount = x.Value.Value }).ToArray().ToJson(Formatting.None)"
+                     data-highlight="@Model.Urn"
+                     data-suffix="@category.Rating.Unit"
+                     data-sort-direction="asc"
+                     data-stats="@SchoolSpendingViewModel.Stats(category.Rating).ToJson(Formatting.None)"
+                     data-has-incomplete-data="@Model.HasIncompleteData">
                 </div>
+                <p class="govuk-body">
+                    <a href="comparison#@category.Rating.CostCategoryAnchorId" class="govuk-link govuk-link--no-visited-state">View all @categoryToLower costs</a>
+                </p>
             </div>
-        }
+        </div>
     }
+}

--- a/web/src/Web.App/Views/Trust/_SchoolsSection.cshtml
+++ b/web/src/Web.App/Views/Trust/_SchoolsSection.cshtml
@@ -32,7 +32,10 @@
                         red = school.Red,
                         amber = school.Amber,
                         green = school.Green,
-                        height = 15
+                        height = 15,
+                        redHref = $"{@Url.Action("Index", "SchoolSpending", new { urn = school.Urn })}#high-priority",
+                        amberHref = $"{@Url.Action("Index", "SchoolSpending", new { urn = school.Urn })}#medium-priority",
+                        greenHref = $"{@Url.Action("Index", "SchoolSpending", new { urn = school.Urn })}#low-priority",
                     })
                 </td>
             </tr>


### PR DESCRIPTION
### Context
[AB#217308](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/217308) - [AB#220879](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/220879)

### Change proposed in this pull request

- Adds functionality to navigate from the school lists bar charts directly to the school spending page at the first cost category of that priority type (ie high, medium, low)
- Refactors both the school spending page and the custom data version to use a partial for each category.
- Also adds CSS to add a min height to the container as without this the page will update after the user has navigated causing the desired element to be out of view.

### Guidance to review 
N/A

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

