### PR TITLE
fix: data source for benchmark census

### DIFF
--- a/web/src/Web.App/Constants/DataSourceTypes.cs
+++ b/web/src/Web.App/Constants/DataSourceTypes.cs
@@ -1,0 +1,7 @@
+﻿namespace Web.App;
+
+public static class DataSourceTypes
+{
+    public const string Spending = "spending";
+    public const string Census = "census";
+}

--- a/web/src/Web.App/ViewComponents/DataSourceViewComponent.cs
+++ b/web/src/Web.App/ViewComponents/DataSourceViewComponent.cs
@@ -7,27 +7,51 @@ namespace Web.App.ViewComponents;
 public class DataSourceViewComponent(IFinanceService financeService) : ViewComponent
 {
     public async Task<IViewComponentResult> InvokeAsync(
-        string kind,
+        string organisationType,
+        string sourceType,
         bool isPartOfTrust,
         string[]? additionText,
         string wrapperClassName = "govuk-grid-row",
         string className = "govuk-grid-column-full")
     {
-        var years = await financeService.GetYears();
-
-        var dataSource = kind switch
+        var dataSource = sourceType switch
         {
-            OrganisationTypes.School when isPartOfTrust =>
-                $"This school's data covers the financial year September {years.Aar - 1} to August {years.Aar} academies accounts return (AAR).",
-            OrganisationTypes.School when !isPartOfTrust =>
-                $"This school's data covers the financial year April {years.Cfr - 1} to March {years.Cfr} consistent financial reporting return (CFR).",
-            OrganisationTypes.Trust =>
-                $"This trust's data covers the financial year September {years.Aar - 1} to August {years.Aar} academies accounts return (AAR).",
-            OrganisationTypes.LocalAuthority =>
-                $"This data covers the financial year April {years.Cfr - 1} to March {years.Cfr} consistent financial reporting return (CFR).",
-            _ => throw new ArgumentOutOfRangeException(nameof(kind))
+            DataSourceTypes.Spending =>
+                await GetSpendingDataSource(organisationType, isPartOfTrust),
+            DataSourceTypes.Census =>
+            [
+                "Workforce data is taken from the workforce census.",
+                "Pupil data is taken from the school census data set in January."
+            ],
+            _ => throw new ArgumentOutOfRangeException(nameof(sourceType))
         };
 
         return View(new DataSourceViewModel(dataSource, additionText, wrapperClassName, className));
+    }
+
+    private async Task<string[]> GetSpendingDataSource(string organisationType, bool isPartOfTrust)
+    {
+        var years = await financeService.GetYears();
+
+        return organisationType switch
+        {
+            OrganisationTypes.School when isPartOfTrust =>
+            [
+                $"This school's data covers the financial year September {years.Aar - 1} to August {years.Aar} academies accounts return (AAR)."
+            ],
+            OrganisationTypes.School when !isPartOfTrust =>
+            [
+                $"This school's data covers the financial year April {years.Cfr - 1} to March {years.Cfr} consistent financial reporting return (CFR)."
+            ],
+            OrganisationTypes.Trust =>
+            [
+                $"This trust's data covers the financial year September {years.Aar - 1} to August {years.Aar} academies accounts return (AAR)."
+            ],
+            OrganisationTypes.LocalAuthority =>
+            [
+                $"This data covers the financial year April {years.Cfr - 1} to March {years.Cfr} consistent financial reporting return (CFR)."
+            ],
+            _ => throw new ArgumentOutOfRangeException(nameof(organisationType))
+        };
     }
 }

--- a/web/src/Web.App/ViewModels/Components/DataSourceViewModel.cs
+++ b/web/src/Web.App/ViewModels/Components/DataSourceViewModel.cs
@@ -1,8 +1,8 @@
 ﻿namespace Web.App.ViewModels.Components;
 
