### PR TITLE
Correct historical BFR test

### DIFF
--- a/data-pipeline/Makefile
+++ b/data-pipeline/Makefile
@@ -14,8 +14,7 @@ build:
 unit-test:
 	poetry run coverage run --rcfile ./pyproject.toml -m pytest --junitxml=tests/output/test-output.xml ./tests/unit;\
 	EXIT_CODE=$$?;\
-	poetry run coverage report --fail-under 65 ;\
-	EXIT_CODE=$$?;\
+	poetry run coverage report --fail-under 65 || EXIT_CODE=$$?;\
 	poetry run coverage html ;\
 	poetry run coverage xml ;\
 	exit $$EXIT_CODE

--- a/data-pipeline/tests/unit/pre_processing/test_bfr.py
+++ b/data-pipeline/tests/unit/pre_processing/test_bfr.py
@@ -48,7 +48,6 @@ def test_historical_bfr_sofa_none():
             {
                 "Trust UPIN": "0",
                 "Company Registration Number": "0",
-                "Total pupils in trust": 0,
             }
         ]
     )
@@ -68,7 +67,6 @@ def test_historical_bfr():
             {
                 "Trust UPIN": "0",
                 "Company Registration Number": "0",
-                "Total pupils in trust": 0,
             }
         ]
     )
@@ -77,6 +75,7 @@ def test_historical_bfr():
             {
                 "Trust UPIN": "0",
                 "EFALineNo": 430,
+                "Y1P2": 2_048.0,
                 "Y2P2": 1_024.0,
             }
         ]


### PR DESCRIPTION
This test _should_ have failed on the previous run.

Need to look into why but this should update the test to reflect the recent change.