### PR TITLE
chore: adds benchmark comparator set unit tests

### DIFF
--- a/platform/tests/Platform.Tests/Benchmark/WhenFunctionReceivesCreateComparatorSetRequest.cs
+++ b/platform/tests/Platform.Tests/Benchmark/WhenFunctionReceivesCreateComparatorSetRequest.cs
@@ -174,7 +174,7 @@ public class WhenFunctionReceivesCreateComparatorSetRequest : ComparatorSetsFunc
         Assert.NotNull(response.HttpResponse);
         Assert.Equal(HttpStatusCode.InternalServerError, response.HttpResponse.StatusCode);
     }
-    
+
     [Fact]
     public async Task CreateUserDefinedTrustShouldCreateSuccessfully()
     {

--- a/platform/tests/Platform.Tests/Benchmark/WhenFunctionReceivesCreateComparatorSetRequest.cs
+++ b/platform/tests/Platform.Tests/Benchmark/WhenFunctionReceivesCreateComparatorSetRequest.cs
@@ -1,0 +1,276 @@
+using AutoFixture;
+using FluentValidation.Results;
+using System.Net;
+using Moq;
+using Platform.Api.Benchmark.ComparatorSets;
+using Xunit;
+
+namespace Platform.Tests.Benchmark;
+
+public class WhenFunctionReceivesCreateComparatorSetRequest : ComparatorSetsFunctionsTestBase
+{
+    private readonly Fixture _fixture = new();
+
+    [Fact]
+    public async Task CreateUserDefinedShouldCreateSuccessfully()
+    {
+
+        var model = _fixture.
+            Build<ComparatorSetUserDefinedRequest>()
+            .Create();
+
+        Service
+            .Setup(
+                d => d.UpsertUserDefinedSchoolAsync(
+                    It.IsAny<ComparatorSetUserDefinedSchool>()));
+
+        Service
+            .Setup(d => d.UpsertUserDataAsync(
+                It.IsAny<ComparatorSetUserData>()));
+
+        Service
+            .Setup(d => d.CurrentYearAsync())
+            .ReturnsAsync("2024");
+
+        SchoolValidator
+            .Setup(
+                d => d.ValidateAsync(
+                    It.IsAny<ComparatorSetUserDefinedSchool>(), default))
+            .ReturnsAsync(new ValidationResult());
+
+        var response =
+            await Functions.CreateUserDefinedSchoolComparatorSetAsync(
+                CreateHttpRequestDataWithBody(model),
+                "123321",
+                "testIdentifier");
+
+        Assert.NotNull(response);
+        Assert.NotNull(response.HttpResponse);
+        Assert.Equal(HttpStatusCode.Accepted, response.HttpResponse.StatusCode);
+        Assert.Empty(response.Messages);
+        Service.Verify(
+            x => x.UpsertUserDefinedSchoolAsync(
+                It.IsAny<ComparatorSetUserDefinedSchool>()), Times.Once());
+        Service.Verify(
+            x => x.UpsertUserDataAsync(
+                It.IsAny<ComparatorSetUserData>()), Times.Once());
+
+    }
+
+    [Fact]
+    public async Task CreateUserDefinedShouldCreateSuccessfullyWithSetGreaterThanTen()
+    {
+        var model = _fixture.
+            Build<ComparatorSetUserDefinedRequest>()
+            .With(x => x.Set, ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"])
+            .Create();
+
+        Service
+            .Setup(
+                d => d.UpsertUserDefinedSchoolAsync(
+                    It.IsAny<ComparatorSetUserDefinedSchool>()));
+
+        Service
+            .Setup(d => d.UpsertUserDataAsync(
+                It.IsAny<ComparatorSetUserData>()));
+
+        Service
+            .Setup(d => d.CurrentYearAsync())
+            .ReturnsAsync("2024");
+
+        SchoolValidator
+            .Setup(
+                d => d.ValidateAsync(
+                    It.IsAny<ComparatorSetUserDefinedSchool>(), default))
+            .ReturnsAsync(new ValidationResult());
+
+        var response =
+            await Functions.CreateUserDefinedSchoolComparatorSetAsync(
+                CreateHttpRequestDataWithBody(model),
+                "123321",
+                "testIdentifier");
+
+        Assert.NotNull(response);
+        Assert.NotNull(response.HttpResponse);
+        Assert.Equal(HttpStatusCode.Accepted, response.HttpResponse.StatusCode);
+        Assert.NotEmpty(response.Messages);
+        Service.Verify(
+            x => x.UpsertUserDefinedSchoolAsync(
+                It.IsAny<ComparatorSetUserDefinedSchool>()), Times.Once());
+        Service.Verify(
+            x => x.UpsertUserDataAsync(
+                It.IsAny<ComparatorSetUserData>()), Times.Once());
+    }
+
+    [Fact]
+    public async Task CreateUserDefinedShouldBeBadRequestWhenInvalid()
+    {
+        var model = _fixture.
+            Build<ComparatorSetUserDefinedRequest>()
+            .Create();
+
+        Service
+            .Setup(
+                d => d.UpsertUserDefinedSchoolAsync(
+                    It.IsAny<ComparatorSetUserDefinedSchool>()));
+
+        Service
+            .Setup(d => d.UpsertUserDataAsync(
+                It.IsAny<ComparatorSetUserData>()));
+
+        Service
+            .Setup(d => d.CurrentYearAsync())
+            .ReturnsAsync("2024");
+
+        SchoolValidator
+            .Setup(
+                d => d.ValidateAsync(
+                    It.IsAny<ComparatorSetUserDefinedSchool>(), default))
+            .ReturnsAsync(new ValidationResult
+            {
+                Errors = [new ValidationFailure("TestName", "test error")]
+            });
+
+        var response =
+            await Functions.CreateUserDefinedSchoolComparatorSetAsync(
+                CreateHttpRequestDataWithBody(model),
+                "123321",
+                "testIdentifier");
+
+        Assert.NotNull(response);
+        Assert.NotNull(response.HttpResponse);
+        Assert.Equal(HttpStatusCode.BadRequest, response.HttpResponse.StatusCode);
+        Assert.Empty(response.Messages);
+        Service.Verify(
+            x => x.UpsertUserDefinedSchoolAsync(
+                It.IsAny<ComparatorSetUserDefinedSchool>()), Times.Never());
+        Service.Verify(
+            x => x.UpsertUserDataAsync(
+                It.IsAny<ComparatorSetUserData>()), Times.Never());
+    }
+
+    [Fact]
+    public async Task CreateUserDefinedShouldBe500OnError()
+    {
+        var set = new[] { "1", "2" };
+
+        var model = _fixture.
+            Build<ComparatorSetUserDefinedRequest>()
+            .With(x => x.Set, set)
+            .Create();
+
+        Service
+            .Setup(
+                d => d.UpsertUserDefinedSchoolAsync(
+                    It.IsAny<ComparatorSetUserDefinedSchool>())).Throws(new Exception());
+
+        var response =
+            await Functions.CreateUserDefinedSchoolComparatorSetAsync(
+                CreateHttpRequestDataWithBody(model),
+                "123321",
+                "testIdentifier");
+
+        Assert.NotNull(response);
+        Assert.NotNull(response.HttpResponse);
+        Assert.Equal(HttpStatusCode.InternalServerError, response.HttpResponse.StatusCode);
+    }
+    
+    [Fact]
+    public async Task CreateUserDefinedTrustShouldCreateSuccessfully()
+    {
+        var model = _fixture.
+            Build<ComparatorSetUserDefinedRequest>()
+            .Create();
+
+        Service
+            .Setup(d => d.UpsertUserDefinedTrustAsync(
+                It.IsAny<ComparatorSetUserDefinedTrust>()));
+
+        Service
+            .Setup(d => d.UpsertUserDataAsync(
+                It.IsAny<ComparatorSetUserData>()));
+
+        TrustValidator
+            .Setup(
+                d => d.ValidateAsync(
+                    It.IsAny<ComparatorSetUserDefinedTrust>(), default))
+            .ReturnsAsync(new ValidationResult());
+
+        var response =
+            await Functions.CreateUserDefinedTrustComparatorSetAsync(CreateHttpRequestDataWithBody(model), "12313",
+                "testIdentifier");
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Service.Verify(
+            x => x.UpsertUserDefinedTrustAsync(
+                It.IsAny<ComparatorSetUserDefinedTrust>()), Times.Once());
+        Service.Verify(
+            x => x.UpsertUserDataAsync(
+                It.IsAny<ComparatorSetUserData>()), Times.Once());
+    }
+
+    [Fact]
+    public async Task CreateUserDefinedTrustShouldBeBadRequestOnValidationFailure()
+    {
+        var model = _fixture.
+                   Build<ComparatorSetUserDefinedRequest>()
+                   .Create();
+
+        Service
+            .Setup(d => d.UpsertUserDefinedTrustAsync(
+                It.IsAny<ComparatorSetUserDefinedTrust>()));
+
+        Service
+            .Setup(d => d.UpsertUserDataAsync(
+                It.IsAny<ComparatorSetUserData>()));
+
+        TrustValidator
+            .Setup(
+                d => d.ValidateAsync(
+                    It.IsAny<ComparatorSetUserDefinedTrust>(), default))
+            .ReturnsAsync(new ValidationResult
+            {
+                Errors = [new ValidationFailure("TestName", "test error")]
+            });
+
+        var response =
+            await Functions.CreateUserDefinedTrustComparatorSetAsync(CreateHttpRequestDataWithBody(model), "12313",
+                "testIdentifier");
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Service.Verify(
+            x => x.UpsertUserDefinedTrustAsync(
+                It.IsAny<ComparatorSetUserDefinedTrust>()), Times.Never());
+        Service.Verify(
+            x => x.UpsertUserDataAsync(
+                It.IsAny<ComparatorSetUserData>()), Times.Never());
+    }
+
+    [Fact]
+    public async Task CreateUserDefinedTrustShouldBe500OnError()
+    {
+        var model = _fixture.
+            Build<ComparatorSetUserDefinedRequest>()
+            .Create();
+
+        Service
+            .Setup(d => d.UpsertUserDefinedTrustAsync(
+                It.IsAny<ComparatorSetUserDefinedTrust>()))
+            .Throws(new Exception());
+
+        TrustValidator
+            .Setup(
+                d => d.ValidateAsync(
+                    It.IsAny<ComparatorSetUserDefinedTrust>(), default))
+            .ReturnsAsync(new ValidationResult());
+
+        var response =
+            await Functions.CreateUserDefinedTrustComparatorSetAsync(CreateHttpRequestDataWithBody(model), "12313",
+                "testIdentifier");
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+}

--- a/platform/tests/Platform.Tests/Benchmark/WhenFunctionReceivesGetComparatorSetRequest.cs
+++ b/platform/tests/Platform.Tests/Benchmark/WhenFunctionReceivesGetComparatorSetRequest.cs
@@ -2,35 +2,143 @@ using System.Net;
 using Moq;
 using Platform.Api.Benchmark.ComparatorSets;
 using Xunit;
+
 namespace Platform.Tests.Benchmark;
 
 public class WhenFunctionReceivesGetComparatorSetRequest : ComparatorSetsFunctionsTestBase
 {
     [Fact]
-    public async Task ShouldReturn200OnValidRequest()
+    public async Task DefaultShouldBeOkOnValidRequest()
     {
         Service
             .Setup(d => d.DefaultSchoolAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync(new ComparatorSetSchool());
 
-        var result =
+        var response =
             await Functions.DefaultSchoolComparatorSetAsync(CreateHttpRequestData(), "12313");
 
-        Assert.NotNull(result);
-        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
-    public async Task ShouldReturn500OnError()
+    public async Task DefaultShouldBe500OnError()
     {
         Service
             .Setup(d => d.DefaultSchoolAsync(It.IsAny<string>(), It.IsAny<string>()))
             .Throws(new Exception());
 
-        var result = await Functions
+        var response = await Functions
             .DefaultSchoolComparatorSetAsync(CreateHttpRequestData(), "12313");
 
-        Assert.NotNull(result);
-        Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CustomShouldBeOkOnValidRequest()
+    {
+        Service
+            .Setup(d => d.CustomSchoolAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new ComparatorSetSchool());
+
+        var response =
+            await Functions.CustomSchoolComparatorSetAsync(CreateHttpRequestData(), "12313", "testIdentifier");
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CustomShouldBe500OnError()
+    {
+        Service
+            .Setup(d => d.CustomSchoolAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Throws(new Exception());
+
+        var response = await Functions
+            .CustomSchoolComparatorSetAsync(CreateHttpRequestData(), "12313", "testIdentifier");
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UserDefinedShouldBeOkOnValidRequest()
+    {
+        Service
+            .Setup(d => d.UserDefinedSchoolAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new ComparatorSetUserDefinedSchool());
+
+        var response =
+            await Functions.UserDefinedSchoolComparatorSetAsync(CreateHttpRequestData(), "12313", "testIdentifier");
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UserDefinedShouldBe500OnError()
+    {
+        Service
+            .Setup(d => d.UserDefinedSchoolAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Throws(new Exception());
+
+        var response = await Functions
+            .UserDefinedSchoolComparatorSetAsync(CreateHttpRequestData(), "12313", "testIdentifier");
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UserDefinedTrustShouldBeOkOnValidRequest()
+    {
+        Service
+            .Setup(
+                d => d.UserDefinedTrustAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new ComparatorSetUserDefinedTrust());
+
+        var response =
+            await Functions.UserDefinedTrustComparatorSetAsync(CreateHttpRequestData(), "12313",
+                "testIdentifier");
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UserDefinedTrustShouldBeNotFoundOnInvalidRequest()
+    {
+        Service
+            .Setup(
+                d => d.UserDefinedTrustAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((ComparatorSetUserDefinedTrust?)null);
+
+        var response =
+            await Functions.UserDefinedTrustComparatorSetAsync(CreateHttpRequestData(), "12313",
+                "testIdentifier");
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UserDefinedTrustShould500OnError()
+    {
+        Service
+            .Setup(
+                d => d.UserDefinedTrustAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Throws(new Exception());
+
+        var response =
+            await Functions.UserDefinedTrustComparatorSetAsync(CreateHttpRequestData(), "12313",
+                "testIdentifier");
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
     }
 }

--- a/platform/tests/Platform.Tests/Benchmark/WhenFunctionReceivesRemoveComparatorSetRequest.cs
+++ b/platform/tests/Platform.Tests/Benchmark/WhenFunctionReceivesRemoveComparatorSetRequest.cs
@@ -1,0 +1,151 @@
+using System.Net;
+using Moq;
+using Platform.Api.Benchmark.ComparatorSets;
+using Xunit;
+
+namespace Platform.Tests.Benchmark;
+
+public class WhenFunctionReceivesRemoveComparatorSetRequest : ComparatorSetsFunctionsTestBase
+{
+    [Fact]
+    public async Task RemoveUserDefinedShouldRemoveSuccessfully()
+    {
+        Service
+            .Setup(
+                d => d.UserDefinedSchoolAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new ComparatorSetUserDefinedSchool());
+
+        Service
+            .Setup(
+                d => d.DeleteSchoolAsync(
+                    It.IsAny<ComparatorSetUserDefinedSchool>()));
+
+        var response =
+            await Functions.RemoveUserDefinedSchoolComparatorSetAsync(CreateHttpRequestData(), "12313", "testIdentifier");
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Service.Verify(
+            x => x.DeleteSchoolAsync(
+                It.IsAny<ComparatorSetUserDefinedSchool>()), Times.Once());
+    }
+
+    [Fact]
+    public async Task RemoveUserDefinedShouldBeNotFoundWhenInvalid()
+    {
+        Service
+            .Setup(
+                d => d.UserDefinedSchoolAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((ComparatorSetUserDefinedSchool?)null);
+
+        Service
+            .Setup(
+                d => d.DeleteSchoolAsync(
+                    It.IsAny<ComparatorSetUserDefinedSchool>()));
+
+        var response =
+            await Functions.RemoveUserDefinedSchoolComparatorSetAsync(CreateHttpRequestData(), "12313", "testIdentifier");
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Service.Verify(
+            x => x.DeleteSchoolAsync(
+                It.IsAny<ComparatorSetUserDefinedSchool>()), Times.Never());
+    }
+
+    [Fact]
+    public async Task RemoveUserDefinedShouldBe500OnError()
+    {
+        Service
+            .Setup(
+                d => d.UserDefinedSchoolAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Throws(new Exception());
+
+        Service
+            .Setup(
+                d => d.DeleteSchoolAsync(
+                    It.IsAny<ComparatorSetUserDefinedSchool>()));
+
+        var response =
+            await Functions.RemoveUserDefinedSchoolComparatorSetAsync(CreateHttpRequestData(), "12313",
+                "testIdentifier");
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task RemoveUserDefinedTrustShouldRemoveSuccessfully()
+    {
+        Service
+            .Setup(
+                d => d.UserDefinedTrustAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new ComparatorSetUserDefinedTrust());
+
+        Service
+            .Setup(
+                d => d.DeleteTrustAsync(
+                    It.IsAny<ComparatorSetUserDefinedTrust>()));
+
+        var response =
+            await Functions.RemoveUserDefinedTrustComparatorSetAsync(CreateHttpRequestData(), "12313", "testIdentifier");
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Service.Verify(
+            x => x.DeleteTrustAsync(
+                It.IsAny<ComparatorSetUserDefinedTrust>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RemoveUserDefinedTrustShouldBeNotFound()
+    {
+        Service
+            .Setup(
+                d => d.UserDefinedTrustAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((ComparatorSetUserDefinedTrust?)null);
+
+        Service
+            .Setup(
+                d => d.DeleteTrustAsync(
+                    It.IsAny<ComparatorSetUserDefinedTrust>()));
+
+        var response =
+            await Functions.RemoveUserDefinedTrustComparatorSetAsync(CreateHttpRequestData(), "12313", "testIdentifier");
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Service.Verify(
+            x => x.DeleteTrustAsync(
+                It.IsAny<ComparatorSetUserDefinedTrust>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RemoveUserDefinedTrustShouldError()
+    {
+        Service
+            .Setup(
+                d => d.UserDefinedTrustAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Throws(new Exception());
+
+        Service
+            .Setup(
+                d => d.DeleteTrustAsync(
+                    It.IsAny<ComparatorSetUserDefinedTrust>()));
+
+        var response =
+            await Functions.RemoveUserDefinedTrustComparatorSetAsync(CreateHttpRequestData(), "12313", "testIdentifier");
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        Service.Verify(
+            x => x.DeleteTrustAsync(
+                It.IsAny<ComparatorSetUserDefinedTrust>()), Times.Never);
+    }
+}


### PR DESCRIPTION
### Context
[AB#219825](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/219825) - [AB#219826](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/219826)

### Change proposed in this pull request
Adds unit tests for platform benchmark comparator set functions

### Guidance to review 
Include any useful information needed to review this change. Include any dependencies that are required for this change. 

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

