### PR TITLE
Modified signature of Comparator functions to accept identifier in route instead of body

### DIFF
--- a/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorSchoolsRequest.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorSchoolsRequest.cs
@@ -5,7 +5,6 @@ namespace Platform.Api.Establishment.Comparators;
 [ExcludeFromCodeCoverage]
 public record ComparatorSchoolsRequest
 {
-    public string? Target { get; set; }
     public CharacteristicList? FinanceType { get; set; }
     public CharacteristicList? OverallPhase { get; set; }
     public CharacteristicList? LAName { get; set; }
@@ -35,8 +34,8 @@ public record ComparatorSchoolsRequest
     public CharacteristicRange? PercentWithHI { get; set; }
     public CharacteristicRange? PercentWithASD { get; set; }
 
-    public string FilterExpression() => new List<string>()
-        .NotValueFilter("URN", Target)
+    public string FilterExpression(string urn) => new List<string>()
+        .NotValueFilter("URN", urn)
         .RangeFilter(nameof(TotalPupils), TotalPupils)
         .RangeFilter(nameof(BuildingAverageAge), BuildingAverageAge)
         .RangeFilter(nameof(TotalInternalFloorArea), TotalInternalFloorArea)

--- a/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorSchoolsService.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorSchoolsService.cs
@@ -7,17 +7,17 @@ namespace Platform.Api.Establishment.Comparators;
 
 public interface IComparatorSchoolsService
 {
-    Task<ComparatorSchools> ComparatorsAsync(ComparatorSchoolsRequest request);
+    Task<ComparatorSchools> ComparatorsAsync(string urn, ComparatorSchoolsRequest request);
 }
 
 [ExcludeFromCodeCoverage]
 public class ComparatorSchoolsService(ISearchConnection<ComparatorSchool> connection) : IComparatorSchoolsService
 {
-    public async Task<ComparatorSchools> ComparatorsAsync(ComparatorSchoolsRequest request)
+    public async Task<ComparatorSchools> ComparatorsAsync(string urn, ComparatorSchoolsRequest request)
     {
-        var school = await connection.LookUpAsync(request.Target);
+        var school = await connection.LookUpAsync(urn);
 
-        var filter = request.FilterExpression();
+        var filter = request.FilterExpression(urn);
         var search = request.SearchExpression();
         var result = await connection.SearchAsync(search, filter, 100000);
 

--- a/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorTrustsRequest.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorTrustsRequest.cs
@@ -5,7 +5,6 @@ namespace Platform.Api.Establishment.Comparators;
 [ExcludeFromCodeCoverage]
 public record ComparatorTrustsRequest
 {
-    public string? Target { get; set; }
     public CharacteristicList? PhasesCovered { get; set; }
     public CharacteristicRange? TotalPupils { get; set; }
     public CharacteristicRange? TotalIncome { get; set; }
@@ -15,8 +14,8 @@ public record ComparatorTrustsRequest
     public CharacteristicRange? PercentSpecialEducationNeeds { get; set; }
     public CharacteristicRange? SchoolsInTrust { get; set; }
 
-    public string FilterExpression() => new List<string>()
-        .NotValueFilter("CompanyNumber", Target)
+    public string FilterExpression(string companyNumber) => new List<string>()
+        .NotValueFilter("CompanyNumber", companyNumber)
         .RangeFilter(nameof(TotalPupils), TotalPupils)
         .RangeFilter(nameof(TotalIncome), TotalIncome)
         .RangeFilter(nameof(TotalInternalFloorArea), TotalInternalFloorArea)

--- a/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorTrustsService.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorTrustsService.cs
@@ -6,17 +6,17 @@ namespace Platform.Api.Establishment.Comparators;
 
 public interface IComparatorTrustsService
 {
-    Task<ComparatorTrusts> ComparatorsAsync(ComparatorTrustsRequest request);
+    Task<ComparatorTrusts> ComparatorsAsync(string companyNumber, ComparatorTrustsRequest request);
 }
 
 [ExcludeFromCodeCoverage]
 public class ComparatorTrustsService(ISearchConnection<ComparatorTrust> connection) : IComparatorTrustsService
 {
-    public async Task<ComparatorTrusts> ComparatorsAsync(ComparatorTrustsRequest request)
+    public async Task<ComparatorTrusts> ComparatorsAsync(string companyNumber, ComparatorTrustsRequest request)
     {
         //var trust = await connection.LookUpAsync(request.Target);
 
-        var filter = request.FilterExpression();
+        var filter = request.FilterExpression(companyNumber);
         var search = request.SearchExpression();
         var result = await connection.SearchAsync(search, filter, 100000);
 

--- a/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorsFunctions.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Comparators/ComparatorsFunctions.cs
@@ -15,11 +15,13 @@ public class ComparatorsFunctions(ILogger<ComparatorsFunctions> logger, ICompara
     [Function(nameof(SchoolComparatorsAsync))]
     [OpenApiOperation(nameof(SchoolComparatorsAsync), "Comparators")]
     [OpenApiSecurityHeader]
+    [OpenApiParameter("identifier", Type = typeof(string), Required = true)]
     [OpenApiRequestBody("application/json", typeof(ComparatorSchoolsRequest), Description = "The comparator characteristics object")]
     [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(ComparatorSchools))]
     [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
     public async Task<HttpResponseData> SchoolComparatorsAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, "post", Route = "comparators/schools")] HttpRequestData req)
+        [HttpTrigger(AuthorizationLevel.Admin, "post", Route = "school/{identifier}/comparators")] HttpRequestData req,
+        string identifier)
     {
         var correlationId = req.GetCorrelationId();
 
@@ -37,7 +39,7 @@ public class ComparatorsFunctions(ILogger<ComparatorsFunctions> logger, ICompara
             {
                 var body = await req.ReadAsJsonAsync<ComparatorSchoolsRequest>();
                 //TODO : Add request validation
-                var comparators = await schoolsService.ComparatorsAsync(body);
+                var comparators = await schoolsService.ComparatorsAsync(identifier, body);
                 return await req.CreateJsonResponseAsync(comparators);
             }
             catch (Exception e)
@@ -51,11 +53,13 @@ public class ComparatorsFunctions(ILogger<ComparatorsFunctions> logger, ICompara
     [Function(nameof(TrustComparatorsAsync))]
     [OpenApiOperation(nameof(TrustComparatorsAsync), "Comparators")]
     [OpenApiSecurityHeader]
+    [OpenApiParameter("identifier", Type = typeof(string), Required = true)]
     [OpenApiRequestBody("application/json", typeof(ComparatorTrustsRequest), Description = "The comparator characteristics object")]
     [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(ComparatorSchools))]
     [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
     public async Task<HttpResponseData> TrustComparatorsAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, "post", Route = "comparators/trusts")] HttpRequestData req)
+        [HttpTrigger(AuthorizationLevel.Admin, "post", Route = "trust/{identifier}/comparators")] HttpRequestData req,
+        string identifier)
     {
         var correlationId = req.GetCorrelationId();
 
@@ -73,7 +77,7 @@ public class ComparatorsFunctions(ILogger<ComparatorsFunctions> logger, ICompara
             {
                 var body = await req.ReadAsJsonAsync<ComparatorTrustsRequest>();
                 //TODO : Add request validation
-                var comparators = await trustsService.ComparatorsAsync(body);
+                var comparators = await trustsService.ComparatorsAsync(identifier, body);
                 return await req.CreateJsonResponseAsync(comparators);
             }
             catch (Exception e)

--- a/platform/tests/Platform.ApiTests/Steps/EstablishmentComparatorsSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/EstablishmentComparatorsSteps.cs
@@ -20,7 +20,6 @@ public class EstablishmentComparatorsSteps(EstablishmentApiDriver api)
     {
         var content = new ComparatorSchoolsRequest
         {
-            Target = urn,
             FinanceType = new CharacteristicList
             {
                 Values = ["Maintained"]
@@ -34,7 +33,7 @@ public class EstablishmentComparatorsSteps(EstablishmentApiDriver api)
 
         api.CreateRequest(ComparatorSchoolsKey, new HttpRequestMessage
         {
-            RequestUri = new Uri("/api/comparators/schools", UriKind.Relative),
+            RequestUri = new Uri($"/api/school/{urn}/comparators", UriKind.Relative),
             Method = HttpMethod.Post,
             Content = new StringContent(content.ToJson(), Encoding.UTF8, "application/json")
         });
@@ -75,7 +74,6 @@ public class EstablishmentComparatorsSteps(EstablishmentApiDriver api)
     {
         var content = new ComparatorTrustsRequest
         {
-            Target = companyNumber,
             PhasesCovered = new CharacteristicList
             {
                 Values = ["Secondary"]
@@ -89,7 +87,7 @@ public class EstablishmentComparatorsSteps(EstablishmentApiDriver api)
 
         api.CreateRequest(ComparatorTrustsKey, new HttpRequestMessage
         {
-            RequestUri = new Uri("/api/comparators/trusts", UriKind.Relative),
+            RequestUri = new Uri($"/api/trust/{companyNumber}/comparators", UriKind.Relative),
             Method = HttpMethod.Post,
             Content = new StringContent(content.ToJson(), Encoding.UTF8, "application/json")
         });

--- a/web/src/Web.App/Controllers/SchoolComparatorsCreateByController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparatorsCreateByController.cs
@@ -346,8 +346,8 @@ public class SchoolComparatorsCreateByController(
                 }
 
                 var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
-                var request = new PostSchoolComparatorsRequest(urn, school.LAName, viewModel);
-                var results = await comparatorApi.CreateSchoolsAsync(request).GetResultOrThrow<ComparatorSchools>();
+                var request = new PostSchoolComparatorsRequest(school.LAName, viewModel);
+                var results = await comparatorApi.CreateSchoolsAsync(urn, request).GetResultOrThrow<ComparatorSchools>();
 
                 // try again if too few results returned
                 // todo: unhappy path(s) under review as part of other ticket(s)

--- a/web/src/Web.App/Controllers/TrustComparatorsCreateByController.cs
+++ b/web/src/Web.App/Controllers/TrustComparatorsCreateByController.cs
@@ -297,8 +297,8 @@ public class TrustComparatorsCreateByController(
                     return RedirectToAction(nameof(Characteristic));
                 }
 
-                var request = new PostTrustComparatorsRequest(companyNumber, viewModel);
-                var results = await comparatorApi.CreateTrustsAsync(request).GetResultOrThrow<ComparatorTrusts>();
+                var request = new PostTrustComparatorsRequest(viewModel);
+                var results = await comparatorApi.CreateTrustsAsync(companyNumber, request).GetResultOrThrow<ComparatorTrusts>();
 
                 // try again if too few results returned
                 // todo: unhappy path(s) under review as part of other ticket(s)

--- a/web/src/Web.App/Infrastructure/Apis/ApiRequests/PostSchoolComparatorsRequest.cs
+++ b/web/src/Web.App/Infrastructure/Apis/ApiRequests/PostSchoolComparatorsRequest.cs
@@ -6,10 +6,8 @@ using Web.App.ViewModels;
 // ReSharper disable UnusedMember.Global
 namespace Web.App.Infrastructure.Apis;
 
-public class PostSchoolComparatorsRequest(string urn, string? laName, UserDefinedSchoolCharacteristicViewModel viewModel)
+public class PostSchoolComparatorsRequest(string? laName, UserDefinedSchoolCharacteristicViewModel viewModel)
 {
-    public string Target => urn;
-
     public CharacteristicList? FinanceType => string.IsNullOrWhiteSpace(viewModel.FinanceType)
         ? null
         : new CharacteristicList(viewModel.FinanceType switch

--- a/web/src/Web.App/Infrastructure/Apis/ApiRequests/PostTrustComparatorsRequest.cs
+++ b/web/src/Web.App/Infrastructure/Apis/ApiRequests/PostTrustComparatorsRequest.cs
@@ -5,10 +5,8 @@
 // ReSharper disable UnusedMember.Global
 namespace Web.App.Infrastructure.Apis;
 
-public class PostTrustComparatorsRequest(string companyNumber, UserDefinedTrustCharacteristicViewModel viewModel)
+public class PostTrustComparatorsRequest(UserDefinedTrustCharacteristicViewModel viewModel)
 {
-    public string Target => companyNumber;
-
     public CharacteristicList? PhasesCovered => viewModel.OverallPhases is { Length: > 0 }
         ? new CharacteristicList(viewModel.OverallPhases!)
         : null;

--- a/web/src/Web.App/Infrastructure/Apis/Benchmark/Api.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Benchmark/Api.cs
@@ -4,10 +4,10 @@ public static class Api
 {
     public static class Comparator
     {
-        private const string BasePath = "api/comparators";
+        private const string BasePath = "api";
 
-        public static string Schools => $"{BasePath}/schools";
-        public static string Trusts => $"{BasePath}/trusts";
+        public static string Schools(string urn) => $"{BasePath}/school/{urn}/comparators";
+        public static string Trusts(string companyNumber) => $"{BasePath}/trust/{companyNumber}/comparators";
     }
 
     public static class ComparatorSet
@@ -18,7 +18,6 @@ public static class Api
         public static string SchoolCustom(string urn, string identifier) => $"{BasePath}/school/{urn}/custom/{identifier}";
         public static string SchoolUserDefined(string urn, string? identifier) => $"{BasePath}/school/{urn}/user-defined/{identifier}";
         public static string TrustUserDefined(string companyNumber, string? identifier) => $"{BasePath}/trust/{companyNumber}/user-defined/{identifier}";
-
     }
 
     public static class CustomData
@@ -29,10 +28,10 @@ public static class Api
     public static class FinancialPlan
     {
         private const string BasePath = "api/financial-plan";
+        public static string All => "api/financial-plans";
 
         public static string Plan(string? urn, int? year) => $"{BasePath}/{urn}/{year}";
         public static string DeploymentPlan(string? urn, int? year) => $"{BasePath}/{urn}/{year}/deployment";
-        public static string All => "api/financial-plans";
     }
 
     public static class UserData

--- a/web/src/Web.App/Infrastructure/Apis/Benchmark/ComparatorApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Benchmark/ComparatorApi.cs
@@ -2,13 +2,15 @@
 
 public class ComparatorApi(HttpClient httpClient, string? key = default) : ApiBase(httpClient, key), IComparatorApi
 {
-    public Task<ApiResult> CreateSchoolsAsync(PostSchoolComparatorsRequest request) => PostAsync(Api.Comparator.Schools, new JsonContent(request));
+    public Task<ApiResult> CreateSchoolsAsync(string urn, PostSchoolComparatorsRequest request)
+        => PostAsync(Api.Comparator.Schools(urn), new JsonContent(request));
 
-    public Task<ApiResult> CreateTrustsAsync(PostTrustComparatorsRequest request) => PostAsync(Api.Comparator.Trusts, new JsonContent(request));
+    public Task<ApiResult> CreateTrustsAsync(string companyNumber, PostTrustComparatorsRequest request)
+        => PostAsync(Api.Comparator.Trusts(companyNumber), new JsonContent(request));
 }
 
 public interface IComparatorApi
 {
-    Task<ApiResult> CreateSchoolsAsync(PostSchoolComparatorsRequest request);
-    Task<ApiResult> CreateTrustsAsync(PostTrustComparatorsRequest request);
+    Task<ApiResult> CreateSchoolsAsync(string urn, PostSchoolComparatorsRequest request);
+    Task<ApiResult> CreateTrustsAsync(string companyNumber, PostTrustComparatorsRequest request);
 }

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -374,8 +374,8 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     public BenchmarkingWebAppClient SetupComparatorApi(ComparatorSchools? comparatorSchools = null, ComparatorTrusts? comparatorTrusts = null)
     {
         ComparatorApi.Reset();
-        ComparatorApi.Setup(api => api.CreateSchoolsAsync(It.IsAny<PostSchoolComparatorsRequest>())).ReturnsAsync(ApiResult.Ok(comparatorSchools));
-        ComparatorApi.Setup(api => api.CreateTrustsAsync(It.IsAny<PostTrustComparatorsRequest>())).ReturnsAsync(ApiResult.Ok(comparatorTrusts));
+        ComparatorApi.Setup(api => api.CreateSchoolsAsync(It.IsAny<string>(), It.IsAny<PostSchoolComparatorsRequest>())).ReturnsAsync(ApiResult.Ok(comparatorSchools));
+        ComparatorApi.Setup(api => api.CreateTrustsAsync(It.IsAny<string>(), It.IsAny<PostTrustComparatorsRequest>())).ReturnsAsync(ApiResult.Ok(comparatorTrusts));
         return this;
     }
 

--- a/web/tests/Web.Tests/Infrastructure/Apis/Requests/GivenAPostSchoolComparatorsRequest.cs
+++ b/web/tests/Web.Tests/Infrastructure/Apis/Requests/GivenAPostSchoolComparatorsRequest.cs
@@ -1,5 +1,4 @@
-﻿using AutoFixture;
-using Web.App.Infrastructure.Apis;
+﻿using Web.App.Infrastructure.Apis;
 using Web.App.ViewModels;
 using Xunit;
 namespace Web.Tests.Infrastructure.Apis.Requests;
@@ -7,27 +6,6 @@ namespace Web.Tests.Infrastructure.Apis.Requests;
 public class GivenAPostSchoolComparatorsRequest
 {
     private const string LAName = "LaName";
-    private readonly Fixture _fixture;
-    private readonly string _urn;
-
-    public GivenAPostSchoolComparatorsRequest()
-    {
-        _fixture = new Fixture();
-        _urn = _fixture.Create<string>();
-    }
-
-    [Fact]
-    public void MapsTarget()
-    {
-        // arrange
-        var viewModel = _fixture.Create<UserDefinedSchoolCharacteristicViewModel>();
-
-        // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).Target;
-
-        // assert
-        Assert.Equal(_urn, actual);
-    }
 
     [Theory]
     [InlineData(null, null)]
@@ -67,7 +45,7 @@ public class GivenAPostSchoolComparatorsRequest
         // act
         CharacteristicList? Action()
         {
-            return new PostSchoolComparatorsRequest(_urn, LAName, viewModel).FinanceType;
+            return new PostSchoolComparatorsRequest(LAName, viewModel).FinanceType;
         }
     }
 
@@ -163,7 +141,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).OverallPhase;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).OverallPhase;
 
         // assert
         Assert.Equal(expected, actual?.Values);
@@ -194,7 +172,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).LAName;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).LAName;
 
         // assert
         Assert.Equal(expected, actual?.Values);
@@ -214,7 +192,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).SchoolPosition;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).SchoolPosition;
 
         // assert
         Assert.Equal(expected == null ? null : [expected], actual?.Values);
@@ -234,7 +212,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).IsPFISchool;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).IsPFISchool;
 
         // assert
         Assert.Equal(expected, actual?.Values);
@@ -273,7 +251,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).LondonWeighting;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).LondonWeighting;
 
         // assert
         Assert.Equal(expected, actual?.Values);
@@ -307,7 +285,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).OfstedDescription;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).OfstedDescription;
 
         // assert
         Assert.Equal(expected, actual?.Values);
@@ -327,7 +305,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).TotalPupils;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).TotalPupils;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -348,7 +326,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).BuildingAverageAge;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).BuildingAverageAge;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -369,7 +347,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).TotalInternalFloorArea;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).TotalInternalFloorArea;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -390,7 +368,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).PercentFreeSchoolMeals;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).PercentFreeSchoolMeals;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -411,7 +389,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).PercentSpecialEducationNeeds;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).PercentSpecialEducationNeeds;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -432,7 +410,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).TotalPupilsSixthForm;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).TotalPupilsSixthForm;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -453,7 +431,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).KS2Progress;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).KS2Progress;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -474,7 +452,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).KS4Progress;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).KS4Progress;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -495,7 +473,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).SchoolsInTrust;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).SchoolsInTrust;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -516,7 +494,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).PercentWithVI;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).PercentWithVI;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -537,7 +515,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).PercentWithSPLD;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).PercentWithSPLD;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -558,7 +536,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).PercentWithSLD;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).PercentWithSLD;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -579,7 +557,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).PercentWithSLCN;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).PercentWithSLCN;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -600,7 +578,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).PercentWithSEMH;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).PercentWithSEMH;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -621,7 +599,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).PercentWithPMLD;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).PercentWithPMLD;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -642,7 +620,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).PercentWithPD;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).PercentWithPD;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -663,7 +641,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).PercentWithOTH;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).PercentWithOTH;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -684,7 +662,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).PercentWithMSI;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).PercentWithMSI;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -706,7 +684,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).PercentWithMLD;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).PercentWithMLD;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -727,7 +705,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).PercentWithHI;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).PercentWithHI;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -748,7 +726,7 @@ public class GivenAPostSchoolComparatorsRequest
         };
 
         // act
