### PR TITLE
Include additional automatically provisioned `azurerm_monitor_diagnostic_setting`s

### DIFF
--- a/core-infrastructure/terraform/storage.tf
+++ b/core-infrastructure/terraform/storage.tf
@@ -81,6 +81,24 @@ resource "azurerm_monitor_diagnostic_setting" "storage-account-data-queue" {
   metric {
     category = "Transaction"
     enabled  = true
+
+    // The following is not used by Log Analytics backed diagnostics, but Terraform adds it anyway and `ignore_changes` 
+    // is not currently supported by block level configuration (https://github.com/hashicorp/terraform/issues/26359). 
+    // The 'deprecated' warning here and below may therefore be ignored.
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  metric {
+    category = "Capacity"
+    enabled  = false
+
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
   }
 
   enabled_log {


### PR DESCRIPTION
### Context
[AB#227131](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/227131) [AB#223831](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/223831)

### Change proposed in this pull request
Include additional automatically provisioned `azurerm_monitor_diagnostic_setting`s and ignore unused `retention_policy`.

See:
- https://github.com/hashicorp/terraform-provider-azurerm/issues/17172 
- https://stackoverflow.com/a/78299394/504477
- https://github.com/hashicorp/terraform/issues/26359

New log output shows that there is now no drift between configuration and state but does include the warning that is safe to ignore:

```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration
and found no differences, so no changes are needed.
╷
│ Warning: Argument is deprecated
│ 
│   with azurerm_monitor_diagnostic_setting.storage-account-data-queue,
│   on storage.tf line 76, in resource "azurerm_monitor_diagnostic_setting" "storage-account-data-queue":
│   76: resource "azurerm_monitor_diagnostic_setting" "storage-account-data-queue" {
│ 
│ `retention_policy` has been deprecated in favor of
│ `azurerm_storage_management_policy` resource - to learn more
│ https://aka.ms/diagnostic_settings_log_retention
```

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~~Your code builds clean without any errors or warnings~~
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

