### PR TITLE
Provision load test resource in `test` environment

### DIFF
--- a/platform/terraform/README.md
+++ b/platform/terraform/README.md
@@ -27,7 +27,9 @@
 
 | Name | Type |
 |------|------|
+| [azurerm_key_vault_access_policy.keyvault_load_test_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_secret.platform-search-key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_load_test.platform-load-test](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/load_test) | resource |
 | [azurerm_resource_group.resource-group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_search_service.search](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/search_service) | resource |
 | [azurerm_storage_account.orchestrator-storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |

--- a/platform/terraform/test.tf
+++ b/platform/terraform/test.tf
@@ -1,0 +1,19 @@
+resource "azurerm_load_test" "platform-load-test" {
+  count               = var.environment == "test" ? 0 : 1
+  name                = "${var.environment-prefix}-platform-load-test"
+  location            = azurerm_resource_group.resource-group.location
+  resource_group_name = azurerm_resource_group.resource-group.name
+  tags                = local.common-tags
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_key_vault_access_policy" "keyvault_load_test_policy" {
+  count              = var.environment == "test" ? 0 : 1
+  key_vault_id       = data.azurerm_key_vault.key-vault.id
+  tenant_id          = azurerm_load_test.platform-load-test.identity[0].tenant_id
+  object_id          = azurerm_load_test.platform-load-test.identity[0].principal_id
+  secret_permissions = ["Get"]
+}


### PR DESCRIPTION
### Context
AB#225957 AB#222362

Cherry-picked from ca31bd514f0d84cdf69aaa04a450c2e18f72a41e

### Change proposed in this pull request
Provision new resource that will in turn contain individual load tests. Only targeting `test` environment at this time.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~~Your code builds clean without any errors or warnings~~
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [ ] ~~You have tested by running locally~~

