### PR TITLE
Modified `LocalAuthority` API response model to include `Schools` collection

### DIFF
--- a/platform/src/apis/Platform.Api.Establishment/LocalAuthorities/LocalAuthorityResponse.cs
+++ b/platform/src/apis/Platform.Api.Establishment/LocalAuthorities/LocalAuthorityResponse.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Platform.Api.Establishment.Schools;
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+namespace Platform.Api.Establishment.LocalAuthorities;
+
+public static class LocalAuthorityResponseFactory
+{
+    public static LocalAuthorityResponse Create(LocalAuthority localAuthority, IEnumerable<School> schools)
+    {
+        return new LocalAuthorityResponse
+        {
+            Code = localAuthority.Code,
+            Name = localAuthority.Name,
+            Schools = schools.Select(s => new LocalAuthoritySchoolModel
+            {
+                URN = s.URN,
+                SchoolName = s.SchoolName,
+                OverallPhase = s.OverallPhase
+            }).ToArray()
+        };
+    }
+}
+
+[ExcludeFromCodeCoverage]
+public record LocalAuthorityResponse
+{
+    public string? Code { get; set; }
+    public string? Name { get; set; }
+    public LocalAuthoritySchoolModel[] Schools { get; set; } = [];
+}
+
+[ExcludeFromCodeCoverage]
+public record LocalAuthoritySchoolModel
+{
+    // ReSharper disable once InconsistentNaming
+    public string? URN { get; set; }
+    public string? SchoolName { get; set; }
+    public string? OverallPhase { get; set; }
+}

--- a/platform/tests/Platform.ApiTests/Features/EstablishmentLocalAuthorities.feature
+++ b/platform/tests/Platform.ApiTests/Features/EstablishmentLocalAuthorities.feature
@@ -4,10 +4,14 @@ Feature: Establishment local authorities endpoints
         Given a valid local authority request with id '201'
         When I submit the local authorities request
         Then the local authority result should be ok and have the following values:
-          | Field  | Value          |
-          | Code   | 201            |
-          | Name   | City of London |
-          
+          | Field | Value          |
+          | Code  | 201            |
+          | Name  | City of London |
+        And the local authority result should contain the following schools:
+          | URN    | SchoolName      | OverallPhase |
+          | 990116 | Test school 237 | Primary      |
+          | 990134 | Test school 1   | Primary      |
+
     Scenario: Sending an invalid local authority request should return not found
         Given an invalid local authority request with id '999'
         When I submit the local authorities request
@@ -17,26 +21,26 @@ Feature: Establishment local authorities endpoints
         Given a valid local authorities suggest request with searchText '201'
         When I submit the local authorities request
         Then the local authorities suggest result should be ok and have the following values:
-          | Field  | Value          |
-          | Text   | *201*          |
-          | Code   | 201            |
-          | Name   | City of London |
-        
+          | Field | Value          |
+          | Text  | *201*          |
+          | Code  | 201            |
+          | Name  | City of London |
+
     Scenario: Sending a valid suggest local authorities request with partial name
         Given a valid local authorities suggest request with searchText 'of'
         When I submit the local authorities request
         Then the local authorities suggest result should be ok and have the following multiple values:
-          | Text                          | Name                        | Code |    
-          | East Riding *of* Yorkshire    | East Riding of Yorkshire    | 811  |
-          | Isles *of* Scilly             | Isles of Scilly             | 420  |
-          | City *of* London              | City of London              | 201  |
-          | Isle *of* Wight               | Isle of Wight               | 921  |
-          
+          | Text                       | Name                     | Code |
+          | East Riding *of* Yorkshire | East Riding of Yorkshire | 811  |
+          | Isles *of* Scilly          | Isles of Scilly          | 420  |
+          | City *of* London           | City of London           | 201  |
+          | Isle *of* Wight            | Isle of Wight            | 921  |
+
     Scenario: Sending a valid suggest local authorities request
         Given a valid local authorities suggest request with searchText 'willNotBeFound'
         When I submit the local authorities request
         Then the local authorities suggest result should be empty