-        var actual = new PostSchoolComparatorsRequest(_urn, LAName, viewModel).PercentWithASD;
+        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).PercentWithASD;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);

--- a/web/tests/Web.Tests/Infrastructure/Apis/Requests/GivenAPostTrustComparatorsRequest.cs
+++ b/web/tests/Web.Tests/Infrastructure/Apis/Requests/GivenAPostTrustComparatorsRequest.cs
@@ -1,33 +1,10 @@
-﻿using AutoFixture;
-using Web.App.Infrastructure.Apis;
+﻿using Web.App.Infrastructure.Apis;
 using Web.App.ViewModels;
 using Xunit;
 namespace Web.Tests.Infrastructure.Apis.Requests;
 
 public class GivenAPostTrustComparatorsRequest
 {
-    private readonly string _companyName;
-    private readonly Fixture _fixture;
-
-    public GivenAPostTrustComparatorsRequest()
-    {
-        _fixture = new Fixture();
-        _companyName = _fixture.Create<string>();
-    }
-
-    [Fact]
-    public void MapsTarget()
-    {
-        // arrange
-        var viewModel = _fixture.Create<UserDefinedTrustCharacteristicViewModel>();
-
-        // act
-        var actual = new PostTrustComparatorsRequest(_companyName, viewModel).Target;
-
-        // assert
-        Assert.Equal(_companyName, actual);
-    }
-
     [Theory]
     [InlineData("false", null, null, null, null)]
     [InlineData("true", 123, 456, 123, 456)]
@@ -42,7 +19,7 @@ public class GivenAPostTrustComparatorsRequest
         };
 
         // act
-        var actual = new PostTrustComparatorsRequest(_companyName, viewModel).TotalPupils;
+        var actual = new PostTrustComparatorsRequest(viewModel).TotalPupils;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -63,7 +40,7 @@ public class GivenAPostTrustComparatorsRequest
         };
 
         // act
-        var actual = new PostTrustComparatorsRequest(_companyName, viewModel).SchoolsInTrust;
+        var actual = new PostTrustComparatorsRequest(viewModel).SchoolsInTrust;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -84,7 +61,7 @@ public class GivenAPostTrustComparatorsRequest
         };
 
         // act
-        var actual = new PostTrustComparatorsRequest(_companyName, viewModel).TotalIncome;
+        var actual = new PostTrustComparatorsRequest(viewModel).TotalIncome;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -105,7 +82,7 @@ public class GivenAPostTrustComparatorsRequest
         };
 
         // act
-        var actual = new PostTrustComparatorsRequest(_companyName, viewModel).TotalInternalFloorArea;
+        var actual = new PostTrustComparatorsRequest(viewModel).TotalInternalFloorArea;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -176,7 +153,7 @@ public class GivenAPostTrustComparatorsRequest
         };
 
         // act
-        var actual = new PostTrustComparatorsRequest(_companyName, viewModel).PhasesCovered;
+        var actual = new PostTrustComparatorsRequest(viewModel).PhasesCovered;
 
         // assert
         Assert.Equal(expected, actual?.Values);
@@ -196,7 +173,7 @@ public class GivenAPostTrustComparatorsRequest
         };
 
         // act
-        var actual = new PostTrustComparatorsRequest(_companyName, viewModel).PercentFreeSchoolMeals;
+        var actual = new PostTrustComparatorsRequest(viewModel).PercentFreeSchoolMeals;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -217,7 +194,7 @@ public class GivenAPostTrustComparatorsRequest
         };
 
         // act
-        var actual = new PostTrustComparatorsRequest(_companyName, viewModel).PercentSpecialEducationNeeds;
+        var actual = new PostTrustComparatorsRequest(viewModel).PercentSpecialEducationNeeds;
 
         // assert
         Assert.Equal(expectedFrom, actual?.From);
@@ -238,7 +215,7 @@ public class GivenAPostTrustComparatorsRequest
         };
 
         // act
-        var actual = new PostTrustComparatorsRequest(_companyName, viewModel).OpenDate;
+        var actual = new PostTrustComparatorsRequest(viewModel).OpenDate;
 
         // assert
         Assert.Equal(expectedFrom == null ? null : DateTime.Parse(expectedFrom), actual?.From);

--- a/web/tests/Web.Tests/Infrastructure/GivenAComparatorApi.cs
+++ b/web/tests/Web.Tests/Infrastructure/GivenAComparatorApi.cs
@@ -20,11 +20,23 @@ public class GivenAComparatorApi(ITestOutputHelper testOutputHelper) : ApiClient
     public async Task CreateSchoolsAsyncShouldCallCorrectUrl()
     {
         var api = new ComparatorApi(HttpClient);
+        var request = new PostSchoolComparatorsRequest("laName", new UserDefinedSchoolCharacteristicViewModel());
+        const string urn = "urn";
 
-        var request = new PostSchoolComparatorsRequest("urn", "laName", new UserDefinedSchoolCharacteristicViewModel());
+        await api.CreateSchoolsAsync(urn, request);
 
-        await api.CreateSchoolsAsync(request);
+        VerifyCall(HttpMethod.Post, $"api/school/{urn}/comparators", request.ToJson(Formatting.None));
+    }
 
-        VerifyCall(HttpMethod.Post, "api/comparators/schools", request.ToJson(Formatting.None));
+    [Fact]
+    public async Task CreateTrustsAsyncShouldCallCorrectUrl()
+    {
+        var api = new ComparatorApi(HttpClient);
+        var request = new PostTrustComparatorsRequest(new UserDefinedTrustCharacteristicViewModel());
+        const string companyNumber = "companyNumber";
+
+        await api.CreateTrustsAsync(companyNumber, request);
+
+        VerifyCall(HttpMethod.Post, $"api/trust/{companyNumber}/comparators", request.ToJson(Formatting.None));
     }
 }


### PR DESCRIPTION
### Context
[AB#230335](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/230334) [AB#229318](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/229318) 

Dependent on #1391

### Change proposed in this pull request
There is further work required to fulfil the user story.

### Guidance to review 
`Platform` changes may be validated locally by running the APIs, after having first configured them to connect to the `d02` database/search. The API tests may then be executed. `Web` may also then be run - pointing to the local APIs - and a custom comparator set request made based on characteristics for both a Trust and a School.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

