### PR TITLE
fix: correct comparator-set upsert

### DIFF
--- a/data-pipeline/src/pipeline/database.py
+++ b/data-pipeline/src/pipeline/database.py
@@ -38,9 +38,16 @@ def receive_before_cursor_execute(
         cursor.fast_executemany = True
 
 
-def upsert(df, table_name, keys: list[str], dtype: dict[str, any] = None):
+def upsert(
+    df: pd.DataFrame,
+    table_name: str,
+    keys: list[str],
+    dtype: dict[str, any] = None,
+    drop_duplicates: bool = True,
+):
     logger.info(f"Connecting to database {engine.url}")
-    df.drop_duplicates(inplace=True)
+    if drop_duplicates:
+        df.drop_duplicates(inplace=True)
 
     update_cols = []
     insert_cols = [*keys]
@@ -71,7 +78,12 @@ def insert_comparator_set(run_type: str, set_type: str, run_id: str, df: pd.Data
         lambda x: json.dumps(x.tolist())
     )
 
-    upsert(write_frame, "ComparatorSet", keys=["RunType", "RunId", "URN", "SetType"])
+    upsert(
+        write_frame,
+        "ComparatorSet",
+        keys=["RunType", "RunId", "URN", "SetType"],
+        drop_duplicates=False,
+    )
     logger.info(
         f"Wrote {len(write_frame)} rows to comparator set {run_type} - {set_type} - {run_id}"
     )


### PR DESCRIPTION
### Context

Only a single entry per comparator-set run is being included for part-year data where pupil/building comparator-set generation would be skipped. This is due to the `drop_duplicates()` call in the `upsert()` function.

This will not consider the index (i.e. `URN`) as part of the duplicate check and, as columns are reduced to just `Pupil` and `Building`, any instances where the comparator set is empty (i.e. `[]`) will be considered duplicates.

[AB#224500](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/224500)

### Change proposed in this pull request

Extend the `upsert()` function to take an optional argument indicating whether deduplication should take place. This will default to `True` to maintain existing behaviour where this is used elsewhere but `insert_comparator_set()` will explicitly pass `False` to avoid the issue observed.

### Guidance to review 

…

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally

