### PR TITLE
fix: use BFR SOFA for pupil figures

### DIFF
--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -327,6 +327,8 @@ def pre_process_bfr(run_type, year):
     )
 
     # Conditionally read in academy/SOFA files, skipping unnecessary data…
+    # TODO: "Company Reg…" isn't referenced for historic data; we can drop the
+    # join to historic academies data and just use the historic SOFA data.
     academies_y2 = None
     bfr_sofa_year_minus_two = None
     if academies_y2_file := try_get_blob(
@@ -337,8 +339,8 @@ def pre_process_bfr(run_type, year):
             columns=[
                 "Trust UPIN",
                 "Company Registration Number",
-                # "Trust Revenue reserve",  # SOFA, EFALineNo == 430.
-                "Total pupils in trust",
+                # "Trust Revenue reserve",  # SOFA, EFALineNo == 430 (Y2P2)
+                # "Total pupils in trust",  # SOFA, EFALineNo == 999 (Y1P2)
             ],
         )
 
@@ -353,6 +355,7 @@ def pre_process_bfr(run_type, year):
                     usecols=[
                         "TrustUPIN",
                         "EFALineNo",
+                        "Y1P2",
                         "Y2P2",
                     ],
                 )
@@ -360,7 +363,7 @@ def pre_process_bfr(run_type, year):
                     {"TrustUPIN": "Trust UPIN"},
                     axis=1,
                 )
-                .query("EFALineNo == 430")
+                .query("EFALineNo in (430, 999,)")
             )
 
     academies_y1 = None
@@ -373,8 +376,8 @@ def pre_process_bfr(run_type, year):
             columns=[
                 "Trust UPIN",
                 "Company Registration Number",
-                # "Trust Revenue reserve",  # SOFA, EFALineNo == 430.
-                "Total pupils in trust",
+                # "Trust Revenue reserve",  # SOFA, EFALineNo == 430 (Y2P2)
+                # "Total pupils in trust",  # SOFA, EFALineNo == 999 (Y1P2)
             ],
         )
 
@@ -389,6 +392,7 @@ def pre_process_bfr(run_type, year):
                     usecols=[
                         "TrustUPIN",
                         "EFALineNo",
+                        "Y1P2",
                         "Y2P2",
                     ],
                 )
@@ -396,7 +400,7 @@ def pre_process_bfr(run_type, year):
                     {"TrustUPIN": "Trust UPIN"},
                     axis=1,
                 )
-                .query("EFALineNo == 430")
+                .query("EFALineNo in (430, 999,)")
             )
 
     # Process BFR data…

--- a/data-pipeline/src/pipeline/pre_processing.py
+++ b/data-pipeline/src/pipeline/pre_processing.py
@@ -1169,18 +1169,19 @@ def build_bfr_historical_data(
 
     - Trust UPIN
     - Company Registration Number
-    - Total pupils in trust
 
     `bfr_sofa_historical` must have:
 
     - Trust UPIN
-    - EFALineNo (containing 430)
+    - EFALineNo (containing 430 and 999)
+    - Y1P2
     - Y2P2
 
     The return value will be of the same form as `academies_historical`,
     with an additional colums:
 
     - "Trust Revenue reserve"
+    - "Total pupils in trust"
 
     :param academies_historical: academy data from a previous year
     :param bfr_sofa_historical: BFR SOFA data from a previous year
@@ -1188,10 +1189,11 @@ def build_bfr_historical_data(
     """
     if academies_historical is not None:
         academies_historical["Trust Revenue reserve"] = 0.0
+        academies_historical["Total pupils in trust"] = 0.0
 
         if bfr_sofa_historical is not None:
             academies_historical = academies_historical.drop(
-                columns=["Trust Revenue reserve"],
+                columns=["Trust Revenue reserve", "Total pupils in trust"],
             )
 
             academies_historical = academies_historical.merge(
@@ -1203,6 +1205,14 @@ def build_bfr_historical_data(
                 how="left",
             )
             academies_historical["Trust Revenue reserve"] *= 1_000
+            academies_historical = academies_historical.merge(
+                bfr_sofa_historical[bfr_sofa_historical["EFALineNo"] == 999].rename(
+                    {"Y1P2": "Total pupils in trust"},
+                    axis=1,
+                )[["Trust UPIN", "Total pupils in trust"]],
+                on="Trust UPIN",
+                how="left",
+            )
 
     return academies_historical
 


### PR DESCRIPTION
### Context

Update pupil figures as per recent comments on the ticket ("should be from…line 999 and the Y1P2 column").

[AB#217947](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/217947)

### Change proposed in this pull request

As per `Trust Revenue reserve`, derive the `Total pupils in trust` from the BFR SOFA file(s).

### Guidance to review

N/A

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally

