### PR TITLE
Set HSTS header `max-age` to `2592000` (30 days) instead of `31536000` (1 year)

### DIFF
--- a/web/src/Web.App/web.config
+++ b/web/src/Web.App/web.config
@@ -4,22 +4,22 @@
         <rewrite>
             <outboundRules>
                 <rule name="Add Strict-Transport-Security when HTTPS" enabled="true">
-                    <match serverVariable="RESPONSE_Strict_Transport_Security" pattern=".*" />
+                    <match serverVariable="RESPONSE_Strict_Transport_Security" pattern=".*"/>
                     <conditions>
-                        <add input="{HTTPS}" pattern="on" ignoreCase="true" />
+                        <add input="{HTTPS}" pattern="on" ignoreCase="true"/>
                     </conditions>
-                    <action type="Rewrite" value="max-age=31536000" />
+                    <action type="Rewrite" value="max-age=2592000"/>
                 </rule>
             </outboundRules>
         </rewrite>
         <httpProtocol>
             <customHeaders>
-                <add name="Referrer-Policy" value="strict-origin" />
-                <add name="Feature-Policy" value="payment 'none'" />
-                <add name="Cross-Origin-Resource-Policy" value="cross-origin" />
-                <add name="Cross-Origin-Embedder-Policy" value="unsafe-none" />
-                <add name="Cross-Origin-Opener-Policy" value="same-origin" />
-                <remove name="X-Powered-By" />
+                <add name="Referrer-Policy" value="strict-origin"/>
+                <add name="Feature-Policy" value="payment 'none'"/>
+                <add name="Cross-Origin-Resource-Policy" value="cross-origin"/>
+                <add name="Cross-Origin-Embedder-Policy" value="unsafe-none"/>
+                <add name="Cross-Origin-Opener-Policy" value="same-origin"/>
+                <remove name="X-Powered-By"/>
             </customHeaders>
         </httpProtocol>
     </system.webServer>


### PR DESCRIPTION
### Context
[AB#216193](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/216193) [AB#215819](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/215819)

### Change proposed in this pull request
Minor configuration change

### Guidance to review 
Change not picked up when debugging Web locally by most web browsers. `hosts` file might need to be modified to do see the header, or else validate in `d13` [feature deployment](https://s198d13-education-benchmarking-c8c4bhdsb0axbma2.a02.azurefd.net/).

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

