### PR TITLE
Moved Comparator functions from Benchmark to Establishment API

### DIFF
--- a/platform/README.md
+++ b/platform/README.md
@@ -49,8 +49,6 @@ Add configuration in `local.settings.json` for `Platform.Api.Benchmark`
   "IsEncrypted": false,
   "Values": {
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-    "Search__Name" : "s198d01-ebis-search",
-    "Search__Key" : "[INSERT KEY VALUE]",
     "Sql__ConnectionString" : "[INSERT CONNECTION STRING VALUE]",
     "PipelineMessageHub__ConnectionString": "UseDevelopmentStorage=true",
     "PipelineMessageHub__JobPendingQueue": "data-pipeline-job-pending",

--- a/platform/src/apis/Platform.Api.Benchmark/Comparators/ComparatorsFunctions.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/Comparators/ComparatorsFunctions.cs
@@ -1,86 +1,23 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Net;
-using System.Threading.Tasks;
+﻿using System.Net;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
-using Microsoft.Extensions.Logging;
-using Platform.Functions.Extensions;
 using Platform.Functions.OpenApi;
 namespace Platform.Api.Benchmark.Comparators;
 
-public class ComparatorsFunctions(ILogger<ComparatorsFunctions> logger, IComparatorSchoolsService schoolsService, IComparatorTrustsService trustsService)
+public class ComparatorsFunctions
 {
     [Function(nameof(SchoolComparatorsAsync))]
-    [OpenApiOperation(nameof(SchoolComparatorsAsync), "Comparators")]
+    [OpenApiOperation(nameof(SchoolComparatorsAsync), "Comparators", Deprecated = true)]
     [OpenApiSecurityHeader]
-    [OpenApiRequestBody("application/json", typeof(ComparatorSchoolsRequest), Description = "The comparator characteristics object")]
-    [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(ComparatorSchools))]
-    [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
-    public async Task<HttpResponseData> SchoolComparatorsAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, "post", Route = "comparators/schools")] HttpRequestData req)
-    {
-        var correlationId = req.GetCorrelationId();
-
-        using (logger.BeginScope(new Dictionary<string, object>
-               {
-                   {
-                       "Application", Constants.ApplicationName
-                   },
-                   {
-                       "CorrelationID", correlationId
-                   }
-               }))
-        {
-            try
-            {
-                var body = await req.ReadAsJsonAsync<ComparatorSchoolsRequest>();
-                //TODO : Add request validation
-                var comparators = await schoolsService.ComparatorsAsync(body);
-                return await req.CreateJsonResponseAsync(comparators);
-            }
-            catch (Exception e)
-            {
-                logger.LogError(e, "Failed to create school comparators");
-                return req.CreateErrorResponse();
-            }
-        }
-    }
+    [OpenApiResponseWithoutBody(HttpStatusCode.Gone)]
+    public HttpResponseData SchoolComparatorsAsync(
+        [HttpTrigger(AuthorizationLevel.Admin, "post", Route = "comparators/schools")] HttpRequestData req) => req.CreateResponse(HttpStatusCode.Gone);
 
     [Function(nameof(TrustComparatorsAsync))]
-    [OpenApiOperation(nameof(TrustComparatorsAsync), "Comparators")]
+    [OpenApiOperation(nameof(TrustComparatorsAsync), "Comparators", Deprecated = true)]
     [OpenApiSecurityHeader]
-    [OpenApiRequestBody("application/json", typeof(ComparatorTrustsRequest), Description = "The comparator characteristics object")]
-    [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(ComparatorSchools))]
-    [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
-    public async Task<HttpResponseData> TrustComparatorsAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, "post", Route = "comparators/trusts")] HttpRequestData req)
-    {
-        var correlationId = req.GetCorrelationId();
-
-        using (logger.BeginScope(new Dictionary<string, object>
-               {
-                   {
-                       "Application", Constants.ApplicationName
-                   },
-                   {
-                       "CorrelationID", correlationId
-                   }
-               }))
-        {
-            try
-            {
-                var body = await req.ReadAsJsonAsync<ComparatorTrustsRequest>();
-                //TODO : Add request validation
-                var comparators = await trustsService.ComparatorsAsync(body);
-                return await req.CreateJsonResponseAsync(comparators);
-            }
-            catch (Exception e)
-            {
-                logger.LogError(e, "Failed to create trust comparators");
-                return req.CreateErrorResponse();
-            }
-        }
-    }
+    [OpenApiResponseWithoutBody(HttpStatusCode.Gone)]
+    public HttpResponseData TrustComparatorsAsync(
+        [HttpTrigger(AuthorizationLevel.Admin, "post", Route = "comparators/trusts")] HttpRequestData req) => req.CreateResponse(HttpStatusCode.Gone);
 }

--- a/platform/src/apis/Platform.Api.Benchmark/Configuration/Services.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/Configuration/Services.cs
@@ -1,20 +1,15 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
-using Azure;
 using FluentValidation;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.DependencyInjection;
-using Platform.Api.Benchmark.Comparators;
 using Platform.Api.Benchmark.ComparatorSets;
 using Platform.Api.Benchmark.CustomData;
 using Platform.Api.Benchmark.FinancialPlans;
 using Platform.Api.Benchmark.UserData;
 using Platform.Functions.Extensions;
-using Platform.Infrastructure;
-using Platform.Search;
 using Platform.Sql;
-
 namespace Platform.Api.Benchmark.Configuration;
 
 [ExcludeFromCodeCoverage]
@@ -34,17 +29,10 @@ internal static class Services
             .AddHealthChecks()
             .AddSqlServer(sqlConnString);
 
-        var searchEndpoint = new Uri($"https://{searchName}.search.windows.net/");
-        var searchCredential = new AzureKeyCredential(searchKey);
-
         serviceCollection
             .AddSingleton<IDatabaseFactory>(new DatabaseFactory(sqlConnString))
-            .AddSingleton<ISearchConnection<ComparatorSchool>>(new SearchConnection<ComparatorSchool>(searchEndpoint, searchCredential, ResourceNames.Search.Indexes.SchoolComparators))
-            .AddSingleton<ISearchConnection<ComparatorTrust>>(new SearchConnection<ComparatorTrust>(searchEndpoint, searchCredential, ResourceNames.Search.Indexes.TrustComparators))
             .AddSingleton<IComparatorSetsService, ComparatorSetsService>()
             .AddSingleton<IFinancialPlansService, FinancialPlansService>()
-            .AddSingleton<IComparatorSchoolsService, ComparatorSchoolsService>()
-            .AddSingleton<IComparatorTrustsService, ComparatorTrustsService>()
             .AddSingleton<IUserDataService, UserDataService>()
             .AddSingleton<ICustomDataService, CustomDataService>();
 

--- a/platform/src/apis/Platform.Api.Benchmark/Platform.Api.Benchmark.csproj
+++ b/platform/src/apis/Platform.Api.Benchmark/Platform.Api.Benchmark.csproj
@@ -17,23 +17,22 @@
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <CopyToPublishDirectory>Never</CopyToPublishDirectory>
         </None>
-        <ProjectReference Include="..\..\abstractions\Platform.Functions\Platform.Functions.csproj" />
-        <PackageReference Include="AspNetCore.HealthChecks.SqlServer" />
-        <PackageReference Include="Dapper.Contrib" />
-        <PackageReference Include="Dapper.SqlBuilder" />
-        <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.OpenApi" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker" />
-        <ProjectReference Include="..\..\abstractions\Platform.Infrastructure\Platform.Infrastructure.csproj" />
-        <ProjectReference Include="..\..\abstractions\Platform.Search\Platform.Search.csproj" />
-        <ProjectReference Include="..\..\abstractions\Platform.Sql\Platform.Sql.csproj" />
+        <ProjectReference Include="..\..\abstractions\Platform.Functions\Platform.Functions.csproj"/>
+        <PackageReference Include="AspNetCore.HealthChecks.SqlServer"/>
+        <PackageReference Include="Dapper.Contrib"/>
+        <PackageReference Include="Dapper.SqlBuilder"/>
+        <PackageReference Include="Microsoft.ApplicationInsights.WorkerService"/>
+        <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights"/>
+        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.OpenApi"/>
+        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage"/>
+        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues"/>
+        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http"/>
+        <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk"/>
+        <PackageReference Include="Microsoft.Azure.Functions.Worker"/>
+        <ProjectReference Include="..\..\abstractions\Platform.Infrastructure\Platform.Infrastructure.csproj"/>
+        <ProjectReference Include="..\..\abstractions\Platform.Sql\Platform.Sql.csproj"/>
     </ItemGroup>
     <ItemGroup>
-        <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext" />
+        <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext"/>
     </ItemGroup>
 </Project>

--- a/platform/src/apis/Platform.Api.Benchmark/packages.lock.json
+++ b/platform/src/apis/Platform.Api.Benchmark/packages.lock.json
@@ -1913,11 +1913,6 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
-      "System.Threading.Channels": {
-        "type": "Transitive",
-        "resolved": "4.7.1",
-        "contentHash": "6akRtHK/wab3246t4p5v3HQrtQk8LboOt5T4dtpNgsp3zvDeM4/Gx8V12t0h+c/W9/enUrilk8n6EQqdQorZAA=="
-      },
       "System.Threading.Tasks": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2012,29 +2007,11 @@
       "platform.infrastructure": {
         "type": "Project"
       },
-      "platform.search": {
-        "type": "Project",
-        "dependencies": {
-          "Azure.Search.Documents": "[11.6.0, )",
-          "FluentValidation": "[11.10.0, )"
-        }
-      },
       "platform.sql": {
         "type": "Project",
         "dependencies": {
           "Dapper": "[2.1.35, )",
           "Microsoft.Data.SqlClient": "[5.2.2, )"
-        }
-      },
-      "Azure.Search.Documents": {
-        "type": "CentralTransitive",
-        "requested": "[11.6.0, )",
-        "resolved": "11.6.0",
-        "contentHash": "M7WLx3ANLPHymfqb4Nwk4EwcWWRiHqdvnxJ7RH857baAbkEZ3FYVCRJmHgxH+ROpYOTVSx30uJzsa573/cdD8A==",
-        "dependencies": {
-          "Azure.Core": "1.41.0",
-          "System.Text.Json": "4.7.2",
-          "System.Threading.Channels": "4.7.1"
         }
       },
       "Dapper": {

--- a/platform/src/apis/Platform.Api.Establishment/Comparators/Characteristics.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Comparators/Characteristics.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-namespace Platform.Api.Benchmark.Comparators;
+namespace Platform.Api.Establishment.Comparators;
 
 [ExcludeFromCodeCoverage]
 public record CharacteristicList

--- a/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorSchool.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorSchool.cs
@@ -1,5 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
-namespace Platform.Api.Benchmark.Comparators;
+namespace Platform.Api.Establishment.Comparators;
 
 [ExcludeFromCodeCoverage]
 public record ComparatorSchool

--- a/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorSchools.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorSchools.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-namespace Platform.Api.Benchmark.Comparators;
+namespace Platform.Api.Establishment.Comparators;
 
 [ExcludeFromCodeCoverage]
 public record ComparatorSchools

--- a/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorSchoolsRequest.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorSchoolsRequest.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-namespace Platform.Api.Benchmark.Comparators;
+namespace Platform.Api.Establishment.Comparators;
 
 [ExcludeFromCodeCoverage]
 public record ComparatorSchoolsRequest

--- a/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorSchoolsService.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorSchoolsService.cs
@@ -3,8 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Platform.Search;
-
-namespace Platform.Api.Benchmark.Comparators;
+namespace Platform.Api.Establishment.Comparators;
 
 public interface IComparatorSchoolsService
 {
@@ -173,8 +172,5 @@ public class ComparatorSchoolsService(ISearchConnection<ComparatorSchool> connec
         return 1 / baseScore + x.Score;
     }
 
-    private static double CalcRatio(double current, double target)
-    {
-        return Math.Abs((current - target) / target);
-    }
+    private static double CalcRatio(double current, double target) => Math.Abs((current - target) / target);
 }

--- a/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorTrust.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorTrust.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
-namespace Platform.Api.Benchmark.Comparators;
+namespace Platform.Api.Establishment.Comparators;
 
 [ExcludeFromCodeCoverage]
 public record ComparatorTrust

--- a/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorTrusts.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorTrusts.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-namespace Platform.Api.Benchmark.Comparators;
+namespace Platform.Api.Establishment.Comparators;
 
 [ExcludeFromCodeCoverage]
 public record ComparatorTrusts

--- a/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorTrustsRequest.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorTrustsRequest.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-namespace Platform.Api.Benchmark.Comparators;
+namespace Platform.Api.Establishment.Comparators;
 
 [ExcludeFromCodeCoverage]
 public record ComparatorTrustsRequest

--- a/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorTrustsService.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorTrustsService.cs
@@ -1,11 +1,8 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Options;
 using Platform.Search;
-
-namespace Platform.Api.Benchmark.Comparators;
+namespace Platform.Api.Establishment.Comparators;
 
 public interface IComparatorTrustsService
 {

--- a/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorsFunctions.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorsFunctions.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Extensions.Logging;
+using Platform.Functions.Extensions;
+using Platform.Functions.OpenApi;
+namespace Platform.Api.Establishment.Comparators;
+
+public class ComparatorsFunctions(ILogger<ComparatorsFunctions> logger, IComparatorSchoolsService schoolsService, IComparatorTrustsService trustsService)
+{
+    [Function(nameof(SchoolComparatorsAsync))]
+    [OpenApiOperation(nameof(SchoolComparatorsAsync), "Comparators")]
+    [OpenApiSecurityHeader]
+    [OpenApiRequestBody("application/json", typeof(ComparatorSchoolsRequest), Description = "The comparator characteristics object")]
+    [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(ComparatorSchools))]
+    [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
+    public async Task<HttpResponseData> SchoolComparatorsAsync(
+        [HttpTrigger(AuthorizationLevel.Admin, "post", Route = "comparators/schools")] HttpRequestData req)
+    {
+        var correlationId = req.GetCorrelationId();
+
+        using (logger.BeginScope(new Dictionary<string, object>
+               {
+                   {
+                       "Application", Constants.ApplicationName
+                   },
+                   {
+                       "CorrelationID", correlationId
+                   }
+               }))
+        {
+            try
+            {
+                var body = await req.ReadAsJsonAsync<ComparatorSchoolsRequest>();
+                //TODO : Add request validation
+                var comparators = await schoolsService.ComparatorsAsync(body);
+                return await req.CreateJsonResponseAsync(comparators);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Failed to create school comparators");
+                return req.CreateErrorResponse();
+            }
+        }
+    }
+
+    [Function(nameof(TrustComparatorsAsync))]
+    [OpenApiOperation(nameof(TrustComparatorsAsync), "Comparators")]
+    [OpenApiSecurityHeader]
+    [OpenApiRequestBody("application/json", typeof(ComparatorTrustsRequest), Description = "The comparator characteristics object")]
+    [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(ComparatorSchools))]
+    [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
+    public async Task<HttpResponseData> TrustComparatorsAsync(
+        [HttpTrigger(AuthorizationLevel.Admin, "post", Route = "comparators/trusts")] HttpRequestData req)
+    {
+        var correlationId = req.GetCorrelationId();
+
+        using (logger.BeginScope(new Dictionary<string, object>
+               {
+                   {
+                       "Application", Constants.ApplicationName
+                   },
+                   {
+                       "CorrelationID", correlationId
+                   }
+               }))
+        {
+            try
+            {
+                var body = await req.ReadAsJsonAsync<ComparatorTrustsRequest>();
+                //TODO : Add request validation
+                var comparators = await trustsService.ComparatorsAsync(body);
+                return await req.CreateJsonResponseAsync(comparators);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Failed to create trust comparators");
+                return req.CreateErrorResponse();
+            }
+        }
+    }
+}

--- a/platform/src/apis/Platform.Api.Establishment/Configuration/Services.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Configuration/Services.cs
@@ -5,6 +5,7 @@ using Azure;
 using FluentValidation;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.DependencyInjection;
+using Platform.Api.Establishment.Comparators;
 using Platform.Api.Establishment.LocalAuthorities;
 using Platform.Api.Establishment.Schools;
 using Platform.Api.Establishment.Trusts;
@@ -12,7 +13,6 @@ using Platform.Functions.Extensions;
 using Platform.Infrastructure;
 using Platform.Search;
 using Platform.Sql;
-
 namespace Platform.Api.Establishment.Configuration;
 
 [ExcludeFromCodeCoverage]
@@ -40,9 +40,13 @@ internal static class Services
             .AddSingleton<ISearchConnection<LocalAuthority>>(new SearchConnection<LocalAuthority>(searchEndpoint, searchCredential, ResourceNames.Search.Indexes.LocalAuthority))
             .AddSingleton<ISearchConnection<School>>(new SearchConnection<School>(searchEndpoint, searchCredential, ResourceNames.Search.Indexes.School))
             .AddSingleton<ISearchConnection<Trust>>(new SearchConnection<Trust>(searchEndpoint, searchCredential, ResourceNames.Search.Indexes.Trust))
+            .AddSingleton<ISearchConnection<ComparatorSchool>>(new SearchConnection<ComparatorSchool>(searchEndpoint, searchCredential, ResourceNames.Search.Indexes.SchoolComparators))
+            .AddSingleton<ISearchConnection<ComparatorTrust>>(new SearchConnection<ComparatorTrust>(searchEndpoint, searchCredential, ResourceNames.Search.Indexes.TrustComparators))
             .AddSingleton<ISchoolsService, SchoolsService>()
             .AddSingleton<ITrustsService, TrustsService>()
-            .AddSingleton<ILocalAuthoritiesService, LocalAuthoritiesService>();
+            .AddSingleton<ILocalAuthoritiesService, LocalAuthoritiesService>()
+            .AddSingleton<IComparatorSchoolsService, ComparatorSchoolsService>()
+            .AddSingleton<IComparatorTrustsService, ComparatorTrustsService>();
 
         serviceCollection
             .AddTransient<IValidator<SuggestRequest>, PostSuggestRequestValidator>();

--- a/platform/tests/Platform.ApiTests/Features/BenchmarkComparators.feature
+++ b/platform/tests/Platform.ApiTests/Features/BenchmarkComparators.feature
@@ -1,51 +1,11 @@
-﻿Feature: Benchmark Comparators Endpoint Testing
+Feature: Benchmark Comparators Endpoint Testing
 
     Scenario: Sending a valid comparator schools request
-        Given a valid comparator schools request for school id '990000'
+        Given a valid comparator schools request
         When I submit the comparator schools request
-        Then the comparator schools should total '234' and contain:
-          | Urn    |
-          | 990211 |
-          | 990059 |
-          | 990223 |
-          | 990070 |
-          | 990111 |
-          | 990156 |
-          | 990047 |
-          | 777042 |
-          | 990082 |
-          | 990186 |
-          | 990205 |
-          | 990183 |
-          | 990239 |
-          | 990031 |
-          | 990245 |
-          | 990180 |
-          | 990115 |
-          | 990100 |
-          | 990242 |
-          | 990155 |
-          | 990146 |
-          | 990131 |
-          | 990247 |
-          | 990008 |
-          | 990226 |
-          | 990087 |
-          | 990191 |
-          | 990012 |
-          | 990122 |
+        Then the comparator schools should return 410 Gone
 
     Scenario: Sending a valid comparator trusts request
-        Given a valid comparator trusts request for company number '10192252'
+        Given a valid comparator trusts request
         When I submit the comparator trusts request
-        Then the comparator trusts should total '25' and contain:
-          | CompanyNumber |
-          | 7185046       |
-          | 7694547       |
-          | 8053276       |
-          | 7930340       |
-          | 7452885       |
-          | 7747126       |
-          | 7695504       |
-          | 7388635       |
-          | 7703941       |
+        Then the comparator trusts should return 410 Gone

--- a/platform/tests/Platform.ApiTests/Features/EstablishmentComparators.feature
+++ b/platform/tests/Platform.ApiTests/Features/EstablishmentComparators.feature
@@ -1,0 +1,51 @@
+﻿Feature: Establishment Comparators Endpoint Testing
+
+    Scenario: Sending a valid comparator schools request
+        Given a valid comparator schools request for school id '990000'
+        When I submit the comparator schools request
+        Then the comparator schools should total '234' and contain:
+          | Urn    |
+          | 990211 |
+          | 990059 |
+          | 990223 |
+          | 990070 |
+          | 990111 |
+          | 990156 |
+          | 990047 |
+          | 777042 |
+          | 990082 |
+          | 990186 |
+          | 990205 |
+          | 990183 |
+          | 990239 |
+          | 990031 |
+          | 990245 |
+          | 990180 |
+          | 990115 |
+          | 990100 |
+          | 990242 |
+          | 990155 |
+          | 990146 |
+          | 990131 |
+          | 990247 |
+          | 990008 |
+          | 990226 |
+          | 990087 |
+          | 990191 |
+          | 990012 |
+          | 990122 |
+
+    Scenario: Sending a valid comparator trusts request
+        Given a valid comparator trusts request for company number '10192252'
+        When I submit the comparator trusts request
+        Then the comparator trusts should total '25' and contain:
+          | CompanyNumber |
+          | 7185046       |
+          | 7694547       |
+          | 8053276       |
+          | 7930340       |
+          | 7452885       |
+          | 7747126       |
+          | 7695504       |
+          | 7388635       |
+          | 7703941       |

--- a/platform/tests/Platform.ApiTests/Platform.ApiTests.csproj
+++ b/platform/tests/Platform.ApiTests/Platform.ApiTests.csproj
@@ -1,44 +1,52 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
-    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
-    <LangVersion>latest</LangVersion>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-  <ItemGroup>
-    <Using Include="TechTalk.SpecFlow" />
-    <PackageReference Include="AutoFixture" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="SpecFlow">
-      <TreatAsUsed>true</TreatAsUsed>
-    </PackageReference>
-    <PackageReference Include="SpecFlow.Assist.Dynamic" />
-    <PackageReference Include="SpecFlow.Plus.LivingDocPlugin">
-      <TreatAsUsed>true</TreatAsUsed>
-    </PackageReference>
-    <PackageReference Include="SpecFlow.xUnit" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="FluentAssertions" />
-    <None Update="appsettings.local.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\abstractions\Platform.Functions\Platform.Functions.csproj" />
-    <ProjectReference Include="..\..\src\apis\Platform.Api.Benchmark\Platform.Api.Benchmark.csproj" />
-    <ProjectReference Include="..\..\src\apis\Platform.Api.Establishment\Platform.Api.Establishment.csproj" />
-    <ProjectReference Include="..\..\src\apis\Platform.Api.Insight\Platform.Api.Insight.csproj" />
-  </ItemGroup>
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+        <LangVersion>latest</LangVersion>
+        <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+    </PropertyGroup>
+    <ItemGroup>
+        <Using Include="TechTalk.SpecFlow"/>
+        <PackageReference Include="AutoFixture"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="SpecFlow">
+            <TreatAsUsed>true</TreatAsUsed>
+        </PackageReference>
+        <PackageReference Include="SpecFlow.Assist.Dynamic"/>
+        <PackageReference Include="SpecFlow.Plus.LivingDocPlugin">
+            <TreatAsUsed>true</TreatAsUsed>
+        </PackageReference>
+        <PackageReference Include="SpecFlow.xUnit"/>
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="FluentAssertions"/>
+        <None Update="appsettings.local.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <None Update="appsettings.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute"/>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\abstractions\Platform.Functions\Platform.Functions.csproj"/>
+        <ProjectReference Include="..\..\src\apis\Platform.Api.Benchmark\Platform.Api.Benchmark.csproj"/>
+        <ProjectReference Include="..\..\src\apis\Platform.Api.Establishment\Platform.Api.Establishment.csproj"/>
+        <ProjectReference Include="..\..\src\apis\Platform.Api.Insight\Platform.Api.Insight.csproj"/>
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Update="Features\BenchmarkComparators.feature.cs">
+            <DependentUpon>BenchmarkComparators.feature</DependentUpon>
+            <AutoGen>true</AutoGen>
+            <DesignTime>true</DesignTime>
+            <Visible>true</Visible>
+        </Compile>
+    </ItemGroup>
 </Project>

--- a/platform/tests/Platform.ApiTests/Steps/BenchmarkComparatorsSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/BenchmarkComparatorsSteps.cs
@@ -1,107 +1,57 @@
-﻿using System.Net;
-using System.Text;
+using System.Net;
 using FluentAssertions;
-using Platform.Api.Benchmark.Comparators;
 using Platform.ApiTests.Drivers;
-using Platform.Functions.Extensions;
-using TechTalk.SpecFlow.Assist;
-using Xunit;
-
 namespace Platform.ApiTests.Steps;
 
 [Binding]
+[Scope(Feature = "Benchmark Comparators Endpoint Testing")]
 public class BenchmarkComparatorsSteps(BenchmarkApiDriver api)
 {
     private const string ComparatorSchoolsKey = "comparator-schools";
     private const string ComparatorTrustsKey = "comparator-trusts";
 
-    [Given("a valid comparator schools request for school id '(.*)'")]
-    public void GivenAValidComparatorSchoolsRequestForSchoolId(string urn)
+    [Given("a valid comparator schools request")]
+    private void GivenAValidComparatorSchoolsRequest()
     {
-        var content = new ComparatorSchoolsRequest
-        {
-            Target = urn,
-            FinanceType = new CharacteristicList { Values = ["Maintained"] },
-            TotalPupils = new CharacteristicRange { From = 100, To = 1000 }
-        };
-
         api.CreateRequest(ComparatorSchoolsKey, new HttpRequestMessage
         {
             RequestUri = new Uri("/api/comparators/schools", UriKind.Relative),
-            Method = HttpMethod.Post,
-            Content = new StringContent(content.ToJson(), Encoding.UTF8, "application/json")
+            Method = HttpMethod.Post
         });
     }
 
     [When("I submit the comparator schools request")]
+    [When("I submit the comparator trusts request")]
     public async Task WhenISubmitTheComparatorSchoolsRequest()
     {
         await api.Send();
     }
 
-    [Then("the comparator schools should total '(.*)' and contain:")]
-    public async Task ThenTheComparatorSchoolsShouldTotalAndContain(string total, Table table)
+    [Then("the comparator schools should return 410 Gone")]
+    private void ThenTheComparatorSchoolsShouldReturnGone()
     {
-        var response = api[ComparatorSchoolsKey].Response;
+        var result = api[ComparatorSchoolsKey].Response;
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-
-        var content = await response.Content.ReadAsByteArrayAsync();
-        var result = content.FromJson<ComparatorSchools>();
-
-        Assert.Equal(total, result.TotalSchools.ToString());
-
-        var set = new List<dynamic>();
-        foreach (var urn in result.Schools ?? [])
-        {
-            set.Add(new { Urn = urn });
-        }
-
-        table.CompareToDynamicSet(set, false);
+        result.Should().NotBeNull();
+        result.StatusCode.Should().Be(HttpStatusCode.Gone);
     }
 
-    [Given("a valid comparator trusts request for company number '(.*)'")]
-    public void GivenAValidComparatorTrustsRequestForTrustId(string companyNumber)
+    [Given("a valid comparator trusts request")]
+    private void GivenAValidComparatorTrustsRequest()
     {
-        var content = new ComparatorTrustsRequest
-        {
-            Target = companyNumber,
-            PhasesCovered = new CharacteristicList { Values = ["Secondary"] },
-            TotalPupils = new CharacteristicRange { From = 500, To = 10000 }
-        };
-
         api.CreateRequest(ComparatorTrustsKey, new HttpRequestMessage
         {
             RequestUri = new Uri("/api/comparators/trusts", UriKind.Relative),
-            Method = HttpMethod.Post,
-            Content = new StringContent(content.ToJson(), Encoding.UTF8, "application/json")
+            Method = HttpMethod.Post
         });
     }
 
-    [When("I submit the comparator trusts request")]
-    public async Task WhenISubmitTheComparatorTrustsRequest()
+    [Then("the comparator trusts should return 410 Gone")]
+    private void ThenTheComparatorTrustsShouldReturnGone()
     {
-        await api.Send();
-    }
+        var result = api[ComparatorTrustsKey].Response;
 
-    [Then("the comparator trusts should total '(.*)' and contain:")]
-    public async Task ThenTheComparatorTrustsShouldTotalAndContain(string total, Table table)
-    {
-        var response = api[ComparatorTrustsKey].Response;
-
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-
-        var content = await response.Content.ReadAsByteArrayAsync();
-        var result = content.FromJson<ComparatorTrusts>();
-
-        Assert.Equal(total, result.TotalTrusts.ToString());
-
-        var set = new List<dynamic>();
-        foreach (var companyNumber in result.Trusts ?? [])
-        {
-            set.Add(new { CompanyNumber = companyNumber });
-        }
-
-        table.CompareToDynamicSet(set, false);
+        result.Should().NotBeNull();
+        result.StatusCode.Should().Be(HttpStatusCode.Gone);
     }
 }

--- a/platform/tests/Platform.ApiTests/Steps/EstablishmentComparatorsSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/EstablishmentComparatorsSteps.cs
@@ -1,0 +1,127 @@
+﻿using System.Net;
+using System.Text;
+using FluentAssertions;
+using Platform.Api.Establishment.Comparators;
+using Platform.ApiTests.Drivers;
+using Platform.Functions.Extensions;
+using TechTalk.SpecFlow.Assist;
+using Xunit;
+namespace Platform.ApiTests.Steps;
+
+[Binding]
+[Scope(Feature = "Establishment Comparators Endpoint Testing")]
+public class EstablishmentComparatorsSteps(EstablishmentApiDriver api)
+{
+    private const string ComparatorSchoolsKey = "comparator-schools";
+    private const string ComparatorTrustsKey = "comparator-trusts";
+
+    [Given("a valid comparator schools request for school id '(.*)'")]
+    public void GivenAValidComparatorSchoolsRequestForSchoolId(string urn)
+    {
+        var content = new ComparatorSchoolsRequest
+        {
+            Target = urn,
+            FinanceType = new CharacteristicList
+            {
+                Values = ["Maintained"]
+            },
+            TotalPupils = new CharacteristicRange
+            {
+                From = 100,
+                To = 1000
+            }
+        };
+
+        api.CreateRequest(ComparatorSchoolsKey, new HttpRequestMessage
+        {
+            RequestUri = new Uri("/api/comparators/schools", UriKind.Relative),
+            Method = HttpMethod.Post,
+            Content = new StringContent(content.ToJson(), Encoding.UTF8, "application/json")
+        });
+    }
+
+    [When("I submit the comparator schools request")]
+    public async Task WhenISubmitTheComparatorSchoolsRequest()
+    {
+        await api.Send();
+    }
+
+    [Then("the comparator schools should total '(.*)' and contain:")]
+    public async Task ThenTheComparatorSchoolsShouldTotalAndContain(string total, Table table)
+    {
+        var response = api[ComparatorSchoolsKey].Response;
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsByteArrayAsync();
+        var result = content.FromJson<ComparatorSchools>();
+
+        Assert.Equal(total, result.TotalSchools.ToString());
+
+        var set = new List<dynamic>();
+        foreach (var urn in result.Schools ?? [])
+        {
+            set.Add(new
+            {
+                Urn = urn
+            });
+        }
+
+        table.CompareToDynamicSet(set, false);
+    }
+
+    [Given("a valid comparator trusts request for company number '(.*)'")]
+    public void GivenAValidComparatorTrustsRequestForCompanyNumber(string companyNumber)
+    {
+        var content = new ComparatorTrustsRequest
+        {
+            Target = companyNumber,
+            PhasesCovered = new CharacteristicList
+            {
+                Values = ["Secondary"]
+            },
+            TotalPupils = new CharacteristicRange
+            {
+                From = 500,
+                To = 10000
+            }
+        };
+
+        api.CreateRequest(ComparatorTrustsKey, new HttpRequestMessage
+        {
+            RequestUri = new Uri("/api/comparators/trusts", UriKind.Relative),
+            Method = HttpMethod.Post,
+            Content = new StringContent(content.ToJson(), Encoding.UTF8, "application/json")
+        });
+    }
+
+    [When("I submit the comparator trusts request")]
+    public async Task WhenISubmitTheComparatorTrustsRequest()
+    {
+        await api.Send();
+    }
+
+    [Then("the comparator trusts should total '(.*)' and contain:")]
+    public async Task ThenTheComparatorTrustsShouldTotalAndContain(string total, Table table)
+    {
+        var response = api[ComparatorTrustsKey].Response;
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsByteArrayAsync();
+        var result = content.FromJson<ComparatorTrusts>();
+
+        Assert.Equal(total, result.TotalTrusts.ToString());
+
+        var set = new List<dynamic>();
+        foreach (var companyNumber in result.Trusts ?? [])
+        {
+            set.Add(new
+            {
+                CompanyNumber = companyNumber
+            });
+        }
+
+        table.CompareToDynamicSet(set, false);
+    }
+}

--- a/platform/tests/Platform.ApiTests/packages.lock.json
+++ b/platform/tests/Platform.ApiTests/packages.lock.json
@@ -2121,7 +2121,6 @@
           "Microsoft.Azure.Functions.Worker.Sdk": "[1.17.4, )",
           "Platform.Functions": "[1.0.0, )",
           "Platform.Infrastructure": "[1.0.0, )",
-          "Platform.Search": "[1.0.0, )",
           "Platform.Sql": "[1.0.0, )"
         }
       },

