### PR TITLE
fix: get BFR data from SOFA

### DIFF
--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -292,7 +292,19 @@ def pre_process_all_schools(run_type, year, data_ref):
 
 
 def pre_process_bfr(run_type, year):
-    logger.info("Processing BFR Data")
+    """
+    Aggregate academies budget forecast return (BFR) from
+    statement of financial returns (SOFA) and three-year forecast
+    (3Y) files.
+
+    Forecast data for previous-and-current years are derived from BFR
+    SOFA data; forecast data for future years are derived from BFR 3Y
+    data.
+
+    :param run_type: "default" or "custom"
+    :param year: financial year in question
+    """
+    logger.info("Processing BFR data.")
 
     bfr_sofa = get_blob(
         raw_container, f"{run_type}/{year}/BFR_SOFA_raw.csv", encoding="unicode-escape"
@@ -302,37 +314,103 @@ def pre_process_bfr(run_type, year):
         raw_container, f"{run_type}/{year}/BFR_3Y_raw.csv", encoding="unicode-escape"
     )
 
-    academies_y2_file = try_get_blob(
-        "pre-processed", f"{run_type}/{year - 2}/academies.parquet"
-    )
     academies_y2 = None
-    if academies_y2_file is not None:
+    if academies_y2_file := try_get_blob(
+        "pre-processed", f"{run_type}/{year - 2}/academies.parquet"
+    ):
         academies_y2 = pd.read_parquet(
             academies_y2_file,
             columns=[
                 "Trust UPIN",
                 "Company Registration Number",
-                "Trust Revenue reserve",
+                # "Trust Revenue reserve",  # SOFA, EFALineNo == 430.
                 "Total pupils in trust",
             ],
         )
+        if bfr_sofa_year_minus_two_file := try_get_blob(
+            raw_container,
+            f"{run_type}/{year - 2}/BFR_SOFA_raw.csv",
+            encoding="unicode-escape",
+        ):
+            bfr_sofa_year_minus_two = (
+                pd.read_csv(
+                    bfr_sofa_year_minus_two_file,
+                    usecols=[
+                        "TrustUPIN",
+                        "EFALineNo",
+                        "Y2P2",
+                    ],
+                )
+                .rename(
+                    {
+                        "TrustUPIN": "Trust UPIN",
+                    }
+                )
+                .query("EFALineNo == 430")
+            )
+            academies_y2 = academies_y2.merge(
+                bfr_sofa_year_minus_two[
+                    bfr_sofa_year_minus_two["EFALineNo"] == 430
+                ].rename(
+                    {"Y2P2": "Trust Revenue reserve"},
+                    axis=1,
+                )[
+                    ["Trust UPIN", "Trust Revenue reserve"]
+                ],
+                on="Trust UPIN",
+                how="left",
+            )
+            academies_y2["Trust Revenue reserve"] *= 1_000
 
-    academies_y1_file = try_get_blob(
-        "pre-processed", f"{run_type}/{year - 1}/academies.parquet"
-    )
     academies_y1 = None
-
-    if academies_y1_file is not None:
+    if academies_y1_file := try_get_blob(
+        "pre-processed", f"{run_type}/{year - 1}/academies.parquet"
+    ):
         academies_y1 = pd.read_parquet(
             academies_y1_file,
             columns=[
                 "Trust UPIN",
                 "Company Registration Number",
-                "Trust Revenue reserve",
+                # "Trust Revenue reserve",  # SOFA, EFALineNo == 430.
                 "Total pupils in trust",
             ],
         )
+        if bfr_sofa_year_minus_two_file := try_get_blob(
+            raw_container,
+            f"{run_type}/{year - 2}/BFR_SOFA_raw.csv",
+            encoding="unicode-escape",
+        ):
+            bfr_sofa_year_minus_two = (
+                pd.read_csv(
+                    bfr_sofa_year_minus_two_file,
+                    usecols=[
+                        "TrustUPIN",
+                        "EFALineNo",
+                        "Y2P2",
+                    ],
+                )
+                .rename(
+                    {
+                        "TrustUPIN": "Trust UPIN",
+                    }
+                )
+                .query("EFALineNo == 430")
+            )
+            academies_y1 = academies_y1.merge(
+                bfr_sofa_year_minus_two[
+                    bfr_sofa_year_minus_two["EFALineNo"] == 430
+                ].rename(
+                    {"y1P2": "Trust Revenue reserve"},
+                    axis=1,
+                )[
+                    ["Trust UPIN", "Trust Revenue reserve"]
+                ],
+                on="Trust UPIN",
+                how="left",
+            )
+            academies_y1["Trust Revenue reserve"] *= 1_000
 
+    # TODO: handle condition where this doesn't exist.
     academies = pd.read_parquet(
         get_blob("pre-processed", f"{run_type}/{year}/academies.parquet"),
         columns=[


### PR DESCRIPTION
### Context

From the main ticket:

> _"…the BFR value for Revenue reserve for Current and previous years takes from the SOFA and efaline 430."_
> _"…where it is a balance, then Y2P2…"_

[AB#217947](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/217947)

### Change proposed in this pull request

Still reading the various `academies` files but replacing values therein with the corresponding `EFALineNo` from the BFR SOFA data for that year.

### Guidance to review 

Note: looked at this and the plan was to replace both `Trust Revenue reserve` and `Total pupils in trust`. However, while the former (line 430) looks roughly right, the latter (which, according to [this doc.](https://assets.publishing.service.gov.uk/media/6605777ff9ab410011eea508/BFR_lines_quick_reference_guide.pdf), should be 999) is `0.0` across the board.

I've therefore only pulled the former.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally

