### PR TITLE
chore: updates deprecated property on azurerm_cosmosdb_sql_container

### DIFF
--- a/web/terraform/cache.tf
+++ b/web/terraform/cache.tf
@@ -41,7 +41,7 @@ resource "azurerm_cosmosdb_sql_container" "session-cache-container" {
   resource_group_name   = azurerm_resource_group.resource-group.name
   account_name          = azurerm_cosmosdb_account.session-cache-account.name
   database_name         = azurerm_cosmosdb_sql_database.session-cache-database.name
-  partition_key_path    = "/id"
+  partition_key_paths   = ["/id"]
   partition_key_version = 1
 }
 


### PR DESCRIPTION
### Context
[AB#226388](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/226388) - [AB#226793](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/226793)

Due to a bug in Terraform we are unable to update the provider version to >4.0 and replace the deprecated property in the same release for azurerm.

This PR updates the deprecated property.
A following PR will update the version [AB#227199](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/227199).

This has been tested in a feature environment `d17` and returns no errors or unexpected changes on `terraform plan`

### Change proposed in this pull request
Updates deprecated property on `azurerm_cosmosdb_sql_container`

### Guidance to review 
N/A

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~Your code builds clean without any errors or warnings~
- [ ] ~You have run all unit/integration tests and they pass~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

