### PR TITLE
Display 'comparator reverted' banner on Trust homepage when custom comparators cleared

### DIFF
--- a/web/src/Web.App/Controllers/TrustComparatorsController.cs
+++ b/web/src/Web.App/Controllers/TrustComparatorsController.cs
@@ -11,7 +11,6 @@ using Web.App.Infrastructure.Apis.Insight;
 using Web.App.Infrastructure.Extensions;
 using Web.App.Services;
 using Web.App.ViewModels;
-
 namespace Web.App.Controllers;
 
 [Controller]
@@ -146,9 +145,14 @@ public class TrustComparatorsController(
 
                 trustComparatorSetService.ClearUserDefinedComparatorSet(companyNumber);
                 trustComparatorSetService.ClearUserDefinedCharacteristic(companyNumber);
-                return RedirectToAction("Index", "Trust", new
+                return RedirectToAction("Index", "Trust", new Dictionary<string, string>
                 {
-                    companyNumber
+                    {
+                        "companyNumber", companyNumber
+                    },
+                    {
+                        "comparator-reverted", "true"
+                    }
                 });
             }
             catch (Exception e)

--- a/web/src/Web.App/Controllers/TrustController.cs
+++ b/web/src/Web.App/Controllers/TrustController.cs
@@ -23,7 +23,8 @@ public class TrustController(
 {
     [HttpGet]
     [TrustRequestTelemetry(TrackedRequestFeature.Home)]
-    public async Task<IActionResult> Index(string companyNumber)
+    public async Task<IActionResult> Index(string companyNumber,
+        [FromQuery(Name = "comparator-reverted")] bool? comparatorReverted)
     {
         using (logger.BeginScope(new
         {
@@ -39,7 +40,7 @@ public class TrustController(
                 var schools = await TrustSchools(companyNumber);
                 var ratings = await RagRatings(schools);
 
-                var viewModel = new TrustViewModel(trust, balance, schools, ratings);
+                var viewModel = new TrustViewModel(trust, balance, schools, ratings, comparatorReverted);
                 return View(viewModel);
             }
             catch (Exception e)

--- a/web/src/Web.App/ViewModels/TrustViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustViewModel.cs
@@ -1,5 +1,4 @@
 using Web.App.Domain;
-
 namespace Web.App.ViewModels;
 
 public class TrustViewModel(Trust trust)
@@ -16,12 +15,14 @@ public class TrustViewModel(Trust trust)
         Trust trust,
         TrustBalance balance,
         IReadOnlyCollection<School> schools,
-        IEnumerable<RagRating> ratings)
+        IEnumerable<RagRating> ratings,
+        bool? comparatorReverted = false)
         : this(trust)
     {
         NumberSchools = schools.Count;
         RevenueReserve = balance.RevenueReserve;
         InYearBalance = balance.InYearBalance;
+        ComparatorReverted = comparatorReverted;
 
         var ratingsArray = ratings.ToArray();
 
@@ -58,7 +59,7 @@ public class TrustViewModel(Trust trust)
                     .OrderByDescending(o => o.RedRatio)
                     .ThenByDescending(o => o.AmberRatio)
                     .ThenBy(o => o.Name)
-            ));
+                ));
     }
 
     public string? CompanyNumber => trust.CompanyNumber;
@@ -102,7 +103,7 @@ public class TrustViewModel(Trust trust)
         .Where(s => s.OverallPhase == OverallPhaseTypes.PostSixteen)
         .SelectMany(s => s.Schools);
 
-
+    public bool? ComparatorReverted { get; }
 
     private IEnumerable<(string? OverallPhase, IOrderedEnumerable<RagSchoolViewModel> Schools)> GroupedSchools { get; } = [];
 

--- a/web/src/Web.App/Views/Trust/Index.cshtml
+++ b/web/src/Web.App/Views/Trust/Index.cshtml
@@ -11,10 +11,28 @@
         <h1 class="govuk-heading-l govuk-!-margin-bottom-1">@Model.Name</h1>
         <p class="govuk-body">
             @Html.TrackedAnchor(
-            TrackedLinks.ChangeOrganisation,
-            Url.Action("Index", "FindOrganisation", new { method = OrganisationTypes.Trust }) ?? "",
-            "Change trust")
+                TrackedLinks.ChangeOrganisation,
+                Url.Action("Index", "FindOrganisation", new
+                {
+                    method = OrganisationTypes.Trust
+                }) ?? "",
+                "Change trust")
         </p>
+    </div>
+    <div class="govuk-grid-column-full">
+        @if (Model.ComparatorReverted == true)
+        {
+            <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+                <div class="govuk-notification-banner__header">
+                    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                        Success
+                    </h2>
+                </div>
+                <div class="govuk-notification-banner__content">
+                    <h3 class="govuk-notification-banner__heading">Your set of trusts has been removed</h3>
+                </div>
+            </div>
+        }
     </div>
 </div>
 
@@ -97,7 +115,9 @@
     </tbody>
 </table>
 
-<p class="govuk-body"><a href="@Url.Action("Index", "TrustSpending", new { companyNumber = Model.CompanyNumber })" class="govuk-link govuk-link--no-visited-state">View all spending priorities for this trust</a></p>
+<p class="govuk-body">
+    <a href="@Url.Action("Index", "TrustSpending", new { companyNumber = Model.CompanyNumber })" class="govuk-link govuk-link--no-visited-state">View all spending priorities for this trust</a>
+</p>
 
 <h2 class="govuk-heading-m">Schools in this trust</h2>
 
@@ -121,8 +141,8 @@
 
 @await Html.PartialAsync("_SchoolsSection", new TrustSchoolsSectionViewModel
 {
-Heading = "Alternative provision",
-Schools = Model.AlternativeProvision
+    Heading = "Alternative provision",
+    Schools = Model.AlternativeProvision
 })
 
 @await Html.PartialAsync("_SchoolsSection", new TrustSchoolsSectionViewModel
@@ -133,14 +153,14 @@ Schools = Model.AlternativeProvision
 
 @await Html.PartialAsync("_SchoolsSection", new TrustSchoolsSectionViewModel
 {
-Heading = "Post 16",
-Schools = Model.PostSixteen
+    Heading = "Post 16",
+    Schools = Model.PostSixteen
 })
 
 @await Html.PartialAsync("_SchoolsSection", new TrustSchoolsSectionViewModel
 {
-Heading = "University technical colleges",
-Schools = Model.UniversityTechnicalColleges
+    Heading = "University technical colleges",
+    Schools = Model.UniversityTechnicalColleges
 })
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/Comparators/WhenViewingComparatorsRevert.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/Comparators/WhenViewingComparatorsRevert.cs
@@ -25,7 +25,7 @@ public class WhenViewingComparatorsCreateRevert(SchoolBenchmarkingWebAppClient c
         Assert.NotNull(action);
 
         page = await Client.SubmitForm(page.Forms[0], action);
-        DocumentAssert.AssertPageUrl(page, Paths.TrustHome(trust.CompanyNumber).ToAbsolute());
+        DocumentAssert.AssertPageUrl(page, Paths.TrustHome(trust.CompanyNumber).ToAbsolute() + "?comparator-reverted=true");
     }
 
     private async Task<(IHtmlDocument page, Trust trust)> SetupNavigateInitPage(bool setupUserData = false)


### PR DESCRIPTION
### Context
[AB#228435](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/228435) [AB#218588](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/218588)

### Guidance to review 
See bug 'Repro Steps'

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

