### PR TITLE
removed typo

### DIFF
--- a/data-pipeline/src/pipeline/pre_processing.py
+++ b/data-pipeline/src/pipeline/pre_processing.py
@@ -999,7 +999,7 @@ def build_academy_data(
         / academies["Total pupils in trust"].astype(float)
     )
 
-    academies["In year balance_CS"] = (
+    academies["In year balance"] = (
         academies["In year balance"] + academies["In year balance_CS"]
     )
 
@@ -1056,8 +1056,6 @@ def build_academy_data(
     academies["Company Registration Number"] = academies[
         "Company Registration Number"
     ].map(mappings.map_company_number)
-
-    academies['Trust Balance'] = academies['Trust Balance'] + (academies["BNCH11000T (Revenue Income)_CS"] - academies["BNCH20000T (Total Costs)_CS"])
     
     return academies.set_index("URN")
 


### PR DESCRIPTION
### Context
In year balance for academies had a typo
[(AB#221270)](https://dev.azure.com/dfe-ssp/s198-DfE-Benchmarking-service/_workitems/edit/221270)

### Change proposed in this pull request
replaced typo and removed "Trust Balance" calculation as part of last fix

### Guidance to review 
Check typo replacement is correct

### Checklist
- [ ] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally

