### PR TITLE
bugfix: correct net catering income cost calc

### DIFF
--- a/data-pipeline/src/pipeline/maintained_schools.py
+++ b/data-pipeline/src/pipeline/maintained_schools.py
@@ -169,11 +169,11 @@ def calc_rag_cost_series(
 
     return maintained_schools
 
-
+# net catering cost, not net catering income
 def calc_catering_net_costs(maintained_schools: pd.DataFrame) -> pd.DataFrame:
     maintained_schools["Catering staff and supplies_Net Costs"] = (
-        maintained_schools["Income_Catering services"]
-        - maintained_schools["Catering staff and supplies_Total"]
+        maintained_schools["Catering staff and supplies_Total"]
+        - maintained_schools["Income_Catering services"]
     )
 
     return maintained_schools

--- a/data-pipeline/src/pipeline/pre_processing.py
+++ b/data-pipeline/src/pipeline/pre_processing.py
@@ -986,14 +986,15 @@ def build_academy_data(
         academies["Total Expenditure"] + academies["Total Expenditure_CS"]
     )
 
+    # net catering cost, not net catering income
     academies["Catering staff and supplies_Net Costs"] = (
-        academies["Income_Catering services"]
-        - academies["Catering staff and supplies_Total"]
+        academies["Catering staff and supplies_Total"]
+        - academies["Income_Catering services"]
     )
 
     academies["Catering staff and supplies_Net Costs_CS"] = (
-        academies["Income_Catering services_CS"]
-        + academies["Catering staff and supplies_Total_CS"]
+        academies["Catering staff and supplies_Total_CS"]
+        - academies["Income_Catering services_CS"]
     )
 
     trust_revenue_reserve = (

--- a/data-pipeline/tests/unit/pre_processing/test_maintained_schools.py
+++ b/data-pipeline/tests/unit/pre_processing/test_maintained_schools.py
@@ -214,7 +214,7 @@ def test_calc_catering_net_costs():
 
     actual = maintained_schools.calc_catering_net_costs(df).iloc[0]
 
-    assert actual["Catering staff and supplies_Net Costs"] == 500
+    assert actual["Catering staff and supplies_Net Costs"] == -500
 
 
 # Waiting on actual confirmation of federation logic.


### PR DESCRIPTION
### Context
[AB#228227](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/228227) ([AB#228605](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/228605))

### Change proposed in this pull request
Corrects Net catering cost calculation. Previous calculation was Net income, rather than cost.

### Guidance to review 
Not tested locally,

### Checklist (add/remove as appropriate)
- [ ] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally

