### PR TITLE
Data-pipeline: handle part-year submissions for maintained schools

### DIFF
--- a/data-pipeline/src/pipeline/comparator_sets.py
+++ b/data-pipeline/src/pipeline/comparator_sets.py
@@ -226,6 +226,7 @@ def select_top_set_urns(
     boarding: np.array,
     regions: np.array,
     distances: np.ndarray,
+    include: np.array,
     base_set_size=60,
     final_set_size=30,
 ) -> np.ndarray:
@@ -244,6 +245,7 @@ def select_top_set_urns(
     :param boarding: boarding status of each org. in this grouping.
     :param regions: regional location of each org. in this grouping.
     :param distances: computed distances of each org. from the first.
+    :param include: whether entry should be considered
     :param base_set_size: The size of the initial sorted set for filtering.
     :param final_set_size: The final desired size of the comparator set.
     :return: URNs of "top" orgs. meeting criteria, ordered by distance.
@@ -252,11 +254,14 @@ def select_top_set_urns(
     target_pfi = pfi[index]
     target_boarding = boarding[index]
 
-    distance_without_urn = np.delete(distances, index)
-    urns_without_urn = np.delete(urns, index)
-    regions_without_urn = np.delete(regions, index)
-    pfi_without_urn = np.delete(pfi, index)
-    boarding_without_urn = np.delete(boarding, index)
+    # skip `index` and any not in `include`…
+    valid_mask = include & (np.arange(len(urns)) != index)
+
+    distance_without_urn = distances[valid_mask]
+    urns_without_urn = urns[valid_mask]
+    regions_without_urn = regions[valid_mask]
+    pfi_without_urn = pfi[valid_mask]
+    boarding_without_urn = boarding[valid_mask]
 
     index_by_distance = np.argsort(distance_without_urn, axis=0, kind="stable")[
         :base_set_size
@@ -293,13 +298,79 @@ def select_top_set_urns(
     return urns
 
 
+def _map_pupil_comparator_set(row: pd.Series) -> bool:
+    """
+    Whether to generate a pupil comparator set for the row in question.
+
+    For partial-year data, financial and pupil data must be present.
+
+    For full-year data, pupil comparator sets are always generated.
+
+    :param row: grouped data
+    :return: whether to generate pupil comparator set
+    """
+    if not row["Partial Years Present"]:
+        return True
+
+    return all(
+        (
+            row["Financial Data Present"],
+            row["Partial Years Present"],
+            row["Pupil Comparator Data Present"],
+        )
+    )
+
+
+def _map_building_comparator_set(row: pd.Series) -> bool:
+    """
+    Whether to generate a building comparator set for the row.
+
+    For partial-year data, financial, pupil and building data must be
+    present.
+
+    For full-year data, building comparator sets are always generated.
+
+    :param row: grouped data
+    :return: whether to generate building comparator set
+    """
+    if not row["Partial Years Present"]:
+        return True
+
+    return all(
+        (
+            row["Financial Data Present"],
+            row["Partial Years Present"],
+            row["Pupil Comparator Data Present"],
+            row["Building Comparator Data Present"],
+        )
+    )
+
+
 # TODO: rename, this does more than distances.
 def compute_distances(
     orig_data: pd.DataFrame,
     grouped_data: pd.DataFrame,
     target_urn: int | None = None,
 ):
-    # TODO: docstring needed to explain this.
+    """
+    Derive the comparator sets for each organisation.
+
+    - comparators are restricted within each phase (e.g. "Nursery")
+    - initially, the similarity "distance" is calculated for every org.
+      relative to every other, for both pupil and building.
+    - for each org. the "top" matches are found, derived from those
+      distance calculations.
+        - this may be skipped if an org. has only submitted
+          partial-year data.
+
+    If `target_urn` is populated, only the org. in question is
+    processed.
+
+    :param orig_data: info. required for comparator-set generation
+    :param grouped_data: info. grouped by school "phase"
+    :param target_urn: optional URN of a specific school, defaults to None
+    :return: updated data
+    """
     pupils = pd.Series(index=orig_data.index, dtype=object)
     buildings = pd.Series(index=orig_data.index, dtype=object)
 
@@ -314,6 +385,8 @@ def compute_distances(
         phase_pfi = np.array(row["Is PFI"])
         phase_boarding = np.array(row["Boarders (name)"])
         phase_regions = np.array(row["GOR (name)"])
+        include_pupils = np.array(row["_GeneratePupilComparatorSet"])
+        include_buildings = np.array(row["_GenerateBuildingComparatorSet"])
 
         # TODO: compares ab/ba and aa.
         # compute best-set for each org. individually.
@@ -322,14 +395,23 @@ def compute_distances(
                 continue
 
             try:
+                if not row["_GeneratePupilComparatorSet"][idx]:
+                    continue
+
                 top_pupil_set_urns = select_top_set_urns(
                     idx,
                     phase_urns,
                     phase_pfi,
                     phase_boarding,
                     phase_regions,
-                    pupil_distances[idx],
+                    distances=pupil_distances[idx],
+                    include=include_pupils,
                 )
+                pupils.loc[urn] = top_pupil_set_urns
+
+                if not row["_GenerateBuildingComparatorSet"][idx]:
+                    continue
+
                 top_building_set_urns = select_top_set_urns(
                     idx,
                     phase_urns,
@@ -337,9 +419,8 @@ def compute_distances(
                     phase_boarding,
                     phase_regions,
                     building_distances[idx],
+                    include=include_buildings,
                 )
-
-                pupils.loc[urn] = top_pupil_set_urns
                 buildings.loc[urn] = top_building_set_urns
             except Exception as error:
                 logger.exception(
@@ -364,9 +445,9 @@ def compute_comparator_set(
     """
     Determine the comparator-sets for the input data.
 
-    TODO: explain the below columns.
-
-    Perform comparator-set derivation, restricted by "phase".
+    Perform comparator-set derivation, restricted by "phase". Data are
+    restricted to the minimal set of columns required to derive each
+    comparator set.
 
     If `data` is "custom" data, the resulting output will be restricted
     to just the `target_urn`. Equally, if the target is not present, an
@@ -399,12 +480,23 @@ def compute_comparator_set(
             "Percentage Primary Need PD",
             "Percentage Primary Need ASD",
             "Percentage Primary Need OTH",
+            "Partial Years Present",
+            "Financial Data Present",
+            "Pupil Comparator Data Present",
+            "Building Comparator Data Present",
         ]
     ].copy()
 
     if target_urn and target_urn not in copy.index:
         return copy.iloc[0:0]
 
+    copy["_GeneratePupilComparatorSet"] = copy.apply(_map_pupil_comparator_set, axis=1)
+    copy["_GenerateBuildingComparatorSet"] = copy.apply(
+        _map_building_comparator_set, axis=1
+    )
+
     classes = copy.reset_index().groupby(["SchoolPhaseType"]).agg(list)
 
-    return compute_distances(copy, classes, target_urn=target_urn)
+    return compute_distances(copy, classes, target_urn=target_urn).drop(
+        columns=["_GeneratePupilComparatorSet", "_GenerateBuildingComparatorSet"],
+    )

--- a/data-pipeline/src/pipeline/comparator_sets.py
+++ b/data-pipeline/src/pipeline/comparator_sets.py
@@ -219,62 +219,6 @@ def compute_pupils_comparator(arg) -> np.ndarray:
     return pupils_calc(pupils, fsm, sen)
 
 
-# def select_top_set_urns(
-#     urns: np.array,
-#     pfi: np.array,
-#     boarding: np.array,
-#     regions: np.array,
-#     distances: np.ndarray,
-#     base_set_size=60,
-#     final_set_size=30,
-# ) -> np.ndarray:
-#     """
-#     Determine the URNs of the closest orgs.
-#
-#     1. take the top (by default) 60 orgs. closest by distance metrics,
-#        with the same PFI and Boarding status.
-#     2. reduce this to those in the same region.
-#     3. if fewer than (by default) 30 results, supplement this with the
-#        closest by distance metrics from the original set.
-#
-#     :param urns: URN of each org. in this grouping.
-#     :param pfi: PFI status of each org. in this grouping.
-#     :param boarding: boarding status of each org. in this grouping.
-#     :param regions: regional location of each org. in this grouping.
-#     :param distances: computed distances of each org. from the first.
-#     :return: URNs of "top" orgs. meeting criteria, orderd by distance.
-#     """
-#     index_by_distance = np.argsort(distances, axis=0, kind="stable")
-#     urns_by_distance = urns[index_by_distance]
-#
-#     pfi_by_distance = pfi[index_by_distance]
-#     boarding_by_distance = boarding[index_by_distance]
-#     same_pfi = pfi_by_distance == pfi_by_distance[0]
-#     same_boarding = boarding_by_distance == boarding_by_distance[0]
-#     same_criteria = np.logical_and(
-#         same_pfi,
-#         same_boarding,
-#     )
-#     top_criteria_index = np.argwhere(same_criteria).flatten()[:base_set_size]
-#
-#     same_region_index = np.argwhere(regions == regions[0]).flatten()
-#     top_regions_index = np.intersect1d(
-#         top_criteria_index,
-#         same_region_index,
-#     )
-#     same_region_urns = urns_by_distance[top_regions_index][:final_set_size]
-#
-#     urns = np.append(
-#         same_region_urns,
-#         np.delete(
-#             urns_by_distance,
-#             same_region_index,
-#         )[: final_set_size - len(same_region_urns)],
-#     )
-#
-#     return urns
-
-
 def select_top_set_urns(
     index: int,
     urns: np.array,

--- a/data-pipeline/src/pipeline/config.py
+++ b/data-pipeline/src/pipeline/config.py
@@ -181,6 +181,14 @@ cost_category_map = {
     },
 }
 
+census_column_map = {
+    "headcount of pupils": "Number of pupils (headcount)",
+    "fte pupils": "Number of pupils",
+    "Total Number of Non-Classroom-based School Support Staff, (Other school support staff plus Administrative staff plus Technicians and excluding Auxiliary staff (Full-Time Equivalent)": "NonClassroomSupportStaffFTE",
+    "Total Number of Non Classroom-based School Support Staff, Excluding Auxiliary Staff (Headcount)": "NonClassroomSupportStaffHeadcount",
+    "% of pupils known to be eligible for free school meals": "Percentage Free school meals",
+}
+
 rag_category_settings = {
     "Teaching and Teaching support staff": {
         "type": "Pupil",
@@ -644,3 +652,29 @@ rag_category_settings = {
         ],
     },
 }
+
+cdc_generated_columns = [
+    "Total Internal Floor Area",
+    "Age Average Score",
+    "Building Age",
+]
+
+sen_generated_columns = [
+    "EHC plan",
+    "SEN support",
+    "Percentage SEN",
+    "Percentage with EHC",
+    "Percentage without EHC",
+    "Percentage Primary Need SPLD",
+    "Percentage Primary Need MLD",
+    "Percentage Primary Need SLD",
+    "Percentage Primary Need PMLD",
+    "Percentage Primary Need SEMH",
+    "Percentage Primary Need SLCN",
+    "Percentage Primary Need HI",
+    "Percentage Primary Need VI",
+    "Percentage Primary Need MSI",
+    "Percentage Primary Need PD",
+    "Percentage Primary Need ASD",
+    "Percentage Primary Need OTH",
+]

--- a/data-pipeline/src/pipeline/maintained_schools.py
+++ b/data-pipeline/src/pipeline/maintained_schools.py
@@ -220,14 +220,16 @@ def map_has_financial_data(
     least _some_ financial data—the data are considered to contain
     financial information.
 
+    Note: colums must be derive as per `map_cost_income_categories()`.
+
     :param maintained_schools: maintained schools data
     :return: updated DataFrame
     """
     financial_columns = list(
-        set(
-            list(config.income_category_map["maintained_schools"].values())
-            + list(config.cost_category_map["maintained_schools"].values())
-        )
+        (
+            config.cost_category_map["maintained_schools"]
+            | config.income_category_map["maintained_schools"]
+        ).values()
     )
 
     maintained_schools["Financial Data Present"] = (

--- a/data-pipeline/src/pipeline/maintained_schools.py
+++ b/data-pipeline/src/pipeline/maintained_schools.py
@@ -3,6 +3,7 @@ import datetime
 import numpy as np
 import pandas as pd
 
+from src.pipeline import config
 import src.pipeline.input_schemas as input_schemas
 import src.pipeline.mappings as mappings
 
@@ -207,3 +208,74 @@ def apply_federation_mapping(
     )
 
     return maintained_schools[~maintained_schools.index.duplicated()]
+
+
+def map_has_financial_data(
+    maintained_schools: pd.DataFrame,
+) -> pd.DataFrame:
+    """
+    Whether the maintained school data contains financial data.
+
+    If all "financial" data columns are _not_ null—i.e. there are at
+    least _some_ financial data—the data are considered to contain
+    financial information.
+
+    :param maintained_schools: maintained schools data
+    :return: updated DataFrame
+    """
+    financial_columns = list(
+        set(
+            list(config.income_category_map["maintained_schools"].values())
+            + list(config.cost_category_map["maintained_schools"].values())
+        )
+    )
+
+    maintained_schools["Financial Data Present"] = (
+        ~maintained_schools[financial_columns].isna().all(axis=1)
+    )
+
+    return maintained_schools
+
+
+def map_has_pupil_comparator_data(
+    maintained_schools: pd.DataFrame,
+) -> pd.DataFrame:
+    """
+    Whether the maintained school data has all the necessary data to
+    create a pupil comparator group.
+
+    Specifically, this is the FSM and SEN data.
+
+    :param maintained_schools: maintained schools data
+    :return: updated DataFrame
+    """
+    pupil_comparator_columns = list(
+        set(list(config.census_column_map.values()) + config.sen_generated_columns)
+    )
+
+    maintained_schools["Pupil Comparator Data Present"] = (
+        ~maintained_schools[pupil_comparator_columns].isna().all(axis=1)
+    )
+
+    return maintained_schools
+
+
+def map_has_building_comparator_data(
+    maintained_schools: pd.DataFrame,
+) -> pd.DataFrame:
+    """
+    Whether the maintained school data has all the necessary data to
+    create a building comparator group.
+
+    Specifically, this is the CDC data.
+
+    :param maintained_schools: maintained schools data
+    :return: updated DataFrame
+    """
+    building_comparator_columns = config.cdc_generated_columns
+
+    maintained_schools["Building Comparator Data Present"] = (
+        ~maintained_schools[building_comparator_columns].isna().all(axis=1)
+    )
+
+    return maintained_schools

--- a/data-pipeline/src/pipeline/pre_processing.py
+++ b/data-pipeline/src/pipeline/pre_processing.py
@@ -37,7 +37,7 @@ def prepare_cdc_data(cdc_file_path, current_year):
     cdc["Building Age"] = (
         cdc.groupby(by=["URN"])["Indicative Age"].mean().astype("Int64")
     )
-    result = cdc[["Total Internal Floor Area", "Age Average Score", "Building Age"]]
+    result = cdc[config.cdc_generated_columns]
 
     return result[~result.index.duplicated(keep="first")]
 
@@ -85,15 +85,7 @@ def prepare_census_data(workforce_census_path, pupil_census_path):
         how="inner",
         rsuffix="_pupil",
         lsuffix="_workforce",
-    ).rename(
-        columns={
-            "headcount of pupils": "Number of pupils (headcount)",
-            "fte pupils": "Number of pupils",
-            "Total Number of Non-Classroom-based School Support Staff, (Other school support staff plus Administrative staff plus Technicians and excluding Auxiliary staff (Full-Time Equivalent)": "NonClassroomSupportStaffFTE",
-            "Total Number of Non Classroom-based School Support Staff, Excluding Auxiliary Staff (Headcount)": "NonClassroomSupportStaffHeadcount",
-            "% of pupils known to be eligible for free school meals": "Percentage Free school meals",
-        }
-    )
+    ).rename(columns=config.census_column_map)
 
     census["Number of pupils"] = (
         census["Number of pupils"] + census["Pupil Dual Registrations"]
@@ -188,27 +180,7 @@ def prepare_sen_data(sen_path):
         (sen["Primary Need OTH"] / sen["Total pupils"]) * 100.0
     ).fillna(0)
 
-    return sen[
-        [
-            "EHC plan",
-            "SEN support",
-            "Percentage SEN",
-            "Percentage with EHC",
-            "Percentage without EHC",
-            "Percentage Primary Need SPLD",
-            "Percentage Primary Need MLD",
-            "Percentage Primary Need SLD",
-            "Percentage Primary Need PMLD",
-            "Percentage Primary Need SEMH",
-            "Percentage Primary Need SLCN",
-            "Percentage Primary Need HI",
-            "Percentage Primary Need VI",
-            "Percentage Primary Need MSI",
-            "Percentage Primary Need PD",
-            "Percentage Primary Need ASD",
-            "Percentage Primary Need OTH",
-        ]
-    ]
+    return sen[config.sen_generated_columns]
 
 
 def prepare_ks2_data(ks2_path):
@@ -1088,6 +1060,11 @@ def build_maintained_school_data(
     (hard_federations, soft_federations) = build_federations_data(
         links_data_path, maintained_schools
     )
+
+    # partial-year checks…
+    maintained_schools = maintained_pipeline.map_has_financial_data(maintained_schools)
+    maintained_schools = maintained_pipeline.map_has_pupil_comparator_data(maintained_schools)
+    maintained_schools = maintained_pipeline.map_has_building_comparator_data(maintained_schools)
 
     # Applying federation mappings
     maintained_schools = maintained_pipeline.apply_federation_mapping(


### PR DESCRIPTION
### Context

Partial-year submission for maintained schools need to be omitted from comparator-set/RAG calculations under certain circumstances.

[AB#224500](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/224500)

### Change proposed in this pull request

1. extend the maintained school data to include indicators which determine whether comparator-sets are calculated
2. in the comparator-set workflow, use these to skip comparator-set calculations.
3. moving some existing pre-processing code to `config.py` for re-use when identifying columns for the above.

### Guidance to review 

See the checks/outcomes in the linked ticket.

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally

