### PR TITLE
feat: updates to displayed phases for la home

### DIFF
--- a/web/src/Web.App/ViewModels/LocalAuthorityViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityViewModel.cs
@@ -9,23 +9,25 @@ public class LocalAuthorityViewModel(LocalAuthority localAuthority)
         IReadOnlyCollection<School> schools)
         : this(localAuthority)
     {
-        PrimarySchools = schools.Where(IsPrimary).OrderBy(x => x.SchoolName);
-        SecondarySchools = schools.Where(IsSecondary).OrderBy(x => x.SchoolName);
-        SpecialOrPruSchools = schools.Where(IsSpecialOrPru).OrderBy(x => x.SchoolName);
-        OtherSchools = schools.Where(IsOther).OrderBy(x => x.SchoolName);
+        GroupedSchools = schools
+            .OrderBy(x => x.SchoolName)
+            .GroupBy(x => x.OverallPhase)
+            .OrderBy(x => LaPhaseOrderMap[x.Key ?? string.Empty]);
     }
 
     public string? Code => localAuthority.Code;
     public string? Name => localAuthority.Name;
-    public IEnumerable<School> PrimarySchools { get; } = [];
-    public IEnumerable<School> SecondarySchools { get; } = [];
-    public IEnumerable<School> SpecialOrPruSchools { get; } = [];
-    public IEnumerable<School> OtherSchools { get; } = [];
+    public IEnumerable<IGrouping<string?, School>> GroupedSchools { get; } = [];
 
-    private static bool IsPrimary(School school) => school.OverallPhase is OverallPhaseTypes.Primary;
-    private static bool IsSecondary(School school) => school.OverallPhase is OverallPhaseTypes.Secondary;
-    private static bool IsSpecialOrPru(School school) => school.OverallPhase is OverallPhaseTypes.Special or OverallPhaseTypes.PupilReferralUnit;
-    private static bool IsOther(School school) => !IsPrimary(school) && !IsSecondary(school) && !IsSpecialOrPru(school);
+    private static Dictionary<string, int> LaPhaseOrderMap => new()
+    {
+        { OverallPhaseTypes.Primary, 1 },
+        { OverallPhaseTypes.Secondary, 2 },
+        { OverallPhaseTypes.Special, 3 },
+        { OverallPhaseTypes.PupilReferralUnit, 4 },
+        { OverallPhaseTypes.Nursery, 5 },
+        { OverallPhaseTypes.AllThrough, 6 }
+    };
 }
 
 public class LocalAuthoritySchoolsSectionViewModel

--- a/web/src/Web.App/Views/LocalAuthority/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthority/Index.cshtml
@@ -27,10 +27,17 @@
     <div class="govuk-grid-column-full">
         <h2 class="govuk-heading-m">Schools in local authority</h2>
         <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-schools">
-            @await Html.PartialAsync("_SchoolsSection", new LocalAuthoritySchoolsSectionViewModel { Heading = "Primary schools", Id = 1, Schools = Model.PrimarySchools })
-            @await Html.PartialAsync("_SchoolsSection", new LocalAuthoritySchoolsSectionViewModel { Heading = "Secondary schools", Id = 2, Schools = Model.SecondarySchools })
-            @await Html.PartialAsync("_SchoolsSection", new LocalAuthoritySchoolsSectionViewModel { Heading = "Specials and Pupil Referrals units (PRUs)", Id = 3, Schools = Model.SpecialOrPruSchools })
-            @await Html.PartialAsync("_SchoolsSection", new LocalAuthoritySchoolsSectionViewModel { Heading = "Other schools", Id = 4, Schools = Model.OtherSchools })
+            @{
+                foreach (var (group, index) in Model.GroupedSchools.Select((group, index) => (group, index)))
+                {
+                    @await Html.PartialAsync("_SchoolsSection", new LocalAuthoritySchoolsSectionViewModel
+                    {
+                        Heading = group.Key,
+                        Schools = group,
+                        Id = index
+                    })
+                }
+            }
         </div>
     </div>
 </div>

--- a/web/src/Web.App/Views/LocalAuthority/_SchoolsSection.cshtml
+++ b/web/src/Web.App/Views/LocalAuthority/_SchoolsSection.cshtml
@@ -1,6 +1,4 @@
-﻿@using Web.App.Extensions
-@model Web.App.ViewModels.LocalAuthoritySchoolsSectionViewModel
-
+﻿@model Web.App.ViewModels.LocalAuthoritySchoolsSectionViewModel
 
 <div class="govuk-accordion__section">
     <div class="govuk-accordion__section-header">
@@ -11,8 +9,6 @@
         </h3>
     </div>
     <div id="accordion-schools-content-@Model.Id" class="govuk-accordion__section-content">
-        @if (Model.Schools.Any())
-        {
         <ul class="govuk-list">
             @foreach (var school in Model.Schools)
             {
@@ -20,12 +16,8 @@
                     <a class="govuk-link govuk-link--no-visited-state" href="@Url.Action("Index", "School", new {urn = school.URN})">@school.SchoolName</a>
                 </li>
             }
-            </ul>
-        }
-        else
-        {
-            <p class="govuk-body">There are no schools to display of this type in this local authority</p>
-        }
+        </ul>
     </div>
 </div>
+
 


### PR DESCRIPTION
### Context
[AB#221010](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/221010) - [AB#221649](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/221649)

### Change proposed in this pull request
Updates to displayed phases for the la home page. phases are no longer grouped as other or special and pru. Also refactored so only the phases within the la are displayed as accordion sections

### Guidance to review 
n/a

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

