### PR TITLE
Use `NameIdentifier` (Guid) claim when managing user data

### DIFF
--- a/platform/src/apis/Platform.Api.Benchmark/UserData/UserDataService.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/UserData/UserDataService.cs
@@ -3,57 +3,67 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Dapper;
 using Platform.Infrastructure.Sql;
-
 namespace Platform.Api.Benchmark.UserData;
 
 public interface IUserDataService
 {
-    Task<IEnumerable<UserData>> QueryAsync(string userId, string? type = null, string? status = null, string? id = null, string? organisationId = null, string? organisationType = null);
+    Task<IEnumerable<UserData>> QueryAsync(string[] userIds, string? type = null, string? status = null, string? id = null, string? organisationId = null, string? organisationType = null);
 }
 
 [ExcludeFromCodeCoverage]
-public class UserDataService : IUserDataService
+public class UserDataService(IDatabaseFactory dbFactory) : IUserDataService
 {
-    private readonly IDatabaseFactory _dbFactory;
-
-    public UserDataService(IDatabaseFactory dbFactory)
-    {
-        _dbFactory = dbFactory;
-    }
-
-    public async Task<IEnumerable<UserData>> QueryAsync(string userId, string? type = null, string? status = null, string? id = null, string? organisationId = null, string? organisationType = null)
+    public async Task<IEnumerable<UserData>> QueryAsync(string[] userIds, string? type = null, string? status = null, string? id = null, string? organisationId = null, string? organisationType = null)
     {
         var builder = new SqlBuilder();
         var template = builder.AddTemplate("SELECT * from UserData /**where**/");
 
-        builder.Where("UserId = @userId AND Status IN ('pending','complete')", new { userId });
+        builder.Where("UserId IN @userIds AND Status IN ('pending','complete')", new
+        {
+            userIds
+        });
 
         if (!string.IsNullOrEmpty(organisationId))
         {
-            builder.Where("OrganisationId = @organisationId", new { organisationId });
+            builder.Where("OrganisationId = @organisationId", new
+            {
+                organisationId
+            });
         }
 
         if (!string.IsNullOrEmpty(organisationId))
         {
-            builder.Where("OrganisationType = @organisationType", new { organisationType });
+            builder.Where("OrganisationType = @organisationType", new
+            {
+                organisationType
+            });
         }
 
         if (!string.IsNullOrEmpty(type))
         {
-            builder.Where("Type = @type", new { type });
+            builder.Where("Type = @type", new
+            {
+                type
+            });
         }
 
         if (!string.IsNullOrEmpty(status))
         {
-            builder.Where("Status = @status", new { status });
+            builder.Where("Status = @status", new
+            {
+                status
+            });
         }
 
         if (!string.IsNullOrEmpty(id))
         {
-            builder.Where("Id = @id", new { id });
+            builder.Where("Id = @id", new
+            {
+                id
+            });
         }
 
-        using var conn = await _dbFactory.GetConnection();
+        using var conn = await dbFactory.GetConnection();
         return await conn.QueryAsync<UserData>(template.RawSql, template.Parameters);
     }
 }

--- a/platform/tests/Platform.ApiTests/Steps/BenchmarkComparatorSetSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/BenchmarkComparatorSetSteps.cs
@@ -6,7 +6,6 @@ using Platform.Api.Benchmark.ComparatorSets;
 using Platform.ApiTests.Drivers;
 using Platform.Functions.Extensions;
 using TechTalk.SpecFlow.Assist;
-
 namespace Platform.ApiTests.Steps;
 
 [Binding]
@@ -15,8 +14,8 @@ public class BenchmarkComparatorSetSteps(BenchmarkApiDriver api)
     private const string DefaultComparatorSetKey = "default-comparator-set";
     private const string UserDefinedComparatorSetKey = "user-defined-comparator-set";
     private const string UserDefinedTrustComparatorSetKey = "user-defined-trust-comparator-set";
-    private const string UserId = "api.test@example.com";
     private readonly Fixture _fixture = new();
+    private readonly string _userGuid = Guid.NewGuid().ToString();
 
     [Then("the comparator result should be accepted")]
     public void ThenTheComparatorResultShouldBeAccepted()
