### PR TITLE
Removed `unsafe-inline` `style-src` from CSP

### DIFF
--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -21,6 +21,7 @@
   background-color: bisque;
   padding: 20px;
 }
+
 .app-tag-login {
   @include govuk-font($size: 19);
   display: block;
@@ -162,6 +163,7 @@ p.priority .govuk-tag {
 
 svg.rag-stack {
   width: 100%;
+  height: 30px;
 
   // colours taken from node_modules/govuk-frontend/dist/govuk/components/tag/_tag.scss
   rect.rag-stack-red {
@@ -193,6 +195,10 @@ svg.rag-stack {
   a:hover rect.rag-stack-green,
   a:active rect.rag-stack-green {
     fill: govuk-tint($rag-green-colour, 20%);
+  }
+
+  &.rag-stack-small {
+    height: 15px;
   }
 }
 

--- a/web/src/Web.App/Middleware/CustomResponseHeadersMiddleware.cs
+++ b/web/src/Web.App/Middleware/CustomResponseHeadersMiddleware.cs
@@ -1,6 +1,5 @@
 ﻿using System.Security.Cryptography;
 using System.Text;
-
 namespace Web.App.Middleware;
 
 public class CustomResponseHeadersMiddleware(RequestDelegate next)
@@ -15,7 +14,7 @@ public class CustomResponseHeadersMiddleware(RequestDelegate next)
         var csp = new StringBuilder();
         csp.Append("default-src 'self';");
         csp.Append("img-src 'self' data:;");
-        csp.Append("style-src 'self' 'unsafe-inline';");
+        csp.Append("style-src 'self';");
         csp.Append($"script-src 'self' 'nonce-{context.Items["csp-nonce"]}' https://js.monitor.azure.com/scripts/b/ai.3.gbl.min.js https://js.monitor.azure.com/scripts/b/ext/ai.clck.2.min.js;");
         csp.Append("object-src 'none';");
         csp.Append("worker-src 'none';");

--- a/web/src/Web.App/ViewComponents/RagStack.cs
+++ b/web/src/Web.App/ViewComponents/RagStack.cs
@@ -9,11 +9,11 @@ public class RagStack : ViewComponent
         int red,
         int amber,
         int green,
-        int? height = null,
+        bool small = false,
         string? redHref = null,
         string? amberHref = null,
         string? greenHref = null)
-        => View(new RagStackViewModel(identifier, red, amber, green, height ?? 30)
+        => View(new RagStackViewModel(identifier, red, amber, green, small)
         {
             RedHref = redHref,
             AmberHref = amberHref,

--- a/web/src/Web.App/ViewModels/Components/RagStackViewModel.cs
+++ b/web/src/Web.App/ViewModels/Components/RagStackViewModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace Web.App.ViewModels.Components;
 
-public class RagStackViewModel(string identifier, int red, int amber, int green, int height)
+public class RagStackViewModel(string identifier, int red, int amber, int green, bool small)
 {
     public string Identifier => identifier;
 
@@ -17,5 +17,5 @@ public class RagStackViewModel(string identifier, int red, int amber, int green,
     public string? AmberHref { get; init; }
     public string? GreenHref { get; init; }
 
-    public int Height => height;
+    public string ClassName => small ? "rag-stack-small" : string.Empty;
 }

--- a/web/src/Web.App/Views/Shared/Components/RagStack/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/RagStack/Default.cshtml
@@ -9,7 +9,7 @@
 }
 else
 {
-    <svg style="height:@(Model.Height)px;" class="rag-stack" role="img" aria-labelledby="@id-rag">
+    <svg class="rag-stack @(Model.ClassName)" role="img" aria-labelledby="@id-rag">
         <title id="@id-rag">@Model.Red high, @Model.Amber medium and @Model.Green low priorities for @Model.Identifier</title>
         @if (Model.RedPercentage > 0)
         {

--- a/web/src/Web.App/Views/Trust/_SchoolsSection.cshtml
+++ b/web/src/Web.App/Views/Trust/_SchoolsSection.cshtml
@@ -32,7 +32,7 @@
                         red = school.Red,
                         amber = school.Amber,
                         green = school.Green,
-                        height = 15,
+                        small = true,
                         redHref = $"{@Url.Action("Index", "SchoolSpending", new { urn = school.Urn })}#high-priority",
                         amberHref = $"{@Url.Action("Index", "SchoolSpending", new { urn = school.Urn })}#medium-priority",
                         greenHref = $"{@Url.Action("Index", "SchoolSpending", new { urn = school.Urn })}#low-priority",


### PR DESCRIPTION
### Context
[AB#216194](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/216194) [AB#215819](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/215819)

### Change proposed in this pull request
Fixed only occurrence of `style=` from Web. JavaScript-rendered inline styles seem to be permitted.

### Guidance to review 
Run `Web` locally, after performing an `npm run build` to get `gulp` to rebuild the CSS. Browse the site, especially those containing charts, plus the Trust landing page.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

