### PR TITLE
Remove redundant Trust financial fields from charts in front end

### DIFF
--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/other-costs.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/other-costs.tsx
@@ -280,42 +280,6 @@ export const OtherCosts: React.FC<{
       };
     }, [data, tableHeadings]);
 
-  const communityFocusedSchoolStaffBarData: HorizontalBarChartWrapperData<OtherCostsData> =
-    useMemo(() => {
-      return {
-        dataPoints:
-          data && Array.isArray(data)
-            ? data.map((trust) => {
-                return {
-                  ...trust,
-                  totalValue: trust.communityFocusedSchoolStaff ?? 0,
-                  schoolValue: trust.schoolCommunityFocusedSchoolStaff ?? 0,
-                  centralValue: trust.centralCommunityFocusedSchoolStaff ?? 0,
-                };
-              })
-            : [],
-        tableHeadings,
-      };
-    }, [data, tableHeadings]);
-
-  const communityFocusedSchoolCostsBarData: HorizontalBarChartWrapperData<OtherCostsData> =
-    useMemo(() => {
-      return {
-        dataPoints:
-          data && Array.isArray(data)
-            ? data.map((trust) => {
-                return {
-                  ...trust,
-                  totalValue: trust.communityFocusedSchoolCosts ?? 0,
-                  schoolValue: trust.schoolCommunityFocusedSchoolCosts ?? 0,
-                  centralValue: trust.centralCommunityFocusedSchoolCosts ?? 0,
-                };
-              })
-            : [],
-        tableHeadings,
-      };
-    }, [data, tableHeadings]);
-
   const elementId = "other-costs";
   const [hash] = useHash();
 
@@ -436,24 +400,6 @@ export const OtherCosts: React.FC<{
             trust
           >
             <h3 className="govuk-heading-s">Supply teacher insurance costs</h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={communityFocusedSchoolStaffBarData}
-            chartName="community focused school staff (maintained schools only)"
-            trust
-          >
-            <h3 className="govuk-heading-s">
-              Community focused school staff (maintained schools only)
-            </h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={communityFocusedSchoolCostsBarData}
-            chartName="community focused school costs (maintained schools only)"
-            trust
-          >
-            <h3 className="govuk-heading-s">
-              Community focused school costs (maintained schools only)
-            </h3>
           </HorizontalBarChartWrapper>
         </div>
       </div>

--- a/front-end-components/src/views/historic-data/partials/income-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/income-section.tsx
@@ -123,26 +123,28 @@ export const IncomeSection: React.FC<{ type: string; id: string }> = ({
             </p>
           </div>
         </div>
-        <div className="govuk-accordion__section">
-          <div className="govuk-accordion__section-header">
-            <h2 className="govuk-accordion__section-heading">
-              <span
-                className="govuk-accordion__section-button"
-                id="accordion-income-heading-3"
-              >
-                Direct revenue financing
-              </span>
-            </h2>
+        {type === "school" && (
+          <div className="govuk-accordion__section">
+            <div className="govuk-accordion__section-header">
+              <h2 className="govuk-accordion__section-heading">
+                <span
+                  className="govuk-accordion__section-button"
+                  id="accordion-income-heading-3"
+                >
+                  Direct revenue financing
+                </span>
+              </h2>
+            </div>
+            <div
+              id="accordion-income-content-3"
+              className="govuk-accordion__section-content"
+            >
+              <p className="govuk-body">
+                <IncomeSectionDirectRevenue data={data} />
+              </p>
+            </div>
           </div>
-          <div
-            id="accordion-income-content-3"
-            className="govuk-accordion__section-content"
-          >
-            <p className="govuk-body">
-              <IncomeSectionDirectRevenue data={data} />
-            </p>
-          </div>
-        </div>
+        )}
       </div>
     </ChartDimensionContext.Provider>
   );

--- a/front-end-components/src/views/historic-data/partials/spending-section-other.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section-other.tsx
@@ -4,7 +4,8 @@ import { Loading } from "src/components/loading";
 
 export const SpendingSectionOther: React.FC<{
   data: SchoolExpenditureHistory[];
-}> = ({ data }) => {
+  type: string;
+}> = ({ data, type }) => {
   return (
     <>
       {data.length > 0 ? (
@@ -183,22 +184,24 @@ export const SpendingSectionOther: React.FC<{
             <h3 className="govuk-heading-s">Supply teacher insurance costs</h3>
           </HistoricChart>
 
-          <HistoricChart
-            chartName="Community focused school staff (maintained schools only)"
-            data={data}
-            seriesConfig={{
-              communityFocusedSchoolStaff: {
-                label:
-                  "Community focused school staff (maintained schools only)",
-                visible: true,
-              },
-            }}
-            valueField="communityFocusedSchoolStaff"
-          >
-            <h3 className="govuk-heading-s">
-              Community focused school staff (maintained schools only)
-            </h3>
-          </HistoricChart>
+          {type === "school" && (
+            <HistoricChart
+              chartName="Community focused school staff (maintained schools only)"
+              data={data}
+              seriesConfig={{
+                communityFocusedSchoolStaff: {
+                  label:
+                    "Community focused school staff (maintained schools only)",
+                  visible: true,
+                },
+              }}
+              valueField="communityFocusedSchoolStaff"
+            >
+              <h3 className="govuk-heading-s">
+                Community focused school staff (maintained schools only)
+              </h3>
+            </HistoricChart>
+          )}
         </>
       ) : (
         <Loading />

--- a/front-end-components/src/views/historic-data/partials/spending-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section.tsx
@@ -265,7 +265,7 @@ export const SpendingSection: React.FC<{ type: string; id: string }> = ({
             className="govuk-accordion__section-content"
           >
             <p className="govuk-body">
-              <SpendingSectionOther data={data} />
+              <SpendingSectionOther data={data} type={type} />
             </p>
           </div>
         </div>


### PR DESCRIPTION
### Context
[AB#228512](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/228512) [AB#226428](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/226428)

### Change proposed in this pull request
Documented fields will no longer be populated after changes to the underlying Trust views. The associated charts may therefore be safely removed.

### Guidance to review 
View Trust income/expenditure current/history to ensure charts are no longer displayed. View corresponding School charts to ensure charts are still present. To validate locally, build and copy `front-end-components` to `Web` first.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

