### PR TITLE
Added App Insights event tracking to 'Save chart as image' buttons

### DIFF
--- a/core-infrastructure/terraform/README.md
+++ b/core-infrastructure/terraform/README.md
@@ -13,6 +13,7 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_azapi"></a> [azapi](#provider\_azapi) | 1.14.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.53.1 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.116.0 |
 | <a name="provider_mssql"></a> [mssql](#provider\_mssql) | 0.3.1 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.6.2 |
@@ -32,6 +33,7 @@ No modules.
 | [azurerm_key_vault_access_policy.terraform_sp_access](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_secret.data-storage-connection-string](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.sql-connection-string](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.sql-connection-string-default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.sql-connection-string-managed-identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.sql-db-name](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.sql-domain-name](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
@@ -66,6 +68,7 @@ No modules.
 | [azurerm_log_analytics_saved_search.get-session-length](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_saved_search.get-sessions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_saved_search.get-tracked-links](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
+| [azurerm_log_analytics_saved_search.get-tracked-save-charts](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_saved_search.get-users](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_saved_search.get-waf-blocked-requests](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_saved_search.get-waf-logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
@@ -121,6 +124,7 @@ No modules.
 | [random_uuid.waf-blocked-requests-per-hour-id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [random_uuid.waf-requests-id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [random_uuid.weekly-active-users-id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
+| [azuread_service_principal.sp](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/service_principal) | data source |
 | [azurerm_client_config.client](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 

--- a/core-infrastructure/terraform/queries.tf
+++ b/core-infrastructure/terraform/queries.tf
@@ -405,3 +405,14 @@ resource "azurerm_log_analytics_query_pack_query" "waf-blocked-requests-per-hour
 
   body = file("${path.module}/queries/waf-blocked-requests-per-hour.kql")
 }
+
+resource "azurerm_log_analytics_saved_search" "get-tracked-save-charts" {
+  name                       = "GetTrackedSaveCharts"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.application-insights-workspace.id
+  category                   = "Function"
+  display_name               = "GetTrackedSaveCharts"
+  function_alias             = "GetTrackedSaveCharts"
+  tags                       = local.query-tags
+
+  query = file("${path.module}/queries/functions/get-tracked-save-charts.kql")
+}

--- a/core-infrastructure/terraform/queries/functions/get-tracked-save-charts.kql
+++ b/core-infrastructure/terraform/queries/functions/get-tracked-save-charts.kql
@@ -2,20 +2,22 @@ AppEvents
 | where
     Properties["baseTypeSource"] == "ClickEvent"
 | where
-    Name in (${trackedEvents})
+    Name == "save-chart-as-image"
 | where 
     isempty(SyntheticSource)
-| extend
-    Source = tostring(Properties["uri"]),
-    Target = tostring(Properties["targetUri"])
+| extend 
+    content=parsejson(tostring(Properties.['content']))
+| mv-expand 
+    content
+| extend 
+    ChartName = content["chart-name"]
 | join kind=leftouter
     GetEstablishmentRequests
     on $left.ParentId == $right.OperationId
 | project
     TimeGenerated,
     Name,
-    Source,
-    Target,
+    ChartName,
     OperationId,
     UserId,
     Establishment,

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -1,4 +1,4 @@
-import { createRef, useContext, useMemo, useState } from "react";
+import { useContext, useMemo, useRef, useState } from "react";
 import { HorizontalBarChart } from "src/components/charts/horizontal-bar-chart";
 import {
   TableChart,
@@ -33,7 +33,7 @@ export function HorizontalBarChartWrapper<
   const dimension = useContext(ChartDimensionContext);
   const selectedEstabishment = useContext(SelectedEstablishmentContext);
   const { hasIncompleteData, hasNoData } = useContext(HasIncompleteDataContext);
-  const ref = createRef<ChartHandler>();
+  const chartRef = useRef<ChartHandler>(null);
   const [imageLoading, setImageLoading] = useState<boolean>();
   const keyField = (trust ? "companyNumber" : "urn") as keyof TData;
   const seriesLabelField = (trust ? "trustName" : "schoolName") as keyof TData;
@@ -83,9 +83,11 @@ export function HorizontalBarChartWrapper<
               className="govuk-button govuk-button--secondary"
               data-module="govuk-button"
               data-prevent-double-click="true"
-              onClick={() => ref.current?.download()}
+              onClick={() => chartRef.current?.download()}
               disabled={imageLoading}
               aria-disabled={imageLoading}
+              data-custom-event-id="save-chart-as-image"
+              data-custom-event-chart-name={chartName}
             >
               Save <span className="govuk-visually-hidden">{chartName}</span> as
               image
@@ -119,7 +121,7 @@ export function HorizontalBarChartWrapper<
                     onImageLoading={setImageLoading}
                     labels
                     margin={20}
-                    ref={ref}
+                    ref={chartRef}
                     seriesConfig={seriesConfig as object}
                     seriesLabelField={seriesLabelField}
                     tickWidth={400}

--- a/front-end-components/src/views/budget-forecast-returns/partials/year-end.tsx
+++ b/front-end-components/src/views/budget-forecast-returns/partials/year-end.tsx
@@ -82,10 +82,12 @@ export const YearEnd: React.FC<{
     setDimension(dimension);
   };
 
+  const chartName = "Year-end revenue reserves";
+
   return (
     <div className="govuk-grid-row govuk-!-margin-top-5">
       <div className="govuk-grid-column-one-half">
-        <h2 className="govuk-heading-m">Year-end revenue reserves</h2>
+        <h2 className="govuk-heading-m">{chartName}</h2>
       </div>
       <div className="govuk-grid-column-one-half">
         <div>
@@ -95,10 +97,12 @@ export const YearEnd: React.FC<{
             disabled={imageLoading}
             aria-disabled={imageLoading}
             onClick={() => chartRef?.current?.download()}
+            data-custom-event-id="save-chart-as-image"
+            data-custom-event-chart-name={chartName.toLowerCase()}
           >
             Save{" "}
             <span className="govuk-visually-hidden">
-              year-end revenue reserves
+              {chartName.toLowerCase()}
             </span>{" "}
             as image
           </button>


### PR DESCRIPTION
### Context
[AB#225439](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/225439) [AB#223210](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/223210)

### Change proposed in this pull request
Custom event tracking for above feature.
Authored Kusto query to return custom events of this type, for future reporting.

### Guidance to review 
Build and copy `front-end-components` locally into `Web`. Set an app insights instrumentation key. Click on 'Save as image' on various charts. Observe App Insights event tracking, e.g.:

TimeGenerated | Name | ChartName | OperationId | UserId | Establishment | Feature | Identifier
-- | -- | -- | -- | -- | -- | -- | --
2024-08-23T07:34:50.291Z | save-chart-as-image | total expenditure | 41082ffdfb434ccfb544ba06e7eda659 | rxCbaKpPR0Ex0IgCQM2qNe | school | benchmark-costs | 107896
2024-08-23T07:39:16.11Z | save-chart-as-image | total teaching and support staff cost | 41082ffdfb434ccfb544ba06e7eda659 | rxCbaKpPR0Ex0IgCQM2qNe | school | benchmark-costs | 107896

> **NOTE:** The `ClickAnalyticsPlugin` tracks left and right mouse button clicks, so it is possible that duplicate rows are returned from the query in this PR

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

