### PR TITLE
fix: OpenApiOperation tag for swagger updated

### DIFF
--- a/platform/src/apis/Platform.Api.Establishment/Trusts/TrustsFunctions.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Trusts/TrustsFunctions.cs
@@ -17,7 +17,7 @@ namespace Platform.Api.Establishment.Trusts;
 public class TrustsFunctions(ILogger<TrustsFunctions> logger, ITrustsService service, IValidator<SuggestRequest> validator)
 {
     [Function(nameof(SingleTrustAsync))]
-    [OpenApiOperation(nameof(SingleTrustAsync), "Schools")]
+    [OpenApiOperation(nameof(SingleTrustAsync), "Trusts")]
     [OpenApiParameter("identifier", Type = typeof(string), Required = true)]
     [OpenApiSecurityHeader]
     [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(Trust))]


### PR DESCRIPTION
### Context
[AB#221688](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/221688) - [AB#221689](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/221689)

### Change proposed in this pull request
Updates OpenApiOperation tag so that this will be displayed correctly in the swagger ui under Trusts

### Guidance to review 
run locally and check swagger

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

