### PR TITLE
chore: terraform provider updates

### DIFF
--- a/core-infrastructure/terraform/acr.tf
+++ b/core-infrastructure/terraform/acr.tf
@@ -18,14 +18,14 @@ resource "azurerm_container_registry" "acr" {
   public_network_access_enabled = true
 
   #TODO: Review as premium is required for reention policy
-  retention_policy {}
+  retention_policy_in_days = 0
 
   identity {
     type = "SystemAssigned"
   }
 
   #TODO: Review as premium is required for trust policy  
-  trust_policy {}
+  trust_policy_enabled = false
 
   tags = local.common-tags
 }

--- a/core-infrastructure/terraform/provider.tf
+++ b/core-infrastructure/terraform/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.87"
+      version = "~> 4.0"
     }
     azapi = {
       source  = "azure/azapi"

--- a/web/terraform/cache.tf
+++ b/web/terraform/cache.tf
@@ -41,7 +41,7 @@ resource "azurerm_cosmosdb_sql_container" "session-cache-container" {
   resource_group_name   = azurerm_resource_group.resource-group.name
   account_name          = azurerm_cosmosdb_account.session-cache-account.name
   database_name         = azurerm_cosmosdb_sql_database.session-cache-database.name
-  partition_key_path    = "/id"
+  partition_key_paths   = ["/id"]
   partition_key_version = 1
 }
 

--- a/web/terraform/provider.tf
+++ b/web/terraform/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.87"
+      version = "~> 4.0"
     }
   }
   backend "azurerm" {}


### PR DESCRIPTION
### Context
[AB#226388](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/226388) - [AB#226504](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/226504)/[AB#226689](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/226689)

Following Dependabot alerts #1287 and #1277 updates required for the latest version of azurerm.

`retention_policy` has been replaced by `retention_policy_in_days`.
[docs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry#retention_policy_in_days)
[4.0 upgrade guide](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide#azurerm_container_registry)

`trust_policy` block has been replaced by `trust_policy_enabled`.
[docs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry#trust_policy_enabled)
[4.0 upgrade guide](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide#azurerm_container_registry)

`partition_key_path` has been replaced by `partition_key_paths`.
[docs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_sql_container#partition_key_paths)
[4.0 upgrade guide](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide#azurerm_cosmosdb_sql_container)


### Change proposed in this pull request
Replaces deprecated properties with the new required properties - see above.
Updates azurerm provider version.

### Guidance to review 
See context

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~Your code builds clean without any errors or warnings~
- [ ] ~You have run all unit/integration tests and they pass~
- [x] Your branch has been rebased onto main
- [ ] ~You have tested by running locally~

