### PR TITLE
chore: adds integration tests for spending and costs default and custom

### DIFF
--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -330,6 +330,15 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         return this;
     }
 
+    public BenchmarkingWebAppClient SetupExpenditureForCustomData(School school, string identifier, SchoolExpenditure expenditure)
+    {
+        ExpenditureApi.Reset();
+        ExpenditureApi
+            .Setup(api => api.SchoolCustom(school.URN, identifier, It.IsAny<ApiQuery?>()))
+            .ReturnsAsync(ApiResult.Ok(expenditure));
+        return this;
+    }
+
     public BenchmarkingWebAppClient SetupSchoolInsight(School school, SchoolCharacteristic? characteristic = null)
     {
         SchoolInsightApi.Reset();

--- a/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataSpending.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataSpending.cs
@@ -1,0 +1,207 @@
+using System.Net;
+using AngleSharp.Html.Dom;
+using AutoFixture;
+using Web.App.Domain;
+using Xunit;
+
+namespace Web.Integration.Tests.Pages.Schools.CustomData;
+
+public class WhenViewingCustomDataSpending(SchoolBenchmarkingWebAppClient client)
+    : PageBase<SchoolBenchmarkingWebAppClient>(client)
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanDisplay(bool withUserData)
+    {
+        var (page, school) = await SetupNavigateInitPage(withUserData);
+
+        if (withUserData)
+        {
+            AssertPageLayout(page, school);
+        }
+        else
+        {
+            DocumentAssert.AssertPageUrl(page, Paths.SchoolHome(school.URN).ToAbsolute());
+        }
+    }
+
+    [Fact]
+    public async Task CanNavigateUsingViewAllCategories()
+    {
+        var (page, school) = await SetupNavigateInitPage(true);
+
+        var categorySections = page.QuerySelectorAll(".govuk-\\!-margin-bottom-4");
+
+        Assert.Equal(9, categorySections.Length);
+
+        var expectedUrl = Paths.SchoolComparisonCustomData(school.URN);
+
+        foreach (var section in categorySections)
+        {
+            var sectionHeading = section.QuerySelector("h3")?.TextContent;
+            Assert.NotNull(sectionHeading);
+
+            var id = CategoryHeadingToIdMap[sectionHeading];
+
+            var anchor = section.QuerySelector(".govuk-link");
+            Assert.NotNull(anchor);
+
+            var targetPage = await Client.Follow(anchor);
+
+            DocumentAssert.AssertPageUrl(targetPage, $"{expectedUrl}#{id}".ToAbsolute());
+            DocumentAssert.TitleAndH1(targetPage, "Benchmark spending - Financial Benchmarking and Insights Tool - GOV.UK",
+                "Benchmark spending");
+        }
+    }
+
+    [Fact]
+    public async Task CanDisplayNotFound()
+    {
+        const string urn = "12345";
+
+        var userData = new[]
+        {
+            new UserData
+            {
+                Type = "custom-data",
+                Id = "123",
+                Status = "complete"
+            }
+        };
+
+        var page = await Client.SetupEstablishmentWithNotFound()
+            .SetupUserData(userData)
+            .Navigate(Paths.SchoolSpendingCustomData(urn));
+
+        PageAssert.IsNotFoundPage(page);
+        DocumentAssert.AssertPageUrl(page, Paths.SchoolSpendingCustomData(urn).ToAbsolute(), HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task CanDisplayProblemWithService()
+    {
+        const string urn = "12345";
+
+        var userData = new[]
+        {
+            new UserData
+            {
+                Type = "custom-data",
+                Id = "123",
+                Status = "complete"
+            }
+        };
+
+        var page = await Client.SetupEstablishmentWithException()
+            .SetupUserData(userData)
+            .Navigate(Paths.SchoolSpendingCustomData(urn));
+
+        PageAssert.IsProblemPage(page);
+        DocumentAssert.AssertPageUrl(page, Paths.SchoolSpendingCustomData(urn).ToAbsolute(),
+            HttpStatusCode.InternalServerError);
+    }
+
+    private async Task<(IHtmlDocument page, School school)> SetupNavigateInitPage(bool withUserData)
+    {
+        var school = Fixture.Build<School>()
+            .With(x => x.URN, "12345")
+            .Create();
+
+        var customDataId = "123";
+
+        var userData = new[]
+        {
+            new UserData
+            {
+                Type = "custom-data",
+                Id = customDataId,
+                Status = "complete"
+            }
+        };
+
+        Assert.NotNull(school.URN);
+
+        var rating = CreateRagRatings(school.URN);
+
+        var expenditure = Fixture.Build<SchoolExpenditure>().Create();
+
+        IHtmlDocument page;
+
+        if (withUserData)
+        {
+            page = await Client.SetupEstablishment(school)
+                .SetupInsights()
+                .SetupUserData(userData)
+                .SetupMetricRagRatingIncCustom(customDataId, rating)
+                .SetupExpenditureForCustomData(school, customDataId, expenditure)
+                .Navigate(Paths.SchoolSpendingCustomData(school.URN));
+        }
+        else
+        {
+            page = await Client.SetupEstablishment(school)
+                .SetupInsights()
+                .SetupUserData()
+                .SetupMetricRagRating(rating)
+                .SetupExpenditure(school, expenditure)
+                .Navigate(Paths.SchoolSpendingCustomData(school.URN));
+        }
+
+        return (page, school);
+    }
+
+    private static void AssertPageLayout(IHtmlDocument page, School school)
+    {
+        DocumentAssert.AssertPageUrl(page, Paths.SchoolSpendingCustomData(school.URN).ToAbsolute());
+        DocumentAssert.TitleAndH1(page, "Spending priorities for this school - Financial Benchmarking and Insights Tool - GOV.UK",
+            "Spending priorities for this school");
+    }
+
+    private RagRating[] CreateRagRatings(string urn)
+    {
+        var random = new Random();
+
+        var statusKeys = Lookups.StatusPriorityMap.Keys.ToList();
+
+        var ratings = new List<RagRating>();
+
+        foreach (var category in AllCostCategories)
+        {
+            var rating = Fixture.Build<RagRating>()
+                .With(r => r.Category, category)
+                .With(r => r.RAG, () => statusKeys[random.Next(statusKeys.Count)])
+                .With(r => r.URN, urn)
+                .Create();
+            ratings.Add(rating);
+        }
+
+        return ratings.ToArray();
+    }
+
+    private static readonly List<string> AllCostCategories =
+    [
+        Category.TeachingStaff,
+        Category.NonEducationalSupportStaff,
+        Category.EducationalSupplies,
+        Category.EducationalIct,
+        Category.PremisesStaffServices,
+        Category.Utilities,
+        Category.AdministrativeSupplies,
+        Category.CateringStaffServices,
+        Category.Other
+    ];
+
+    private static Dictionary<string, string> CategoryHeadingToIdMap => new()
+    {
+        { "Teaching and Teaching support staff", "teaching-and-teaching-support-staff" },
+        { "Non-educational support staff", "non-educational-support-staff-and-services" },
+        { "Educational supplies", "educational-supplies" },
+        { "Educational ICT", "educational-ict" },
+        { "Premises staff and services", "premises-staff-and-services" },
+        { "Utilities", "utilities" },
+        { "Administrative supplies", "administrative-supplies" },
+        { "Catering staff and supplies", "catering-staff-and-supplies" },
+        { "Other costs", "other-costs" },
+    };
+
+}

--- a/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingSpending.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingSpending.cs
@@ -1,0 +1,168 @@
+using System.Net;
+using AngleSharp.Html.Dom;
+using AutoFixture;
+using Web.App.Domain;
+using Xunit;
+
+namespace Web.Integration.Tests.Pages.Schools;
+
+public class WhenViewingSpending(SchoolBenchmarkingWebAppClient client)
+    : PageBase<SchoolBenchmarkingWebAppClient>(client)
+{
+    [Theory]
+    [InlineData(EstablishmentTypes.Academies)]
+    [InlineData(EstablishmentTypes.Maintained)]
+    public async Task CanDisplay(string financeType)
+    {
+        var (page, school) = await SetupNavigateInitPage(financeType);
+
+        AssertPageLayout(page, school);
+    }
+
+    [Theory]
+    [InlineData(EstablishmentTypes.Academies)]
+    [InlineData(EstablishmentTypes.Maintained)]
+    public async Task CanNavigateUsingViewAllCategories(string financeType)
+    {
+        var (page, school) = await SetupNavigateInitPage(financeType);
+
+        var categorySections = page.QuerySelectorAll(".govuk-\\!-margin-bottom-4");
+
+        Assert.Equal(9, categorySections.Length);
+
+        var expectedUrl = Paths.SchoolComparison(school.URN);
+
+        foreach (var section in categorySections)
+        {
+            var sectionHeading = section.QuerySelector("h3")?.TextContent;
+            Assert.NotNull(sectionHeading);
+
+            var id = CategoryHeadingToIdMap[sectionHeading];
+
+            var anchor = section.QuerySelector(".govuk-link");
+            Assert.NotNull(anchor);
+
+            var targetPage = await Client.Follow(anchor);
+
+            DocumentAssert.AssertPageUrl(targetPage, $"{expectedUrl}#{id}".ToAbsolute());
+            DocumentAssert.TitleAndH1(targetPage, "Benchmark spending - Financial Benchmarking and Insights Tool - GOV.UK",
+                "Benchmark spending");
+        }
+    }
+
+    [Theory]
+    [InlineData(EstablishmentTypes.Academies)]
+    [InlineData(EstablishmentTypes.Maintained)]
+    public async Task CanNavigateToCustomData(string financeType)
+    {
+        var (page, school) = await SetupNavigateInitPage(financeType);
+
+        var anchor = page.QuerySelector("#custom-data-link");
+        Assert.NotNull(anchor);
+
+        var targetPage = await Client.Follow(anchor);
+
+        DocumentAssert.AssertPageUrl(targetPage, Paths.SchoolCustomData(school.URN).ToAbsolute());
+    }
+
+    [Fact]
+    public async Task CanDisplayNotFound()
+    {
+        const string urn = "12345";
+        var page = await Client.SetupEstablishmentWithNotFound()
+            .Navigate(Paths.SchoolSpending(urn));
+
+        PageAssert.IsNotFoundPage(page);
+        DocumentAssert.AssertPageUrl(page, Paths.SchoolSpending(urn).ToAbsolute(), HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task CanDisplayProblemWithService()
+    {
+        const string urn = "12345";
+        var page = await Client.SetupEstablishmentWithException()
+            .Navigate(Paths.SchoolSpending(urn));
+
+        PageAssert.IsProblemPage(page);
+        DocumentAssert.AssertPageUrl(page, Paths.SchoolSpending(urn).ToAbsolute(),
+            HttpStatusCode.InternalServerError);
+    }
+
+    private async Task<(IHtmlDocument page, School school)> SetupNavigateInitPage(string financeType)
+    {
+        var school = Fixture.Build<School>()
+            .With(x => x.URN, "12345")
+            .With(x => x.FinanceType, financeType)
+            .Create();
+
+        Assert.NotNull(school.URN);
+
+        var rating = CreateRagRatings(school.URN);
+
+        var expenditure = Fixture.Build<SchoolExpenditure>().Create();
+
+        var page = await Client.SetupEstablishment(school)
+            .SetupInsights()
+            .SetupUserData()
+            .SetupMetricRagRating(rating)
+            .SetupExpenditure(school, expenditure)
+            .Navigate(Paths.SchoolSpending(school.URN));
+
+        return (page, school);
+    }
+
+    private static void AssertPageLayout(IHtmlDocument page, School school)
+    {
+        DocumentAssert.AssertPageUrl(page, Paths.SchoolSpending(school.URN).ToAbsolute());
+        DocumentAssert.TitleAndH1(page, "Spending priorities for this school - Financial Benchmarking and Insights Tool - GOV.UK",
+            "Spending priorities for this school");
+    }
+
+    private RagRating[] CreateRagRatings(string urn)
+    {
+        var random = new Random();
+
+        var statusKeys = Lookups.StatusPriorityMap.Keys.ToList();
+
+        var ratings = new List<RagRating>();
+
+        foreach (var category in AllCostCategories)
+        {
+            var rating = Fixture.Build<RagRating>()
+                .With(r => r.Category, category)
+                .With(r => r.RAG, () => statusKeys[random.Next(statusKeys.Count)])
+                .With(r => r.URN, urn)
+                .Create();
+            ratings.Add(rating);
+        }
+
+        return ratings.ToArray();
+    }
+
+    private static readonly List<string> AllCostCategories =
+    [
+        Category.TeachingStaff,
+        Category.NonEducationalSupportStaff,
+        Category.EducationalSupplies,
+        Category.EducationalIct,
+        Category.PremisesStaffServices,
+        Category.Utilities,
+        Category.AdministrativeSupplies,
+        Category.CateringStaffServices,
+        Category.Other
+    ];
+
+    private static Dictionary<string, string> CategoryHeadingToIdMap => new()
+    {
+        { "Teaching and Teaching support staff", "teaching-and-teaching-support-staff" },
+        { "Non-educational support staff", "non-educational-support-staff-and-services" },
+        { "Educational supplies", "educational-supplies" },
+        { "Educational ICT", "educational-ict" },
+        { "Premises staff and services", "premises-staff-and-services" },
+        { "Utilities", "utilities" },
+        { "Administrative supplies", "administrative-supplies" },
+        { "Catering staff and supplies", "catering-staff-and-supplies" },
+        { "Other costs", "other-costs" },
+    };
+
+}

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -33,6 +33,7 @@ public static class Paths
     public static string SchoolComparisonCustomData(string? urn) => $"/school/{urn}/comparison/custom-data";
     public static string SchoolCensus(string? urn) => $"/school/{urn}/census";
     public static string SchoolCensusCustomData(string? urn) => $"/school/{urn}/census/custom-data";
+    public static string SchoolSpending(string? urn) => $"/school/{urn}/spending-and-costs";
     public static string SchoolSpendingCustomData(string? urn) => $"/school/{urn}/spending-and-costs/custom-data";
     public static string SchoolInvestigation(string? urn) => $"/school/{urn}/investigation";
     public static string SchoolFinancialPlanning(string? urn) => $"/school/{urn}/financial-planning";


### PR DESCRIPTION
### Context
[AB#224502](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/224502) - [AB#224934](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/224934)

### Change proposed in this pull request
Adds integration tests to cover the expected behaviour for the school spending (spending and costs) pages. Both default and custom

### Guidance to review 
N/A

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

