### PR TITLE
Allow toggle between Gross and Net total catering income in UI

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -93,7 +93,7 @@
       <button type="submit">Submit</button>
     </form>-->
     <!--<div id="compare-your-trust" data-id="07465701"></div>-->
-    <!--<div id="compare-your-costs" data-type="school" data-id="140565"></div>-->
+    <div id="compare-your-costs" data-type="school" data-id="107896"></div>
     <!--<div id="historic-data" data-type="school" data-id="140565"></div>-->
     <!--<div
       id="compare-your-costs"
@@ -101,7 +101,7 @@
       data-id="383"
     ></div>-->
     <!--<div id="budget-forecast-returns" data-id="01532445"></div>-->
-    <div id="historic-data" data-type="trust" data-id="10377760"></div>
+    <!--<div id="historic-data" data-type="trust" data-id="10377760"></div>-->
     <script type="module" src="/src/main.tsx"></script>
     <script
       type="module"

--- a/front-end-components/src/components/total-catering-costs-type/component.tsx
+++ b/front-end-components/src/components/total-catering-costs-type/component.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { TotalCateringCostsTypeProps } from "src/components/total-catering-costs-type";
+import { TotalCateringCostsField } from "src/services";
+
+export const TotalCateringCostsType: React.FC<TotalCateringCostsTypeProps> = (
+  props
+) => {
+  const { field, onChange, prefix } = props;
+
+  return (
+    <div className="govuk-form-group">
+      <fieldset className="govuk-fieldset">
+        <legend className="govuk-fieldset__legend govuk-!-margin-bottom-1">
+          <h2 className="govuk-fieldset__heading">Display income cost as</h2>
+        </legend>
+        <div
+          className="govuk-radios govuk-radios--small govuk-radios--inline"
+          data-module="govuk-radios"
+        >
+          <div className="govuk-radios__item">
+            <input
+              className="govuk-radios__input"
+              id={prefix ? `${prefix}-type-gross` : "type-gross"}
+              name={prefix ? `${prefix}ChangedCostsType` : "changedCostsType"}
+              type="radio"
+              value="totalGrossCateringCosts"
+              onChange={(e) =>
+                onChange(e.target.value as TotalCateringCostsField)
+              }
+              checked={field == "totalGrossCateringCosts"}
+            />
+            <label
+              className="govuk-label govuk-radios__label"
+              htmlFor={prefix ? `${prefix}-type-gross` : "type-gross"}
+            >
+              Gross
+            </label>
+          </div>
+          <div className="govuk-radios__item">
+            <input
+              className="govuk-radios__input"
+              id={prefix ? `${prefix}-type-net` : "type-net"}
+              name={prefix ? `${prefix}ChangedCostsType` : "changedCostsType"}
+              type="radio"
+              value="totalNetCateringCosts"
+              onChange={(e) =>
+                onChange(e.target.value as TotalCateringCostsField)
+              }
+              checked={field == "totalNetCateringCosts"}
+            />
+            <label
+              className="govuk-label govuk-radios__label"
+              htmlFor={prefix ? `${prefix}-type-net` : "type-net"}
+            >
+              Net
+            </label>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+  );
+};

--- a/front-end-components/src/components/total-catering-costs-type/index.tsx
+++ b/front-end-components/src/components/total-catering-costs-type/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/components/total-catering-costs-type/types";
+export * from "src/components/total-catering-costs-type/component";

--- a/front-end-components/src/components/total-catering-costs-type/types.tsx
+++ b/front-end-components/src/components/total-catering-costs-type/types.tsx
@@ -1,0 +1,7 @@
+import { TotalCateringCostsField } from "src/services";
+
+export type TotalCateringCostsTypeProps = {
+  field: TotalCateringCostsField;
+  onChange: (field: TotalCateringCostsField) => void;
+  prefix?: string;
+};

--- a/front-end-components/src/services/types.tsx
+++ b/front-end-components/src/services/types.tsx
@@ -16,6 +16,7 @@ export type AdministrativeSuppliesExpenditure = SchoolExpenditure &
 
 type CateringStaffServicesExpenditureBase = {
   totalGrossCateringCosts: number;
+  totalNetCateringCosts: number;
   cateringStaffCosts: number;
   cateringSuppliesCosts: number;
 };
