### PR TITLE
display chosen school for comparators table

### DIFF
--- a/web/src/Web.App/Views/SchoolComparators/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolComparators/Index.cshtml
@@ -4,6 +4,8 @@
 @model Web.App.ViewModels.SchoolComparatorsViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.SchoolComparators;
+    var chosenSchoolPupil = Model.PupilSchools.FirstOrDefault(x => x.URN == Model.Urn);
+    var chosenSchoolBuilding = Model.BuildingSchools.FirstOrDefault(x => x.URN == Model.Urn);
 }
 
 @await Component.InvokeAsync("EstablishmentHeading", new
@@ -49,7 +51,7 @@
             </ul>
             <div class="govuk-tabs__panel" id="running">
                 <h2 class="govuk-heading-l">Running cost categories</h2>
-                <p class="govuk-body">We've chosen @Model.PupilSchools.Count(x => x.URN != Model.Urn) similar schools to benchmark this school against running cost categories, which includes all staffing (excluding premises staff), ICT, consultancy and catering.</p>
+                <p class="govuk-body">We've chosen @Model.PupilSchools.Count() similar schools to benchmark this school against running cost categories, which includes all staffing (excluding premises staff), ICT, consultancy and catering.</p>
                 <h3 class="govuk-heading-m">How we chose these schools</h3>
                 <p class="govuk-body">We chose these schools based on:</p>
                 <ul class="govuk-list govuk-list--bullet">
@@ -72,34 +74,57 @@
                     </thead>
                     <tbody class="govuk-table__body">
 
-                    @foreach (var school in Model.PupilSchools.Where(x => x.URN != Model.Urn))
-                    {
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">
-                                <strong>@school.SchoolName</strong>
-                                <br/>
-                                <span class="govuk-hint">@school.Address</span>
-                            </td>
-                            <td class="govuk-table__cell">
-                                @school.OverallPhase
-                            </td>
-                            <td class="govuk-table__cell">
+                        @if (chosenSchoolPupil != null)
+                        {
+                            <tr class="govuk-table__row">
+                                <td class="govuk-table__cell">
+                                    <strong>@chosenSchoolPupil.SchoolName</strong>
+                                    <br/>
+                                    <span class="govuk-hint">(Your chosen school)</span>
+                                </td>
+                                <td class="govuk-table__cell">
+                                    @chosenSchoolPupil.OverallPhase
+                                </td>
+                                <td class="govuk-table__cell">
+                                    @chosenSchoolPupil.TotalPupils.GetValueOrDefault().ToNumberSeparator()
+                                </td>
+                                <td class="govuk-table__cell">
+                                    @chosenSchoolPupil.PercentSpecialEducationNeeds.ToPercent()
+                                </td>
+                                <td class="govuk-table__cell">
+                                    @chosenSchoolPupil.PercentFreeSchoolMeals.ToPercent()
+                                </td>
+                            </tr>
+                        }
+
+                        @foreach (var school in Model.PupilSchools.Where(x => x.URN != Model.Urn))
+                        {
+                            <tr class="govuk-table__row">
+                                <td class="govuk-table__cell">
+                                    <strong>@school.SchoolName</strong>
+                                    <br/>
+                                    <span class="govuk-hint">@school.Address</span>
+                                </td>
+                                <td class="govuk-table__cell">
+                                    @school.OverallPhase
+                                </td>
+                                <td class="govuk-table__cell">
                                     @school.TotalPupils.GetValueOrDefault().ToNumberSeparator()
-                            </td>
-                            <td class="govuk-table__cell">
-                                @school.PercentSpecialEducationNeeds.ToPercent()
-                            </td>
-                            <td class="govuk-table__cell">
-                                @school.PercentFreeSchoolMeals.ToPercent()
-                            </td>
-                        </tr>
-                    }
+                                </td>
+                                <td class="govuk-table__cell">
+                                    @school.PercentSpecialEducationNeeds.ToPercent()
+                                </td>
+                                <td class="govuk-table__cell">
+                                    @school.PercentFreeSchoolMeals.ToPercent()
+                                </td>
+                            </tr>
+                        }
                     </tbody>
                 </table>
             </div>
             <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="building">
                 <h2 class="govuk-heading-l">Building cost categories</h2>
-                <p class="govuk-body">We've chosen @Model.BuildingSchools.Count(x => x.URN != Model.Urn) similar schools to benchmark this school against building cost categories, which includes utilities, cleaning and maintenance.</p>
+                <p class="govuk-body">We've chosen @Model.BuildingSchools.Count() similar schools to benchmark this school against building cost categories, which includes utilities, cleaning and maintenance.</p>
                 <h3 class="govuk-heading-m">How we chose these schools</h3>
                 <p class="govuk-body">We chose these schools based on:</p>
                 <ul class="govuk-list govuk-list--bullet">
@@ -121,39 +146,65 @@
                     </tr>
                     </thead>
                     <tbody class="govuk-table__body">
+                        
+                        @if (chosenSchoolBuilding != null)
+                        {
+                            <tr class="govuk-table__row">
+                                <td class="govuk-table__cell">
+                                    <strong>@chosenSchoolBuilding.SchoolName</strong>
+                                    <br/>
+                                    <span class="govuk-hint">(Your chosen school)</span>
+                                </td>
+                                <td class="govuk-table__cell">
+                                    @chosenSchoolBuilding.OverallPhase
+                                </td>
+                                <td class="govuk-table__cell">
+                                    @chosenSchoolBuilding.TotalPupils.GetValueOrDefault().ToNumberSeparator()
+                                </td>
+                                @if (User.Identity is { IsAuthenticated: true })
+                                {
+                                    <td class="govuk-table__cell">
+                                        @chosenSchoolBuilding.TotalInternalFloorArea
+                                    </td>
+                                    <td class="govuk-table__cell">
+                                        @chosenSchoolBuilding.BuildingAverageAge.ToAge()
+                                    </td>
+                                }
+                                else
+                                {
+                                    <td class="govuk-table__cell" colspan="2" rowspan="@Model.BuildingSchools.Count()" style="text-align: center; vertical-align: top;">
+                                        @Html.ActionLink("Sign in", "Signin", "Home", new { redirectUri = ViewContext.HttpContext.Request.Path }, new { @class = "govuk-link govuk-link--no-visited-state" })
+                                        to see
+                                    </td>
+                                }
+                            </tr>
+                        }
 
-                    @foreach (var (index, school) in Model.BuildingSchools.Where(x => x.URN != Model.Urn).Select((school, index) => (index, school)))
-                    {
-                        <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">
-                                <strong>@school.SchoolName</strong>
-                                <br/>
-                                <span class="govuk-hint">@school.Address</span>
-                            </td>
-                            <td class="govuk-table__cell">
-                                @school.OverallPhase
-                            </td>
-                            <td class="govuk-table__cell">
-                                    @school.TotalPupils.GetValueOrDefault().ToNumberSeparator()
-                            </td>
-                            @if (User.Identity is { IsAuthenticated: true })
-                            {
+                        @foreach (var school in Model.BuildingSchools.Where(x => x.URN != Model.Urn))
+                        {
+                            <tr class="govuk-table__row">
                                 <td class="govuk-table__cell">
-                                    @school.TotalInternalFloorArea
+                                    <strong>@school.SchoolName</strong>
+                                    <br/>
+                                    <span class="govuk-hint">@school.Address</span>
                                 </td>
                                 <td class="govuk-table__cell">
-                                    @school.BuildingAverageAge.ToAge()
+                                    @school.OverallPhase
                                 </td>
-                            }
-                            else if (index == 0)
-                            {
-                                <td class="govuk-table__cell" colspan="2" rowspan="@Model.BuildingSchools.Count()" style="text-align: center; vertical-align: top;">
-                                    @Html.ActionLink("Sign in", "Signin", "Home", new { redirectUri = ViewContext.HttpContext.Request.Path }, new { @class = "govuk-link govuk-link--no-visited-state" })
-                                    to see
+                                <td class="govuk-table__cell">
+                                        @school.TotalPupils.GetValueOrDefault().ToNumberSeparator()
                                 </td>
-                            }
-                        </tr>
-                    }
+                                @if (User.Identity is { IsAuthenticated: true })
+                                {
+                                    <td class="govuk-table__cell">
+                                        @school.TotalInternalFloorArea
+                                    </td>
+                                    <td class="govuk-table__cell">
+                                        @school.BuildingAverageAge.ToAge()
+                                    </td>
+                                }
+                            </tr>
+                        }
                     </tbody>
                 </table>
             </div>

--- a/web/src/Web.App/Views/SchoolComparators/UserDefined.cshtml
+++ b/web/src/Web.App/Views/SchoolComparators/UserDefined.cshtml
@@ -3,6 +3,7 @@
 @model Web.App.ViewModels.SchoolComparatorsViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.SchoolComparatorsUserDefined;
+    var chosenSchool = Model.UserDefinedSchools.FirstOrDefault(x => x.URN == Model.Urn);
 }
 
 @await Component.InvokeAsync("EstablishmentHeading", new
@@ -33,28 +34,51 @@
             </thead>
             <tbody class="govuk-table__body">
 
-            @foreach (var school in Model.UserDefinedSchools.Where(x => x.URN != Model.Urn))
-            {
-                <tr class="govuk-table__row">
-                    <td class="govuk-table__cell">
-                        <strong>@school.SchoolName</strong>
-                        <br/>
-                        <span class="govuk-hint">@school.Address</span>
-                    </td>
-                    <td class="govuk-table__cell">
-                        @school.OverallPhase
-                    </td>
-                    <td class="govuk-table__cell">
+                @if (chosenSchool != null)
+                {
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell">
+                            <strong>@chosenSchool.SchoolName</strong>
+                            <br/>
+                            <span class="govuk-hint">(Your chosen school)</span>
+                        </td>
+                        <td class="govuk-table__cell">
+                            @chosenSchool.OverallPhase
+                        </td>
+                        <td class="govuk-table__cell">
+                            @chosenSchool.TotalPupils.GetValueOrDefault().ToNumberSeparator()
+                        </td>
+                        <td class="govuk-table__cell">
+                            @chosenSchool.PercentSpecialEducationNeeds.ToPercent()
+                        </td>
+                        <td class="govuk-table__cell">
+                            @chosenSchool.PercentFreeSchoolMeals.ToPercent()
+                        </td>
+                    </tr>
+                }
+
+                @foreach (var school in Model.UserDefinedSchools.Where(x => x.URN != Model.Urn))
+                {
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell">
+                            <strong>@school.SchoolName</strong>
+                            <br/>
+                            <span class="govuk-hint">@school.Address</span>
+                        </td>
+                        <td class="govuk-table__cell">
+                            @school.OverallPhase
+                        </td>
+                        <td class="govuk-table__cell">
                             @school.TotalPupils.GetValueOrDefault().ToNumberSeparator()
-                    </td>
-                    <td class="govuk-table__cell">
-                        @school.PercentSpecialEducationNeeds.ToPercent()
-                    </td>
-                    <td class="govuk-table__cell">
-                        @school.PercentFreeSchoolMeals.ToPercent()
-                    </td>
-                </tr>
-            }
+                        </td>
+                        <td class="govuk-table__cell">
+                            @school.PercentSpecialEducationNeeds.ToPercent()
+                        </td>
+                        <td class="govuk-table__cell">
+                            @school.PercentFreeSchoolMeals.ToPercent()
+                        </td>
+                    </tr>
+                }
             </tbody>
         </table>
     </div>

--- a/web/src/Web.App/Views/SchoolComparators/Workforce.cshtml
+++ b/web/src/Web.App/Views/SchoolComparators/Workforce.cshtml
@@ -4,6 +4,7 @@
 @model Web.App.ViewModels.SchoolComparatorsViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.SchoolComparators;
+    var chosenSchool = Model.PupilSchools.FirstOrDefault(x => x.URN == Model.Urn);
 }
 
 @await Component.InvokeAsync("EstablishmentHeading", new
@@ -34,7 +35,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-        <p class="govuk-body">We've chosen @Model.PupilSchools.Count(x => x.URN != Model.Urn) similar schools to benchmark this school against running cost categories, which includes all staffing (excluding premises staff), ICT, consultancy and catering.</p>
+        <p class="govuk-body">We've chosen @Model.PupilSchools.Count() similar schools to benchmark this school against running cost categories, which includes all staffing (excluding premises staff), ICT, consultancy and catering.</p>
         <h2 class="govuk-heading-m">How we chose these schools</h2>
         <p class="govuk-body">We chose these schools based on:</p>
         <ul class="govuk-list govuk-list--bullet">
@@ -57,12 +58,35 @@
             </thead>
             <tbody class="govuk-table__body">
 
+                @if (chosenSchool != null)
+                {
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell">
+                            <strong>@chosenSchool.SchoolName</strong>
+                            <br/>
+                            <span class="govuk-hint">(Your chosen school)</span>
+                        </td>
+                        <td class="govuk-table__cell">
+                            @chosenSchool.OverallPhase
+                        </td>
+                        <td class="govuk-table__cell">
+                            @chosenSchool.TotalPupils.GetValueOrDefault().ToNumberSeparator()
+                        </td>
+                        <td class="govuk-table__cell">
+                            @chosenSchool.PercentSpecialEducationNeeds.ToPercent()
+                        </td>
+                        <td class="govuk-table__cell">
+                            @chosenSchool.PercentFreeSchoolMeals.ToPercent()
+                        </td>
+                    </tr>
+                }
+
                 @foreach (var school in Model.PupilSchools.Where(x => x.URN != Model.Urn))
                 {
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">
                             <strong>@school.SchoolName</strong>
-                            <br />
+                            <br/>
                             <span class="govuk-hint">@school.Address</span>
                         </td>
                         <td class="govuk-table__cell">


### PR DESCRIPTION
### Context
[AB#216448](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/216448) - [AB#222015](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/222015)

see update 3 on the story and comments.

### Change proposed in this pull request
For default, workforce and user defined comparator page this displays the chosen school to the table at row 1 as per the design.
Also amends the count for the default comparator page to now show the whole set including the chosen school

### Guidance to review 
N/A

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