--- a/platform/tests/Platform.Tests/Establishment/WhenExpressionBuilderAddsFilterToList.cs
+++ b/platform/tests/Platform.Tests/Establishment/WhenExpressionBuilderAddsFilterToList.cs
@@ -1,7 +1,6 @@
-﻿using Platform.Api.Benchmark.Comparators;
+﻿using Platform.Api.Establishment.Comparators;
 using Xunit;
-
-namespace Platform.Tests.Benchmark;
+namespace Platform.Tests.Establishment;
 
 public class WhenExpressionBuilderAddsFilterToList
 {

--- a/platform/tests/Platform.Tests/packages.lock.json
+++ b/platform/tests/Platform.Tests/packages.lock.json
@@ -2022,7 +2022,6 @@
           "Microsoft.Azure.Functions.Worker.Sdk": "[1.17.4, )",
           "Platform.Functions": "[1.0.0, )",
           "Platform.Infrastructure": "[1.0.0, )",
-          "Platform.Search": "[1.0.0, )",
           "Platform.Sql": "[1.0.0, )"
         }
       },

--- a/web/src/Web.App/Extensions/ServiceCollectionExtensions.cs
+++ b/web/src/Web.App/Extensions/ServiceCollectionExtensions.cs
@@ -45,7 +45,6 @@ public static class ServiceCollectionExtensions
 
         services.AddHttpClient<IFinancialPlanApi, FinancialPlanApi>().Configure<FinancialPlanApi>(section);
         services.AddHttpClient<ICustomDataApi, CustomDataApi>().Configure<CustomDataApi>(section);