@@ -125,10 +126,12 @@ export type AdministrativeSuppliesTrustExpenditure = TrustExpenditure &
 type CateringStaffServicesTrustExpenditureBase =
   CateringStaffServicesExpenditureBase & {
     schoolTotalGrossCateringCosts: number;
+    schoolTotalNetCateringCosts: number;
     schoolCateringStaffCosts: number;
     schoolCateringSuppliesCosts: number;
 
     centralTotalGrossCateringCosts: number;
+    centralTotalNetCateringCosts: number;
     centralCateringStaffCosts: number;
     centralCateringSuppliesCosts: number;
   };
@@ -375,3 +378,8 @@ export type BudgetForecastReturn = {
   percentVariance?: number;
   varianceStatus?: string;
 };
+
+export type TotalCateringCostsField = keyof Pick<
+  CateringStaffServicesExpenditureBase,
+  "totalGrossCateringCosts" | "totalNetCateringCosts"
+>;

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
@@ -23,7 +23,12 @@ import {
 } from "src/composed/horizontal-bar-chart-wrapper";
 import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
-import { ExpenditureApi, CateringStaffServicesExpenditure } from "src/services";
+import {
+  ExpenditureApi,
+  CateringStaffServicesExpenditure,
+  TotalCateringCostsField,
+} from "src/services";
+import { TotalCateringCostsType } from "src/components/total-catering-costs-type";
 
 export const CateringStaffServices: React.FC<{
   type: string;
@@ -33,6 +38,8 @@ export const CateringStaffServices: React.FC<{
   const phase = useContext(PhaseContext);
   const customDataId = useContext(CustomDataContext);
   const [data, setData] = useState<CateringStaffServicesExpenditure[] | null>();
+  const [totalCateringCostsField, setTotalCateringCostsField] =
+    useState<TotalCateringCostsField>("totalGrossCateringCosts");
   const getData = useCallback(async () => {
     setData(null);
     return await ExpenditureApi.query<CateringStaffServicesExpenditure>(
@@ -78,12 +85,15 @@ export const CateringStaffServices: React.FC<{
           data?.map((school) => {
             return {
               ...school,
-              value: school.totalGrossCateringCosts,
+              value:
+                (totalCateringCostsField == "totalGrossCateringCosts"
+                  ? school.totalGrossCateringCosts
+                  : school.totalNetCateringCosts) ?? 0,
             };
           }) ?? [],
         tableHeadings,
       };
-    }, [data, tableHeadings]);
+    }, [data, tableHeadings, totalCateringCostsField]);
 
   const cateringStaffBarData: HorizontalBarChartWrapperData<CateringStaffServicesData> =
     useMemo(() => {
@@ -149,12 +159,22 @@ export const CateringStaffServices: React.FC<{
               chartName="total catering costs"
             >
               <h3 className="govuk-heading-s">Total catering costs</h3>
-              <ChartDimensions
-                dimensions={CostCategories}
-                handleChange={handleSelectChange}
-                elementId="total-catering-costs"
-                value={dimension.value}
-              />
+              <div className="govuk-grid-row">
+                <div className="govuk-grid-column-one-half">
+                  <ChartDimensions
+                    dimensions={CostCategories}
+                    handleChange={handleSelectChange}
+                    elementId="total-catering-costs"
+                    value={dimension.value}
+                  />
+                </div>
+                <div className="govuk-grid-column-one-half">
+                  <TotalCateringCostsType
+                    field={totalCateringCostsField}
+                    onChange={setTotalCateringCostsField}
+                  />
+                </div>
+              </div>
             </HorizontalBarChartWrapper>
             <HorizontalBarChartWrapper
               data={cateringStaffBarData}

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/types.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/types.tsx
@@ -82,6 +82,7 @@ export type CateringStaffServicesData = {
   urn: string;
   schoolType: string;
   totalGrossCateringCosts: number;
+  totalNetCateringCosts: number;
   cateringStaffCosts: number;
   cateringSuppliesCosts: number;
   totalPupils: bigint;

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/catering-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/catering-staff-services.tsx
@@ -18,11 +18,13 @@ import classNames from "classnames";
 import {
   ExpenditureApi,
   CateringStaffServicesTrustExpenditure,
+  TotalCateringCostsField,
 } from "src/services";
 import {
   BreakdownExclude,
   BreakdownInclude,
 } from "src/components/central-services-breakdown";
+import { TotalCateringCostsType } from "src/components/total-catering-costs-type";
 
 export const CateringStaffServices: React.FC<{
   id: string;
@@ -32,6 +34,8 @@ export const CateringStaffServices: React.FC<{
   const [data, setData] = useState<
     CateringStaffServicesTrustExpenditure[] | null
   >();
+  const [totalCateringCostsField, setTotalCateringCostsField] =
+    useState<TotalCateringCostsField>("totalGrossCateringCosts");
   const getData = useCallback(async () => {
     setData(null);
     return await ExpenditureApi.trust<CateringStaffServicesTrustExpenditure>(
@@ -76,15 +80,24 @@ export const CateringStaffServices: React.FC<{
             ? data.map((trust) => {
                 return {
                   ...trust,
-                  totalValue: trust.totalGrossCateringCosts ?? 0,
-                  schoolValue: trust.schoolTotalGrossCateringCosts ?? 0,
-                  centralValue: trust.centralTotalGrossCateringCosts ?? 0,
+                  totalValue:
+                    (totalCateringCostsField == "totalGrossCateringCosts"
+                      ? trust.totalGrossCateringCosts
+                      : trust.totalNetCateringCosts) ?? 0,
+                  schoolValue:
+                    (totalCateringCostsField == "totalGrossCateringCosts"
+                      ? trust.schoolTotalGrossCateringCosts
+                      : trust.schoolTotalNetCateringCosts) ?? 0,
+                  centralValue:
+                    (totalCateringCostsField == "totalGrossCateringCosts"
+                      ? trust.centralTotalGrossCateringCosts
+                      : trust.centralTotalNetCateringCosts) ?? 0,
                 };
               })
             : [],
         tableHeadings,
       };
-    }, [data, tableHeadings]);
+    }, [data, tableHeadings, totalCateringCostsField]);
 
   const cateringStaffBarData: HorizontalBarChartWrapperData<CateringStaffServicesData> =
     useMemo(() => {
@@ -155,12 +168,22 @@ export const CateringStaffServices: React.FC<{
             trust
           >
             <h3 className="govuk-heading-s">Total catering costs</h3>
-            <ChartDimensions
-              dimensions={CostCategories}
-              handleChange={handleSelectChange}
-              elementId="total-catering-costs"
-              value={dimension.value}
-            />
+            <div className="govuk-grid-row">
+              <div className="govuk-grid-column-one-half">
+                <ChartDimensions
+                  dimensions={CostCategories}
+                  handleChange={handleSelectChange}
+                  elementId="total-catering-costs"
+                  value={dimension.value}
+                />
+              </div>
+              <div className="govuk-grid-column-one-half">
+                <TotalCateringCostsType
+                  field={totalCateringCostsField}
+                  onChange={setTotalCateringCostsField}
+                />
+              </div>
+            </div>
           </HorizontalBarChartWrapper>
           <HorizontalBarChartWrapper
             data={cateringStaffBarData}

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/types.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/types.tsx
@@ -60,6 +60,7 @@ export type AdministrativeSuppliesData = {
 export type CateringStaffServicesData = {
   companyNumber: string;
   totalGrossCateringCosts: number;
+  totalNetCateringCosts: number;
   cateringStaffCosts: number;
   cateringSuppliesCosts: number;
   trustName: string;

--- a/front-end-components/src/views/historic-data/partials/spending-section-catering-services.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section-catering-services.tsx
@@ -1,26 +1,42 @@
 import { HistoricChart } from "src/composed/historic-chart-composed";
-import { SchoolExpenditureHistory } from "src/services";
+import {
+  SchoolExpenditureHistory,
+  TotalCateringCostsField,
+} from "src/services";
 import { Loading } from "src/components/loading";
+import { useState } from "react";
+import { TotalCateringCostsType } from "src/components/total-catering-costs-type";
 
 export const SpendingSectionCateringServices: React.FC<{
   data: SchoolExpenditureHistory[];
 }> = ({ data }) => {
+  const [totalCateringCostsField, setTotalCateringCostsField] =
+    useState<TotalCateringCostsField>("totalGrossCateringCosts");
+
   return (
     <>
       {data.length > 0 ? (
         <>
           <HistoricChart
-            chartName="Total gross catering costs"
+            chartName="Total catering costs"
             data={data}
             seriesConfig={{
               totalGrossCateringCosts: {
                 label: "Total gross catering costs",
-                visible: true,
+                visible: totalCateringCostsField == "totalGrossCateringCosts",
+              },
+              totalNetCateringCosts: {
+                label: "Total net catering costs",
+                visible: totalCateringCostsField == "totalNetCateringCosts",
               },
             }}
-            valueField="totalGrossCateringCosts"
+            valueField={totalCateringCostsField}
           >
-            <h3 className="govuk-heading-s">Total gross catering costs</h3>
+            <h3 className="govuk-heading-s">Total catering costs</h3>
+            <TotalCateringCostsType
+              field={totalCateringCostsField}
+              onChange={setTotalCateringCostsField}
+            />
           </HistoricChart>
 
           <HistoricChart

--- a/web/src/Web.App/Domain/Insight/Expenditure.cs
+++ b/web/src/Web.App/Domain/Insight/Expenditure.cs
@@ -28,6 +28,7 @@ public abstract record ExpenditureBase
     public decimal? SchoolWaterSewerageCosts { get; set; }
     public decimal? SchoolAdministrativeSuppliesCosts { get; set; }
     public decimal? SchoolTotalGrossCateringCosts { get; set; }
+    public decimal? SchoolTotalNetCateringCosts { get; set; }
     public decimal? SchoolCateringStaffCosts { get; set; }
     public decimal? SchoolCateringSuppliesCosts { get; set; }
     public decimal? SchoolTotalOtherCosts { get; set; }
@@ -71,6 +72,7 @@ public abstract record ExpenditureBase
     public decimal? CentralWaterSewerageCosts { get; set; }
     public decimal? CentralAdministrativeSuppliesCosts { get; set; }
     public decimal? CentralTotalGrossCateringCosts { get; set; }
+    public decimal? CentralTotalNetCateringCosts { get; set; }
     public decimal? CentralCateringStaffCosts { get; set; }
     public decimal? CentralCateringSuppliesCosts { get; set; }
     public decimal? CentralTotalOtherCosts { get; set; }
@@ -114,6 +116,7 @@ public abstract record ExpenditureBase
     public decimal? WaterSewerageCosts { get; set; }
     public decimal? AdministrativeSuppliesCosts { get; set; }
     public decimal? TotalGrossCateringCosts { get; set; }
+    public decimal? TotalNetCateringCosts { get; set; }
     public decimal? CateringStaffCosts { get; set; }
     public decimal? CateringSuppliesCosts { get; set; }
     public decimal? TotalOtherCosts { get; set; }

--- a/web/tests/Web.E2ETests/Features/School/CompareYourCosts.feature
+++ b/web/tests/Web.E2ETests/Features/School/CompareYourCosts.feature
@@ -84,3 +84,80 @@ Feature: School compare your costs
         Given I am on compare your costs page for school with URN '777042'
         When I select the school name on the chart
         Then I am navigated to selected school home page
+
+    Scenario: View Catering staff and services using Gross figures
+        Given I am on compare your costs page for school with URN '777042'
+        And table view is selected
+        And Section 'catering staff' is visible
+        And the 'catering staff' dimension is 'actuals'
+        Then the following is shown for 'catering staff'
+          | School name             | Local Authority         | School type                        | Number of pupils | Amount   |
+          | Test academy school 353 | Bolton                  | Academy special converter          | 1326             | £274,213 |
+          | Test academy school 444 | Lincolnshire            | Academy sponsor led                | 991              | £162,523 |
+          | Test academy school 365 | North Lincolnshire      | Academy special sponsor led        | 407              | £130,448 |
+          | Test academy school 411 | Telford and Wrekin      | Academy sponsor led                | 399              | £95,978  |
+          | Test school 263         | Redbridge               | Community school                   | 114              | £89,788  |
+          | Test academy school 147 | Cheshire West & Chester | Academy special converter          | 418              | £84,186  |
+          | Test school 7           | Dorset                  | Local authority nursery school     | 317              | £78,876  |
+          | Test academy school 111 | Reading                 | Free schools alternative provision | 317              | £78,876  |
+          | Test academy school 414 | Cornwall                | Academy sponsor led                | 317              | £78,876  |
+          | Test school 26          | Hounslow                | Community school                   | 769              | £73,448  |
+          | Test academy school 407 | Blackpool               | Academy converter                  | 367              | £67,969  |
+          | Test academy school 191 | Bexley                  | Free school 16 to 19               | 367              | £67,969  |
+          | Test academy school 246 | Sunderland              | Academy converter                  | 236              | £61,038  |
+          | Test academy school 133 | Shropshire              | Academy special converter          | 260              | £59,263  |
+          | Test school 48          | South Tyneside          | Community school                   | 883              | £56,633  |
+          | Test academy school 456 | Westmorland and Furness | Academy 16-19 converter            | 339              | £54,988  |
+          | Test academy school 498 | Islington               | Academy 16-19 converter            | 216              | £52,373  |
+          | Test school 102         | Hammersmith and Fulham  | Community school                   | 212              | £51,070  |
+          | Test academy school 162 | West Northamptonshire   | Academy special converter          | 231              | £50,014  |
+          | Test academy school 465 | Enfield                 | Academy 16-19 converter            | 231              | £50,014  |
+          | Test academy school 496 | Hackney                 | Academy 16 to 19 sponsor led       | 191              | £48,949  |
+          | Test academy school 469 | Hillingdon              | Free school 16 to 19               | 235              | £46,965  |
+          | Test school 158         | Newcastle upon Tyne     | Community school                   | 206              | £46,029  |
+          | Test academy school 435 | Bradford                | Academy sponsor led                | 204              | £44,110  |
+          | Test academy school 333 | Hampshire               | Free schools alternative provision | 190              | £42,269  |
+          | Test school 149         | Barnsley                | Pupil referral unit                | 232              | £41,903  |
+          | Test academy school 12  | Hounslow                | Academy sponsor led                | 232              | £41,903  |
+          | Test academy school 466 | Haringey                | Academy 16-19 converter            | 232              | £41,903  |
+          | Test school 154         | Kirklees                | Community school                   | 174              | £41,338  |
+          | Test school 243         | Lambeth                 | Voluntary aided school             | 174              | £41,338  |
+
+    Scenario: View Catering staff and services using Net figures
+        Given I am on compare your costs page for school with URN '777042'
+        And table view is selected
+        And Section 'catering staff' is visible
+        And the 'catering staff' dimension is 'actuals'
+        When I click on display as Net
+        Then the following is shown for 'catering staff'
+          | School name             | Local Authority         | School type                        | Number of pupils | Amount   |
+          | Test academy school 353 | Bolton                  | Academy special converter          | 1326             | £358,159 |
+          | Test academy school 444 | Lincolnshire            | Academy sponsor led                | 991              | £162,523 |
+          | Test academy school 365 | North Lincolnshire      | Academy special sponsor led        | 407              | £159,854 |
+          | Test academy school 411 | Telford and Wrekin      | Academy sponsor led                | 399              | £109,578 |
+          | Test academy school 162 | West Northamptonshire   | Academy special converter          | 231              | £99,307  |
+          | Test academy school 465 | Enfield                 | Academy 16-19 converter            | 231              | £99,307  |
+          | Test school 263         | Redbridge               | Community school                   | 114              | £95,795  |
+          | Test academy school 147 | Cheshire West & Chester | Academy special converter          | 418              | £91,847  |
+          | Test school 7           | Dorset                  | Local authority nursery school     | 317              | £89,783  |
+          | Test academy school 111 | Reading                 | Free schools alternative provision | 317              | £89,783  |
+          | Test academy school 414 | Cornwall                | Academy sponsor led                | 317              | £89,783  |
+          | Test academy school 246 | Sunderland              | Academy converter                  | 236              | £77,919  |
+          | Test academy school 407 | Blackpool               | Academy converter                  | 367              | £74,137  |
+          | Test academy school 191 | Bexley                  | Free school 16 to 19               | 367              | £74,137  |
+          | Test school 26          | Hounslow                | Community school                   | 769              | £73,448  |
+          | Test academy school 133 | Shropshire              | Academy special converter          | 260              | £70,053  |
+          | Test academy school 456 | Westmorland and Furness | Academy 16-19 converter            | 339              | £69,488  |
+          | Test academy school 498 | Islington               | Academy 16-19 converter            | 216              | £63,191  |
+          | Test school 102         | Hammersmith and Fulham  | Community school                   | 212              | £59,232  |
+          | Test academy school 469 | Hillingdon              | Free school 16 to 19               | 235              | £58,290  |
+          | Test academy school 496 | Hackney                 | Academy 16 to 19 sponsor led       | 191              | £57,188  |
+          | Test school 48          | South Tyneside          | Community school                   | 883              | £56,633  |
+          | Test academy school 333 | Hampshire               | Free schools alternative provision | 190              | £55,255  |
+          | Test academy school 435 | Bradford                | Academy sponsor led                | 204              | £53,473  |
+          | Test school 158         | Newcastle upon Tyne     | Community school                   | 206              | £50,814  |
+          | Test school 154         | Kirklees                | Community school                   | 174              | £47,932  |
+          | Test school 243         | Lambeth                 | Voluntary aided school             | 174              | £47,932  |
+          | Test school 149         | Barnsley                | Pupil referral unit                | 232              | £41,903  |
+          | Test academy school 12  | Hounslow                | Academy sponsor led                | 232              | £41,903  |
+          | Test academy school 466 | Haringey                | Academy 16-19 converter            | 232              | £41,903  |

--- a/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
@@ -1,6 +1,5 @@
 using Microsoft.Playwright;
 using Xunit;
-
 namespace Web.E2ETests.Pages.School;
 
 public enum ComparisonChartNames
@@ -40,21 +39,43 @@ public class CompareYourCostsPage(IPage page)
     private ILocator CateringServicesAccordionContent => page.Locator(Selectors.SectionContent8);
     private ILocator OtherAccordionContent => page.Locator(Selectors.SectionContent9);
     private ILocator PremisesDimension => page.Locator(Selectors.PremisesDimension);
+    private ILocator CateringStaffAndServicesDimension => page.Locator(Selectors.CateringStaffAndServicesDimension);
+    private ILocator CateringStaffAndServicesTables => page.Locator(Selectors.CateringStaffAndServicesTables);
+    private ILocator ViewAsGrossRadio => page.Locator(Selectors.TypeGross);
+    private ILocator ViewAsNetRadio => page.Locator(Selectors.TypeNet);
 
     private ILocator SaveAsImageButtons =>
-        page.Locator(Selectors.Button, new PageLocatorOptions { HasText = "Save" });
+        page.Locator(Selectors.Button, new PageLocatorOptions
+        {
+            HasText = "Save"
+        });
     private ILocator ComparatorSetDetails =>
         page.Locator(Selectors.GovLink,
-            new PageLocatorOptions { HasText = "We've chosen 2 sets of similar schools" });
+            new PageLocatorOptions
+            {
+                HasText = "We've chosen 2 sets of similar schools"
+            });
     private ILocator ComparatorSetLink => page.Locator(Selectors.GovLink,
-        new PageLocatorOptions { HasText = "Choose your own similar schools" });
+        new PageLocatorOptions
+        {
+            HasText = "Choose your own similar schools"
+        });
     private ILocator CustomComparatorLink => page.Locator(Selectors.GovLink,
-        new PageLocatorOptions { HasText = "Choose a new or saved set of your own schools" });
+        new PageLocatorOptions
+        {
+            HasText = "Choose a new or saved set of your own schools"
+        });
 
     private ILocator CustomDataLink => page.Locator(Selectors.GovLink,
-        new PageLocatorOptions { HasText = "Change the data for this school" });
+        new PageLocatorOptions
+        {
+            HasText = "Change the data for this school"
+        });
     private ILocator SimilarSchoolLink => page.Locator(Selectors.GovLink,
-        new PageLocatorOptions { HasText = "30 similar schools" });
+        new PageLocatorOptions
+        {
+            HasText = "30 similar schools"
+        });
     private ILocator ComparatorSetDetailsText => page.Locator(Selectors.GovDetailsText);
     private ILocator ChartBars => page.Locator(Selectors.ChartBars);
     private ILocator AdditionalDetailsPopUps => page.Locator(Selectors.AdditionalDetailsPopUps);
@@ -207,6 +228,11 @@ public class CompareYourCostsPage(IPage page)
 
     }
 
+    public async Task ClickViewAsNet()
+    {
+        await ViewAsNetRadio.Click();
+    }
+
     private async Task IsSectionContentVisible(ComparisonChartNames chartName, bool visibility, string chartMode)
     {
         var contentLocator = chartName switch
@@ -250,6 +276,7 @@ public class CompareYourCostsPage(IPage page)
         var chart = chartName switch
         {
             ComparisonChartNames.TotalExpenditure => TotalExpenditureTable,
+            ComparisonChartNames.CateringStaffAndServices => CateringStaffAndServicesTables.First,
             _ => throw new ArgumentOutOfRangeException(nameof(chartName))
         };
 
@@ -262,15 +289,16 @@ public class CompareYourCostsPage(IPage page)
         {
             ComparisonChartNames.Premises => PremisesDimension,
             ComparisonChartNames.TotalExpenditure => TotalExpenditureDimension,
+            ComparisonChartNames.CateringStaffAndServices => CateringStaffAndServicesDimension,
             _ => throw new ArgumentOutOfRangeException(nameof(chartName))
         };
 
         return chart;
     }
 
-    private ILocator SectionLink(string sectionId)
-    {
-        return page.Locator("button",
-            new PageLocatorOptions { Has = page.Locator($"span{sectionId}") });
-    }
+    private ILocator SectionLink(string sectionId) => page.Locator("button",
+        new PageLocatorOptions
+        {
+            Has = page.Locator($"span{sectionId}")
+        });
 }

--- a/web/tests/Web.E2ETests/Pages/School/HistoricDataPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/HistoricDataPage.cs
@@ -68,7 +68,7 @@ public class HistoricDataPage(IPage page)
         "Energy costs",
         "Water and sewerage costs",
         "Administration supplies (non educational) costs",
-        "Total gross catering costs",
+        "Total catering costs",
         "Catering staff costs",
         "Catering supplies costs",
         "Total other costs",

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -131,4 +131,9 @@ public static class Selectors
     public const string CookiesSavedBanner = "#cookies-saved-banner";
     public const string CookieFormRadioFormat = "#AnalyticsCookiesEnabled-{0}";
     public const string CookieFormButton = "#cookie-settings-button";
+
+    public const string TypeGross = "#type-gross";
+    public const string TypeNet = "#type-net";
+    public const string CateringStaffAndServicesDimension = "#total-catering-costs-dimension";
+    public const string CateringStaffAndServicesTables = "#catering-staff-and-supplies table";
 }

--- a/web/tests/Web.E2ETests/Steps/School/CompareYourCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/CompareYourCostsSteps.cs
@@ -2,7 +2,6 @@ using Microsoft.Playwright;
 using Web.E2ETests.Drivers;
 using Web.E2ETests.Pages.School;
 using Xunit;
-
 namespace Web.E2ETests.Steps.School;
 
 [Binding]
@@ -117,6 +116,7 @@ public class CompareYourCostsSteps(PageDriver driver)
         await _comparisonPage.AreTablesShown();
     }
 
+    [Given("Section '(.*)' is visible")]
     [When("I click section link for '(.*)'")]
     public async Task WhenIClickSectionLinkFor(string chartName)
     {
@@ -151,6 +151,7 @@ public class CompareYourCostsSteps(PageDriver driver)
             "total expenditure" => ComparisonChartNames.TotalExpenditure,
             "total number of teachers" => ComparisonChartNames.Premises,
             "non educational support staff" => ComparisonChartNames.NonEducationalSupportStaff,
+            "catering staff" => ComparisonChartNames.CateringStaffAndServices,
             _ => throw new ArgumentOutOfRangeException(nameof(chartName))
         };
     }
@@ -182,6 +183,13 @@ public class CompareYourCostsSteps(PageDriver driver)
     {
         Assert.NotNull(_schoolHomePage);
         await _schoolHomePage.IsDisplayed();
+    }
+
+    [When("I click on display as Net")]
+    public async Task WhenIClickOnDisplayAsNet()
+    {
+        Assert.NotNull(_comparisonPage);
+        await _comparisonPage.ClickViewAsNet();
     }
 
     private static string CompareYourCostsUrl(string urn) => $"{TestConfiguration.ServiceUrl}/school/{urn}/comparison";


### PR DESCRIPTION
### Context
[AB#225534](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/225534) [AB#214976](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/214976)

### Change proposed in this pull request
Added radio buttons to Total Catering Costs charts to toggle between Gross and Net values.

### Guidance to review 
All expenditure charts are affected, including custom comparators and history for both Schools and Trusts.

### Checklist
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

