### PR TITLE
Modified regex for highlighting search suggestions

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -99,7 +99,7 @@
       data-id="02387916"
       data-phases='["Secondary","Primary","Post-16"]'
     ></div>-->
-    <div id="compare-your-costs" data-type="school" data-id="103837"></div>
+    <!--<div id="compare-your-costs" data-type="school" data-id="103837"></div>-->
     <!--<div id="historic-data" data-type="school" data-id="140565"></div>-->
     <!--<div
       id="compare-your-costs"
@@ -108,6 +108,17 @@
     ></div>-->
     <!--<div id="budget-forecast-returns" data-id="01532445"></div>-->
     <!--<div id="historic-data" data-type="trust" data-id="10377760"></div>-->
+    <div id="find-organisation"
+        data-company-number=""
+        data-find-method="school"
+        data-la-error=""
+        data-la-input=""
+        data-school-error=""
+        data-school-input=""
+        data-trust-error=""
+        data-trust-input=""
+        data-urn=""
+      >
     <script type="module" src="/src/main.tsx"></script>
     <script
       type="module"

--- a/front-end-components/package-lock.json
+++ b/front-end-components/package-lock.json
@@ -46,6 +46,7 @@
         "eslint-plugin-react-refresh": "^0.4.6",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "jest-theories": "^1.5.1",
         "prettier": "^3.2.5",
         "prettier-eslint": "^16.3.0",
         "typescript": "^5.2.2",
@@ -8161,6 +8162,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/jest-theories": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/jest-theories/-/jest-theories-1.5.1.tgz",
+      "integrity": "sha512-70f2NKcy4kJSufJKSzKfoZmaGbvBzWnwFe1BaxJDAbu6/rKXU5p27G3o2AsyaIJggit7LCui2/9RAfaBPXVVqQ==",
+      "dev": true,
+      "dependencies": {
+        "string-format": "^2.0.0"
+      }
+    },
     "node_modules/jest-util": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
@@ -10132,6 +10142,12 @@
       "engines": {
         "node": ">=2.0.0"
       }