-        services.AddHttpClient<IComparatorApi, ComparatorApi>().Configure<ComparatorApi>(section);
         services.AddHttpClient<IComparatorSetApi, ComparatorSetApi>().Configure<ComparatorSetApi>(section);
         services.AddHttpClient<IUserDataApi, UserDataApi>().Configure<UserDataApi>(section);
         services.AddHttpClient<IHealthApi, HealthApi>().Configure<HealthApi>(section);
@@ -59,6 +58,7 @@ public static class ServiceCollectionExtensions
 
         services.AddHttpClient<IEstablishmentApi, EstablishmentApi>().Configure<EstablishmentApi>(section);
         services.AddHttpClient<IHealthApi, HealthApi>().Configure<HealthApi>(section);
+        services.AddHttpClient<IComparatorApi, ComparatorApi>().Configure<ComparatorApi>(section);
 
         return services;
     }


### PR DESCRIPTION
### Context
[AB#230334](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/230334) [AB#229318](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/229318)

### Change proposed in this pull request
Old endpoints marked as deprecated and set to return `410 Gone`.
There is further work required to fulfil the user story.

### Guidance to review 
`Platform` changes may be validated locally by running the APIs, after having first configured them to connect to the `d02` database/search. The API tests may then be executed. `Web` may also then be run - pointing to the local APIs - and a custom comparator set request made based on characteristics for both a Trust and a School.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

