### PR TITLE
feat: updates to trust home displayed school phases

### DIFF
--- a/web/src/Web.App/Domain/OverallPhaseTypes.cs
+++ b/web/src/Web.App/Domain/OverallPhaseTypes.cs
@@ -10,6 +10,20 @@ public static class OverallPhaseTypes
     public const string PupilReferralUnit = "Pupil referral unit";
     public const string AllThrough = "All-through";
     public const string Nursery = "Nursery";
+    public const string PostSixteen = "Post-16";
+    public const string AlternativeProvision = "Alternative Provision";
+    public const string UniversityTechnicalCollege = "University technical college";
 
-    public static string[] All => [Primary, Secondary, Special, PupilReferralUnit, AllThrough, Nursery];
+    public static string[] All =>
+    [
+        Primary,
+        Secondary,
+        Special,
+        PupilReferralUnit,
+        AllThrough,
+        Nursery,
+        PostSixteen,
+        AlternativeProvision,
+        UniversityTechnicalCollege
+    ];
 }

--- a/web/src/Web.App/ViewModels/TrustViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustViewModel.cs
@@ -74,10 +74,6 @@ public class TrustViewModel(Trust trust)
     public IEnumerable<School> Schools { get; } = [];
     public IEnumerable<RagCostCategoryViewModel> Ratings { get; } = [];
 
-    public IEnumerable<RagSchoolViewModel> NurserySchools => GroupedSchools
-        .Where(s => s.OverallPhase == OverallPhaseTypes.Nursery)
-        .SelectMany(s => s.Schools);
-
     public IEnumerable<RagSchoolViewModel> PrimarySchools => GroupedSchools
         .Where(s => s.OverallPhase == OverallPhaseTypes.Primary)
         .SelectMany(s => s.Schools);
@@ -86,13 +82,27 @@ public class TrustViewModel(Trust trust)
         .Where(s => s.OverallPhase == OverallPhaseTypes.Secondary)
         .SelectMany(s => s.Schools);
 
+    public IEnumerable<RagSchoolViewModel> Special => GroupedSchools
+        .Where(s => s.OverallPhase is OverallPhaseTypes.Special)
+        .SelectMany(s => s.Schools);
+
+    public IEnumerable<RagSchoolViewModel> AlternativeProvision => GroupedSchools
+        .Where(s => s.OverallPhase is OverallPhaseTypes.AlternativeProvision)
+        .SelectMany(s => s.Schools);
+
     public IEnumerable<RagSchoolViewModel> AllThroughSchools => GroupedSchools
         .Where(s => s.OverallPhase == OverallPhaseTypes.AllThrough)
         .SelectMany(s => s.Schools);
 
-    public IEnumerable<RagSchoolViewModel> SpecialOrPruSchools => GroupedSchools
-        .Where(s => s.OverallPhase is OverallPhaseTypes.Special or OverallPhaseTypes.PupilReferralUnit)
+    public IEnumerable<RagSchoolViewModel> UniversityTechnicalColleges => GroupedSchools
+        .Where(s => s.OverallPhase == OverallPhaseTypes.UniversityTechnicalCollege)
         .SelectMany(s => s.Schools);
+
+    public IEnumerable<RagSchoolViewModel> PostSixteen => GroupedSchools
+        .Where(s => s.OverallPhase == OverallPhaseTypes.PostSixteen)
+        .SelectMany(s => s.Schools);
+
+
 
     private IEnumerable<(string? OverallPhase, IOrderedEnumerable<RagSchoolViewModel> Schools)> GroupedSchools { get; } = [];
 

--- a/web/src/Web.App/Views/Trust/Index.cshtml
+++ b/web/src/Web.App/Views/Trust/Index.cshtml
@@ -102,12 +102,6 @@
 
 @await Html.PartialAsync("_SchoolsSection", new TrustSchoolsSectionViewModel
 {
-    Heading = "Nursery schools",
-    Schools = Model.NurserySchools
-})
-
-@await Html.PartialAsync("_SchoolsSection", new TrustSchoolsSectionViewModel
-{
     Heading = "Primary schools",
     Schools = Model.PrimarySchools
 })
