### PR TITLE
Added Azure Search to Establishment API health checks

### DIFF
--- a/platform/Directory.Packages.props
+++ b/platform/Directory.Packages.props
@@ -1,62 +1,63 @@
 <Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageVersion Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.2" />
-    <PackageVersion Include="AutoFixture" Version="4.18.1" />
-    <PackageVersion Include="Azure.Search.Documents" Version="11.6.0" />
-    <PackageVersion Include="AzureExtensions.Swashbuckle" Version="3.3.2" />
-    <PackageVersion Include="CommandLineParser" Version="2.9.1" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageVersion>
-    <PackageVersion Include="Dapper" Version="2.1.35" />
-    <PackageVersion Include="Dapper.Contrib" Version="2.0.78" />
-    <PackageVersion Include="Dapper.SqlBuilder" Version="2.0.78" />
-    <PackageVersion Include="dbup-sqlserver" Version="5.0.40" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.1" />
-    <PackageVersion Include="FluentValidation" Version="11.10.0" />
-    <PackageVersion Include="JsonSubTypes" Version="2.0.1" />
-    <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
-    <PackageVersion Include="Microsoft.Azure.Core.NewtonsoftJson" Version="2.0.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="1.19.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.4.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.1.5" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.OpenApi" Version="1.5.1" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage" Version="6.6.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.OpenApi.Core" Version="1.5.1" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.NET.Sdk.Functions" Version="4.4.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="SpecFlow" Version="3.9.74" />
-    <PackageVersion Include="SpecFlow.Assist.Dynamic" Version="1.4.2" />
-    <PackageVersion Include="SpecFlow.Plus.LivingDocPlugin" Version="3.9.57" />
-    <PackageVersion Include="SpecFlow.xUnit" Version="3.9.74" />
-    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
-    <PackageVersion Include="xunit" Version="2.9.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageVersion>
-  </ItemGroup>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include="AspNetCore.HealthChecks.AzureSearch" Version="8.0.1"/>
+        <PackageVersion Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.2"/>
+        <PackageVersion Include="AutoFixture" Version="4.18.1"/>
+        <PackageVersion Include="Azure.Search.Documents" Version="11.6.0"/>
+        <PackageVersion Include="AzureExtensions.Swashbuckle" Version="3.3.2"/>
+        <PackageVersion Include="CommandLineParser" Version="2.9.1"/>
+        <PackageVersion Include="coverlet.collector" Version="6.0.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageVersion>
+        <PackageVersion Include="Dapper" Version="2.1.35"/>
+        <PackageVersion Include="Dapper.Contrib" Version="2.0.78"/>
+        <PackageVersion Include="Dapper.SqlBuilder" Version="2.0.78"/>
+        <PackageVersion Include="dbup-sqlserver" Version="5.0.40"/>
+        <PackageVersion Include="FluentAssertions" Version="6.12.1"/>
+        <PackageVersion Include="FluentValidation" Version="11.10.0"/>
+        <PackageVersion Include="JsonSubTypes" Version="2.0.1"/>
+        <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0"/>
+        <PackageVersion Include="Microsoft.Azure.Core.NewtonsoftJson" Version="2.0.0"/>
+        <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="1.23.0"/>
+        <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="1.19.0"/>
+        <PackageVersion Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.4.0"/>
+        <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0"/>
+        <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.1.5"/>
+        <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0"/>
+        <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.OpenApi" Version="1.5.1"/>
+        <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage" Version="6.6.0"/>
+        <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.0"/>
+        <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1"/>
+        <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4"/>
+        <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.OpenApi.Core" Version="1.5.1"/>
+        <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.7"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2"/>
+        <PackageVersion Include="Microsoft.NET.Sdk.Functions" Version="4.4.0"/>
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
+        <PackageVersion Include="Moq" Version="4.20.72"/>
+        <PackageVersion Include="Newtonsoft.Json" Version="13.0.3"/>
+        <PackageVersion Include="SpecFlow" Version="3.9.74"/>
+        <PackageVersion Include="SpecFlow.Assist.Dynamic" Version="1.4.2"/>
+        <PackageVersion Include="SpecFlow.Plus.LivingDocPlugin" Version="3.9.57"/>
+        <PackageVersion Include="SpecFlow.xUnit" Version="3.9.74"/>
+        <PackageVersion Include="System.Linq.Async" Version="6.0.1"/>
+        <PackageVersion Include="System.Text.Json" Version="8.0.4"/>
+        <PackageVersion Include="xunit" Version="2.9.0"/>
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageVersion>
+    </ItemGroup>
 </Project>

--- a/platform/Platform.sln.DotSettings
+++ b/platform/Platform.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=FTE/@EntryIndexedValue">FTE</s:String>
 	<s:Boolean x:Key="/Default/Environment/Filtering/FileMasksToExclude/=_002A_002Eg_002Ecs/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=actuals/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=actuals/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=azuresearch/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/platform/src/abstractions/Platform.Infrastructure/ResourceNames.cs
+++ b/platform/src/abstractions/Platform.Infrastructure/ResourceNames.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-
 namespace Platform.Infrastructure;
 
 [ExcludeFromCodeCoverage]
@@ -32,6 +31,8 @@ public static class ResourceNames
             public const string LocalAuthority = "local-authority-index";
             public const string SchoolComparators = "school-comparators-index";
             public const string TrustComparators = "trust-comparators-index";
+
+            public static readonly string[] All = [School, Trust, LocalAuthority, SchoolComparators, TrustComparators];
         }
 
         public static class Suggesters
@@ -41,5 +42,4 @@ public static class ResourceNames
             public const string LocalAuthority = "local-authority-suggester";
         }
     }
-
 }

--- a/platform/src/apis/Platform.Api.Establishment/Platform.Api.Establishment.csproj
+++ b/platform/src/apis/Platform.Api.Establishment/Platform.Api.Establishment.csproj
@@ -17,19 +17,20 @@
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <CopyToPublishDirectory>Never</CopyToPublishDirectory>
         </None>
-        <PackageReference Include="Dapper.Contrib" />
-        <PackageReference Include="Dapper.SqlBuilder" />
-        <ProjectReference Include="..\..\abstractions\Platform.Functions\Platform.Functions.csproj" />
-        <PackageReference Include="AspNetCore.HealthChecks.SqlServer" />
-        <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.OpenApi" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker" />
-        <ProjectReference Include="..\..\abstractions\Platform.Infrastructure\Platform.Infrastructure.csproj" />
-        <ProjectReference Include="..\..\abstractions\Platform.Search\Platform.Search.csproj" />
-        <ProjectReference Include="..\..\abstractions\Platform.Sql\Platform.Sql.csproj" />
+        <PackageReference Include="AspNetCore.HealthChecks.AzureSearch"/>
+        <PackageReference Include="Dapper.Contrib"/>
+        <PackageReference Include="Dapper.SqlBuilder"/>
+        <ProjectReference Include="..\..\abstractions\Platform.Functions\Platform.Functions.csproj"/>
+        <PackageReference Include="AspNetCore.HealthChecks.SqlServer"/>
+        <PackageReference Include="Microsoft.ApplicationInsights.WorkerService"/>
+        <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights"/>
+        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.OpenApi"/>
+        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage"/>
+        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http"/>
+        <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk"/>
+        <PackageReference Include="Microsoft.Azure.Functions.Worker"/>
+        <ProjectReference Include="..\..\abstractions\Platform.Infrastructure\Platform.Infrastructure.csproj"/>
+        <ProjectReference Include="..\..\abstractions\Platform.Search\Platform.Search.csproj"/>
+        <ProjectReference Include="..\..\abstractions\Platform.Sql\Platform.Sql.csproj"/>
     </ItemGroup>
 </Project>

--- a/platform/src/apis/Platform.Api.Establishment/packages.lock.json
+++ b/platform/src/apis/Platform.Api.Establishment/packages.lock.json
@@ -2,6 +2,16 @@
   "version": 2,
   "dependencies": {
     "net8.0": {
+      "AspNetCore.HealthChecks.AzureSearch": {
+        "type": "Direct",
+        "requested": "[8.0.1, )",
+        "resolved": "8.0.1",
+        "contentHash": "rEpoQN11MnaAXuWIL4N0z0cCxYmRg6u5vy1/tsxlMgnLwoQBJ5hun9noL5sxlGu21PXD/RsEEpd+j8PIRZg/QQ==",
+        "dependencies": {
+          "Azure.Search.Documents": "11.5.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.0"
+        }
+      },
       "AspNetCore.HealthChecks.SqlServer": {
         "type": "Direct",
         "requested": "[8.0.2, )",

--- a/platform/tests/Platform.ApiTests/packages.lock.json
+++ b/platform/tests/Platform.ApiTests/packages.lock.json
@@ -2127,6 +2127,7 @@
       "platform.api.establishment": {
         "type": "Project",
         "dependencies": {
+          "AspNetCore.HealthChecks.AzureSearch": "[8.0.1, )",
           "AspNetCore.HealthChecks.SqlServer": "[8.0.2, )",
           "Dapper.Contrib": "[2.0.78, )",
           "Dapper.SqlBuilder": "[2.0.78, )",
@@ -2189,6 +2190,16 @@
         "dependencies": {
           "Dapper": "[2.1.35, )",
           "Microsoft.Data.SqlClient": "[5.2.2, )"
+        }
+      },
+      "AspNetCore.HealthChecks.AzureSearch": {
+        "type": "CentralTransitive",
+        "requested": "[8.0.1, )",
+        "resolved": "8.0.1",
+        "contentHash": "rEpoQN11MnaAXuWIL4N0z0cCxYmRg6u5vy1/tsxlMgnLwoQBJ5hun9noL5sxlGu21PXD/RsEEpd+j8PIRZg/QQ==",
+        "dependencies": {
+          "Azure.Search.Documents": "11.5.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.0"
         }
       },
       "AspNetCore.HealthChecks.SqlServer": {

--- a/platform/tests/Platform.Tests/packages.lock.json
+++ b/platform/tests/Platform.Tests/packages.lock.json
@@ -2028,6 +2028,7 @@
       "platform.api.establishment": {
         "type": "Project",
         "dependencies": {
+          "AspNetCore.HealthChecks.AzureSearch": "[8.0.1, )",
           "AspNetCore.HealthChecks.SqlServer": "[8.0.2, )",
           "Dapper.Contrib": "[2.0.78, )",
           "Dapper.SqlBuilder": "[2.0.78, )",
@@ -2090,6 +2091,16 @@
         "dependencies": {
           "Dapper": "[2.1.35, )",
           "Microsoft.Data.SqlClient": "[5.2.2, )"
+        }
+      },
+      "AspNetCore.HealthChecks.AzureSearch": {
+        "type": "CentralTransitive",
+        "requested": "[8.0.1, )",
+        "resolved": "8.0.1",
+        "contentHash": "rEpoQN11MnaAXuWIL4N0z0cCxYmRg6u5vy1/tsxlMgnLwoQBJ5hun9noL5sxlGu21PXD/RsEEpd+j8PIRZg/QQ==",
+        "dependencies": {
+          "Azure.Search.Documents": "11.5.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.0"
         }
       },
       "AspNetCore.HealthChecks.SqlServer": {


### PR DESCRIPTION
### Context
[AB#230339](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/230339) [AB#229318](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/229318) 

Dependent on #1391

### Change proposed in this pull request
There is further work required to fulfil the user story.

### Guidance to review 
Run `Establishment` API locally and either use Swagger UI, or else browse to `/api/health` directly. If Azure Search and Azure SQL is available then `Healthy` will be returned. Modify the Search Key in config and restart the service. Hitting the health check endpoint should return `Unhealthy` and detail logged in an exception.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

