### PR TITLE
fixed double counting of Academies funding

### DIFF
--- a/data-pipeline/src/pipeline/pre_processing.py
+++ b/data-pipeline/src/pipeline/pre_processing.py
@@ -410,9 +410,6 @@ def prepare_central_services_data(cs_path, current_year: int):
         - central_services_financial[
             "BNCH21707 (Direct revenue financing (Revenue contributions to capital))"
         ]
-        + central_services_financial[
-            "BNCH11123-BTI011-A (MAT Central services - Income)"
-        ]
     )
 
     central_services_financial.rename(
@@ -538,7 +535,6 @@ def prepare_aar_data(aar_path, current_year: int):
         aar["Income_Total grant funding"]
         + aar["Income_Total self generated funding"]
         - aar["BNCH21707 (Direct revenue financing (Revenue contributions to capital))"]
-        + aar["BNCH11123-BAI011-A (Academies - Income)"]
     )
 
     aar.rename(


### PR DESCRIPTION
### Context
Fix double counting of BNCH11123-BTI011-A (MAT Central services - Income) and BNCH11123-BAI011-A (Academies - Income)

### Change proposed in this pull request
Removed the double counting of BNCH11123-BTI011-A (MAT Central services - Income) and BNCH11123-BAI011-A (Academies - Income)

### Guidance to review 
Check that double counting of BNCH11123-BTI011-A (MAT Central services - Income) and BNCH11123-BAI011-A (Academies - Income) no longer occurs

### Checklist
- [ ] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally

