### PR TITLE
Add DLQ query to OI dashboard

### DIFF
--- a/core-infrastructure/terraform/README.md
+++ b/core-infrastructure/terraform/README.md
@@ -41,9 +41,9 @@ No modules.
 | [azurerm_key_vault_secret.sql-user-name](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_log_analytics_query_pack.query-pack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_query_pack) | resource |
 | [azurerm_log_analytics_query_pack_query.custom-data-funnel](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_query_pack_query) | resource |
+| [azurerm_log_analytics_query_pack_query.dlq-new-messages-per-hour](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_query_pack_query) | resource |
 | [azurerm_log_analytics_query_pack_query.feature-requests](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_query_pack_query) | resource |
 | [azurerm_log_analytics_query_pack_query.feature-requests-by-auth](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_query_pack_query) | resource |
-| [azurerm_log_analytics_query_pack_query.get-dlq-message-count](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_query_pack_query) | resource |
 | [azurerm_log_analytics_query_pack_query.pipeline-runs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_query_pack_query) | resource |
 | [azurerm_log_analytics_query_pack_query.popular-commercial-resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_query_pack_query) | resource |
 | [azurerm_log_analytics_query_pack_query.popular-local-authority-requests](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_query_pack_query) | resource |
@@ -65,8 +65,8 @@ No modules.
 | [azurerm_log_analytics_saved_search.get-commercial-resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_saved_search.get-establishment-requests](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_saved_search.get-feature-requests](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
-| [azurerm_log_analytics_saved_search.get-message-count-by-queue-name](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_saved_search.get-new-users](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
+| [azurerm_log_analytics_saved_search.get-queue-put-messages](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_saved_search.get-session-length](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_saved_search.get-sessions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_saved_search.get-tracked-links](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
@@ -76,6 +76,7 @@ No modules.
 | [azurerm_log_analytics_saved_search.get-waf-logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_workspace.application-insights-workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_monitor_action_group.action-group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
+| [azurerm_monitor_diagnostic_setting.storage-account-data-queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_smart_detector_alert_rule.failure-anomalies-detector](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_smart_detector_alert_rule) | resource |
 | [azurerm_mssql_database.sql-db](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_database) | resource |
 | [azurerm_mssql_database_extended_auditing_policy.db-audit-policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_database_extended_auditing_policy) | resource |
@@ -110,9 +111,9 @@ No modules.
 | [mssql_user.sp-user](https://registry.terraform.io/providers/betr-io/mssql/0.3.1/docs/resources/user) | resource |
 | [random_password.sql-admin-password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_uuid.custom-data-funnel-id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
+| [random_uuid.dlq-new-messages-per-hour-id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [random_uuid.feature-requests-by-auth-id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [random_uuid.feature-requests-id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
-| [random_uuid.get-dlq-message-count-id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [random_uuid.pipeline-runs-id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [random_uuid.popular-commercial-resources-id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [random_uuid.popular-local-authority-requests-id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |

--- a/core-infrastructure/terraform/dashboards.tf
+++ b/core-infrastructure/terraform/dashboards.tf
@@ -70,7 +70,7 @@ locals {
   failures-query-prefix               = replace(replace(file("${path.module}/queries/failures-query-prefix.kql"), "/[\r\n]+/", "\\n"), "\"", "\\\"")
   waf-requests-query                  = replace(replace(file("${path.module}/queries/waf-requests.kql"), "/[\r\n]+/", "\\n"), "\"", "\\\"")
   waf-blocked-requests-per-hour-query = replace(replace(file("${path.module}/queries/waf-blocked-requests-per-hour.kql"), "/[\r\n]+/", "\\n"), "\"", "\\\"")
-  dlq-message-count                   = replace(replace(file("${path.module}/queries/dlq-message-count.kql"), "/[\r\n]+/", "\\n"), "\"", "\\\"")
+  dlq-new-messages-per-hour-query     = replace(replace(file("${path.module}/queries/dlq-new-messages-per-hour.kql"), "/[\r\n]+/", "\\n"), "\"", "\\\"")
 }
 
 resource "azurerm_portal_dashboard" "oi-dashboard" {
@@ -102,5 +102,9 @@ resource "azurerm_portal_dashboard" "oi-dashboard" {
       waf_blocked_requests_per_hour_id    = azurerm_log_analytics_query_pack_query.waf-blocked-requests-per-hour.name,
       waf_blocked_requests_per_hour_query = local.waf-blocked-requests-per-hour-query,
       waf_blocked_requests_per_hour_title = azurerm_log_analytics_query_pack_query.waf-blocked-requests-per-hour.description
+
+      dlq_new_messages_per_hour_id    = azurerm_log_analytics_query_pack_query.dlq-new-messages-per-hour.name,
+      dlq_new_messages_per_hour_query = local.dlq-new-messages-per-hour-query,
+      dlq_new_messages_per_hour_title = azurerm_log_analytics_query_pack_query.dlq-new-messages-per-hour.description
   })
 }

--- a/core-infrastructure/terraform/dashboards/oi.tpl
+++ b/core-infrastructure/terraform/dashboards/oi.tpl
@@ -498,7 +498,7 @@
                     "position": {
                         "x": 3,
                         "y": 3,
-                        "colSpan": 6,
+                        "colSpan": 5,
                         "rowSpan": 4
                     },
                     "metadata": {
@@ -602,7 +602,7 @@
                 },
                 "7": {
                     "position": {
-                        "x": 9,
+                        "x": 8,
                         "y": 3,
                         "colSpan": 6,
                         "rowSpan": 4
@@ -664,6 +664,124 @@
                 },
                 "8": {
                     "position": {
+                        "x": 14,
+                        "y": 3,
+                        "colSpan": 5,
+                        "rowSpan": 4
+                    },
+                    "metadata": {
+                        "inputs": [
+                            {
+                                "name": "resourceTypeMode",
+                                "isOptional": true
+                            },
+                            {
+                                "name": "ComponentId",
+                                "isOptional": true
+                            },
+                            {
+                                "name": "Scope",
+                                "value": {
+                                    "resourceIds": [
+                                        "${workspace_id}"
+                                    ]
+                                },
+                                "isOptional": true
+                            },
+                            {
+                                "name": "PartId",
+                                "value": "${dlq_new_messages_per_hour_id}",
+                                "isOptional": true
+                            },
+                            {
+                                "name": "Version",
+                                "value": "2.0",
+                                "isOptional": true
+                            },
+                            {
+                                "name": "TimeRange",
+                                "value": "P1D",
+                                "isOptional": true
+                            },
+                            {
+                                "name": "DashboardId",
+                                "isOptional": true
+                            },
+                            {
+                                "name": "DraftRequestParameters",
+                                "isOptional": true
+                            },
+                            {
+                                "name": "Query",
+                                "value": "${dlq_new_messages_per_hour_query}",
+                                "isOptional": true
+                            },
+                            {
+                                "name": "ControlType",
+                                "value": "FrameControlChart",
+                                "isOptional": true
+                            },
+                            {
+                                "name": "SpecificChart",
+                                "value": "UnstackedColumn",
+                                "isOptional": true
+                            },
+                            {
+                                "name": "PartTitle",
+                                "isOptional": true
+                            },
+                            {
+                                "name": "PartSubTitle",
+                                "isOptional": true
+                            },
+                            {
+                                "name": "Dimensions",
+                                "value": {
+                                    "xAxis": {
+                                        "name": "TimeGenerated",
+                                        "type": "datetime"
+                                    },
+                                    "yAxis": [
+                                        {
+                                            "name": "NewMessageCount",
+                                            "type": "long"
+                                        }
+                                    ],
+                                    "splitBy": [
+                                        {
+                                            "name": "QueueName",
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "aggregation": "Sum"
+                                },
+                                "isOptional": true
+                            },
+                            {
+                                "name": "LegendOptions",
+                                "value": {
+                                    "isEnabled": false,
+                                    "position": "Bottom"
+                                },
+                                "isOptional": true
+                            },
+                            {
+                                "name": "IsQueryContainTimeRange",
+                                "value": false,
+                                "isOptional": true
+                            }
+                        ],
+                        "type": "Extension/Microsoft_OperationsManagementSuite_Workspace/PartType/LogsDashboardPart",
+                        "settings": {
+                            "content": {
+                                "PartTitle": "${dlq_new_messages_per_hour_title}",
+                                "PartSubTitle": "${environment}"
+                            }
+                        }
+                    }
+                },
+                "9": {
+                    "position": {
                         "x": 0,
                         "y": 7,
                         "colSpan": 3,
@@ -683,7 +801,7 @@
                         }
                     }
                 },
-                "9": {
+                "10": {
                     "position": {
                         "x": 3,
                         "y": 7,
@@ -828,7 +946,7 @@
                         }
                     }
                 },
-                "10": {
+                "11": {
                     "position": {
                         "x": 9,
                         "y": 7,
@@ -944,7 +1062,7 @@
                         }
                     }
                 },
-                "11": {
+                "12": {
                     "position": {
                         "x": 0,
                         "y": 11,
@@ -965,7 +1083,7 @@
                         }
                     }
                 },
-                "12": {
+                "13": {
                     "position": {
                         "x": 3,
                         "y": 11,
@@ -1076,7 +1194,7 @@
                         }
                     }
                 },
-                "13": {
+                "14": {
                     "position": {
                         "x": 9,
                         "y": 11,
@@ -1192,7 +1310,7 @@
                         }
                     }
                 },
-                "14": {
+                "15": {
                     "position": {
                         "x": 0,
                         "y": 15,
@@ -1215,7 +1333,7 @@
                         }
                     }
                 },
-                "15": {
+                "16": {
                     "position": {
                         "x": 3,
                         "y": 15,
@@ -1319,14 +1437,17 @@
                             "value": "Past 24 hours"
                         },
                         "filteredPartIds": [
-                            "StartboardPart-MonitorChartPart-601c0e92-821c-4e93-945d-13a0211991a8",
-                            "StartboardPart-MonitorChartPart-601c0e92-821c-4e93-945d-13a0211991aa",
-                            "StartboardPart-MonitorChartPart-601c0e92-821c-4e93-945d-13a0211991ac",
-                            "StartboardPart-MonitorChartPart-601c0e92-821c-4e93-945d-13a0211991ae",
-                            "StartboardPart-MonitorChartPart-601c0e92-821c-4e93-945d-13a0211991b2",
-                            "StartboardPart-MonitorChartPart-601c0e92-821c-4e93-945d-13a0211991ba",
-                            "StartboardPart-MonitorChartPart-601c0e92-821c-4e93-945d-13a0211991be",
-                            "StartboardPart-ApplicationMapPart-601c0e92-821c-4e93-945d-13a0211991c2"
+                            "StartboardPart-MonitorChartPart-793f5af7-5688-4761-b16d-bd4985d8410b",
+                            "StartboardPart-MonitorChartPart-793f5af7-5688-4761-b16d-bd4985d84119",
+                            "StartboardPart-MonitorChartPart-793f5af7-5688-4761-b16d-bd4985d8411b",
+                            "StartboardPart-MonitorChartPart-793f5af7-5688-4761-b16d-bd4985d8411d",
+                            "StartboardPart-MonitorChartPart-793f5af7-5688-4761-b16d-bd4985d84121",
+                            "StartboardPart-MonitorChartPart-793f5af7-5688-4761-b16d-bd4985d84127",
+                            "StartboardPart-MonitorChartPart-793f5af7-5688-4761-b16d-bd4985d8410d",
+                            "StartboardPart-LogsDashboardPart-793f5af7-5688-4761-b16d-bd4985d84111",
+                            "StartboardPart-LogsDashboardPart-793f5af7-5688-4761-b16d-bd4985d84113",
+                            "StartboardPart-ApplicationMapPart-793f5af7-5688-4761-b16d-bd4985d84117",
+                            "StartboardPart-LogsDashboardPart-793f5af7-5688-4761-b16d-bd4985d84129"
                         ]
                     }
                 }

--- a/core-infrastructure/terraform/queries.tf
+++ b/core-infrastructure/terraform/queries.tf
@@ -417,26 +417,28 @@ resource "azurerm_log_analytics_saved_search" "get-tracked-save-charts" {
   query = file("${path.module}/queries/functions/get-tracked-save-charts.kql")
 }
 
-resource "azurerm_log_analytics_saved_search" "get-message-count-by-queue-name" {
-  name                       = "GetMessagesByQueueName"
+resource "azurerm_log_analytics_saved_search" "get-queue-put-messages" {
+  name                       = "GetQueuePutMessages"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.application-insights-workspace.id
   category                   = "Function"
-  display_name               = "GetMessagesByQueueName"
-  function_alias             = "GetMessagesByQueueName"
+  display_name               = "GetQueuePutMessages"
+  function_alias             = "GetQueuePutMessages"
   tags                       = local.query-tags
 
-  query = file("${path.module}/queries/functions/get-messages-by-queue-name.kql")
+  query = templatefile("${path.module}/queries/functions/get-queue-put-messages.kql", {
+    storageAccountName = azurerm_storage_account.data.name
+  })
 }
 
-resource "random_uuid" "get-dlq-message-count-id" {}
+resource "random_uuid" "dlq-new-messages-per-hour-id" {}
 
-resource "azurerm_log_analytics_query_pack_query" "get-dlq-message-count" {
-  name          = random_uuid.get-dlq-message-count-id.result
+resource "azurerm_log_analytics_query_pack_query" "dlq-new-messages-per-hour" {
+  name          = random_uuid.dlq-new-messages-per-hour-id.result
   query_pack_id = azurerm_log_analytics_query_pack.query-pack.id
-  display_name  = "DLQ message count"
-  description   = "Count of messages on the dead-letter queue."
+  display_name  = "DLQ new messages"
+  description   = "New messages added to the dead-letter queue."
   categories    = ["applications"]
   tags          = local.query-tags
 
-  body = file("${path.module}/queries/dlq-message-count.kql")
+  body = file("${path.module}/queries/dlq-new-messages-per-hour.kql")
 }

--- a/core-infrastructure/terraform/queries/dlq-message-count.kql
+++ b/core-infrastructure/terraform/queries/dlq-message-count.kql
@@ -1,4 +1,0 @@
-GetMessagesByQueueName
-| where QueueName == "data-pipeline-dlq"
-| summarize MessageCount = count() by QueueName, bin(TimeGenerated, 1h)
-| order by TimeGenerated desc, QueueName asc

--- a/core-infrastructure/terraform/queries/dlq-new-messages-per-hour.kql
+++ b/core-infrastructure/terraform/queries/dlq-new-messages-per-hour.kql
@@ -1,0 +1,11 @@
+GetQueuePutMessages
+| where
+    OperationName == "PutMessage" 
+| where 
+    QueueName == "data-pipeline-job-dlq"
+| summarize 
+    NewMessageCount = count()
+    by QueueName, bin(TimeGenerated, 1h)
+| order by 
+    TimeGenerated desc,
+    QueueName asc

--- a/core-infrastructure/terraform/queries/functions/get-messages-by-queue-name.kql
+++ b/core-infrastructure/terraform/queries/functions/get-messages-by-queue-name.kql
@@ -1,3 +1,0 @@
-StorageQueueLogs
-| extend QueueName = tostring(split(parseurl(Uri).Path, "/")[1])
-| where OperationName == "GetMessages"

--- a/core-infrastructure/terraform/queries/functions/get-queue-put-messages.kql
+++ b/core-infrastructure/terraform/queries/functions/get-queue-put-messages.kql
@@ -1,0 +1,9 @@
+StorageQueueLogs
+| extend 
+    QueueName = tostring(split(parseurl(Uri).Path, "/")[1])
+| where 
+    AccountName == "${storageAccountName}"
+| where
+    OperationName == "PutMessage" 
+// `PutMessage` is the API operation when a new message is added to the queue, 
+// rather than cumulative total of current number of messages in the queue.

--- a/core-infrastructure/terraform/storage.tf
+++ b/core-infrastructure/terraform/storage.tf
@@ -72,3 +72,18 @@ resource "azurerm_key_vault_secret" "data-storage-connection-string" {
   content_type = "connection-string"
   depends_on   = [azurerm_key_vault_access_policy.terraform_sp_access]
 }
+
+resource "azurerm_monitor_diagnostic_setting" "storage-account-data-queue" {
+  name                       = "${azurerm_storage_account.data.name}-queue-logs"
+  target_resource_id         = "${azurerm_storage_account.data.id}/queueServices/default/"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.application-insights-workspace.id
+
+  metric {
+    category = "Transaction"
+    enabled  = true
+  }
+
+  enabled_log {
+    category = "StorageWrite"
+  }
+}


### PR DESCRIPTION
### Context
[AB#227012](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/227012) [AB#223831](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/223831)

### Change proposed in this pull request
Switched query to use count of `PutMessage` rather than `GetMessages`. 
Added missing Diagnostic Settings infrastructure configuration.
Appended chart displaying query results to OI dashboard.

### Guidance to review 
Modified OI dashboard deployed to `d11` feature environment. Add a message to the `dlq` queue and wait ~5 minutes for the updated metric to be displayed in the chart.

![image](https://github.com/user-attachments/assets/bffc2101-da53-4f03-ad5d-e083d343d7eb)

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~~Your code builds clean without any errors or warnings~~
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

