### PR TITLE
fix: updates to edit user defined trust comparator set journey

### DIFF
--- a/web/src/Web.App/Constants/PageTitles.cs
+++ b/web/src/Web.App/Constants/PageTitles.cs
@@ -68,6 +68,7 @@ public static class PageTitles
     public const string TrustComparatorsCreateByCharacteristic = "Choose characteristics to find matching trusts";
     public const string TrustComparatorsPreview = "Trusts successfully matched";
     public const string TrustComparatorsSubmit = "Generating benchmarking data";
+    public const string TrustComparatorsSubmitEdit = "Updating benchmarking data";
     public const string TrustComparatorsUserDefined = "Your set of trusts";
     public const string TrustComparatorsRevert = "Remove all your trusts?";
     public const string TrustToTrustHome = "Benchmark spending for this trust";

--- a/web/src/Web.App/Controllers/TrustComparatorsCreateByController.cs
+++ b/web/src/Web.App/Controllers/TrustComparatorsCreateByController.cs
@@ -116,7 +116,10 @@ public class TrustComparatorsCreateByController(
                 }
 
                 var trustCharacteristics = await GetTrustCharacteristics<TrustCharacteristicUserDefined>(userDefinedSet.Set);
-                var viewModel = new TrustComparatorsByNameViewModel(trust, trustCharacteristics);
+
+                var isEdit = !string.IsNullOrEmpty(userDefinedSet.RunId);
+
+                var viewModel = new TrustComparatorsByNameViewModel(trust, trustCharacteristics, isEdit);
                 return View(viewModel);
             }
             catch (Exception e)
@@ -215,6 +218,8 @@ public class TrustComparatorsCreateByController(
                     userDefinedSet.Set = list.ToArray();
                 }
 
+                var isEdit = !string.IsNullOrEmpty(userDefinedSet.RunId);
+
                 var request = new PutComparatorSetUserDefinedRequest
                 {
                     Identifier = userDefinedSet.RunId == null ? Guid.NewGuid() : Guid.Parse(userDefinedSet.RunId),
@@ -225,7 +230,7 @@ public class TrustComparatorsCreateByController(
                 await comparatorSetApi.UpsertUserDefinedTrustAsync(companyNumber, request).EnsureSuccess();
                 trustComparatorSetService.ClearUserDefinedComparatorSet(companyNumber);
                 trustComparatorSetService.ClearUserDefinedCharacteristic(companyNumber);
-                var viewModel = new TrustComparatorsSubmittedViewModel(trust, request);
+                var viewModel = new TrustComparatorsSubmittedViewModel(trust, request, isEdit);
                 return View(viewModel);
             }
             catch (Exception e)

--- a/web/src/Web.App/ViewModels/TrustComparatorsByNameViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustComparatorsByNameViewModel.cs
@@ -3,7 +3,7 @@ using Web.App.Domain;
 
 namespace Web.App.ViewModels;
 
-public class TrustComparatorsByNameViewModel(Trust trust, TrustCharacteristicUserDefined[]? trustCharacteristics)
+public class TrustComparatorsByNameViewModel(Trust trust, TrustCharacteristicUserDefined[]? trustCharacteristics, bool isEdit)
 {
     public string? CompanyNumber => trust.CompanyNumber;
     public string? Name => trust.TrustName;
@@ -13,6 +13,7 @@ public class TrustComparatorsByNameViewModel(Trust trust, TrustCharacteristicUse
         .Concat([trust.CompanyNumber])
         .OfType<string>()
         .ToArray();
+    public bool IsEdit => isEdit;
 }
 
 public record TrustComparatorRemoveViewModel

--- a/web/src/Web.App/ViewModels/TrustComparatorsChosenTrustsViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustComparatorsChosenTrustsViewModel.cs
@@ -2,8 +2,9 @@
 
 namespace Web.App.ViewModels;
 
-public class TrustComparatorsChosenTrustsViewModel(string? companyNumber, TrustCharacteristicUserDefined[]? trustCharacteristics)
+public class TrustComparatorsChosenTrustsViewModel(string? companyNumber, TrustCharacteristicUserDefined[]? trustCharacteristics, bool isEdit)
 {
     public string? CompanyNumber => companyNumber;
     public IOrderedEnumerable<TrustCharacteristicUserDefined>? Trusts => trustCharacteristics?.OrderBy(c => c.TrustName);
+    public bool IsEdit => isEdit;
 }

--- a/web/src/Web.App/ViewModels/TrustComparatorsSubmittedViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustComparatorsSubmittedViewModel.cs
@@ -2,9 +2,10 @@
 using Web.App.Infrastructure.Apis;
 namespace Web.App.ViewModels;
 
-public class TrustComparatorsSubmittedViewModel(Trust trust, PutComparatorSetUserDefinedRequest request)
+public class TrustComparatorsSubmittedViewModel(Trust trust, PutComparatorSetUserDefinedRequest request, bool isEdit)
 {
     public string? CompanyNumber => trust.CompanyNumber;
     public string? Name => trust.TrustName;
     public Guid Identifier => request.Identifier;
+    public bool IsEdit => isEdit;
 }

--- a/web/src/Web.App/Views/TrustComparatorsCreateBy/Name.cshtml
+++ b/web/src/Web.App/Views/TrustComparatorsCreateBy/Name.cshtml
@@ -58,7 +58,7 @@
             novalidate = "novalidate"
         }))
 {
-    @await Html.PartialAsync("_ChosenTrusts", new TrustComparatorsChosenTrustsViewModel(Model.CompanyNumber, Model.Trusts))
+    @await Html.PartialAsync("_ChosenTrusts", new TrustComparatorsChosenTrustsViewModel(Model.CompanyNumber, Model.Trusts, Model.IsEdit))
 }
 
 @if (Model.Trusts != null && Model.Trusts.Any(x => x.CompanyNumber != Model.CompanyNumber))