-    
+
     Scenario: Sending an invalid suggest local authorities request returns the validation results
         Given an invalid local authorities suggest request
         When I submit the local authorities request

--- a/platform/tests/Platform.ApiTests/Steps/EstablishmentLocalAuthoritiesSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/EstablishmentLocalAuthoritiesSteps.cs
@@ -7,7 +7,6 @@ using Platform.Functions;
 using Platform.Functions.Extensions;
 using Platform.Search;
 using TechTalk.SpecFlow.Assist;
-
 namespace Platform.ApiTests.Steps;
 
 [Binding]
@@ -27,7 +26,7 @@ public class EstablishmentLocalAuthoritiesSteps(EstablishmentApiDriver api)
     }
 
     [Given("an invalid local authority request with id '(.*)'")]
-    private void GivenAnInvalidValidLocalAuthorityRequestWithId(string id)
+    private void GivenAnInvalidLocalAuthorityRequestWithId(string id)
     {
         api.CreateRequest(RequestKey, new HttpRequestMessage
         {
@@ -37,9 +36,14 @@ public class EstablishmentLocalAuthoritiesSteps(EstablishmentApiDriver api)
     }
 
     [Given("a valid local authorities suggest request with searchText '(.*)")]
-    private void GivenAValidLocalAuthoritiesSuggestRequest(string searchText)
+    private void GivenAValidLocalAuthoritiesSuggestRequestWithSearchText(string searchText)
     {
-        var content = new { SearchText = searchText, Size = 5, SuggesterName = "local-authority-suggester" };
+        var content = new
+        {
+            SearchText = searchText,
+            Size = 5,
+            SuggesterName = "local-authority-suggester"
+        };
 
         api.CreateRequest(SuggestRequestKey, new HttpRequestMessage
         {
@@ -52,7 +56,10 @@ public class EstablishmentLocalAuthoritiesSteps(EstablishmentApiDriver api)
     [Given("an invalid local authorities suggest request")]
     private void GivenAnInvalidLocalAuthoritiesSuggestRequest()
     {
-        var content = new { Size = 0 };
+        var content = new
+        {
+            Size = 0
+        };
 
         api.CreateRequest(SuggestRequestKey, new HttpRequestMessage
         {
@@ -69,7 +76,7 @@ public class EstablishmentLocalAuthoritiesSteps(EstablishmentApiDriver api)
     }
 
     [Then("the local authority result should be ok and have the following values:")]
-    private async Task ThenTheLocalAuthorityResultShouldHaveValues(Table table)
+    private async Task ThenTheLocalAuthorityResultShouldBeOkAndHaveTheFollowingValues(Table table)
     {
         var response = api[RequestKey].Response;
 
@@ -77,9 +84,29 @@ public class EstablishmentLocalAuthoritiesSteps(EstablishmentApiDriver api)
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var content = await response.Content.ReadAsByteArrayAsync();
-        var result = content.FromJson<LocalAuthority>();
+        var result = content.FromJson<LocalAuthorityResponse>();
 
         table.CompareToInstance(result);
+    }
+
+    [Then("the local authority result should contain the following schools:")]
+    private async Task ThenTheLocalAuthorityResultShouldContainTheFollowingSchools(Table table)
+    {
+        var response = api[RequestKey].Response;
+
+        response.Should().NotBeNull();
+
+        var content = await response.Content.ReadAsByteArrayAsync();
+        var result = content.FromJson<LocalAuthorityResponse>();
+
+        var set = result.Schools.Select(s => new
+        {
+            s.URN,
+            s.SchoolName,
+            s.OverallPhase
+        }).ToList();
+
+        table.CompareToSet(set);
     }
 
     [Then("the local authority result should be not found")]
@@ -92,7 +119,7 @@ public class EstablishmentLocalAuthoritiesSteps(EstablishmentApiDriver api)
     }
 
     [Then("the local authorities suggest result should be ok and have the following values:")]
-    private async Task ThenTheLocalAuthoritiesSuggestResultShouldHaveValues(Table table)
+    private async Task ThenTheLocalAuthoritiesSuggestResultShouldBeOkAndHaveTheFollowingValues(Table table)
     {
         var response = api[SuggestRequestKey].Response;
 
@@ -115,7 +142,7 @@ public class EstablishmentLocalAuthoritiesSteps(EstablishmentApiDriver api)
     }
 
     [Then("the local authorities suggest result should be ok and have the following multiple values:")]
-    private async Task ThenTheLocalAuthoritiesSuggestResultShouldHaveMultipleValues(Table table)
+    private async Task ThenTheLocalAuthoritiesSuggestResultShouldBeOkAndHaveTheFollowingMultipleValues(Table table)
     {
         var response = api[SuggestRequestKey].Response;
 
@@ -150,7 +177,7 @@ public class EstablishmentLocalAuthoritiesSteps(EstablishmentApiDriver api)
     }
 
     [Then("the local authorities suggest result should be bad request and have the following validation errors:")]
-    private async Task ThenTheLocalAuthoritiesSuggestResultShouldHaveTheFollowValidationErrors(Table table)
+    private async Task ThenTheLocalAuthoritiesSuggestResultShouldBeBadRequestAndHaveTheFollowingValidationErrors(Table table)
     {
         var response = api[SuggestRequestKey].Response;
 

--- a/platform/tests/Platform.Tests/Establishment/LocalAuthoritiesFunctionsTestBase.cs
+++ b/platform/tests/Platform.Tests/Establishment/LocalAuthoritiesFunctionsTestBase.cs
@@ -2,20 +2,22 @@ using FluentValidation;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Platform.Api.Establishment.LocalAuthorities;
+using Platform.Api.Establishment.Schools;
 using Platform.Search;
-
 namespace Platform.Tests.Establishment;
 
 public class LocalAuthoritiesFunctionsTestBase : FunctionsTestBase
 {
     protected readonly LocalAuthoritiesFunctions Functions;
-    protected readonly Mock<ILocalAuthoritiesService> Service;
+    protected readonly Mock<ILocalAuthoritiesService> LocalAuthoritiesService;
+    protected readonly Mock<ISchoolsService> SchoolsService;
     protected readonly Mock<IValidator<SuggestRequest>> Validator;
 
     protected LocalAuthoritiesFunctionsTestBase()
     {
-        Service = new Mock<ILocalAuthoritiesService>();
+        LocalAuthoritiesService = new Mock<ILocalAuthoritiesService>();
+        SchoolsService = new Mock<ISchoolsService>();
         Validator = new Mock<IValidator<SuggestRequest>>();
-        Functions = new LocalAuthoritiesFunctions(new NullLogger<LocalAuthoritiesFunctions>(), Service.Object, Validator.Object);
+        Functions = new LocalAuthoritiesFunctions(new NullLogger<LocalAuthoritiesFunctions>(), LocalAuthoritiesService.Object, SchoolsService.Object, Validator.Object);
     }
 }

--- a/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesGetLocalAuthorityRequest.cs
+++ b/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesGetLocalAuthorityRequest.cs
@@ -1,32 +1,58 @@
 using System.Net;
+using AutoFixture;
 using Moq;
 using Platform.Api.Establishment.LocalAuthorities;
+using Platform.Api.Establishment.Schools;
 using Xunit;
 namespace Platform.Tests.Establishment;
 
 public class WhenFunctionReceivesGetLocalAuthorityRequest : LocalAuthoritiesFunctionsTestBase
 {
+    private readonly string _laCode;
+    private readonly LocalAuthority _localAuthority;
+    private readonly IEnumerable<School> _schools;
+
+    public WhenFunctionReceivesGetLocalAuthorityRequest()
+    {
+        var fixture = new Fixture();
+        _laCode = fixture.Create<string>();
+        _localAuthority = fixture
+            .Build<LocalAuthority>()
+            .With(l => l.Code, _laCode)
+            .Create();
+        _schools = fixture
+            .Build<School>()
+            .CreateMany(10);
+    }
+
     [Fact]
     public async Task ShouldReturn200OnValidRequest()
     {
-        Service
-            .Setup(d => d.GetAsync(It.IsAny<string>()))
-            .ReturnsAsync(new LocalAuthority());
+        LocalAuthoritiesService
+            .Setup(d => d.GetAsync(_laCode))
+            .ReturnsAsync(_localAuthority);
+        SchoolsService
+            .Setup(s => s.QueryAsync(null, _laCode, null))
+            .ReturnsAsync(_schools);
 
-        var result = await Functions.SingleLocalAuthorityAsync(CreateHttpRequestData(), "1");
+        var result = await Functions.SingleLocalAuthorityAsync(CreateHttpRequestData(), _laCode);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+
+        var actual = await result.ReadAsJsonAsync<LocalAuthorityResponse>();
+        Assert.NotNull(actual);
+        Assert.Equal(_laCode, actual.Code);
     }
 
     [Fact]
     public async Task ShouldReturn404OnInvalidRequest()
     {
-        Service
-            .Setup(d => d.GetAsync(It.IsAny<string>()))
+        LocalAuthoritiesService
+            .Setup(d => d.GetAsync(_laCode))
             .ReturnsAsync((LocalAuthority?)null);
 
-        var result = await Functions.SingleLocalAuthorityAsync(CreateHttpRequestData(), "1");
+        var result = await Functions.SingleLocalAuthorityAsync(CreateHttpRequestData(), _laCode);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.NotFound, result.StatusCode);
@@ -35,11 +61,11 @@ public class WhenFunctionReceivesGetLocalAuthorityRequest : LocalAuthoritiesFunc
     [Fact]
     public async Task ShouldReturn500OnError()
     {
-        Service
-            .Setup(d => d.GetAsync(It.IsAny<string>()))
+        LocalAuthoritiesService
+            .Setup(d => d.GetAsync(_laCode))
             .Throws(new Exception());
 
-        var result = await Functions.SingleLocalAuthorityAsync(CreateHttpRequestData(), "1");
+        var result = await Functions.SingleLocalAuthorityAsync(CreateHttpRequestData(), _laCode);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);

--- a/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesSuggestLocalAuthoritiesRequest.cs
+++ b/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesSuggestLocalAuthoritiesRequest.cs
@@ -4,7 +4,6 @@ using Moq;
 using Platform.Api.Establishment.LocalAuthorities;
 using Platform.Functions;
 using Platform.Search;
-using Platform.Tests.Extensions;
 using Xunit;
 namespace Platform.Tests.Establishment;
 
@@ -13,7 +12,7 @@ public class WhenFunctionReceivesSuggestLocalAuthoritiesRequest : LocalAuthoriti
     [Fact]
     public async Task ShouldReturn200OnValidRequest()
     {
-        Service
+        LocalAuthoritiesService
             .Setup(d => d.SuggestAsync(It.IsAny<SuggestRequest>(), It.IsAny<string[]?>()))
             .ReturnsAsync(new SuggestResponse<LocalAuthority>());
 

--- a/platform/tests/Platform.Tests/Establishment/WhenLocalAuthorityResponseFactoryCreatesResponse.cs
+++ b/platform/tests/Platform.Tests/Establishment/WhenLocalAuthorityResponseFactoryCreatesResponse.cs
@@ -1,0 +1,43 @@
+﻿using AutoFixture;
+using Platform.Api.Establishment.LocalAuthorities;
+using Platform.Api.Establishment.Schools;
+using Xunit;
+namespace Platform.Tests.Establishment;
+
+public class WhenLocalAuthorityResponseFactoryCreatesResponse
+{
+    private readonly LocalAuthority _localAuthority;
+    private readonly IEnumerable<School> _schools;
+
+    public WhenLocalAuthorityResponseFactoryCreatesResponse()
+    {
+        var fixture = new Fixture();
+        _localAuthority = fixture.Create<LocalAuthority>();
+        _schools = fixture.Build<School>().CreateMany(5);
+    }
+
+    [Fact]
+    public void ShouldBuildResponseModelWithMappedLocalAuthorityProperties()
+    {
+        var response = LocalAuthorityResponseFactory.Create(_localAuthority, _schools);
+
+        Assert.Equal(_localAuthority.Code, response.Code);
+        Assert.Equal(_localAuthority.Name, response.Name);
+    }
+
+    [Fact]
+    public void ShouldBuildResponseModelWithMappedLocalSchoolProperties()
+    {
+        var response = LocalAuthorityResponseFactory.Create(_localAuthority, _schools);
+
+        Assert.Equal(_schools.Count(), response.Schools.Length);
+        for (var i = 0; i < _schools.Count(); i++)
+        {
+            var school = response.Schools.ElementAtOrDefault(i);
+            Assert.NotNull(school);
+            Assert.Equal(_schools.ElementAt(i).URN, school.URN);
+            Assert.Equal(_schools.ElementAt(i).SchoolName, school.SchoolName);
+            Assert.Equal(_schools.ElementAt(i).OverallPhase, school.OverallPhase);
+        }
+    }
+}

--- a/web/src/Web.App/Controllers/LocalAuthorityCensusController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityCensusController.cs
@@ -7,7 +7,6 @@ using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.Establishment;
 using Web.App.Infrastructure.Extensions;
 using Web.App.ViewModels;
-
 namespace Web.App.Controllers;
 
 [Controller]
@@ -23,21 +22,16 @@ public class LocalAuthorityCensusController(
     public async Task<IActionResult> Index(string code)
     {
         using (logger.BeginScope(new
-        {
-            code
-        }))
+               {
+                   code
+               }))
         {
             try
             {
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.LocalAuthorityCensus(code);
 
-                var localAuthority = LocalAuthority(code);
-                var schools = Schools(code);
-
-                await Task.WhenAll(localAuthority, schools);
-
-                var phases = Phases(schools.Result);
-                var viewModel = new LocalAuthorityCensusViewModel(localAuthority.Result, phases);
+                var localAuthority = await LocalAuthority(code);
+                var viewModel = new LocalAuthorityCensusViewModel(localAuthority);
                 return View(viewModel);
             }
             catch (Exception e)
@@ -48,18 +42,7 @@ public class LocalAuthorityCensusController(
         }
     }
 
-    private static string[] Phases(School[] schools) => schools
-        .GroupBy(x => x.OverallPhase)
-        .OrderByDescending(x => x.Count())
-        .Select(x => x.Key)
-        .OfType<string>()
-        .ToArray();
-
     private async Task<LocalAuthority> LocalAuthority(string code) => await establishmentApi
         .GetLocalAuthority(code)
         .GetResultOrThrow<LocalAuthority>();
-
-    private async Task<School[]> Schools(string code) => await establishmentApi
-        .QuerySchools(new ApiQuery().AddIfNotNull("laCode", code))
-        .GetResultOrThrow<School[]>();
 }

--- a/web/src/Web.App/Controllers/LocalAuthorityController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityController.cs
@@ -8,7 +8,6 @@ using Web.App.Infrastructure.Apis.Establishment;
 using Web.App.Infrastructure.Extensions;
 using Web.App.TagHelpers;
 using Web.App.ViewModels;
-
 namespace Web.App.Controllers;
 
 [Controller]
@@ -25,20 +24,16 @@ public class LocalAuthorityController(
     public async Task<IActionResult> Index(string code)
     {
         using (logger.BeginScope(new
-        {
-            code
-        }))
+               {
+                   code
+               }))
         {
             try
             {
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.LocalAuthorityHome(code);
 
-                var authority = LocalAuthority(code);
-                var schools = LocalAuthoritySchools(code);
-
-                await Task.WhenAll(authority, schools);
-
-                var viewModel = new LocalAuthorityViewModel(authority.Result, schools.Result);
+                var authority = await LocalAuthority(code);
+                var viewModel = new LocalAuthorityViewModel(authority);
                 return View(viewModel);
             }
             catch (Exception e)
@@ -55,9 +50,9 @@ public class LocalAuthorityController(
     public async Task<IActionResult> Resources(string code)
     {
         using (logger.BeginScope(new
-        {
-            code
-        }))
+               {
+                   code
+               }))
         {
             try
             {

--- a/web/src/Web.App/Domain/Establishment/LocalAuthority.cs
+++ b/web/src/Web.App/Domain/Establishment/LocalAuthority.cs
@@ -1,4 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+// ReSharper disable ClassNeverInstantiated.Global
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+// ReSharper disable AutoPropertyCanBeMadeGetOnly.Global
 
 namespace Web.App.Domain;
 
@@ -7,4 +10,6 @@ public record LocalAuthority
 {
     public string? Code { get; set; }
     public string? Name { get; set; }
-};
+
+    public LocalAuthoritySchool[] Schools { get; set; } = [];
+}

--- a/web/src/Web.App/Domain/Establishment/LocalAuthoritySchool.cs
+++ b/web/src/Web.App/Domain/Establishment/LocalAuthoritySchool.cs
@@ -1,0 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+namespace Web.App.Domain;
+
+[ExcludeFromCodeCoverage]
+public record LocalAuthoritySchool
+{
+    public string? URN { get; set; }
+    public string? SchoolName { get; set; }
+    public string? OverallPhase { get; set; }
+}

--- a/web/src/Web.App/ViewModels/LocalAuthorityCensusViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityCensusViewModel.cs
@@ -1,10 +1,14 @@
 ﻿using Web.App.Domain;
-
 namespace Web.App.ViewModels;
 
-public class LocalAuthorityCensusViewModel(LocalAuthority localAuthority, string[] phases)
+public class LocalAuthorityCensusViewModel(LocalAuthority localAuthority)
 {
     public string? Code => localAuthority.Code;
     public string? Name => localAuthority.Name;
-    public string[] Phases => phases;
+    public string[] Phases => localAuthority.Schools
+        .GroupBy(x => x.OverallPhase)
+        .OrderByDescending(x => x.Count())
+        .Select(x => x.Key)
+        .OfType<string>()
+        .ToArray();
 }

--- a/web/src/Web.App/ViewModels/LocalAuthorityComparisonViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityComparisonViewModel.cs
@@ -1,10 +1,14 @@
 ﻿using Web.App.Domain;
-
 namespace Web.App.ViewModels;
 
-public class LocalAuthorityComparisonViewModel(LocalAuthority localAuthority, string[] phases)
+public class LocalAuthorityComparisonViewModel(LocalAuthority localAuthority)
 {
     public string? Code => localAuthority.Code;
     public string? Name => localAuthority.Name;
-    public string[] Phases => phases;
+    public string[] Phases => localAuthority.Schools
+        .GroupBy(x => x.OverallPhase)
+        .OrderByDescending(x => x.Count())
+        .Select(x => x.Key)
+        .OfType<string>()
+        .ToArray();
 }

--- a/web/src/Web.App/ViewModels/LocalAuthorityViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityViewModel.cs
@@ -1,32 +1,35 @@
 ﻿using Web.App.Domain;
-
 namespace Web.App.ViewModels;
 
 public class LocalAuthorityViewModel(LocalAuthority localAuthority)
 {
-    public LocalAuthorityViewModel(
-        LocalAuthority localAuthority,
-        IReadOnlyCollection<School> schools)
-        : this(localAuthority)
-    {
-        GroupedSchools = schools
-            .OrderBy(x => x.SchoolName)
-            .GroupBy(x => x.OverallPhase)
-            .OrderBy(x => LaPhaseOrderMap[x.Key ?? string.Empty]);
-    }
-
     public string? Code => localAuthority.Code;
     public string? Name => localAuthority.Name;
-    public IEnumerable<IGrouping<string?, School>> GroupedSchools { get; } = [];
+    public IEnumerable<IGrouping<string?, LocalAuthoritySchool>> GroupedSchools { get; } = localAuthority.Schools
+        .OrderBy(x => x.SchoolName)
+        .GroupBy(x => x.OverallPhase)
+        .OrderBy(x => LaPhaseOrderMap[x.Key ?? string.Empty]);
 
     private static Dictionary<string, int> LaPhaseOrderMap => new()
     {
-        { OverallPhaseTypes.Primary, 1 },
-        { OverallPhaseTypes.Secondary, 2 },
-        { OverallPhaseTypes.Special, 3 },
-        { OverallPhaseTypes.PupilReferralUnit, 4 },
-        { OverallPhaseTypes.Nursery, 5 },
-        { OverallPhaseTypes.AllThrough, 6 }
+        {
+            OverallPhaseTypes.Primary, 1
+        },
+        {
+            OverallPhaseTypes.Secondary, 2
+        },
+        {
+            OverallPhaseTypes.Special, 3
+        },
+        {
+            OverallPhaseTypes.PupilReferralUnit, 4
+        },
+        {
+            OverallPhaseTypes.Nursery, 5
+        },
+        {
+            OverallPhaseTypes.AllThrough, 6
+        }
     };
 }
 
@@ -34,5 +37,5 @@ public class LocalAuthoritySchoolsSectionViewModel
 {
     public string? Heading { get; init; }
     public int Id { get; init; }
-    public IEnumerable<School> Schools { get; init; } = [];
+    public IEnumerable<LocalAuthoritySchool> Schools { get; init; } = [];
 }

--- a/web/tests/Web.Tests/ViewModels/GivenALocalAuthorityCensusViewModel.cs
+++ b/web/tests/Web.Tests/ViewModels/GivenALocalAuthorityCensusViewModel.cs
@@ -1,0 +1,44 @@
+using AutoFixture;
+using Web.App.Domain;
+using Web.App.ViewModels;
+using Xunit;
+namespace Web.Tests.ViewModels;
+
+public class GivenALocalAuthorityCensusViewModel
+{
+    private readonly Fixture _fixture = new();
+    private readonly LocalAuthority _localAuthority;
+
+    public GivenALocalAuthorityCensusViewModel()
+    {
+        var schools = _fixture.Build<LocalAuthoritySchool>()
+            .Without(x => x.OverallPhase)
+            .CreateMany(20)
+            .ToArray();
+
+        for (var i = 0; i < schools.Length; i++)
+        {
+            schools[i].OverallPhase = i < 2
+                ? OverallPhaseTypes.Nursery
+                : i < 6
+                    ? OverallPhaseTypes.Primary
+                    : OverallPhaseTypes.Secondary;
+        }
+
+        _localAuthority = _fixture
+            .Build<LocalAuthority>()
+            .With(l => l.Schools, schools)
+            .Create();
+    }
+
+    [Fact]
+    public void WhenContainsSchools()
+    {
+        var vm = new LocalAuthorityCensusViewModel(_localAuthority);
+
+        string[] expected = ["Secondary", "Primary", "Nursery"];
+        Assert.Equal(expected, vm.Phases);
+        Assert.Equal(_localAuthority.Code, vm.Code);
+        Assert.Equal(_localAuthority.Name, vm.Name);
+    }
+}

--- a/web/tests/Web.Tests/ViewModels/GivenALocalAuthorityComparisonViewModel.cs
+++ b/web/tests/Web.Tests/ViewModels/GivenALocalAuthorityComparisonViewModel.cs
@@ -1,0 +1,44 @@
+using AutoFixture;
+using Web.App.Domain;
+using Web.App.ViewModels;
+using Xunit;
+namespace Web.Tests.ViewModels;
+
+public class GivenALocalAuthorityComparisonViewModel
+{
+    private readonly Fixture _fixture = new();
+    private readonly LocalAuthority _localAuthority;
+
+    public GivenALocalAuthorityComparisonViewModel()
+    {
+        var schools = _fixture.Build<LocalAuthoritySchool>()
+            .Without(x => x.OverallPhase)
+            .CreateMany(20)
+            .ToArray();
+
+        for (var i = 0; i < schools.Length; i++)
+        {
+            schools[i].OverallPhase = i < 2
+                ? OverallPhaseTypes.Nursery
+                : i < 6
+                    ? OverallPhaseTypes.Primary
+                    : OverallPhaseTypes.Secondary;
+        }
+
+        _localAuthority = _fixture
+            .Build<LocalAuthority>()
+            .With(l => l.Schools, schools)
+            .Create();
+    }
+
+    [Fact]
+    public void WhenContainsSchools()
+    {
+        var vm = new LocalAuthorityComparisonViewModel(_localAuthority);
+
+        string[] expected = ["Secondary", "Primary", "Nursery"];
+        Assert.Equal(expected, vm.Phases);
+        Assert.Equal(_localAuthority.Code, vm.Code);
+        Assert.Equal(_localAuthority.Name, vm.Name);
+    }
+}

--- a/web/tests/Web.Tests/ViewModels/GivenALocalAuthorityViewModel.cs
+++ b/web/tests/Web.Tests/ViewModels/GivenALocalAuthorityViewModel.cs
@@ -1,0 +1,66 @@
+using AutoFixture;
+using Web.App.Domain;
+using Web.App.ViewModels;
+using Xunit;
+namespace Web.Tests.ViewModels;
+
+public class GivenALocalAuthorityViewModel
+{
+    private readonly Fixture _fixture = new();
+    private readonly LocalAuthority _localAuthority;
+    private readonly LocalAuthoritySchool[] _schools;
+
+    public GivenALocalAuthorityViewModel()
+    {
+        _schools = _fixture.Build<LocalAuthoritySchool>()
+            .Without(x => x.OverallPhase)
+            .CreateMany(20)
+            .ToArray();
+
+        for (var i = 0; i < _schools.Length; i++)
+        {
+            _schools[i].URN = i.ToString();
+            _schools[i].OverallPhase = i < 2
+                ? OverallPhaseTypes.Nursery
+                : i < 6
+                    ? OverallPhaseTypes.Primary
+                    : OverallPhaseTypes.Secondary;
+        }
+
+        _localAuthority = _fixture
+            .Build<LocalAuthority>()
+            .With(l => l.Schools, _schools)
+            .Create();
+    }
+
+    [Fact]
+    public void WhenContainsSchools()
+    {
+        var vm = new LocalAuthorityViewModel(_localAuthority);
+
+        var nurserySchools = _schools
+            .Where(s => int.Parse(s.URN!) < 2)
+            .OrderBy(s => s.SchoolName);
+        Assert.Equal(nurserySchools, vm.GroupedSchools
+            .Where(g => g.Key == OverallPhaseTypes.Nursery)
+            .SelectMany(g => g));
+
+        var primarySchools = _schools
+            .Where(s => int.Parse(s.URN!) >= 2 && int.Parse(s.URN!) < 6)
+            .OrderBy(s => s.SchoolName);
+        Assert.Equal(primarySchools, vm.GroupedSchools
+            .Where(g => g.Key == OverallPhaseTypes.Primary)
+            .SelectMany(g => g));
+
+        var secondarySchools = _schools
+            .Where(s => int.Parse(s.URN!) >= 6)
+            .OrderBy(s => s.SchoolName);
+        Assert.Equal(secondarySchools, vm.GroupedSchools
+            .Where(g => g.Key == OverallPhaseTypes.Secondary)
+            .SelectMany(g => g));
+
+        Assert.Equal([OverallPhaseTypes.Primary, OverallPhaseTypes.Secondary, OverallPhaseTypes.Nursery], vm.GroupedSchools.Select(g => g.Key));
+        Assert.Equal(_localAuthority.Code, vm.Code);
+        Assert.Equal(_localAuthority.Name, vm.Name);
+    }
+}


### PR DESCRIPTION
### Context
AB#230396 AB#229325

### Change proposed in this pull request
Perform single API call to obtain Local Authority and related part-School collection rather than require multiple API calls to achieve the same result.

### Guidance to review 
Build and run Platform and Web locally and then browse to Local Authority home/census/comparison. Visually, results should be identical before and after this change.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

