### PR TITLE
Ensure Docker build for `data-pipeline` targets correct architecture

### DIFF
--- a/data-pipeline/Makefile
+++ b/data-pipeline/Makefile
@@ -9,7 +9,7 @@ run-pipeline-dev-mode:
     poetry run python -m src.pipeline.main
 
 build: 
-	docker build $(tags) --file docker/pipeline-worker/Dockerfile .
+	docker build $(tags) --file docker/pipeline-worker/Dockerfile . --platform="linux/amd64"
 
 unit-test:
 	poetry run coverage run --rcfile ./pyproject.toml -m pytest --junitxml=tests/output/test-output.xml ./tests/unit;\


### PR DESCRIPTION
### Context
[AB#226820](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/226820) [AB#225091](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/225091)

### Change proposed in this pull request
Explicitly target `linux/amd64` rather than the default from the source device that initiated the build. 

For example when building on MacOS the following is returned when attempting to provision an incorrectly targeted image:

```
Status: "Failed"
│ Code: "ContainerAppOperationError"
│ Message: "Failed to provision revision for container app 's198d50-ebis-data-pipeline'. Error details: The following field(s) are either invalid or missing. Field
│ 'template.containers.edis-data-pipeline.image' is invalid with details: 'Invalid value: \"s198d50acr.azurecr.io/fbit-data-pipeline:1.0.0-manual.0\": image OS/Arc must be linux/amd64 but     
│ found linux/arm64';.."
│ Activity Id: ""
```

This has been pushed to `d12` feature environment for validation.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~~Your code builds clean without any errors or warnings~~
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

