### PR TITLE
Modified logging configuration across Function Apps to reduce noise

### DIFF
--- a/platform/README.md
+++ b/platform/README.md
@@ -29,7 +29,9 @@ Add configuration in `local.settings.json` for `Platform.Api.Establishment`
     "ASPNETCORE_ENVIRONMENT": "Development",
     "Search__Name" : "s198d01-ebis-search",
     "Search__Key" : "[INSERT KEY VALUE]",
-    "Sql__ConnectionString" : "[INSERT CONNECTION STRING VALUE]"
+    "Sql__ConnectionString" : "[INSERT CONNECTION STRING VALUE]",
+    "AzureFunctionsJobHost__logging__logLevel__default": "Information",
+    "AzureFunctionsJobHost__logging__logLevel__Function": "Information"
   },
   "Host": {
     "CORS": "*",
@@ -51,7 +53,9 @@ Add configuration in `local.settings.json` for `Platform.Api.Benchmark`
     "Search__Key" : "[INSERT KEY VALUE]",
     "Sql__ConnectionString" : "[INSERT CONNECTION STRING VALUE]",
     "PipelineMessageHub__ConnectionString": "UseDevelopmentStorage=true",
-    "PipelineMessageHub__JobPendingQueue": "data-pipeline-job-pending"
+    "PipelineMessageHub__JobPendingQueue": "data-pipeline-job-pending",
+    "AzureFunctionsJobHost__logging__logLevel__default": "Information",
+    "AzureFunctionsJobHost__logging__logLevel__Function": "Information"
   },
   "Host": {
     "CORS": "*",
@@ -70,7 +74,9 @@ Add configuration in `local.settings.json` for `Platform.Api.Insight`
   "Values": {
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "ASPNETCORE_ENVIRONMENT": "Development",
-    "Sql__ConnectionString" : "[INSERT CONNECTION STRING VALUE]"
+    "Sql__ConnectionString" : "[INSERT CONNECTION STRING VALUE]",
+    "AzureFunctionsJobHost__logging__logLevel__default": "Information",
+    "AzureFunctionsJobHost__logging__logLevel__Function": "Information"
   },
   "Host": {
     "CORS": "*",
@@ -97,7 +103,9 @@ Add configuration in `local.settings.json` for `Platform.Orchestrator`
         "PipelineMessageHub__JobFinishedQueue": "data-pipeline-job-finished",
         "PipelineMessageHub__JobStartQueue": "data-pipeline-job-start",
         "PipelineMessageHub__JobPendingQueue": "data-pipeline-job-pending",
-        "Sql__ConnectionString" : "[INSERT CONNECTION STRING VALUE]"
+        "Sql__ConnectionString" : "[INSERT CONNECTION STRING VALUE]",
+        "AzureFunctionsJobHost__logging__logLevel__default": "Information",
+        "AzureFunctionsJobHost__logging__logLevel__Function": "Information"
     },
     "Host": {
         "CORS": "*",
@@ -120,7 +128,9 @@ Add configuration in `local.settings.json` for `Platform.UserDataCleanUp`
         "AzureWebJobsStorage": "UseDevelopmentStorage=true",
         "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "Sql__ConnectionString" : "[INSERT CONNECTION STRING VALUE]"
+        "Sql__ConnectionString" : "[INSERT CONNECTION STRING VALUE]",
+        "AzureFunctionsJobHost__logging__logLevel__default": "Information",
+        "AzureFunctionsJobHost__logging__logLevel__Function": "Information"
     },
     "Host": {
         "CORS": "*",

--- a/platform/src/apis/Platform.Api.Benchmark/Configuration/Logging.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/Configuration/Logging.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 namespace Platform.Api.Benchmark.Configuration;
@@ -9,18 +8,6 @@ internal static class Logging
 {
     internal static void Configure(ILoggingBuilder builder)
     {
-        builder.Services.Configure<LoggerFilterOptions>(options =>
-        {
-            // The Application Insights SDK adds a default logging filter that instructs ILogger to capture only Warning and more severe logs.
-            // Application Insights requires an explicit override. Log levels can also be configured using appsettings.json. For more information,
-            // see https://learn.microsoft.com/en-us/azure/azure-monitor/app/worker-service#ilogger-logs
-            var toRemove = options.Rules
-                .FirstOrDefault(rule => rule.ProviderName == "Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider");
-
-            if (toRemove is not null)
-            {
-                options.Rules.Remove(toRemove);
-            }
-        });
+        builder.Services.Configure<LoggerFilterOptions>(_ => { });
     }
 }

--- a/platform/src/apis/Platform.Api.Benchmark/host.json
+++ b/platform/src/apis/Platform.Api.Benchmark/host.json
@@ -3,6 +3,9 @@
   "logging": {
     "logLevel": {
       "default": "Warning",
+      "Host.Aggregator": "Trace",
+      "Host.Results": "Information",
+      "Function": "Warning",
       "Microsoft": "Warning"
     },
     "applicationInsights": {

--- a/platform/src/apis/Platform.Api.Establishment/Configuration/Logging.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Configuration/Logging.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 namespace Platform.Api.Establishment.Configuration;
@@ -9,18 +8,6 @@ internal static class Logging
 {
     internal static void Configure(ILoggingBuilder builder)
     {
-        builder.Services.Configure<LoggerFilterOptions>(options =>
-        {
-            // The Application Insights SDK adds a default logging filter that instructs ILogger to capture only Warning and more severe logs.
-            // Application Insights requires an explicit override. Log levels can also be configured using appsettings.json. For more information,
-            // see https://learn.microsoft.com/en-us/azure/azure-monitor/app/worker-service#ilogger-logs
-            var toRemove = options.Rules
-                .FirstOrDefault(rule => rule.ProviderName == "Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider");
-
-            if (toRemove is not null)
-            {
-                options.Rules.Remove(toRemove);
-            }
-        });
+        builder.Services.Configure<LoggerFilterOptions>(_ => { });
     }
 }

--- a/platform/src/apis/Platform.Api.Establishment/host.json
+++ b/platform/src/apis/Platform.Api.Establishment/host.json
@@ -3,6 +3,9 @@
   "logging": {
     "logLevel": {
       "default": "Warning",
+      "Host.Aggregator": "Trace",
+      "Host.Results": "Information",
+      "Function": "Warning",
       "Microsoft": "Warning"
     },
     "applicationInsights": {

--- a/platform/src/apis/Platform.Api.Insight/Configuration/Logging.cs
+++ b/platform/src/apis/Platform.Api.Insight/Configuration/Logging.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 namespace Platform.Api.Insight.Configuration;
@@ -9,18 +8,6 @@ internal static class Logging
 {
     internal static void Configure(ILoggingBuilder builder)
     {
-        builder.Services.Configure<LoggerFilterOptions>(options =>
-        {
-            // The Application Insights SDK adds a default logging filter that instructs ILogger to capture only Warning and more severe logs.
-            // Application Insights requires an explicit override. Log levels can also be configured using appsettings.json. For more information,
-            // see https://learn.microsoft.com/en-us/azure/azure-monitor/app/worker-service#ilogger-logs
-            var toRemove = options.Rules
-                .FirstOrDefault(rule => rule.ProviderName == "Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider");
-
-            if (toRemove is not null)
-            {
-                options.Rules.Remove(toRemove);
-            }
-        });
+        builder.Services.Configure<LoggerFilterOptions>(_ => { });
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/host.json
+++ b/platform/src/apis/Platform.Api.Insight/host.json
@@ -3,6 +3,9 @@
   "logging": {
     "logLevel": {
       "default": "Warning",
+      "Host.Aggregator": "Trace",
+      "Host.Results": "Information",
+      "Function": "Warning",
       "Microsoft": "Warning"
     },
     "applicationInsights": {

--- a/platform/src/apis/Platform.Orchestrator/Configuration/Logging.cs
+++ b/platform/src/apis/Platform.Orchestrator/Configuration/Logging.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 namespace Platform.Orchestrator.Configuration;
@@ -9,18 +8,6 @@ internal static class Logging
 {
     internal static void Configure(ILoggingBuilder builder)
     {
-        builder.Services.Configure<LoggerFilterOptions>(options =>
-        {
-            // The Application Insights SDK adds a default logging filter that instructs ILogger to capture only Warning and more severe logs.
-            // Application Insights requires an explicit override. Log levels can also be configured using appsettings.json. For more information,
-            // see https://learn.microsoft.com/en-us/azure/azure-monitor/app/worker-service#ilogger-logs
-            var toRemove = options.Rules
-                .FirstOrDefault(rule => rule.ProviderName == "Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider");
-
-            if (toRemove is not null)
-            {
-                options.Rules.Remove(toRemove);
-            }
-        });
+        builder.Services.Configure<LoggerFilterOptions>(_ => { });
     }
 }

--- a/platform/src/apis/Platform.Orchestrator/host.json
+++ b/platform/src/apis/Platform.Orchestrator/host.json
@@ -3,6 +3,9 @@
   "logging": {
     "logLevel": {
       "default": "Warning",
+      "Host.Aggregator": "Trace",
+      "Host.Results": "Information",
+      "Function": "Warning",
       "Microsoft": "Warning"
     },
     "applicationInsights": {

--- a/platform/src/apis/Platform.UserDataCleanUp/Configuration/Logging.cs
+++ b/platform/src/apis/Platform.UserDataCleanUp/Configuration/Logging.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 namespace Platform.UserDataCleanUp.Configuration;
@@ -9,18 +8,6 @@ internal static class Logging
 {
     internal static void Configure(ILoggingBuilder builder)
     {
-        builder.Services.Configure<LoggerFilterOptions>(options =>
-        {
-            // The Application Insights SDK adds a default logging filter that instructs ILogger to capture only Warning and more severe logs.
-            // Application Insights requires an explicit override. Log levels can also be configured using appsettings.json. For more information,
-            // see https://learn.microsoft.com/en-us/azure/azure-monitor/app/worker-service#ilogger-logs
-            var toRemove = options.Rules
-                .FirstOrDefault(rule => rule.ProviderName == "Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider");
-
-            if (toRemove is not null)
-            {
-                options.Rules.Remove(toRemove);
-            }
-        });
+        builder.Services.Configure<LoggerFilterOptions>(_ => { });
     }
 }

--- a/platform/src/apis/Platform.UserDataCleanUp/host.json
+++ b/platform/src/apis/Platform.UserDataCleanUp/host.json
@@ -3,6 +3,9 @@
   "logging": {
     "logLevel": {
       "default": "Warning",
+      "Host.Aggregator": "Trace",
+      "Host.Results": "Information",
+      "Function": "Warning",
       "Microsoft": "Warning"
     },
     "applicationInsights": {


### PR DESCRIPTION
### Context
[AB#227839](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/227839) [AB#227696](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/227696)

### Change proposed in this pull request
Set appropriate `logLevel`s across all Function App `host.json` files.
Removed exclusion of `ApplicationInsightsLoggerProvider` rule from logger configuration across all Function Apps.
Updated Platform `README.md` to include `logLevel` overrides for local development.

### Guidance to review 
Set appropriate `local.settings.json` for each Function App (including AI instrumentation key) and run locally.
Hit an endpoint and observe the results in Application Insights.
Modify or remove `logLevel` override configuration to observe different results in Application Insights.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