-public class DataSourceViewModel(string dataSource, string[]? additionText, string wrapperClassName, string className)
+public class DataSourceViewModel(string[] dataSource, string[]? additionText, string wrapperClassName, string className)
 {
-    public string DataSource => dataSource;
+    public string[] DataSource => dataSource;
     public string[] AdditionText => additionText ?? [];
     public string WrapperClassName => wrapperClassName;
     public string ClassName => className;

--- a/web/src/Web.App/Views/LocalAuthority/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthority/Index.cshtml
@@ -19,7 +19,11 @@
     </div>
 </div>
 
-@await Component.InvokeAsync("DataSource", new { kind = OrganisationTypes.LocalAuthority })
+@await Component.InvokeAsync("DataSource", new
+{
+    organisationType = OrganisationTypes.LocalAuthority,
+    sourceType = DataSourceTypes.Spending,
+})
 
 <hr class="govuk-section-break govuk-section-break--m">
 

--- a/web/src/Web.App/Views/LocalAuthorityCensus/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityCensus/Index.cshtml
@@ -9,8 +9,9 @@
 
 @await Component.InvokeAsync("DataSource", new
     {
-        kind = OrganisationTypes.LocalAuthority,
-        additionText = new[] { "View pupil and workforce data for schools in this local authority." }
+        organisationType = OrganisationTypes.LocalAuthority,
+        sourceType = DataSourceTypes.Census,
+        additionText = new[] { "View pupil and workforce data for schools in this local authority." },
     })
 
 <div id="compare-your-census"

--- a/web/src/Web.App/Views/LocalAuthorityComparison/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityComparison/Index.cshtml
@@ -7,7 +7,12 @@
 
 @await Component.InvokeAsync("EstablishmentHeading", new { title = ViewData[ViewDataKeys.Title], name = Model.Name, id = Model.Code, kind = OrganisationTypes.LocalAuthority })
 
-@await Component.InvokeAsync("DataSource", new { kind = OrganisationTypes.LocalAuthority, additionText = new[] { "View the spending for schools in this local authority." } })
+@await Component.InvokeAsync("DataSource", new 
+    { 
+        organisationType = OrganisationTypes.LocalAuthority,
+        sourceType = DataSourceTypes.Spending,
+        additionText = new[] { "View the spending for schools in this local authority." } 
+    })
 
 <div id="compare-your-costs"
      data-type="@OrganisationTypes.LocalAuthority"

--- a/web/src/Web.App/Views/School/Index.cshtml
+++ b/web/src/Web.App/Views/School/Index.cshtml
@@ -33,7 +33,8 @@
 
 @await Component.InvokeAsync("DataSource", new
 {
-    kind = OrganisationTypes.School,
+    organisationType = OrganisationTypes.School,
+    sourceType = DataSourceTypes.Spending,
     isPartOfTrust = Model.IsPartOfTrust,
     additionText = string.IsNullOrEmpty(Model.UserDefinedSetId)
         ? null

--- a/web/src/Web.App/Views/SchoolCensus/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolCensus/Index.cshtml
@@ -16,7 +16,6 @@
 {
     organisationType = OrganisationTypes.School,
     sourceType = DataSourceTypes.Census,
-    isPartOfTrust = Model.IsPartOfTrust,
     additionText = new[] { "Benchmark your pupil and workforce data against similar schools." }
 })
 

--- a/web/src/Web.App/Views/SchoolCensus/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolCensus/Index.cshtml
@@ -14,9 +14,10 @@
 
 @await Component.InvokeAsync("DataSource", new
 {
-    kind = OrganisationTypes.School, 
-    isPartOfTrust = Model.IsPartOfTrust, 
-        additionText = new[] { "Benchmark your pupil and workforce data against similar schools." }
+    organisationType = OrganisationTypes.School,
+    sourceType = DataSourceTypes.Census,
+    isPartOfTrust = Model.IsPartOfTrust,
+    additionText = new[] { "Benchmark your pupil and workforce data against similar schools." }
 })
 
 @await Component.InvokeAsync("ComparatorSetDetails", new

--- a/web/src/Web.App/Views/SchoolComparison/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/Index.cshtml
@@ -13,9 +13,10 @@
 
 @await Component.InvokeAsync("DataSource", new
 {
-    kind = OrganisationTypes.School, 
+    organisationType = OrganisationTypes.School,
+    sourceType = DataSourceTypes.Spending,
     isPartOfTrust = Model.IsPartOfTrust, 
-        additionText = new[] { "Benchmark your spending against similar schools." }
+    additionText = new[] { "Benchmark your spending against similar schools." }
 })
 
 @await Component.InvokeAsync("ComparatorSetDetails", new

--- a/web/src/Web.App/Views/SchoolSpending/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/Index.cshtml
@@ -15,7 +15,8 @@
 
 @await Component.InvokeAsync("DataSource", new
 {
-    kind = OrganisationTypes.School,
+    organisationType = OrganisationTypes.School,
+    sourceType = DataSourceTypes.Spending,
     isPartOfTrust = Model.IsPartOfTrust
 })
 

--- a/web/src/Web.App/Views/Shared/Components/DataSource/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/DataSource/Default.cshtml
@@ -6,6 +6,9 @@
         {
             <p class="govuk-body">@text</p>    
         }
-        <p class="govuk-body">@Model.DataSource</p>
+        @foreach (var dataSource in @Model.DataSource)
+        {
+            <p class="govuk-body">@dataSource</p>
+        }
     </div>
 </div>

--- a/web/src/Web.App/Views/Trust/Index.cshtml
+++ b/web/src/Web.App/Views/Trust/Index.cshtml
@@ -20,7 +20,8 @@
 
 @await Component.InvokeAsync("DataSource", new
 {
-    kind = OrganisationTypes.Trust,
+    organisationType = OrganisationTypes.Trust,
+    sourceType = DataSourceTypes.Spending,
     isPartOfTrust = true
 })
 

--- a/web/src/Web.App/Views/TrustCensus/Index.cshtml
+++ b/web/src/Web.App/Views/TrustCensus/Index.cshtml
@@ -11,7 +11,6 @@
 {
     organisationType = OrganisationTypes.Trust,
     sourceType = DataSourceTypes.Census,
-    isPartOfTrust = true, 
     additionText = new[] { "View pupil and workforce data for schools in this trust." },
 })
 

--- a/web/src/Web.App/Views/TrustCensus/Index.cshtml
+++ b/web/src/Web.App/Views/TrustCensus/Index.cshtml
@@ -7,7 +7,13 @@
 
 @await Component.InvokeAsync("EstablishmentHeading", new { title = ViewData[ViewDataKeys.Title], name = Model.Name, id = Model.CompanyNumber, kind = OrganisationTypes.Trust })
 
-@await Component.InvokeAsync("DataSource", new { kind = OrganisationTypes.Trust, isPartOfTrust = true, additionText = new[] { "View pupil and workforce data for schools in this trust." } })
+@await Component.InvokeAsync("DataSource", new
+{
+    organisationType = OrganisationTypes.Trust,
+    sourceType = DataSourceTypes.Census,
+    isPartOfTrust = true, 
+    additionText = new[] { "View pupil and workforce data for schools in this trust." },
+})
 
 <div id="compare-your-census" 
      data-type="@OrganisationTypes.Trust" 

--- a/web/src/Web.App/Views/TrustComparators/Index.cshtml
+++ b/web/src/Web.App/Views/TrustComparators/Index.cshtml
@@ -52,7 +52,8 @@
 
 @await Component.InvokeAsync("DataSource", new
 {
-    kind = OrganisationTypes.Trust,
+    organisationType = OrganisationTypes.Trust,
+    sourceType = DataSourceTypes.Spending,
     isPartOfTrust = true,
     className = "govuk-grid-column-full"
 })

--- a/web/src/Web.App/Views/TrustComparison/Index.cshtml
+++ b/web/src/Web.App/Views/TrustComparison/Index.cshtml
@@ -7,7 +7,13 @@
 
 @await Component.InvokeAsync("EstablishmentHeading", new { title = ViewData[ViewDataKeys.Title], name = Model.Name, id = Model.CompanyNumber, kind = OrganisationTypes.Trust })
 
-@await Component.InvokeAsync("DataSource", new { kind = OrganisationTypes.Trust, isPartOfTrust = true, additionText = new[] { "View the spending between schools in this trust." } })
+@await Component.InvokeAsync("DataSource", new
+{
+    organisationType = OrganisationTypes.Trust,
+    sourceType = DataSourceTypes.Spending,
+    isPartOfTrust = true, 
+    additionText = new[] { "View the spending between schools in this trust." }
+})
 
 <div id="compare-your-costs" 
      data-type="@OrganisationTypes.Trust" 

--- a/web/src/Web.App/Views/TrustSpending/Index.cshtml
+++ b/web/src/Web.App/Views/TrustSpending/Index.cshtml
@@ -17,7 +17,8 @@
 
 @await Component.InvokeAsync("DataSource", new
 {
-    kind = OrganisationTypes.Trust,
+    organisationType = OrganisationTypes.Trust,
+    sourceType = DataSourceTypes.Spending,
     isPartOfTrust = true,
     className = "govuk-grid-column-full"
 })


### PR DESCRIPTION
### Context
[AB#219193](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/219193) - [AB#225244](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/225244)

### Change proposed in this pull request
Updates content for the benchmark pupil and workforce data page for school, la and trust to correctly call out the data source as workforce census and school census as per the ticket.
Refactors DataSource component to use additional parameter sourceType

### Guidance to review 
N/A

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

