### PR TITLE
fix: omit removal of closed schools data

### DIFF
--- a/data-pipeline/src/pipeline/pre_processing.py
+++ b/data-pipeline/src/pipeline/pre_processing.py
@@ -667,8 +667,7 @@ def prepare_schools_data(base_data_path, links_data_path):
     ).sort_values(by="URN")
 
     return schools[
-        schools["CloseDate"].isna()
-        & ((schools["Rank"] == 1) | (schools["Rank"].isna()))
+        (schools["Rank"] == 1) | (schools["Rank"].isna())
     ].drop(columns=["LinkURN", "LinkName", "LinkType", "LinkEstablishedDate", "Rank"])
 
 


### PR DESCRIPTION
### Context

Previously, only schools with an empty `CloseDate` were retained, effectively removing any maintained-schools which had made part-year submissions.

[AB#224500](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/224500)

### Change proposed in this pull request

Drop the `CloseDate` filter on the `schools`/GIAS dataset.

### Guidance to review 

See `pipeline.maintained_schools#create_master_list()`, line 30: this is where the `schools` data are joined to `managed_schools`. As there's no `how` parameter passed, it'll default to `inner` which is where the above problem creeps in.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally

