### PR TITLE
Show horizontal chart bar in 'warning' colour if part-year data present for school

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -99,7 +99,7 @@
       data-id="02387916"
       data-phases='["Secondary","Primary","Post-16"]'
     ></div>-->
-    <div id="compare-your-costs" data-type="school" data-id="107896"></div>
+    <div id="compare-your-costs" data-type="school" data-id="103837"></div>
     <!--<div id="historic-data" data-type="school" data-id="140565"></div>-->
     <!--<div
       id="compare-your-costs"

--- a/front-end-components/src/components/charts/establishment-tick/component.tsx
+++ b/front-end-components/src/components/charts/establishment-tick/component.tsx
@@ -2,27 +2,38 @@
 import { Text } from "recharts";
 import { EstablishmentTickProps } from "src/components/charts/establishment-tick";
 import { ChartLink } from "../chart-link";
-import { createElement, useState } from "react";
+import { createElement, useMemo, useState } from "react";
 
 export function EstablishmentTick(props: EstablishmentTickProps) {
   const {
     className,
-    highlightedItemKey,
-    linkToEstablishment,
-    href,
-    payload: { value },
     establishmentKeyResolver,
+    highlightedItemKey,
+    href,
+    linkToEstablishment,
+    payload: { value },
+    specialItemFlags,
     tickFormatter,
+    tooltip,
     verticalAnchor,
     visibleTicksCount,
-    tooltip,
     ...rest
   } = props;
   const [focused, setFocused] = useState<boolean>();
-  const key =
-    linkToEstablishment &&
-    establishmentKeyResolver &&
-    establishmentKeyResolver(value);
+  const key = useMemo(() => {
+    return (
+      linkToEstablishment &&
+      establishmentKeyResolver &&
+      establishmentKeyResolver(value)
+    );
+  }, [establishmentKeyResolver, linkToEstablishment, value]);
+
+  const partYear = useMemo(() => {
+    return (
+      key && specialItemFlags && specialItemFlags(key).includes("partYear")
+    );
+  }, [key, specialItemFlags]);
+
   if (!key) {
     return <Text>{value}</Text>;
   }
@@ -30,7 +41,7 @@ export function EstablishmentTick(props: EstablishmentTickProps) {
   const name = String(value);
   const truncateAt = (rest.width as number)
     ? Math.floor((rest.width as number) / 7)
-    : 50;
+    : 45;
   return (
     <>
       <line
@@ -41,6 +52,7 @@ export function EstablishmentTick(props: EstablishmentTickProps) {
         height={rest.height}
         className="establishment-tick-focus"
       ></line>
+      {partYear && <Exclamation offset={rest.y} />}
       <text
         fontWeight={key === highlightedItemKey ? "bold" : "normal"}
         className="recharts-text establishment-tick"
@@ -72,3 +84,16 @@ export function EstablishmentTick(props: EstablishmentTickProps) {
     </>
   );
 }
+
+const Exclamation = ({ offset }: { offset?: string | number }) => {
+  return (
+    <>
+      <circle cx={18} cy={offset} r={8} fill="#fff"></circle>
+      <path
+        transform={`translate(5,${parseInt((offset ?? 0).toString()) - 12}),scale(0.75,0.75)`}
+        fill="#000"
+        d="M18,6A12,12,0,1,0,30,18,12,12,0,0,0,18,6Zm-1.49,6a1.49,1.49,0,0,1,3,0v6.89a1.49,1.49,0,1,1-3,0ZM18,25.5a1.72,1.72,0,1,1,1.72-1.72A1.72,1.72,0,0,1,18,25.5Z"
+      ></path>
+    </>
+  );
+};

--- a/front-end-components/src/components/charts/establishment-tick/types.tsx
+++ b/front-end-components/src/components/charts/establishment-tick/types.tsx
@@ -1,5 +1,5 @@
 import { BaseAxisProps, CartesianTickItem } from "recharts/types/util/types";
-import { TickProps } from "../types";
+import { SpecialItemFlag, TickProps } from "../types";
 import { FunctionComponent } from "react";
 import { TooltipProps } from "recharts/types/component/Tooltip";
 import {
@@ -10,11 +10,12 @@ import {
 export interface EstablishmentTickProps
   extends Omit<BaseAxisProps, "scale">,
     Omit<TickProps, "href" | "type" | "onClick" | "ref" | "textAnchor"> {
-  highlightedItemKey?: string;
-  linkToEstablishment?: boolean;
-  href: (key: string) => string;
-  payload: CartesianTickItem;
   establishmentKeyResolver?: (name: string) => string | undefined;
-  verticalAnchor: unknown;
+  highlightedItemKey?: string;
+  href: (key: string) => string;
+  linkToEstablishment?: boolean;
+  payload: CartesianTickItem;
+  specialItemFlags?: (key: string) => SpecialItemFlag[];
   tooltip?: FunctionComponent<TooltipProps<ValueType, NameType>>;
+  verticalAnchor: unknown;
 }

--- a/front-end-components/src/components/charts/types.tsx
+++ b/front-end-components/src/components/charts/types.tsx
@@ -16,6 +16,7 @@ export interface ChartProps<TData extends ChartDataSeries>
   hideYAxis?: boolean;
   highlightActive?: boolean;
   highlightedItemKeys?: ChartSeriesValue[];
+  specialItemKeys?: Record<SpecialItemFlag, ChartSeriesValue[]>;
   keyField: keyof TData;
   labels?: boolean;
   legend?: boolean;
@@ -78,8 +79,12 @@ export interface ValueFormatterOptions {
 }
 
 export interface ValueFormatterProps {
-  valueFormatter?: (
-    value: ValueFormatterValue,
-    options?: Partial<ValueFormatterOptions>
-  ) => string;
+  valueFormatter?: ValueFormatterType;
 }
+
+export type ValueFormatterType = (
+  value: ValueFormatterValue,
+  options?: Partial<ValueFormatterOptions>
+) => string;
+
+export type SpecialItemFlag = "partYear";

--- a/front-end-components/src/index.css
+++ b/front-end-components/src/index.css
@@ -21,10 +21,12 @@
   --stack-1-colour: #e6e6e6;
   --stack-1-active-colour: #d1d1d1;
   --series-highlight-colour: #12436d;
+  --stack-1-highlight-colour: #94c4ed;
   --link-colour: #1d70b8;
   --link-hover-colour: #003078;
   --table-grid-colour: #b1b4b6;
   --focus-colour: #fd0;
+  --warning-colour: #f47738;
 }
 
 .recharts-wrapper .chart-cell,
@@ -33,8 +35,18 @@
   fill: var(--series-0-colour);
 }
 
+.recharts-wrapper .chart-cell {
+  stroke: var(--series-0-colour);
+  stroke-width: 3px;
+}
+
+.recharts-wrapper .chart-cell.chart-cell-active {
+  stroke: var(--series-0-active-colour);
+}
+
 .recharts-wrapper .chart-cell.chart-cell-highlight {
   fill: var(--series-highlight-colour);
+  stroke: var(--series-highlight-colour);
 }
 
 .recharts-wrapper .chart-cell.chart-cell-active:not(.chart-cell-highlight) {
@@ -92,11 +104,24 @@
 
 .recharts-wrapper .chart-cell.chart-cell-series-1.chart-cell-stack-1 {
   fill: var(--stack-1-colour);
+  stroke: var(--stack-1-colour);
+  stroke-width: 3px;
 }
 
 .recharts-wrapper
   .chart-cell.chart-cell-series-1.chart-cell-stack-1.chart-cell-active {
   fill: var(--stack-1-active-colour);
+}
+
+.recharts-wrapper
+  .chart-cell.chart-cell-series-1.chart-cell-stack-1.chart-cell-highlight {
+  stroke: var(--stack-1-highlight-colour);
+  fill: var(--stack-1-highlight-colour);
+}
+
+.recharts-wrapper .chart-cell.chart-cell-part-year {
+  stroke: var(--warning-colour);
+  fill: var(--warning-colour);
 }
 
 .recharts-wrapper

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -105,7 +105,7 @@ if (compareCostsElement) {
     root.render(
       <React.StrictMode>
         <CompareYourCosts
-          type={type}
+          type={type as "school" | "trust"}
           id={id}
           phases={phasesParsed}
           customDataId={customDataId}

--- a/front-end-components/src/services/types.tsx
+++ b/front-end-components/src/services/types.tsx
@@ -5,6 +5,7 @@ export type SchoolExpenditure = {
   laName: string;
   totalPupils: bigint;
   totalInternalFloorArea: number;
+  periodCoveredByReturn: number;
 };
 
 type AdministrativeSuppliesExpenditureBase = {

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/administrative-supplies.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/administrative-supplies.tsx
@@ -5,7 +5,10 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { AdministrativeSuppliesData } from "src/views/compare-your-costs/partials/accordion-sections/types";
+import {
+  AdministrativeSuppliesData,
+  CompareYourCostsProps,
+} from "src/views/compare-your-costs/partials/accordion-sections/types";
 import {
   CostCategories,
   PoundsPerPupil,
@@ -28,10 +31,10 @@ import {
   AdministrativeSuppliesExpenditure,
 } from "src/services";
 
-export const AdministrativeSupplies: React.FC<{
-  type: string;
-  id: string;
-}> = ({ type, id }) => {
+export const AdministrativeSupplies: React.FC<CompareYourCostsProps> = ({
+  type,
+  id,
+}) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const phase = useContext(PhaseContext);
   const customDataId = useContext(CustomDataContext);

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
@@ -5,7 +5,10 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { CateringStaffServicesData } from "src/views/compare-your-costs/partials/accordion-sections/types";
+import {
+  CateringStaffServicesData,
+  CompareYourCostsProps,
+} from "src/views/compare-your-costs/partials/accordion-sections/types";
 import {
   CostCategories,
   PoundsPerPupil,
@@ -30,10 +33,10 @@ import {
 } from "src/services";
 import { TotalCateringCostsType } from "src/components/total-catering-costs-type";
 
-export const CateringStaffServices: React.FC<{
-  type: string;
-  id: string;
-}> = ({ type, id }) => {
+export const CateringStaffServices: React.FC<CompareYourCostsProps> = ({
+  type,
+  id,
+}) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const phase = useContext(PhaseContext);
   const customDataId = useContext(CustomDataContext);

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-ict.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-ict.tsx
@@ -5,7 +5,10 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { EducationalIctData } from "src/views/compare-your-costs/partials/accordion-sections/types";
+import {
+  CompareYourCostsProps,
+  EducationalIctData,
+} from "src/views/compare-your-costs/partials/accordion-sections/types";
 import {
   CostCategories,
   PoundsPerPupil,
@@ -25,10 +28,10 @@ import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
 import { ExpenditureApi, EducationalIctExpenditure } from "src/services";
 
-export const EducationalIct: React.FC<{
-  type: string;
-  id: string;
-}> = ({ type, id }) => {
+export const EducationalIct: React.FC<CompareYourCostsProps> = ({
+  type,
+  id,
+}) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const phase = useContext(PhaseContext);
   const customDataId = useContext(CustomDataContext);

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-supplies.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-supplies.tsx
@@ -5,7 +5,10 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { EducationalSuppliesData } from "src/views/compare-your-costs/partials/accordion-sections/types";
+import {
+  CompareYourCostsProps,
+  EducationalSuppliesData,
+} from "src/views/compare-your-costs/partials/accordion-sections/types";
 import {
   CostCategories,
   PoundsPerPupil,
@@ -25,10 +28,10 @@ import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
 import { ExpenditureApi, EducationalSuppliesExpenditure } from "src/services";
 
-export const EducationalSupplies: React.FC<{
-  type: string;
-  id: string;
-}> = ({ type, id }) => {
+export const EducationalSupplies: React.FC<CompareYourCostsProps> = ({
+  type,
+  id,
+}) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const phase = useContext(PhaseContext);
   const customDataId = useContext(CustomDataContext);

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/non-educational-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/non-educational-support-staff.tsx
@@ -5,7 +5,10 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { NonEducationalSupportStaffData } from "src/views/compare-your-costs/partials/accordion-sections/types";
+import {
+  CompareYourCostsProps,
+  NonEducationalSupportStaffData,
+} from "src/views/compare-your-costs/partials/accordion-sections/types";
 import {
   CostCategories,
   PoundsPerPupil,
@@ -28,10 +31,10 @@ import {
   NonEducationalSupportStaffExpenditure,
 } from "src/services";
 
-export const NonEducationalSupportStaff: React.FC<{
-  type: string;
-  id: string;
-}> = ({ type, id }) => {
+export const NonEducationalSupportStaff: React.FC<CompareYourCostsProps> = ({
+  type,
+  id,
+}) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const phase = useContext(PhaseContext);
   const customDataId = useContext(CustomDataContext);

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/other-costs.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/other-costs.tsx
@@ -5,7 +5,10 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { OtherCostsData } from "src/views/compare-your-costs/partials/accordion-sections/types";
+import {
+  CompareYourCostsProps,
+  OtherCostsData,
+} from "src/views/compare-your-costs/partials/accordion-sections/types";
 import {
   CostCategories,
   PoundsPerPupil,
@@ -25,10 +28,7 @@ import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
 import { ExpenditureApi, OtherCostsDataExpenditure } from "src/services";
 
-export const OtherCosts: React.FC<{
-  type: string;
-  id: string;
-}> = ({ type, id }) => {
+export const OtherCosts: React.FC<CompareYourCostsProps> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const phase = useContext(PhaseContext);
   const customDataId = useContext(CustomDataContext);

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
@@ -5,7 +5,10 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { PremisesStaffServicesData } from "src/views/compare-your-costs/partials/accordion-sections/types";
+import {
+  CompareYourCostsProps,
+  PremisesStaffServicesData,
+} from "src/views/compare-your-costs/partials/accordion-sections/types";
 import {
   PoundsPerMetreSq,
   PremisesCategories,
@@ -25,10 +28,10 @@ import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
 import { ExpenditureApi, PremisesStaffServicesExpenditure } from "src/services";
 
-export const PremisesStaffServices: React.FC<{
-  type: string;
-  id: string;
-}> = ({ type, id }) => {
+export const PremisesStaffServices: React.FC<CompareYourCostsProps> = ({
+  type,
+  id,
+}) => {
   const [dimension, setDimension] = useState(PoundsPerMetreSq);
   const phase = useContext(PhaseContext);
   const customDataId = useContext(CustomDataContext);

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/teaching-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/teaching-support-staff.tsx
@@ -5,7 +5,10 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { TeachingSupportStaffData } from "src/views/compare-your-costs/partials/accordion-sections/types";
+import {
+  CompareYourCostsProps,
+  TeachingSupportStaffData,
+} from "src/views/compare-your-costs/partials/accordion-sections/types";
 import {
   CostCategories,
   PoundsPerPupil,
@@ -25,7 +28,7 @@ import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
 import { ExpenditureApi, TeachingSupportStaffExpenditure } from "src/services";
 
-export const TeachingSupportStaff: React.FC<{ type: string; id: string }> = ({
+export const TeachingSupportStaff: React.FC<CompareYourCostsProps> = ({
   type,
   id,
 }) => {

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/types.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/types.tsx
@@ -111,3 +111,8 @@ export type OtherCostsData = {
   schoolName: string;
   laName: string;
 };
+
+export type CompareYourCostsProps = {
+  type: "school" | "trust";
+  id: string;
+};

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/utilities.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/utilities.tsx
@@ -5,7 +5,10 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { UtilitiesData } from "src/views/compare-your-costs/partials/accordion-sections/types";
+import {
+  CompareYourCostsProps,
+  UtilitiesData,
+} from "src/views/compare-your-costs/partials/accordion-sections/types";
 import {
   PoundsPerMetreSq,
   PremisesCategories,
@@ -25,10 +28,7 @@ import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
 import { ExpenditureApi, UtilitiesExpenditure } from "src/services";
 
-export const Utilities: React.FC<{
-  type: string;
-  id: string;
-}> = ({ type, id }) => {
+export const Utilities: React.FC<CompareYourCostsProps> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerMetreSq);
   const phase = useContext(PhaseContext);
   const customDataId = useContext(CustomDataContext);

--- a/front-end-components/src/views/compare-your-costs/partials/expenditure-accordion.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/expenditure-accordion.tsx
@@ -11,8 +11,9 @@ import {
   TeachingSupportStaff,
   Utilities,
 } from "src/views/compare-your-costs/partials/accordion-sections";
+import { CompareYourCostsProps } from "./accordion-sections/types";
 
-export const ExpenditureAccordion: React.FC<{ type: string; id: string }> = ({
+export const ExpenditureAccordion: React.FC<CompareYourCostsProps> = ({
   type,
   id,
 }) => {

--- a/front-end-components/src/views/compare-your-costs/partials/total-expenditure.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/total-expenditure.tsx
@@ -23,8 +23,9 @@ import {
   HorizontalBarChartWrapperData,
 } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, TotalExpenditureExpenditure } from "src/services";
+import { CompareYourCostsProps } from "./accordion-sections/types";
 
-export const TotalExpenditure: React.FC<{ type: string; id: string }> = ({
+export const TotalExpenditure: React.FC<CompareYourCostsProps> = ({
   type,
   id,
 }) => {

--- a/front-end-components/src/views/compare-your-costs/types.tsx
+++ b/front-end-components/src/views/compare-your-costs/types.tsx
@@ -1,6 +1,6 @@
-export type CompareYourCostsViewProps = {
-  type: string;
-  id: string;
+import { CompareYourCostsProps } from "./partials/accordion-sections/types";
+
+export type CompareYourCostsViewProps = CompareYourCostsProps & {
   phases: string[] | null;
   customDataId: string | undefined;
 };


### PR DESCRIPTION
### Context
[AB#228229](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/228229) [AB#228013](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/228013)

### Change proposed in this pull request
Also display exclamation mark next to school name

### Guidance to review 
Find a school with part-year data (e.g. URN `103837`) and view Spending Priorities charts.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