@@ -71,7 +70,10 @@ public class BenchmarkComparatorSetSteps(BenchmarkApiDriver api)
     public async Task GivenIHaveAValidUserDefinedComparatorSetGetRequestForSchoolIdContaining(string urn, Table table)
     {
         var set = GetFirstColumnsFromTableRowsAsString(table)
-            .Concat(new[] { urn })
+            .Concat(new[]
+            {
+                urn
+            })
             .ToArray();
         var identifier = PutUserDefinedComparatorRequest(urn, set);
         await WhenISubmitTheUserDefinedComparatorSetRequest();
@@ -153,7 +155,10 @@ public class BenchmarkComparatorSetSteps(BenchmarkApiDriver api)
     public async Task GivenIHaveAValidUserDefinedComparatorSetGetRequestForTrustIdContaining(string companyNumber, Table table)
     {
         var set = GetFirstColumnsFromTableRowsAsString(table)
-            .Concat(new[] { companyNumber })
+            .Concat(new[]
+            {
+                companyNumber
+            })
             .ToArray();
         var identifier = PutUserDefinedTrustComparatorRequest(companyNumber, set);
         await WhenISubmitTheUserDefinedComparatorSetRequest();
@@ -169,7 +174,10 @@ public class BenchmarkComparatorSetSteps(BenchmarkApiDriver api)
     public async Task GivenIHaveAValidDeleteUserDefinedComparatorSetGetRequestForTrustIdContaining(string companyNumber, Table table)
     {
         var set = GetFirstColumnsFromTableRowsAsString(table)
-            .Concat(new[] { companyNumber })
+            .Concat(new[]
+            {
+                companyNumber
+            })
             .ToArray();
         var identifier = PutUserDefinedTrustComparatorRequest(companyNumber, set);
         await WhenISubmitTheUserDefinedComparatorSetRequest();
@@ -225,7 +233,10 @@ public class BenchmarkComparatorSetSteps(BenchmarkApiDriver api)
         var set = new List<dynamic>();
         foreach (var urn in result.Building ?? [])
         {
-            set.Add(new { Urn = urn });
+            set.Add(new
+            {
+                Urn = urn
+            });
         }
 
         table.CompareToDynamicSet(set, false);
@@ -244,7 +255,10 @@ public class BenchmarkComparatorSetSteps(BenchmarkApiDriver api)
         var set = new List<dynamic>();
         foreach (var urn in result.Pupil ?? [])
         {
-            set.Add(new { Urn = urn });
+            set.Add(new
+            {
+                Urn = urn
+            });
         }
 
         table.CompareToDynamicSet(set, false);
@@ -263,7 +277,10 @@ public class BenchmarkComparatorSetSteps(BenchmarkApiDriver api)
         var set = new List<dynamic>();
         foreach (var urn in result.Building ?? [])
         {
-            set.Add(new { Urn = urn });
+            set.Add(new
+            {
+                Urn = urn
+            });
         }
 
         table.CompareToDynamicSet(set, false);
@@ -282,7 +299,10 @@ public class BenchmarkComparatorSetSteps(BenchmarkApiDriver api)
         var set = new List<dynamic>();
         foreach (var companyNumber in result.Set ?? [])
         {
-            set.Add(new { CompanyNumber = companyNumber });
+            set.Add(new
+            {
+                CompanyNumber = companyNumber
+            });
         }
 
         table.CompareToDynamicSet(set, false);
@@ -301,7 +321,7 @@ public class BenchmarkComparatorSetSteps(BenchmarkApiDriver api)
         var identifier = Guid.NewGuid();
         var content = new ComparatorSetUserDefinedRequest
         {
-            UserId = UserId,
+            UserId = _userGuid,
             Set = set
         };
 
@@ -329,7 +349,7 @@ public class BenchmarkComparatorSetSteps(BenchmarkApiDriver api)
         var identifier = Guid.NewGuid();
         var content = new ComparatorSetUserDefinedRequest
         {
-            UserId = UserId,
+            UserId = _userGuid,
             Set = set
         };
 

--- a/platform/tests/Platform.ApiTests/Steps/BenchmarkCustomDataSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/BenchmarkCustomDataSteps.cs
@@ -5,14 +5,13 @@ using Platform.Api.Benchmark.CustomData;
 using Platform.ApiTests.Drivers;
 using Platform.Functions.Extensions;
 using Xunit;
-
 namespace Platform.ApiTests.Steps;
 
 [Binding]
 public class BenchmarkCustomDataSteps(BenchmarkApiDriver api)
 {
     private const string CustomDataKey = "custom-data";
-    private const string UserId = "api.test@example.com";
+    private readonly string _userGuid = Guid.NewGuid().ToString();
 
     [Given("I have a valid custom data get request for school id '(.*)' containing:")]
     public async Task GivenIHaveAValidCustomDataGetRequestForSchoolIdContaining(string urn, Table table)
@@ -87,7 +86,7 @@ public class BenchmarkCustomDataSteps(BenchmarkApiDriver api)
         api.CreateRequest(CustomDataKey, new HttpRequestMessage
         {
             RequestUri = new Uri($"/api/custom-data/school/{urn}/{identifier}", UriKind.Relative),
-            Method = HttpMethod.Get,
+            Method = HttpMethod.Get
         });
     }
 
@@ -111,15 +110,17 @@ public class BenchmarkCustomDataSteps(BenchmarkApiDriver api)
         api.CreateRequest(CustomDataKey, new HttpRequestMessage
         {
             RequestUri = new Uri($"/api/custom-data/school/{urn}/{identifier}", UriKind.Relative),
-            Method = HttpMethod.Delete,
+            Method = HttpMethod.Delete
         });
     }
 
-    private static string GetJsonFromTable(Table table)
+    private string GetJsonFromTable(Table table)
     {
         var content = new Dictionary<string, object>
         {
-            { "UserId", UserId }
+            {
+                "UserId", _userGuid
+            }
         };
         foreach (var row in table.Rows)
         {
@@ -130,5 +131,4 @@ public class BenchmarkCustomDataSteps(BenchmarkApiDriver api)
 
         return content.ToJson();
     }
-
 }

--- a/platform/tests/Platform.ApiTests/Steps/BenchmarkUserDataSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/BenchmarkUserDataSteps.cs
@@ -5,14 +5,13 @@ using Platform.Api.Benchmark.UserData;
 using Platform.ApiTests.Drivers;
 using Platform.Functions.Extensions;
 using Xunit;
-
 namespace Platform.ApiTests.Steps;
 
 [Binding]
 public class BenchmarkUserDataSteps(BenchmarkApiDriver api)
 {
     private const string UserDataKey = "user-data";
-    private const string UserId = "api.test@example.com";
+    private readonly string _userGuid = Guid.NewGuid().ToString();
 
     [Given("I have a valid user data get request for school id '(.*)' containing custom data:")]
     public async Task GivenIHaveAValidUserDataGetRequestForSchoolIdContainingCustomData(string urn, Table table)
@@ -40,7 +39,7 @@ public class BenchmarkUserDataSteps(BenchmarkApiDriver api)
 
         var row = result.MaxBy(r => r.Expiry);
         Assert.NotNull(row);
-        Assert.Equal(UserId, row.UserId);
+        Assert.Equal(_userGuid, row.UserId);
         Assert.Equal("custom-data", row.Type);
         var nextMonth = DateTimeOffset.Now.AddMonths(1).AddDays(-1);
         Assert.InRange(row.Expiry, nextMonth.AddMinutes(-1), nextMonth.AddMinutes(1));
@@ -51,7 +50,7 @@ public class BenchmarkUserDataSteps(BenchmarkApiDriver api)
     {
         api.CreateRequest(UserDataKey, new HttpRequestMessage
         {
-            RequestUri = new Uri($"/api/user-data?userId={UserId}&organisationId={urn}&organisationType=school&id={identifier}", UriKind.Relative),
+            RequestUri = new Uri($"/api/user-data?userId={_userGuid}&organisationId={urn}&organisationType=school&id={identifier}", UriKind.Relative),
             Method = HttpMethod.Get
         });
     }
@@ -71,11 +70,13 @@ public class BenchmarkUserDataSteps(BenchmarkApiDriver api)
         return identifier;
     }
 
-    private static string GetJsonFromTable(Table table)
+    private string GetJsonFromTable(Table table)
     {
         var content = new Dictionary<string, object>
         {
-            { "UserId", UserId }
+            {
+                "UserId", _userGuid
+            }
         };
         foreach (var row in table.Rows)
         {

--- a/web/src/Web.App/Controllers/SchoolComparatorsCreateByController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparatorsCreateByController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.FeatureManagement.Mvc;
 using Web.App.Attributes;
-using Web.App.Attributes.RequestTelemetry;
 using Web.App.Domain;
 using Web.App.Extensions;
 using Web.App.Infrastructure.Apis;
@@ -221,7 +220,7 @@ public class SchoolComparatorsCreateByController(
                 {
                     Identifier = userDefinedSet.RunId == null ? Guid.NewGuid() : Guid.Parse(userDefinedSet.RunId),
                     Set = userDefinedSet.Set,
-                    UserId = User.UserId()
+                    UserId = User.UserGuid().ToString()
                 };
 
                 await comparatorSetApi.UpsertUserDefinedSchoolAsync(urn, request).EnsureSuccess();

--- a/web/src/Web.App/Controllers/SchoolCustomDataChangeController.cs
+++ b/web/src/Web.App/Controllers/SchoolCustomDataChangeController.cs
@@ -11,7 +11,6 @@ using Web.App.Infrastructure.Extensions;
 using Web.App.Services;
 using Web.App.TagHelpers;
 using Web.App.ViewModels;
-
 namespace Web.App.Controllers;
 
 [Controller]
@@ -208,12 +207,15 @@ public class SchoolCustomDataChangeController(
                     await customDataService.RemoveCustomData(urn, userData.CustomData);
                 }
 
-                await customDataService.CreateCustomData(urn, User.UserId());
+                await customDataService.CreateCustomData(urn, User.UserGuid().ToString());
 
                 customDataService.ClearCustomDataFromSession(urn);
                 // todo: persist orchestrator job ID to auth user data
 
-                return RedirectToAction("Submit", new { urn });
+                return RedirectToAction("Submit", new
+                {
+                    urn
+                });
             }
             catch (Exception e)
             {
@@ -227,7 +229,10 @@ public class SchoolCustomDataChangeController(
     [Route("submit")]
     public async Task<IActionResult> Submit(string urn)
     {
-        using (logger.BeginScope(new { urn }))
+        using (logger.BeginScope(new
+        {
+            urn
+        }))
         {
             try
             {

--- a/web/src/Web.App/Controllers/TrustComparatorsCreateByController.cs
+++ b/web/src/Web.App/Controllers/TrustComparatorsCreateByController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.FeatureManagement.Mvc;
 using Web.App.Attributes;
-using Web.App.Attributes.RequestTelemetry;
 using Web.App.Domain;
 using Web.App.Extensions;
 using Web.App.Infrastructure.Apis;
@@ -220,7 +219,7 @@ public class TrustComparatorsCreateByController(
                 {
                     Identifier = userDefinedSet.RunId == null ? Guid.NewGuid() : Guid.Parse(userDefinedSet.RunId),
                     Set = userDefinedSet.Set,
-                    UserId = User.UserId()
+                    UserId = User.UserGuid().ToString()
                 };
 
                 await comparatorSetApi.UpsertUserDefinedTrustAsync(companyNumber, request).EnsureSuccess();

--- a/web/src/Web.App/Services/UserDataService.cs
+++ b/web/src/Web.App/Services/UserDataService.cs
@@ -4,7 +4,6 @@ using Web.App.Extensions;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.Benchmark;
 using Web.App.Infrastructure.Extensions;
-
 namespace Web.App.Services;
 
 public interface IUserDataService
@@ -31,6 +30,7 @@ public class UserDataService(IUserDataApi api) : IUserDataService
         }
 
         var query = new ApiQuery()
+            .AddIfNotNull("userId", user.UserGuid().ToString())
             .AddIfNotNull("userId", user.UserId())
             .AddIfNotNull("id", identifier)
             .AddIfNotNull("type", ComparatorSet)
@@ -50,6 +50,7 @@ public class UserDataService(IUserDataApi api) : IUserDataService
 
 
         var query = new ApiQuery()
+            .AddIfNotNull("userId", user.UserGuid().ToString())
             .AddIfNotNull("userId", user.UserId())
             .AddIfNotNull("id", identifier)
             .AddIfNotNull("type", CustomData)
@@ -70,6 +71,7 @@ public class UserDataService(IUserDataApi api) : IUserDataService
 
 
         var query = new ApiQuery()
+            .AddIfNotNull("userId", user.UserGuid().ToString())
             .AddIfNotNull("userId", user.UserId())
             .AddIfNotNull("id", identifier)
             .AddIfNotNull("type", ComparatorSet)
@@ -89,6 +91,7 @@ public class UserDataService(IUserDataApi api) : IUserDataService
 
 
         var query = new ApiQuery()
+            .AddIfNotNull("userId", user.UserGuid().ToString())
             .AddIfNotNull("userId", user.UserId())
             .AddIfNotNull("organisationType", OrganisationSchool)
             .AddIfNotNull("organisationId", urn);
@@ -108,6 +111,7 @@ public class UserDataService(IUserDataApi api) : IUserDataService
 
 
         var query = new ApiQuery()
+            .AddIfNotNull("userId", user.UserGuid().ToString())
             .AddIfNotNull("userId", user.UserId())
             .AddIfNotNull("organisationType", OrganisationTrust)
             .AddIfNotNull("organisationId", companyNumber);


### PR DESCRIPTION
### Context
AB#221003 AB#219590

### Change proposed in this pull request
Use `NameIdentifier` instead of `Email` claim when setting `UserData` to reduce PII being persisted.
Use `Email` or `NameIdentifier` when getting, for backwards compatibility. 

### Guidance to review 
Submit user defined comparator set or custom data and then attempt to view expected output in UI.
`UserData` database table may also be inspected to ensure user Guid used instead of email address. Historical entries with email address identifier will not be mutated but should still be honoured.
Financial Plan journey not changed at this time as the 'last updated by' value is displayed in the UI and a GUID may confuse the user.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

