### PR TITLE
Replace `Donut` chart with `UnstackedColumn` when displaying WAF hits by rule name in OI dashboard

### DIFF
--- a/core-infrastructure/terraform/dashboards/oi.tpl
+++ b/core-infrastructure/terraform/dashboards/oi.tpl
@@ -1025,7 +1025,7 @@
                             },
                             {
                                 "name": "SpecificChart",
-                                "value": "Donut",
+                                "value": "UnstackedColumn",
                                 "isOptional": true
                             },
                             {
@@ -1040,7 +1040,7 @@
                                 "name": "Dimensions",
                                 "value": {
                                     "xAxis": {
-                                        "name": "Path",
+                                        "name": "RuleName",
                                         "type": "string"
                                     },
                                     "yAxis": [
@@ -1049,12 +1049,7 @@
                                             "type": "long"
                                         }
                                     ],
-                                    "splitBy": [
-                                        {
-                                            "name": "RuleName",
-                                            "type": "string"
-                                        }
-                                    ],
+                                    "splitBy": [],
                                     "aggregation": "Sum"
                                 },
                                 "isOptional": true
@@ -1062,7 +1057,7 @@
                             {
                                 "name": "LegendOptions",
                                 "value": {
-                                    "isEnabled": true,
+                                    "isEnabled": false,
                                     "position": "Bottom"
                                 },
                                 "isOptional": true


### PR DESCRIPTION
### Context
[AB#220583](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/220583) [AB#219227](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/219227)

### Change proposed in this pull request
Switch chart type displayed in OI dashboard for this query.

### Guidance to review 
When pointing to the prod WAF, the results should now be more readable, e.g.:

![image](https://github.com/user-attachments/assets/ef37222b-17e5-4434-ab4d-970af2df9145)

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~~Your code builds clean without any errors or warnings~~
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

