### PR TITLE
fix: include empty comparator-sets for part-year data

### DIFF
--- a/data-pipeline/src/pipeline/comparator_sets.py
+++ b/data-pipeline/src/pipeline/comparator_sets.py
@@ -405,6 +405,7 @@ def compute_distances(
             try:
                 if not row["_GeneratePupilComparatorSet"][idx]:
                     pupils.loc[urn] = np.array([])
+                    buildings.loc[urn] = np.array([])
                     continue
 
                 top_pupil_set_urns = select_top_set_urns(


### PR DESCRIPTION
### Context

Failed pipeline run with `AttributeError: 'float' object has no attribute 'tolist'`.

[AB#224500](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/224500)

### Change proposed in this pull request

Include an empty array for skipped comparator-sets to they can be correctly serialised as per existing behaviour.

### Guidance to review 

The previous fix resolved the issue for _pupils_. However, as _buildings_ requires both pupils and building data, an early exit for the former still caused an issue for the latter.

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally

