### PR TITLE
fix: include empty comparator-sets for part-year data

### DIFF
--- a/data-pipeline/src/pipeline/comparator_sets.py
+++ b/data-pipeline/src/pipeline/comparator_sets.py
@@ -404,6 +404,7 @@ def compute_distances(
 
             try:
                 if not row["_GeneratePupilComparatorSet"][idx]:
+                    pupils.loc[urn] = np.array([])
                     continue
 
                 top_pupil_set_urns = select_top_set_urns(
@@ -418,6 +419,7 @@ def compute_distances(
                 pupils.loc[urn] = top_pupil_set_urns
 
                 if not row["_GenerateBuildingComparatorSet"][idx]:
+                    buildings.loc[urn] = np.array([])
                     continue
 
                 top_building_set_urns = select_top_set_urns(


### PR DESCRIPTION
### Context

Failed pipeline run with `AttributeError: 'float' object has no attribute 'tolist'`.

As we were skipping comparator-set generation for part-year records, this would have been a `numpy.nan`, hence the error.

[AB#224500](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/224500)

### Change proposed in this pull request

Include an empty array for skipped comparator-sets to they can be correctly serialised as per existing behaviour.

### Guidance to review 

…

### Checklist (add/remove as appropriate)

- [ ] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally

