### PR TITLE
Remove references to `HasIncompleteData` from `front-end` and `web`

### DIFF
--- a/documentation/features/3_Incomplete-Data.md
+++ b/documentation/features/3_Incomplete-Data.md
@@ -1,5 +1,9 @@
 # Incomplete Data
 
+## Status
+
+**This feature has been deprecated in favour of consuming `PeriodCoveredByReturn` directly to determine part-year (incomplete data) status.**
+
 ## Introduction
 
 This document provides detailed information for developers about the implementation, usage, and integration of the Incomplete Data feature within the system.

--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -99,7 +99,7 @@
       data-id="02387916"
       data-phases='["Secondary","Primary","Post-16"]'
     ></div>-->
-    <div id="compare-your-costs" data-type="school" data-id="148853"></div>
+    <div id="compare-your-costs" data-type="school" data-id="143996"></div>
     <!--<div id="historic-data" data-type="school" data-id="130962"></div>-->
     <!--<div
       id="compare-your-costs"

--- a/front-end-components/src/composed/comparison-chart-summary/composed.tsx
+++ b/front-end-components/src/composed/comparison-chart-summary/composed.tsx
@@ -8,7 +8,6 @@ import {
 } from "src/components/charts/utils";
 import { Stat } from "src/components/charts/stat";
 import { ResolvedStat } from "src/components/charts/resolved-stat";
-import { WarningBanner } from "src/components/warning-banner";
 
 export function ComparisonChartSummary<TData extends ChartDataSeries>(
   props: ComparisonChartSummaryComposedProps<TData>
@@ -21,7 +20,6 @@ export function ComparisonChartSummary<TData extends ChartDataSeries>(
     valueField,
     suffix,
     chartStats,
-    hasIncompleteData,
     ...rest
   } = props;
 
@@ -52,10 +50,6 @@ export function ComparisonChartSummary<TData extends ChartDataSeries>(
 
   return (
     <>
-      <WarningBanner
-        isRendered={hasIncompleteData}
-        message="Some schools are missing data for this financial year"
-      />
       <div className="composed-chart-wrapper">
         <div className="composed-chart">
           <VerticalBarChart

--- a/front-end-components/src/composed/comparison-chart-summary/types.tsx
+++ b/front-end-components/src/composed/comparison-chart-summary/types.tsx
@@ -13,7 +13,6 @@ export type ComparisonChartSummaryComposedProps<TData extends ChartDataSeries> =
     sortDirection: ChartSortDirection;
     chartStats: ComparisonChartStats;
     valueField: keyof TData;
-    hasIncompleteData: boolean;
   };
 
 export type ComparisonChartStats = {

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -25,7 +25,6 @@ import {
 } from "src/components/charts/utils";
 import { EstablishmentTick } from "src/components/charts/establishment-tick";
 import { SchoolDataTooltip } from "src/components/charts/school-data-tooltip";
-import { WarningBanner } from "src/components/warning-banner";
 import { ErrorBanner } from "src/components/error-banner";
 import { TrustDataTooltip } from "src/components/charts/trust-data-tooltip";
 import { CartesianTickItem } from "recharts/types/util/types";
@@ -44,7 +43,7 @@ export function HorizontalBarChartWrapper<
   const { chartMode } = useChartModeContext();
   const dimension = useContext(ChartDimensionContext);
   const selectedEstabishment = useContext(SelectedEstablishmentContext);
-  const { hasIncompleteData, hasNoData } = useContext(HasIncompleteDataContext);
+  const { hasNoData } = useContext(HasIncompleteDataContext);
   const chartRef = useRef<ChartHandler>(null);
   const [imageLoading, setImageLoading] = useState<boolean>();
   const keyField = (trust ? "companyNumber" : "urn") as keyof TData;
@@ -175,10 +174,6 @@ export function HorizontalBarChartWrapper<
           </div>
         )}
       </div>
-      <WarningBanner
-        isRendered={hasIncompleteData}
-        message="Some schools are missing data for this financial year"
-      />
       <ErrorBanner
         isRendered={hasNoData}
         message="No financial return data available"

--- a/front-end-components/src/contexts/contexts.tsx
+++ b/front-end-components/src/contexts/contexts.tsx
@@ -18,7 +18,6 @@ export const ChartDimensionContext = createContext<Dimension>({
 export const SelectedEstablishmentContext = createContext("");
 
 interface HasIncompleteData {
-  hasIncompleteData?: boolean;
   hasNoData?: boolean;
 }
 export const HasIncompleteDataContext = createContext<HasIncompleteData>({});

--- a/front-end-components/src/index.css
+++ b/front-end-components/src/index.css
@@ -54,7 +54,11 @@
   stroke: var(--series-highlight-colour);
 }
 
-.recharts-wrapper .chart-cell.chart-cell-active:not(.chart-cell-highlight) {
+.recharts-wrapper
+  .chart-cell.chart-cell-active:not(
+    .chart-cell-highlight,
+    .chart-cell.chart-cell-part-year
+  ) {
   fill: var(--series-0-active-colour);
 }
 

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -740,8 +740,7 @@ const spendingAndCostsComposedElements = document.querySelectorAll<HTMLElement>(
 
 if (spendingAndCostsComposedElements) {
   spendingAndCostsComposedElements.forEach((element) => {
-    const { highlight, json, sortDirection, suffix, stats, hasIncompleteData } =
-      element.dataset;
+    const { highlight, json, sortDirection, suffix, stats } = element.dataset;
     if (json && stats) {
       const root = ReactDOM.createRoot(element);
       const data = JSON.parse(json) as {
@@ -767,7 +766,6 @@ if (spendingAndCostsComposedElements) {
             sortDirection={(sortDirection as ChartSortDirection) || "asc"}
             valueField="amount"
             valueUnit="currency"
-            hasIncompleteData={hasIncompleteData === "True"}
           />
         </React.StrictMode>
       );

--- a/front-end-components/src/views/compare-your-census/partials/auxiliary-staff.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/auxiliary-staff.tsx
@@ -80,11 +80,10 @@ export const AuxiliaryStaff: React.FC<{ type: string; id: string }> = ({
     setDimension(dimension);
   };
 
-  const hasIncompleteData = false;
   const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
+    <HasIncompleteDataContext.Provider value={{ hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <HorizontalBarChartWrapper
           data={chartData}

--- a/front-end-components/src/views/compare-your-census/partials/headcount.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/headcount.tsx
@@ -82,11 +82,10 @@ export const Headcount: React.FC<{ type: string; id: string }> = ({
     setDimension(dimension);
   };
 
-  const hasIncompleteData = false;
   const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
+    <HasIncompleteDataContext.Provider value={{ hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <HorizontalBarChartWrapper
           data={chartData}

--- a/front-end-components/src/views/compare-your-census/partials/non-classroom-support.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/non-classroom-support.tsx
@@ -80,11 +80,10 @@ export const NonClassroomSupport: React.FC<{ type: string; id: string }> = ({
     setDimension(dimension);
   };
 
-  const hasIncompleteData = false;
   const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
+    <HasIncompleteDataContext.Provider value={{ hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <HorizontalBarChartWrapper
           data={chartData}

--- a/front-end-components/src/views/compare-your-census/partials/school-workforce.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/school-workforce.tsx
@@ -81,11 +81,10 @@ export const SchoolWorkforce: React.FC<{ type: string; id: string }> = ({
     setDimension(dimension);
   };
 
-  const hasIncompleteData = false;
   const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
+    <HasIncompleteDataContext.Provider value={{ hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <HorizontalBarChartWrapper
           data={chartData}

--- a/front-end-components/src/views/compare-your-census/partials/senior-leadership.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/senior-leadership.tsx
@@ -80,11 +80,10 @@ export const SeniorLeadership: React.FC<{ type: string; id: string }> = ({
     setDimension(dimension);
   };
 
-  const hasIncompleteData = false;
   const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
+    <HasIncompleteDataContext.Provider value={{ hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <HorizontalBarChartWrapper
           data={chartData}

--- a/front-end-components/src/views/compare-your-census/partials/teaching-assistants.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/teaching-assistants.tsx
@@ -80,11 +80,10 @@ export const TeachingAssistants: React.FC<{ type: string; id: string }> = ({
     setDimension(dimension);
   };
 
-  const hasIncompleteData = false;
   const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
+    <HasIncompleteDataContext.Provider value={{ hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <HorizontalBarChartWrapper
           data={chartData}

--- a/front-end-components/src/views/compare-your-census/partials/total-teachers-qualified.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/total-teachers-qualified.tsx
@@ -66,11 +66,10 @@ export const TotalTeachersQualified: React.FC<{ type: string; id: string }> = ({
       };
     }, [data]);
 
-  const hasIncompleteData = false;
   const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
+    <HasIncompleteDataContext.Provider value={{ hasNoData }}>
       <ChartDimensionContext.Provider value={Percent}>
         <HorizontalBarChartWrapper
           data={chartData}

--- a/front-end-components/src/views/compare-your-census/partials/total-teachers.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/total-teachers.tsx
@@ -80,11 +80,10 @@ export const TotalTeachers: React.FC<{ type: string; id: string }> = ({
     setDimension(dimension);
   };
 
-  const hasIncompleteData = false;
   const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
+    <HasIncompleteDataContext.Provider value={{ hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <HorizontalBarChartWrapper
           data={chartData}

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/administrative-supplies.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/administrative-supplies.tsx
@@ -93,11 +93,10 @@ export const AdministrativeSupplies: React.FC<CompareYourCostsProps> = ({
   const elementId = "administrative-supplies";
   const [hash] = useHash();
 
-  const hasIncompleteData = false;
   const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
+    <HasIncompleteDataContext.Provider value={{ hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <div
           className={classNames("govuk-accordion__section", {

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
@@ -129,11 +129,10 @@ export const CateringStaffServices: React.FC<CompareYourCostsProps> = ({
   const elementId = "catering-staff-and-supplies";
   const [hash] = useHash();
 
-  const hasIncompleteData = false;
   const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
+    <HasIncompleteDataContext.Provider value={{ hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <div
           className={classNames("govuk-accordion__section", {

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-ict.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-ict.tsx
@@ -88,11 +88,10 @@ export const EducationalIct: React.FC<CompareYourCostsProps> = ({
   const elementId = "educational-ict";
   const [hash] = useHash();
 
-  const hasIncompleteData = false;
   const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
+    <HasIncompleteDataContext.Provider value={{ hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <div
           className={classNames("govuk-accordion__section", {

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-supplies.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-supplies.tsx
@@ -119,11 +119,10 @@ export const EducationalSupplies: React.FC<CompareYourCostsProps> = ({
   const elementId = "educational-supplies";
   const [hash] = useHash();
 
-  const hasIncompleteData = false;
   const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
+    <HasIncompleteDataContext.Provider value={{ hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <div
           className={classNames("govuk-accordion__section", {

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/non-educational-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/non-educational-support-staff.tsx
@@ -152,11 +152,10 @@ export const NonEducationalSupportStaff: React.FC<CompareYourCostsProps> = ({
   const elementId = "non-educational-support-staff-and-services";
   const [hash] = useHash();
 
-  const hasIncompleteData = false;
   const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
+    <HasIncompleteDataContext.Provider value={{ hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <div
           className={classNames("govuk-accordion__section", {

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/other-costs.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/other-costs.tsx
@@ -270,11 +270,10 @@ export const OtherCosts: React.FC<CompareYourCostsProps> = ({ type, id }) => {
   const elementId = "other-costs";
   const [hash] = useHash();
 
-  const hasIncompleteData = false;
   const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
+    <HasIncompleteDataContext.Provider value={{ hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <div
           className={classNames("govuk-accordion__section", {

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
@@ -147,11 +147,10 @@ export const PremisesStaffServices: React.FC<CompareYourCostsProps> = ({
   const elementId = "premises-staff-and-services";
   const [hash] = useHash();
 
-  const hasIncompleteData = false;
   const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
+    <HasIncompleteDataContext.Provider value={{ hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <div
           className={classNames("govuk-accordion__section", {

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/teaching-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/teaching-support-staff.tsx
@@ -161,11 +161,10 @@ export const TeachingSupportStaff: React.FC<CompareYourCostsProps> = ({
   const elementId = "teaching-and-teaching-support-staff";
   const [hash] = useHash();
 
-  const hasIncompleteData = false;
   const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
+    <HasIncompleteDataContext.Provider value={{ hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <div
           className={classNames("govuk-accordion__section", {

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/utilities.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/utilities.tsx
@@ -116,11 +116,10 @@ export const Utilities: React.FC<CompareYourCostsProps> = ({ type, id }) => {
   const elementId = "utilities";
   const [hash] = useHash();
 
-  const hasIncompleteData = false;
   const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
+    <HasIncompleteDataContext.Provider value={{ hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <div
           className={classNames("govuk-accordion__section", {

--- a/front-end-components/src/views/compare-your-costs/partials/total-expenditure.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/total-expenditure.tsx
@@ -82,11 +82,10 @@ export const TotalExpenditure: React.FC<CompareYourCostsProps> = ({
     setDimension(dimension);
   };
 
-  const hasIncompleteData = false;
   const hasNoData = data?.length === 0;
 
   return (
-    <HasIncompleteDataContext.Provider value={{ hasIncompleteData, hasNoData }}>
+    <HasIncompleteDataContext.Provider value={{ hasNoData }}>
       <ChartDimensionContext.Provider value={dimension}>
         <HorizontalBarChartWrapper
           data={chartData}

--- a/front-end-components/src/views/compare-your-costs/view.tsx
+++ b/front-end-components/src/views/compare-your-costs/view.tsx
@@ -35,7 +35,7 @@ export const CompareYourCosts: React.FC<CompareYourCostsViewProps> = (
               handlePhaseChange={setPhase}
             />
             {/*<HasIncompleteDataContext.Provider*/}
-            {/*  value={{ hasIncompleteData, hasNoData }}*/}
+            {/*  value={{ hasNoData }}*/}
             {/*>*/}
             <TotalExpenditure id={id} type={type} />
             <ExpenditureAccordion id={id} type={type} />

--- a/web/src/Web.App/Domain/Insight/Expenditure.cs
+++ b/web/src/Web.App/Domain/Insight/Expenditure.cs
@@ -144,7 +144,6 @@ public record SchoolExpenditure : ExpenditureBase
     public decimal? TotalPupils { get; set; }
     public decimal? TotalInternalFloorArea { get; set; }
     public int? PeriodCoveredByReturn { get; set; }
-    public bool HasIncompleteData { get; set; }
 }
 
 public record TrustExpenditure : ExpenditureBase

--- a/web/src/Web.App/ViewModels/SchoolSpendingViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolSpendingViewModel.cs
@@ -36,8 +36,6 @@ public class SchoolSpendingViewModel(
         .ThenByDescending(x => x.Rating.Decile)
         .ThenByDescending(x => x.Rating.Value);
 
-    public bool HasIncompleteData => pupilExpenditure.Concat(areaExpenditure).Any(x => x.HasIncompleteData);
-
     public static ChartStatsViewModel Stats(RagRating rating) => new()
     {
         Average = rating.Mean,

--- a/web/src/Web.App/Views/SchoolSpending/CustomData.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/CustomData.cshtml
@@ -32,7 +32,6 @@
         Costs = Model.HighPriorityCosts,
         Id = "high-priority",
         Urn = Model.Urn,
-        HasIncompleteData = Model.HasIncompleteData,
         IsCustomData = true
             
     })
@@ -42,7 +41,6 @@
         Costs = Model.MediumPriorityCosts,
         Id = "medium-priority",
         Urn = Model.Urn,
-        HasIncompleteData = Model.HasIncompleteData,
         IsCustomData = true
     })
 }
@@ -61,7 +59,6 @@
         Costs = Model.LowPriorityCosts,
         Id = "low-priority",
         Urn = Model.Urn,
-        HasIncompleteData = Model.HasIncompleteData,
         IsCustomData = true
     })
 }

--- a/web/src/Web.App/Views/SchoolSpending/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/Index.cshtml
@@ -40,16 +40,14 @@
     {
         Costs = Model.HighPriorityCosts,
         Id = "high-priority",
-        Urn = Model.Urn,
-        HasIncompleteData = Model.HasIncompleteData
+        Urn = Model.Urn
     })
     
     @await Html.PartialAsync("_Costs", new CostsViewModel
     {
         Costs = Model.MediumPriorityCosts,
         Id = "medium-priority",
-        Urn = Model.Urn,
-        HasIncompleteData = Model.HasIncompleteData
+        Urn = Model.Urn
     })    
 }
 
@@ -66,7 +64,6 @@
     {
         Costs = Model.LowPriorityCosts,
         Id = "low-priority",
-        Urn = Model.Urn,
-        HasIncompleteData = Model.HasIncompleteData
+        Urn = Model.Urn
     }) 
 }


### PR DESCRIPTION
### Context
[AB#229891](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/229891) [AB#228244](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/228244)

### Change proposed in this pull request
Remove dependency on `hasIncompleteData` on chart series data from `front-end`.
Remove dependency on `HasIncompleteData` on SchoolExpenditure model in `web`.
Documentation update.

### Guidance to review 
There should be no noticeable differences in the UI as part of this change, as the property was never being set following earlier changes (as discussed in the linked story). A smoke test of benchmarking / expenditure pages should be sufficient.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