--- a/web/src/Web.App/Views/TrustComparatorsCreateBy/Submit.cshtml
+++ b/web/src/Web.App/Views/TrustComparatorsCreateBy/Submit.cshtml
@@ -1,7 +1,9 @@
 ﻿@using Web.App.TagHelpers
 @model Web.App.ViewModels.TrustComparatorsSubmittedViewModel
 @{
-    ViewData[ViewDataKeys.Title] = PageTitles.TrustComparatorsSubmit;
+    ViewData[ViewDataKeys.Title] = Model.IsEdit
+        ? PageTitles.TrustComparatorsSubmitEdit
+        : PageTitles.TrustComparatorsSubmit;
 }
 
 <div class="govuk-grid-row">

--- a/web/src/Web.App/Views/TrustComparatorsCreateBy/_ChosenTrusts.cshtml
+++ b/web/src/Web.App/Views/TrustComparatorsCreateBy/_ChosenTrusts.cshtml
@@ -11,7 +11,7 @@
         class="govuk-button"
         data-module="govuk-button"
         id="create-set">
-        Create a set using these trusts
+        @(Model.IsEdit ? "Change your set": "Create a set using these trusts")
     </a>
     <table class="govuk-table">
         <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden">Chosen trusts (@Model.Trusts.Count(x => x.CompanyNumber != Model.CompanyNumber))</caption>

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/Comparators/WhenViewingComparatorsCreateSubmit.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/Comparators/WhenViewingComparatorsCreateSubmit.cs
@@ -10,14 +10,16 @@ namespace Web.Integration.Tests.Pages.Trusts.Comparators;
 
 public class WhenViewingComparatorsCreateSubmit(SchoolBenchmarkingWebAppClient client) : PageBase<SchoolBenchmarkingWebAppClient>(client)
 {
-    [Fact]
-    public async Task CanDisplay()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanDisplay(bool isEdit)
     {
-        var page = await SetupNavigateInitPage();
-        AssertPageLayout(page);
+        var page = await SetupNavigateInitPage(isEdit);
+        AssertPageLayout(page, isEdit);
     }
 
-    private async Task<IHtmlDocument> SetupNavigateInitPage()
+    private async Task<IHtmlDocument> SetupNavigateInitPage(bool isEdit)
     {
         var trust = Fixture.Build<Trust>()
             .With(x => x.CompanyNumber, "12345")
@@ -27,7 +29,8 @@ public class WhenViewingComparatorsCreateSubmit(SchoolBenchmarkingWebAppClient c
         var set = new UserDefinedTrustComparatorSet
         {
             Set = ["1", "2", "3"],
-            TotalTrusts = 123
+            TotalTrusts = 123,
+            RunId = isEdit ? Guid.NewGuid().ToString() : null
         };
         var sessionState = new ConcurrentDictionary<string, byte[]>
         {
@@ -50,10 +53,16 @@ public class WhenViewingComparatorsCreateSubmit(SchoolBenchmarkingWebAppClient c
         return page;
     }
 
-    private static void AssertPageLayout(IHtmlDocument page)
+    private static void AssertPageLayout(IHtmlDocument page, bool isEdit)
     {
-        DocumentAssert.TitleAndH1(page,
-            "Generating benchmarking data - Financial Benchmarking and Insights Tool - GOV.UK",
-            "Generating benchmarking data");
+        var expectedTitle = isEdit
+            ? "Updating benchmarking data - Financial Benchmarking and Insights Tool - GOV.UK"
+            : "Generating benchmarking data - Financial Benchmarking and Insights Tool - GOV.UK";
+
+        var expectedHeading = isEdit
+            ? "Updating benchmarking data"
+            : "Generating benchmarking data";
+
+        DocumentAssert.TitleAndH1(page, expectedTitle, expectedHeading);
     }
 }


### PR DESCRIPTION
### Context
[AB#218109](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/218109) - [AB#222934](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/222934)
Issue 31 and 40

### Change proposed in this pull request
Use `UserDefinedTrustComparatorSet.RunId` to set whether this is an edit or not and conditionally display the button text for the create by name page, title and heading for the submit page as per the AC

### Guidance to review 
N/A 

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