@@ -120,14 +114,32 @@
 
 @await Html.PartialAsync("_SchoolsSection", new TrustSchoolsSectionViewModel
 {
-    Heading = "Specials and Pupil Referrals units (PRUs)",
-    Schools = Model.SpecialOrPruSchools
+    Heading = "Special",
+    Schools = Model.Special
+})
+
+@await Html.PartialAsync("_SchoolsSection", new TrustSchoolsSectionViewModel
+{
+Heading = "Alternative provision",
+Schools = Model.AlternativeProvision
 })
 
 @await Html.PartialAsync("_SchoolsSection", new TrustSchoolsSectionViewModel
 {
     Heading = "All-through",
     Schools = Model.AllThroughSchools
+})
+
+@await Html.PartialAsync("_SchoolsSection", new TrustSchoolsSectionViewModel
+{
+Heading = "Post 16",
+Schools = Model.PostSixteen
+})
+
+@await Html.PartialAsync("_SchoolsSection", new TrustSchoolsSectionViewModel
+{
+Heading = "University technical colleges",
+Schools = Model.UniversityTechnicalColleges
 })
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingHome.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingHome.cs
@@ -148,9 +148,6 @@ public class WhenViewingHome(SchoolBenchmarkingWebAppClient client) : PageBase<S
         Assert.Equal(AllCostCategories.Count - 1, costCategoryRagRows?.Length);
 
         // school phases
-        var nurserySchoolRag = page.QuerySelector("#school-rag-nursery-schools") as IHtmlTableElement;
-        var nurserySchoolRagRows = nurserySchoolRag?.Bodies.First().Rows;
-        Assert.Equal(schools.Count(s => s.OverallPhase == OverallPhaseTypes.Nursery), nurserySchoolRagRows?.Length ?? 0);
 
         var primarySchoolRag = page.QuerySelector("#school-rag-primary-schools") as IHtmlTableElement;
         var primarySchoolRagRows = primarySchoolRag?.Bodies.First().Rows;
@@ -160,12 +157,20 @@ public class WhenViewingHome(SchoolBenchmarkingWebAppClient client) : PageBase<S
         var secondarySchoolRagRows = secondarySchoolRag?.Bodies.First().Rows;
         Assert.Equal(schools.Count(s => s.OverallPhase == OverallPhaseTypes.Secondary), secondarySchoolRagRows?.Length ?? 0);
 
-        var specialSchoolRag = page.QuerySelector("#school-rag-specials-and-pupil-referrals-units-prus") as IHtmlTableElement;
+        var specialSchoolRag = page.QuerySelector("#school-rag-special") as IHtmlTableElement;
         var specialSchoolRagRows = specialSchoolRag?.Bodies.First().Rows;
-        Assert.Equal(schools.Count(s => s.OverallPhase is OverallPhaseTypes.Special or OverallPhaseTypes.PupilReferralUnit), specialSchoolRagRows?.Length ?? 0);
+        Assert.Equal(schools.Count(s => s.OverallPhase is OverallPhaseTypes.Special), specialSchoolRagRows?.Length ?? 0);
 
-        var allThroughSchoolRag = page.QuerySelector("#school-rag-all-through") as IHtmlTableElement;
-        var allThroughSchoolRagRows = allThroughSchoolRag?.Bodies.First().Rows;
-        Assert.Equal(schools.Count(s => s.OverallPhase == OverallPhaseTypes.AllThrough), allThroughSchoolRagRows?.Length ?? 0);
+        var alternativeProvisionSchoolRag = page.QuerySelector("#school-rag-alternative-provision") as IHtmlTableElement;
+        var alternativeProvisionSchoolRagRows = alternativeProvisionSchoolRag?.Bodies.First().Rows;
+        Assert.Equal(schools.Count(s => s.OverallPhase is OverallPhaseTypes.AlternativeProvision), alternativeProvisionSchoolRagRows?.Length ?? 0);
+
+        var postSixteenSchoolRag = page.QuerySelector("#school-rag-post-16") as IHtmlTableElement;
+        var postSixteenSchoolRagRows = postSixteenSchoolRag?.Bodies.First().Rows;
+        Assert.Equal(schools.Count(s => s.OverallPhase == OverallPhaseTypes.PostSixteen), postSixteenSchoolRagRows?.Length ?? 0);
+
+        var universityTechnicalCollegeRag = page.QuerySelector("#school-rag-university-technical-colleges") as IHtmlTableElement;
+        var universityTechnicalCollegeRagRows = universityTechnicalCollegeRag?.Bodies.First().Rows;
+        Assert.Equal(schools.Count(s => s.OverallPhase == OverallPhaseTypes.UniversityTechnicalCollege), universityTechnicalCollegeRagRows?.Length ?? 0);
     }
 }


### PR DESCRIPTION
### Context
[AB#221010](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/221010) - [AB#221882](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/221882)

### Change proposed in this pull request
updates phases displayed as rag stack tables on the trust home page to match the phases detailed in the ticket for academies

### Guidance to review 
N/A

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