+    },
+    "node_modules/string-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string-format/-/string-format-2.0.0.tgz",
+      "integrity": "sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==",
+      "dev": true
     },
     "node_modules/string-length": {
       "version": "4.0.2",

--- a/front-end-components/package.json
+++ b/front-end-components/package.json
@@ -55,6 +55,7 @@
     "eslint-plugin-react-refresh": "^0.4.6",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "jest-theories": "^1.5.1",
     "prettier": "^3.2.5",
     "prettier-eslint": "^16.3.0",
     "typescript": "^5.2.2",

--- a/front-end-components/src/views/find-organisation/partials/la-input.tsx
+++ b/front-end-components/src/views/find-organisation/partials/la-input.tsx
@@ -6,6 +6,7 @@ import {
   SuggestResult,
 } from "src/views/find-organisation";
 import { v4 as uuidv4 } from "uuid";
+import { suggestionFormatter } from "../utils";
 
 const LaInput: React.FunctionComponent<LaInputProps> = (props) => {
   const { input, code, exclude } = props;
@@ -64,9 +65,7 @@ const LaInput: React.FunctionComponent<LaInputProps> = (props) => {
         minLength={3}
         onSelected={handleSelected}
         onSuggest={handleSuggest}
-        suggestionFormatter={(item) =>
-          item?.text ? item.text.replace(/\*(.*)\*/, "<b>$1</b>") : ""
-        }
+        suggestionFormatter={suggestionFormatter}
         valueFormatter={(item) => item?.document?.name ?? ""}
       />
       <input value={selectedCode} name="code" type="hidden" />

--- a/front-end-components/src/views/find-organisation/partials/school-input.tsx
+++ b/front-end-components/src/views/find-organisation/partials/school-input.tsx
@@ -6,6 +6,7 @@ import {
   SuggestResult,
 } from "src/views/find-organisation";
 import { v4 as uuidv4 } from "uuid";
+import { suggestionFormatter } from "../utils";
 
 const SchoolInput: React.FunctionComponent<SchoolInputProps> = (props) => {
   const { input, urn, exclude } = props;
@@ -64,9 +65,7 @@ const SchoolInput: React.FunctionComponent<SchoolInputProps> = (props) => {
         minLength={3}
         onSelected={handleSelected}
         onSuggest={handleSuggest}
-        suggestionFormatter={(item) =>
-          item?.text ? item.text.replace(/\*(.*)\*/, "<b>$1</b>") : ""
-        }
+        suggestionFormatter={suggestionFormatter}
         valueFormatter={(item) => item?.document?.schoolName ?? ""}
       />
       <input value={selectedUrn} name="urn" type="hidden" />

--- a/front-end-components/src/views/find-organisation/partials/trust-input.tsx
+++ b/front-end-components/src/views/find-organisation/partials/trust-input.tsx
@@ -6,6 +6,7 @@ import {
   TrustInputProps,
 } from "src/views/find-organisation";
 import { v4 as uuidv4 } from "uuid";
+import { suggestionFormatter } from "../utils";
 
 const TrustInput: React.FunctionComponent<TrustInputProps> = (props) => {
   const { input, companyNumber, exclude } = props;
@@ -65,9 +66,7 @@ const TrustInput: React.FunctionComponent<TrustInputProps> = (props) => {
         minLength={3}
         onSelected={handleSelected}
         onSuggest={handleSuggest}
-        suggestionFormatter={(item) =>
-          item?.text ? item.text.replace(/\*(.*)\*/, "<b>$1</b>") : ""
-        }
+        suggestionFormatter={suggestionFormatter}
         valueFormatter={(item) => item?.document?.trustName ?? ""}
       />
       <input value={selectedCompanyNumber} name="companyNumber" type="hidden" />

--- a/front-end-components/src/views/find-organisation/utils.test.ts
+++ b/front-end-components/src/views/find-organisation/utils.test.ts
@@ -1,0 +1,63 @@
+import theoretically from "jest-theories";
+import { suggestionFormatter } from "./utils";
+import { SuggestResult } from "./types";
+
+describe("Find org utils", () => {
+  describe("suggestionFormatter()", () => {
+    const theories: { input: SuggestResult<string>; expected: string }[] = [
+      {
+        input: {
+          id: "",
+          text: "Future *Acad*emies Watford (Watford, WD25 7HW)",
+          document: "",
+        },
+        expected: "Future <b>Acad</b>emies Watford (Watford, WD25 7HW)",
+      },
+      {
+        input: {
+          id: "",
+          text: "NCEA Bishop's Primary School (*Acad*emy Road, Ashington, NE63 9FZ)",
+          document: "",
+        },
+        expected:
+          "NCEA Bishop's Primary School (<b>Acad</b>emy Road, Ashington, NE63 9FZ)",
+      },
+      {
+        input: {
+          id: "",
+          text: "Folkestone Primary (*Acad*emy Lane, Folkestone, CT19 5FP)",
+          document: "",
+        },
+        expected:
+          "Folkestone Primary (<b>Acad</b>emy Lane, Folkestone, CT19 5FP)",
+      },
+      {
+        input: {
+          id: "",
+          text: "Knole *Acad*emy (Knole *Acad*emy, Sevenoaks, TN13 3LE)",
+          document: "",
+        },
+        expected:
+          "Knole <b>Acad</b>emy (Knole <b>Acad</b>emy, Sevenoaks, TN13 3LE)",
+      },
+      {
+        input: {
+          id: "",
+          text: "Ryecroft *Acad*emy (Ryecroft *Acad*emy, Leeds, LS12 5AW)",
+          document: "",
+        },
+        expected:
+          "Ryecroft <b>Acad</b>emy (Ryecroft <b>Acad</b>emy, Leeds, LS12 5AW)",
+      },
+    ];
+
+    theoretically(
+      "the suggestion {input} is correctly marked up using <b> tags",
+      theories,
+      (theory) => {
+        const output = suggestionFormatter<string>(theory.input);
+        expect(output).toBe(theory.expected);
+      }
+    );
+  });
+});

--- a/front-end-components/src/views/find-organisation/utils.ts
+++ b/front-end-components/src/views/find-organisation/utils.ts
@@ -1,0 +1,8 @@
+import { SuggestResult } from "./types";
+
+/**
+ * Formatter to use when rendering a suggestion to be displayed
+ */
+export function suggestionFormatter<T>(item: SuggestResult<T>): string {
+  return item?.text ? item.text.replace(/\*([^\\*]+)\*/g, "<b>$1</b>") : "";
+}


### PR DESCRIPTION
### Context
[AB#229209](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/229209) [AB#228611](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/228611)

### Change proposed in this pull request
Included test coverage with the above

### Guidance to review 
To validate locally, build and copy from `front-end` to `web`. Then perform an organisation that may return multiple highlighted elements (see Bug for examples).

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

