### PR TITLE
fix: amend deduplication during DB merge

### DIFF
--- a/data-pipeline/src/pipeline/database.py
+++ b/data-pipeline/src/pipeline/database.py
@@ -43,11 +43,12 @@ def upsert(
     table_name: str,
     keys: list[str],
     dtype: dict[str, any] = None,
-    drop_duplicates: bool = True,
 ):
     logger.info(f"Connecting to database {engine.url}")
-    if drop_duplicates:
-        df.drop_duplicates(inplace=True)
+    _index = df.index.name
+    df.reset_index(inplace=True)
+    df.drop_duplicates(inplace=True)
+    df.set_index(_index, inplace=True)
 
     update_cols = []
     insert_cols = [*keys]
@@ -82,7 +83,6 @@ def insert_comparator_set(run_type: str, set_type: str, run_id: str, df: pd.Data
         write_frame,
         "ComparatorSet",
         keys=["RunType", "RunId", "URN", "SetType"],
-        drop_duplicates=False,
     )
     logger.info(
         f"Wrote {len(write_frame)} rows to comparator set {run_type} - {set_type} - {run_id}"


### PR DESCRIPTION
### Context

Reports of missing data from the service. Specifically, this has manifested in missing RAG metrics though as this appears to be caused by the `upsert()` function, this could be more widespread.

[AB#227113](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/227113)

### Change proposed in this pull request

- retain in-place `drop_duplicates()` behaviour
- update this to take the index (typically the URN but potentially not always) into account

### Guidance to review

Note: this also reverts 7d71c4c540fe86644f86071ed6419005b14972b1 as it's no longer necessary.

Currently difficult to validate as this resides in the DB layer but:

```python
import pandas as pd


df = pd.read_parquet("output/metric-rag/2023/maintained_schools.parquet")

print("Original:", len(df.index))
print("Previous drop-duplicates:", len(df.drop_duplicates().index))

_index = df.index.name
df.reset_index(inplace=True)
df.drop_duplicates(inplace=True)
df.set_index(_index, inplace=True)
print("New drop-duplicates inc. URN:", len(df.index))
```

This produces:

```sh
Original: 474698
Previous drop-duplicates: 405879
New drop-duplicates inc. URN: 474698
```

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally

