### PR TITLE
fix: data source for pupil and school census

### DIFF
--- a/web/src/Web.App/Views/School/History.cshtml
+++ b/web/src/Web.App/Views/School/History.cshtml
@@ -3,8 +3,8 @@
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.HistoricData;
     var dataSource = Model.IsPartOfTrust
-        ? "All data is from academies accounts return (AAR) return."
-        : "All data is from consistent financial reporting (CFR).";
+        ? "Financial data is from academies accounts return (AAR) return."
+        : "Financial data is from consistent financial reporting (CFR).";
 }
 
 @await Component.InvokeAsync("EstablishmentHeading", new { title = ViewData[ViewDataKeys.Title], name = Model.Name, id = Model.Urn, kind = OrganisationTypes.School })
@@ -13,6 +13,8 @@
     <div class="govuk-grid-column-two-thirds">
         <p class="govuk-body">View data from previous financial years.</p>
         <p class="govuk-body">@dataSource</p>
+        <p class="govuk-body">Workforce data is taken from the workforce census.</p>
+        <p class="govuk-body">Pupil data is taken from the school census data set in January.</p>
     </div>
 </div>
 


### PR DESCRIPTION
### Context
[AB#219193](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/219193) - [AB#223775](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/223775)

### Change proposed in this pull request
Updates content for the historic page to correctly call out the data source for the pupil and workforce tab as workforce census and school census as per the ticket.

### Guidance to review 
n/a

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

