### PR TITLE
Displayed tooltip in Horizontal line charts when row focused via keypress

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -93,7 +93,13 @@
       <button type="submit">Submit</button>
     </form>-->
     <!--<div id="compare-your-trust" data-id="07465701"></div>-->
-    <div id="compare-your-costs" data-type="school" data-id="107896"></div>
+    <div
+      id="compare-your-costs"
+      data-type="trust"
+      data-id="02387916"
+      data-phases='["Secondary","Primary","Post-16"]'
+    ></div>
+    <!--<div id="compare-your-costs" data-type="school" data-id="107896"></div>-->
     <!--<div id="historic-data" data-type="school" data-id="140565"></div>-->
     <!--<div
       id="compare-your-costs"

--- a/front-end-components/src/components/charts/establishment-tick/component.tsx
+++ b/front-end-components/src/components/charts/establishment-tick/component.tsx
@@ -2,6 +2,7 @@
 import { Text } from "recharts";
 import { EstablishmentTickProps } from "src/components/charts/establishment-tick";
 import { ChartLink } from "../chart-link";
+import { createElement, useState } from "react";
 
 export function EstablishmentTick(props: EstablishmentTickProps) {
   const {
@@ -14,13 +15,15 @@ export function EstablishmentTick(props: EstablishmentTickProps) {
     tickFormatter,
     verticalAnchor,
     visibleTicksCount,
+    tooltip,
     ...rest
   } = props;
-  const urn =
+  const [focused, setFocused] = useState<boolean>();
+  const key =
     linkToEstablishment &&
     establishmentKeyResolver &&
     establishmentKeyResolver(value);
-  if (!urn) {
+  if (!key) {
     return <Text>{value}</Text>;
   }
 
@@ -30,25 +33,25 @@ export function EstablishmentTick(props: EstablishmentTickProps) {
     : 50;
   return (
     <>
-      {urn && (
-        <line
-          x1={rest.x}
-          y1={rest.y}
-          y2={rest.y}
-          width={rest.width}
-          height={rest.height}
-          className="establishment-tick-focus"
-        ></line>
-      )}
+      <line
+        x1={rest.x}
+        y1={rest.y}
+        y2={rest.y}
+        width={rest.width}
+        height={rest.height}
+        className="establishment-tick-focus"
+      ></line>
       <text
-        fontWeight={urn === highlightedItemKey ? "bold" : "normal"}
+        fontWeight={key === highlightedItemKey ? "bold" : "normal"}
         className="recharts-text establishment-tick"
         {...rest}
       >
         <ChartLink
-          href={href(urn)}
+          href={href(key)}
           className="govuk-link govuk-link--no-visited-state"
           aria-label={name}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
         >
           {name
             .substring(0, truncateAt)
@@ -59,6 +62,13 @@ export function EstablishmentTick(props: EstablishmentTickProps) {
           {name.length > truncateAt && "…"}
         </ChartLink>
       </text>
+      {tooltip && focused && (
+        <foreignObject x="428" y="30" width="400" height="200">
+          <div className="recharts-tooltip-wrapper">
+            {createElement(tooltip, { active: true })}
+          </div>
+        </foreignObject>
+      )}
     </>
   );
 }

--- a/front-end-components/src/components/charts/establishment-tick/types.tsx
+++ b/front-end-components/src/components/charts/establishment-tick/types.tsx
@@ -1,5 +1,11 @@
 import { BaseAxisProps, CartesianTickItem } from "recharts/types/util/types";
 import { TickProps } from "../types";
+import { FunctionComponent } from "react";
+import { TooltipProps } from "recharts/types/component/Tooltip";
+import {
+  NameType,
+  ValueType,
+} from "recharts/types/component/DefaultTooltipContent";
 
 export interface EstablishmentTickProps
   extends Omit<BaseAxisProps, "scale">,
@@ -10,4 +16,5 @@ export interface EstablishmentTickProps
   payload: CartesianTickItem;
   establishmentKeyResolver?: (name: string) => string | undefined;
   verticalAnchor: unknown;
+  tooltip?: FunctionComponent<TooltipProps<ValueType, NameType>>;
 }

--- a/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
@@ -191,6 +191,7 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
           }}
           onMouseMove={handleBarChartMouseMove}
           ref={rechartsRef}
+          className="recharts-wrapper-horizontal-bar-chart"
         >
           {grid && <CartesianGrid />}
           {!!tooltip && <Tooltip content={tooltip} />}

--- a/front-end-components/src/components/charts/line-chart/component.tsx
+++ b/front-end-components/src/components/charts/line-chart/component.tsx
@@ -152,6 +152,7 @@ function LineChartInner<TData extends ChartDataSeries>(
             left: margin,
           }}
           ref={rechartsRef}
+          className="recharts-wrapper-line-chart"
         >
           {grid && <CartesianGrid vertical={false} />}
           <XAxis

--- a/front-end-components/src/components/charts/vertical-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/vertical-bar-chart/component.tsx
@@ -138,6 +138,7 @@ function VerticalBarChartInner<TData extends ChartDataSeries>(
           }}
           onMouseMove={handleBarChartMouseMove}
           ref={rechartsRef}
+          className="recharts-wrapper-vertical-bar-chart"
         >
           {grid && (
             <CartesianGrid

--- a/front-end-components/src/index.css
+++ b/front-end-components/src/index.css
@@ -281,6 +281,16 @@
 }
 
 .recharts-wrapper
+  foreignObject
+  > .recharts-tooltip-wrapper
+  .tooltip-table
+  > caption {
+  width: 370px;
+  overflow: visible;
+  white-space: pre-wrap;
+}
+
+.recharts-wrapper
   .recharts-tooltip-wrapper
   .tooltip-table
   > tbody
@@ -342,6 +352,10 @@
 
 .recharts-wrapper tspan::selection {
   background-color: var(--grid-colour);
+}
+
+.recharts-wrapper.recharts-wrapper-horizontal-bar-chart > .recharts-surface {
+  overflow: visible;
 }
 
 /* end recharts */


### PR DESCRIPTION
### Context
[AB#225682](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/225682) [AB#225478](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/225478)

### Change proposed in this pull request
Required to resolve A02 from accessibility audit, whereby tooltip should be visible in charts by users who are unable to hover over a column bar using a pointing device.

### Guidance to review 
Keyboard tabbing between schools or trusts on benchmarking charts should display the tooltip without the need to use a mouse.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

