### PR TITLE
Modified `Trust` API response model to include `Schools` collection

### DIFF
--- a/platform/src/apis/Platform.Api.Establishment/Trusts/TrustResponse.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Trusts/TrustResponse.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Platform.Api.Establishment.Schools;
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+namespace Platform.Api.Establishment.Trusts;
+
+public static class TrustResponseFactory
+{
+    public static TrustResponse Create(Trust trust, IEnumerable<School> schools)
+    {
+        return new TrustResponse
+        {
+            CompanyNumber = trust.CompanyNumber,
+            TrustName = trust.TrustName,
+            Schools = schools.Select(s => new TrustSchoolModel
+            {
+                URN = s.URN,
+                SchoolName = s.SchoolName,
+                OverallPhase = s.OverallPhase
+            }).ToArray()
+        };
+    }
+}
+
+[ExcludeFromCodeCoverage]
+public record TrustResponse
+{
+    public string? CompanyNumber { get; set; }
+    public string? TrustName { get; set; }
+    public TrustSchoolModel[] Schools { get; set; } = [];
+}
+
+[ExcludeFromCodeCoverage]
+public record TrustSchoolModel
+{
+    // ReSharper disable once InconsistentNaming
+    public string? URN { get; set; }
+    public string? SchoolName { get; set; }
+    public string? OverallPhase { get; set; }
+}

--- a/platform/tests/Platform.ApiTests/Features/EstablishmentTrusts.feature
+++ b/platform/tests/Platform.ApiTests/Features/EstablishmentTrusts.feature
@@ -1,12 +1,15 @@
 Feature: Establishment trusts endpoints
 
     Scenario: Sending a valid trust request
-        Given a valid trust request with id '7539918'
+        Given a valid trust request with id '10647453'
         When I submit the trust request
         Then the trust result should be ok and have the following values:
-          | Field          | Value                  |
-          | CompanyNumber  | 7539918                |
-          | TrustName      | Test Company/Trust  1  |
+          | Field         | Value                   |
+          | CompanyNumber | 10647453                |
+          | TrustName     | Test Company/Trust  227 |
+        And the trust result should contain the following schools:
+          | URN    | SchoolName              | OverallPhase |
+          | 990639 | Test academy school 453 | 16 plus      |
 
     Scenario: Sending an invalid trust request should return not found
         Given an invalid trust request with id '99999999'
@@ -17,27 +20,27 @@ Feature: Establishment trusts endpoints
         Given a valid trust suggest request with searchText '7539918'
         When I submit the trust request
         Then the trust suggest result should be ok and have the following values:
-          | Field          | Value                  |
-          | Text           | *7539918*              |
-          | CompanyNumber  | 7539918                |
-          | TrustName      | Test Company/Trust  1  |        
-        
+          | Field         | Value                 |
+          | Text          | *7539918*             |
+          | CompanyNumber | 7539918               |
+          | TrustName     | Test Company/Trust  1 |
+
     Scenario: Sending a valid suggest trust request with partial name
         Given a valid trust suggest request with searchText 'test'
         When I submit the trust request
         Then the trust suggest result should be ok and have the following multiple values:
-          | Text                         | TrustName                  | CompanyNumber |    
-          | *Test* Company/Trust  334    | Test Company/Trust  334    | 10038640      |
-          | *Test* Company/Trust  262    | Test Company/Trust  262    | 10264735      |
-          | *Test* Company/Trust  301    | Test Company/Trust  301    | 4464331       |
-          | *Test* Company/Trust  56     | Test Company/Trust  56     | 6897239       |
-          | *Test* Company/Trust  286    | Test Company/Trust  286    | 7465701       |
-          
+          | Text                      | TrustName               | CompanyNumber |
+          | *Test* Company/Trust  334 | Test Company/Trust  334 | 10038640      |
+          | *Test* Company/Trust  262 | Test Company/Trust  262 | 10264735      |
+          | *Test* Company/Trust  301 | Test Company/Trust  301 | 4464331       |
+          | *Test* Company/Trust  56  | Test Company/Trust  56  | 6897239       |
+          | *Test* Company/Trust  286 | Test Company/Trust  286 | 7465701       |
+
     Scenario: Sending a valid suggest trust request
         Given a valid trust suggest request with searchText 'willNotBeFound'
         When I submit the trust request
         Then the trust suggest result should be empty
-    
+
     Scenario: Sending an invalid suggest trust request returns the validation results
         Given an invalid trust suggest request
         When I submit the trust request

--- a/platform/tests/Platform.ApiTests/Steps/EstablishmentTrustsSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/EstablishmentTrustsSteps.cs
@@ -7,7 +7,6 @@ using Platform.Functions;
 using Platform.Functions.Extensions;
 using Platform.Search;
 using TechTalk.SpecFlow.Assist;
-
 namespace Platform.ApiTests.Steps;
 
 [Binding]
@@ -27,7 +26,7 @@ public class EstablishmentTrustsSteps(EstablishmentApiDriver api)
     }
 
     [Given("an invalid trust request with id '(.*)'")]
-    private void GivenAnInvalidValidTrustRequestWithId(string id)
+    private void GivenAnInvalidTrustRequestWithId(string id)
     {
         api.CreateRequest(RequestKey, new HttpRequestMessage
         {
@@ -37,9 +36,14 @@ public class EstablishmentTrustsSteps(EstablishmentApiDriver api)
     }
 
     [Given("a valid trust suggest request with searchText '(.*)")]
-    private void GivenAValidTrustsSuggestRequest(string searchText)
+    private void GivenAValidTrustSuggestRequestWithSearchText(string searchText)
     {
-        var content = new { SearchText = searchText, Size = 5, SuggesterName = "trust-suggester" };
+        var content = new
+        {
+            SearchText = searchText,
+            Size = 5,
+            SuggesterName = "trust-suggester"
+        };
 
         api.CreateRequest(SuggestRequestKey, new HttpRequestMessage
         {
@@ -50,9 +54,12 @@ public class EstablishmentTrustsSteps(EstablishmentApiDriver api)
     }
 
     [Given("an invalid trust suggest request")]
-    private void GivenAnInvalidTrustsSuggestRequest()
+    private void GivenAnInvalidTrustSuggestRequest()
     {
-        var content = new { Size = 0 };
+        var content = new
+        {
+            Size = 0
+        };
 
         api.CreateRequest(SuggestRequestKey, new HttpRequestMessage
         {
@@ -63,13 +70,13 @@ public class EstablishmentTrustsSteps(EstablishmentApiDriver api)
     }
 
     [When("I submit the trust request")]
-    private async Task WhenISubmitTheTrustsRequest()
+    private async Task WhenISubmitTheTrustRequest()
     {
         await api.Send();
     }
 
     [Then("the trust result should be ok and have the following values:")]
-    private async Task ThenTheTrustResultShouldHaveValues(Table table)
+    private async Task ThenTheTrustResultShouldBeOkAndHaveTheFollowingValues(Table table)
     {
         var response = api[RequestKey].Response;
 
@@ -77,9 +84,29 @@ public class EstablishmentTrustsSteps(EstablishmentApiDriver api)
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var content = await response.Content.ReadAsByteArrayAsync();
-        var result = content.FromJson<Trust>();
+        var result = content.FromJson<TrustResponse>();
 
         table.CompareToInstance(result);
+    }
+
+    [Then("the trust result should contain the following schools:")]
+    private async Task ThenTheTrustResultShouldContainTheFollowingSchools(Table table)
+    {
+        var response = api[RequestKey].Response;
+
+        response.Should().NotBeNull();
+
+        var content = await response.Content.ReadAsByteArrayAsync();
+        var result = content.FromJson<TrustResponse>();
+
+        var set = result.Schools.Select(s => new
+        {
+            s.URN,
+            s.SchoolName,
+            s.OverallPhase
+        }).ToList();
+
+        table.CompareToSet(set);
     }
 
     [Then("the trust result should be not found")]
@@ -92,7 +119,7 @@ public class EstablishmentTrustsSteps(EstablishmentApiDriver api)
     }
 
     [Then("the trust suggest result should be ok and have the following values:")]
-    private async Task ThenTheTrustsSuggestResultShouldShouldHaveValues(Table table)
+    private async Task ThenTheTrustSuggestResultShouldBeOkAndHaveTheFollowingValues(Table table)
     {
         var response = api[SuggestRequestKey].Response;
 
@@ -115,7 +142,7 @@ public class EstablishmentTrustsSteps(EstablishmentApiDriver api)
     }
 
     [Then("the trust suggest result should be ok and have the following multiple values:")]
-    private async Task ThenTheTrustsSuggestResultShouldHaveMultipleValues(Table table)
+    private async Task ThenTheTrustSuggestResultShouldBeOkAndHaveTheFollowingMultipleValues(Table table)
     {
         var response = api[SuggestRequestKey].Response;
 
@@ -136,7 +163,7 @@ public class EstablishmentTrustsSteps(EstablishmentApiDriver api)
     }
 
     [Then("the trust suggest result should be empty")]
-    private async Task ThenTheTrustsSuggestResultShouldBeEmpty()
+    private async Task ThenTheTrustSuggestResultShouldBeEmpty()
     {
         var response = api[SuggestRequestKey].Response;
 
@@ -150,7 +177,7 @@ public class EstablishmentTrustsSteps(EstablishmentApiDriver api)
     }
 
     [Then("the trust suggest result should be bad request and have the following validation errors:")]
-    private async Task ThenTheTrustsSuggestResultShouldHaveTheFollowValidationErrors(Table table)
+    private async Task ThenTheTrustSuggestResultShouldBeBadRequestAndHaveTheFollowingValidationErrors(Table table)
     {
         var response = api[SuggestRequestKey].Response;
 

--- a/platform/tests/Platform.Tests/Establishment/TrustsFunctionsTestBase.cs
+++ b/platform/tests/Platform.Tests/Establishment/TrustsFunctionsTestBase.cs
@@ -1,21 +1,23 @@
 using FluentValidation;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Platform.Api.Establishment.Schools;
 using Platform.Api.Establishment.Trusts;
 using Platform.Search;
-
 namespace Platform.Tests.Establishment;
 
 public class TrustsFunctionsTestBase : FunctionsTestBase
 {
     protected readonly TrustsFunctions Functions;
-    protected readonly Mock<ITrustsService> Service;
+    protected readonly Mock<ISchoolsService> SchoolsService;
+    protected readonly Mock<ITrustsService> TrustsService;
     protected readonly Mock<IValidator<SuggestRequest>> Validator;
 
     protected TrustsFunctionsTestBase()
     {
-        Service = new Mock<ITrustsService>();
+        TrustsService = new Mock<ITrustsService>();
+        SchoolsService = new Mock<ISchoolsService>();
         Validator = new Mock<IValidator<SuggestRequest>>();
-        Functions = new TrustsFunctions(new NullLogger<TrustsFunctions>(), Service.Object, Validator.Object);
+        Functions = new TrustsFunctions(new NullLogger<TrustsFunctions>(), TrustsService.Object, SchoolsService.Object, Validator.Object);
     }
 }

--- a/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesGetTrustRequest.cs
+++ b/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesGetTrustRequest.cs
@@ -1,33 +1,58 @@
 using System.Net;
+using AutoFixture;
 using Moq;
+using Platform.Api.Establishment.Schools;
 using Platform.Api.Establishment.Trusts;
 using Xunit;
 namespace Platform.Tests.Establishment;
 
 public class WhenFunctionReceivesGetTrustRequest : TrustsFunctionsTestBase
 {
+    private readonly string _companyNumber;
+    private readonly IEnumerable<School> _schools;
+    private readonly Trust _trust;
+
+    public WhenFunctionReceivesGetTrustRequest()
+    {
+        var fixture = new Fixture();
+        _companyNumber = fixture.Create<string>();
+        _trust = fixture
+            .Build<Trust>()
+            .With(l => l.CompanyNumber, _companyNumber)
+            .Create();
+        _schools = fixture
+            .Build<School>()
+            .CreateMany(10);
+    }
+
     [Fact]
     public async Task ShouldReturn200OnValidRequest()
     {
-        Service
-            .Setup(d => d.GetAsync(It.IsAny<string>()))
-            .ReturnsAsync(new Trust());
+        TrustsService
+            .Setup(d => d.GetAsync(_companyNumber))
+            .ReturnsAsync(_trust);
+        SchoolsService
+            .Setup(s => s.QueryAsync(_companyNumber, null, null))
+            .ReturnsAsync(_schools);
 
-        var result = await Functions.SingleTrustAsync(CreateHttpRequestData(), "1");
+        var result = await Functions.SingleTrustAsync(CreateHttpRequestData(), _companyNumber);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+
+        var actual = await result.ReadAsJsonAsync<TrustResponse>();
+        Assert.NotNull(actual);
+        Assert.Equal(_companyNumber, actual.CompanyNumber);
     }
 
     [Fact]
     public async Task ShouldReturn404OnInvalidRequest()
     {
-
-        Service
-            .Setup(d => d.GetAsync(It.IsAny<string>()))
+        TrustsService
+            .Setup(d => d.GetAsync(_companyNumber))
             .ReturnsAsync((Trust?)null);
 
-        var result = await Functions.SingleTrustAsync(CreateHttpRequestData(), "1");
+        var result = await Functions.SingleTrustAsync(CreateHttpRequestData(), _companyNumber);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.NotFound, result.StatusCode);
@@ -36,11 +61,11 @@ public class WhenFunctionReceivesGetTrustRequest : TrustsFunctionsTestBase
     [Fact]
     public async Task ShouldReturn500OnError()
     {
-        Service
-            .Setup(d => d.GetAsync(It.IsAny<string>()))
+        TrustsService
+            .Setup(d => d.GetAsync(_companyNumber))
             .Throws(new Exception());
 
-        var result = await Functions.SingleTrustAsync(CreateHttpRequestData(), "1");
+        var result = await Functions.SingleTrustAsync(CreateHttpRequestData(), _companyNumber);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);

--- a/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesSuggestTrustsRequest.cs
+++ b/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesSuggestTrustsRequest.cs
@@ -4,7 +4,6 @@ using Moq;
 using Platform.Api.Establishment.Trusts;
 using Platform.Functions;
 using Platform.Search;
-using Platform.Tests.Extensions;
 using Xunit;
 namespace Platform.Tests.Establishment;
 
@@ -13,7 +12,7 @@ public class WhenFunctionReceivesSuggestTrustsRequest : TrustsFunctionsTestBase
     [Fact]
     public async Task ShouldReturn200OnValidRequest()
     {
-        Service
+        TrustsService
             .Setup(d => d.SuggestAsync(It.IsAny<SuggestRequest>(), It.IsAny<string[]?>()))
             .ReturnsAsync(new SuggestResponse<Trust>());
 

--- a/web/src/Web.App/Controllers/TrustCensusController.cs
+++ b/web/src/Web.App/Controllers/TrustCensusController.cs
@@ -31,14 +31,8 @@ public class TrustCensusController(
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.TrustCensus(companyNumber);
 
                 var trust = await establishmentApi.GetTrust(companyNumber).GetResultOrThrow<Trust>();
-
-                var query = new ApiQuery().AddIfNotNull("companyNumber", companyNumber);
-                var schools = await establishmentApi.QuerySchools(query).GetResultOrThrow<School[]>();
-
-                var phases = schools.GroupBy(x => x.OverallPhase).OrderByDescending(x => x.Count()).Select(x => x.Key).OfType<string>().ToArray();
-
+                var phases = trust.Schools.GroupBy(x => x.OverallPhase).OrderByDescending(x => x.Count()).Select(x => x.Key).OfType<string>().ToArray();
                 var viewModel = new TrustCensusViewModel(trust, phases);
-
                 return View(viewModel);
             }
             catch (Exception e)

--- a/web/src/Web.App/Controllers/TrustComparisonController.cs
+++ b/web/src/Web.App/Controllers/TrustComparisonController.cs
@@ -31,15 +31,8 @@ public class TrustComparisonController(
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.TrustComparison(companyNumber);
 
                 var trust = await establishmentApi.GetTrust(companyNumber).GetResultOrThrow<Trust>();
-
-                var query = new ApiQuery().AddIfNotNull("companyNumber", companyNumber);
-                var schools = await establishmentApi.QuerySchools(query).GetResultOrThrow<School[]>();
-
-                var phases = schools.GroupBy(x => x.OverallPhase).OrderByDescending(x => x.Count()).Select(x => x.Key).OfType<string>().ToArray();
-
+                var phases = trust.Schools.GroupBy(x => x.OverallPhase).OrderByDescending(x => x.Count()).Select(x => x.Key).OfType<string>().ToArray();
                 var viewModel = new TrustComparisonViewModel(trust, phases);
-
-
                 return View(viewModel);
             }
             catch (Exception e)

--- a/web/src/Web.App/Controllers/TrustController.cs
+++ b/web/src/Web.App/Controllers/TrustController.cs
@@ -37,10 +37,9 @@ public class TrustController(
 
                 var trust = await Trust(companyNumber);
                 var balance = await TrustBalance(companyNumber);
-                var schools = await TrustSchools(companyNumber);
-                var ratings = await RagRatings(schools);
+                var ratings = await RagRatings(trust.Schools);
 
-                var viewModel = new TrustViewModel(trust, balance, schools, ratings, comparatorReverted);
+                var viewModel = new TrustViewModel(trust, balance, ratings, comparatorReverted);
                 return View(viewModel);
             }
             catch (Exception e)
@@ -66,9 +65,7 @@ public class TrustController(
                 ViewData[ViewDataKeys.Backlink] = HomeLink(companyNumber);
 
                 var trust = await Trust(companyNumber);
-                var schools = await TrustSchools(companyNumber);
-
-                var viewModel = new TrustViewModel(trust, schools);
+                var viewModel = new TrustViewModel(trust);
                 return View(viewModel);
             }
             catch (Exception e)
@@ -133,7 +130,7 @@ public class TrustController(
         }
     }
 
-    private static ApiQuery BuildQuery(School[] schools)
+    private static ApiQuery BuildQuery(TrustSchool[] schools)
     {
         var query = new ApiQuery();
         foreach (var school in schools)
@@ -144,17 +141,13 @@ public class TrustController(
         return query;
     }
 
-    private async Task<RagRating[]> RagRatings(School[] schools) => await metricRagRatingApi
+    private async Task<RagRating[]> RagRatings(TrustSchool[] schools) => await metricRagRatingApi
         .GetDefaultAsync(BuildQuery(schools))
         .GetResultOrThrow<RagRating[]>();
 
     private async Task<TrustBalance> TrustBalance(string companyNumber) => await balanceApi
         .Trust(companyNumber)
         .GetResultOrThrow<TrustBalance>();
-
-    private async Task<School[]> TrustSchools(string companyNumber) => await establishmentApi
-        .QuerySchools(new ApiQuery().AddIfNotNull("companyNumber", companyNumber))
-        .GetResultOrDefault<School[]>() ?? [];
 
     private async Task<Trust> Trust(string companyNumber) => await establishmentApi
         .GetTrust(companyNumber)

--- a/web/src/Web.App/Controllers/TrustPlanningController.cs
+++ b/web/src/Web.App/Controllers/TrustPlanningController.cs
@@ -33,13 +33,10 @@ public class TrustPlanningController(
             try
             {
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.TrustPlanning(companyNumber);
+
                 var trust = await establishmentApi.GetTrust(companyNumber).GetResultOrThrow<Trust>();
-                var trustQuery = new ApiQuery().AddIfNotNull("companyNumber", companyNumber);
-                var schools = await establishmentApi.QuerySchools(trustQuery).GetResultOrDefault<School[]>() ?? [];
-
-                var plans = await financialPlanService.List(schools.Select(x => x.URN).OfType<string>().ToArray());
-                var viewModel = new TrustPlanningViewModel(trust, schools, plans.ToArray());
-
+                var plans = await financialPlanService.List(trust.Schools.Select(x => x.URN).OfType<string>().ToArray());
+                var viewModel = new TrustPlanningViewModel(trust, plans.ToArray());
                 return View(viewModel);
             }
             catch (Exception e)

--- a/web/src/Web.App/Controllers/TrustSpendingController.cs
+++ b/web/src/Web.App/Controllers/TrustSpendingController.cs
@@ -39,11 +39,8 @@ public class TrustSpendingController(ILogger<TrustController> logger, IEstablish
                 }));
 
                 var trust = await establishmentApi.GetTrust(companyNumber).GetResultOrThrow<Trust>();
-                var trustQuery = new ApiQuery().AddIfNotNull("companyNumber", companyNumber);
-                var schools = await establishmentApi.QuerySchools(trustQuery).GetResultOrDefault<School[]>() ?? [];
-
                 var schoolsQuery = new ApiQuery();
-                foreach (var school in schools)
+                foreach (var school in trust.Schools)
                 {
                     schoolsQuery.AddIfNotNull("urns", school.URN);
                 }
@@ -80,7 +77,7 @@ public class TrustSpendingController(ILogger<TrustController> logger, IEstablish
                 }
 
                 var ratings = await metricRagRatingApi.GetDefaultAsync(schoolsQuery).GetResultOrThrow<RagRating[]>();
-                var viewModel = new TrustSpendingViewModel(trust, schools, ratings, categories, priorities);
+                var viewModel = new TrustSpendingViewModel(trust, ratings, categories, priorities);
 
                 return View(viewModel);
             }

--- a/web/src/Web.App/Domain/Establishment/Trust.cs
+++ b/web/src/Web.App/Domain/Establishment/Trust.cs
@@ -10,4 +10,6 @@ public record Trust
     public string? CFOName { get; set; }
     public string? CFOEmail { get; set; }
     public DateTime? OpenDate { get; set; }
+
+    public TrustSchool[] Schools { get; set; } = [];
 }

--- a/web/src/Web.App/Domain/Establishment/TrustSchool.cs
+++ b/web/src/Web.App/Domain/Establishment/TrustSchool.cs
@@ -1,0 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+namespace Web.App.Domain;
+
+[ExcludeFromCodeCoverage]
+public record TrustSchool
+{
+    public string? URN { get; set; }
+    public string? SchoolName { get; set; }
+    public string? OverallPhase { get; set; }
+}

--- a/web/src/Web.App/ViewModels/TrustPlanningViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustPlanningViewModel.cs
@@ -1,12 +1,11 @@
 ﻿using Web.App.Domain;
-
 namespace Web.App.ViewModels;
 
-public class TrustPlanningViewModel(Trust trust, School[] schools, FinancialPlan[] plans)
+public class TrustPlanningViewModel(Trust trust, FinancialPlan[] plans)
 {
     public string? CompanyNumber => trust.CompanyNumber;
     public string? Name => trust.TrustName;
 
-    public School[] Schools => schools;
+    public TrustSchool[] Schools => trust.Schools;
     public FinancialPlan[] Plans => plans.Where(x => x.IsComplete).ToArray();
 }

--- a/web/src/Web.App/ViewModels/TrustSpendingViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustSpendingViewModel.cs
@@ -3,14 +3,13 @@ namespace Web.App.ViewModels;
 
 public class TrustSpendingViewModel(
     Trust trust,
-    IReadOnlyCollection<School> schools,
     IEnumerable<RagRating> ratings,
     string[]? categories,
     string[]? priorities)
 {
     public string? CompanyNumber => trust.CompanyNumber;
     public string? Name => trust.TrustName;
-    public int NumberSchools => schools.Count;
+    public int NumberSchools => trust.Schools.Length;
 
     public string[] CostCategories => (categories ?? [])
         .Where(c => !string.IsNullOrWhiteSpace(c))
@@ -50,7 +49,7 @@ public class TrustSpendingViewModel(
 
     private IEnumerable<RagSchoolSpendingSchoolViewModel> SelectSchools(IGrouping<string?, RagRating> grouping)
     {
-        return grouping.SelectMany(g => schools
+        return grouping.SelectMany(g => trust.Schools
                 .Where(s => s.URN == g.URN)
                 .Select(s => new RagSchoolSpendingSchoolViewModel(s, g)))
             .OrderByDescending(s => s.Value);
@@ -89,7 +88,7 @@ public class RagSchoolsSpendingCategoryViewModel(string? category, IEnumerable<R
     public IEnumerable<RagSchoolSpendingSchoolViewModel> Schools => schools;
 }
 
-public class RagSchoolSpendingSchoolViewModel(School? school, RagRating? rating)
+public class RagSchoolSpendingSchoolViewModel(TrustSchool? school, RagRating? rating)
 {
     public string? Urn => school?.URN;
     public string? Name => school?.SchoolName;

--- a/web/src/Web.App/ViewModels/TrustViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustViewModel.cs
@@ -5,21 +5,12 @@ public class TrustViewModel(Trust trust)
 {
     public TrustViewModel(
         Trust trust,
-        IReadOnlyCollection<School> schools)
-        : this(trust)
-    {
-        Schools = schools;
-    }
-
-    public TrustViewModel(
-        Trust trust,
         TrustBalance balance,
-        IReadOnlyCollection<School> schools,
         IEnumerable<RagRating> ratings,
         bool? comparatorReverted = false)
         : this(trust)
     {
-        NumberSchools = schools.Count;
+        NumberSchools = Schools.Count();
         RevenueReserve = balance.RevenueReserve;
         InYearBalance = balance.InYearBalance;
         ComparatorReverted = comparatorReverted;
@@ -44,7 +35,7 @@ public class TrustViewModel(Trust trust)
             .ThenByDescending(o => o.AmberRatio)
             .ThenBy(o => o.Category);
 
-        GroupedSchools = schools
+        GroupedSchools = Schools
             .GroupBy(x => x.OverallPhase)
             .Select(x => (
                 OverallPhase: x.Key,
@@ -72,7 +63,7 @@ public class TrustViewModel(Trust trust)
     public int Low { get; }
     public int Medium { get; }
     public int High { get; }
-    public IEnumerable<School> Schools { get; } = [];
+    public IEnumerable<TrustSchool> Schools => trust.Schools;
     public IEnumerable<RagCostCategoryViewModel> Ratings { get; } = [];
 
     public IEnumerable<RagSchoolViewModel> PrimarySchools => GroupedSchools

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -140,16 +140,11 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         return this;
     }
 
-    public BenchmarkingWebAppClient SetupEstablishment(Trust trust, School[] schools)
+    public BenchmarkingWebAppClient SetupEstablishment(Trust trust, TrustSchool[] schools)
     {
         EstablishmentApi.Reset();
+        trust.Schools = schools;
         EstablishmentApi.Setup(api => api.GetTrust(trust.CompanyNumber)).ReturnsAsync(ApiResult.Ok(trust));
-        EstablishmentApi
-            .Setup(api =>
-                api.QuerySchools(It.Is<ApiQuery>(x =>
-                    x.Any(q => q.Key == "companyNumber" && q.Value == trust.CompanyNumber))))
-            .ReturnsAsync(ApiResult.Ok(schools));
-
         return this;
     }
 
@@ -286,7 +281,10 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     {
         BalanceApi.Reset();
 
-        BalanceApi.Setup(api => api.School(It.IsAny<string?>(), It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(balance ?? new SchoolBalance { PeriodCoveredByReturn = 12 }));
+        BalanceApi.Setup(api => api.School(It.IsAny<string?>(), It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(balance ?? new SchoolBalance
+        {
+            PeriodCoveredByReturn = 12
+        }));
 
         return this;
     }
@@ -322,7 +320,10 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         ExpenditureApi.Reset();
         ExpenditureApi
             .Setup(api => api.School(school.URN, It.IsAny<ApiQuery?>()))
-            .ReturnsAsync(ApiResult.Ok(expenditure ?? new SchoolExpenditure { PeriodCoveredByReturn = 12 }));
+            .ReturnsAsync(ApiResult.Ok(expenditure ?? new SchoolExpenditure
+            {
+                PeriodCoveredByReturn = 12
+            }));
         return this;
     }
 

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingCensus.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingCensus.cs
@@ -3,12 +3,11 @@ using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using AngleSharp.XPath;
 using AutoFixture;
-using Web.App.Domain;
-using Xunit;
-using Web.App;
-using Web.App.Extensions;
 using Newtonsoft.Json;
-
+using Web.App;
+using Web.App.Domain;
+using Web.App.Extensions;
+using Xunit;
 namespace Web.Integration.Tests.Pages.Trusts;
 
 public class WhenViewingCensus(SchoolBenchmarkingWebAppClient client) : PageBase<SchoolBenchmarkingWebAppClient>(client)
@@ -62,13 +61,11 @@ public class WhenViewingCensus(SchoolBenchmarkingWebAppClient client) : PageBase
         var trust = Fixture.Build<Trust>()
             .Create();
 
-        var primarySchools = Fixture.Build<School>()
-            .With(x => x.TrustCompanyNumber, trust.CompanyNumber)
+        var primarySchools = Fixture.Build<TrustSchool>()
             .With(x => x.OverallPhase, OverallPhaseTypes.Primary)
             .CreateMany(9);
 
-        var secondarySchools = Fixture.Build<School>()
-            .With(x => x.TrustCompanyNumber, trust.CompanyNumber)
+        var secondarySchools = Fixture.Build<TrustSchool>()
             .With(x => x.OverallPhase, OverallPhaseTypes.Secondary)
             .CreateMany(11);
 

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingComparison.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingComparison.cs
@@ -3,12 +3,11 @@ using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using AngleSharp.XPath;
 using AutoFixture;
-using Web.App.Domain;
-using Xunit;
-using Web.App;
-using Web.App.Extensions;
 using Newtonsoft.Json;
-
+using Web.App;
+using Web.App.Domain;
+using Web.App.Extensions;
+using Xunit;
 namespace Web.Integration.Tests.Pages.Trusts;
 
 public class WhenViewingComparison(SchoolBenchmarkingWebAppClient client) : PageBase<SchoolBenchmarkingWebAppClient>(client)
@@ -62,13 +61,11 @@ public class WhenViewingComparison(SchoolBenchmarkingWebAppClient client) : Page
         var trust = Fixture.Build<Trust>()
             .Create();
 
-        var primarySchools = Fixture.Build<School>()
-            .With(x => x.TrustCompanyNumber, trust.CompanyNumber)
+        var primarySchools = Fixture.Build<TrustSchool>()
             .With(x => x.OverallPhase, OverallPhaseTypes.Primary)
             .CreateMany(9);
 
-        var secondarySchools = Fixture.Build<School>()
-            .With(x => x.TrustCompanyNumber, trust.CompanyNumber)
+        var secondarySchools = Fixture.Build<TrustSchool>()
             .With(x => x.OverallPhase, OverallPhaseTypes.Secondary)
             .CreateMany(11);
 
@@ -117,4 +114,3 @@ public class WhenViewingComparison(SchoolBenchmarkingWebAppClient client) : Page
         Assert.Equal(4, toolsLinks.Count);
     }
 }
-

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingDetails.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingDetails.cs
@@ -1,10 +1,8 @@
 ﻿using System.Net;
-using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using AutoFixture;
 using Web.App.Domain;
 using Xunit;
-
 namespace Web.Integration.Tests.Pages.Trusts;
 
 public class WhenViewingDetails(SchoolBenchmarkingWebAppClient client) : PageBase<SchoolBenchmarkingWebAppClient>(client)
@@ -52,15 +50,13 @@ public class WhenViewingDetails(SchoolBenchmarkingWebAppClient client) : PageBas
         DocumentAssert.AssertPageUrl(page, Paths.TrustDetails(companyName).ToAbsolute(), HttpStatusCode.InternalServerError);
     }
 
-    private async Task<(IHtmlDocument page, Trust trust, School[] schools)> SetupNavigateInitPage()
+    private async Task<(IHtmlDocument page, Trust trust, TrustSchool[] schools)> SetupNavigateInitPage()
     {
         var trust = Fixture.Build<Trust>()
             .Create();
 
-        var schools = Fixture.Build<School>()
-            .With(x => x.TrustCompanyNumber, trust.CompanyNumber)
+        var schools = Fixture.Build<TrustSchool>()
             .CreateMany(30).ToArray();
-
 
         var page = await Client.SetupEstablishment(trust, schools)
             .SetupBalance(trust)
@@ -72,7 +68,7 @@ public class WhenViewingDetails(SchoolBenchmarkingWebAppClient client) : PageBas
         return (page, trust, schools);
     }
 
-    private static void AssertPageLayout(IHtmlDocument page, Trust trust, School[] schools)
+    private static void AssertPageLayout(IHtmlDocument page, Trust trust, TrustSchool[] schools)
     {
         DocumentAssert.AssertPageUrl(page, Paths.TrustDetails(trust.CompanyNumber).ToAbsolute());
         DocumentAssert.BackLink(page, "Back", Paths.TrustHome(trust.CompanyNumber).ToAbsolute());
@@ -92,7 +88,6 @@ public class WhenViewingDetails(SchoolBenchmarkingWebAppClient client) : PageBas
             var schoolName = schoolElement.QuerySelector("a")?.TextContent;
             var school = schools.FirstOrDefault(s => s.SchoolName == schoolName);
             Assert.NotNull(school);
-            Assert.Equal(trust.CompanyNumber, school.TrustCompanyNumber);
         }
     }
 }

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingHome.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingHome.cs
@@ -69,16 +69,15 @@ public class WhenViewingHome(SchoolBenchmarkingWebAppClient client) : PageBase<S
         DocumentAssert.AssertPageUrl(page, Paths.TrustHome(companyName).ToAbsolute(), HttpStatusCode.InternalServerError);
     }
 
-    private async Task<(IHtmlDocument page, Trust trust, RagRating[] ratings, School[] schools)> SetupNavigateInitPage()
+    private async Task<(IHtmlDocument page, Trust trust, RagRating[] ratings, TrustSchool[] schools)> SetupNavigateInitPage()
     {
         var random = new Random();
 
         var trust = Fixture.Build<Trust>()
             .Create();
 
-        var schools = Fixture.Build<School>()
+        var schools = Fixture.Build<TrustSchool>()
             .With(x => x.OverallPhase, () => OverallPhaseTypes.All.ElementAt(random.Next(0, OverallPhaseTypes.All.Length - 1)))
-            .With(x => x.TrustCompanyNumber, trust.CompanyNumber)
             .CreateMany(20).ToArray();
 
         var values = AllCostCategories.Where(k => k.Key != 9).Select(c => c.Value);
@@ -114,7 +113,7 @@ public class WhenViewingHome(SchoolBenchmarkingWebAppClient client) : PageBase<S
         return (page, trust, ratings, schools);
     }
 
-    private static void AssertPageLayout(IHtmlDocument page, Trust trust, RagRating[] ratings, School[] schools)
+    private static void AssertPageLayout(IHtmlDocument page, Trust trust, RagRating[] ratings, TrustSchool[] schools)
     {
         var expectedBreadcrumbs = new[]
         {

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingSpending.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingSpending.cs
@@ -101,16 +101,15 @@ public partial class WhenViewingSpending(SchoolBenchmarkingWebAppClient client) 
         DocumentAssert.AssertPageUrl(page, Paths.TrustSpending(companyName, [], []).ToAbsolute(), HttpStatusCode.InternalServerError);
     }
 
-    private async Task<(IHtmlDocument page, Trust trust, RagRating[] ratings, School[] schools)> SetupNavigateInitPage(string[]? categories = null, string[]? priorities = null)
+    private async Task<(IHtmlDocument page, Trust trust, RagRating[] ratings, TrustSchool[] schools)> SetupNavigateInitPage(string[]? categories = null, string[]? priorities = null)
     {
         var random = new Random();
 
         var trust = Fixture.Build<Trust>()
             .Create();
 
-        var schools = Fixture.Build<School>()
+        var schools = Fixture.Build<TrustSchool>()
             .With(x => x.OverallPhase, () => OverallPhaseTypes.All.ElementAt(random.Next(0, OverallPhaseTypes.All.Length - 1)))
-            .With(x => x.TrustCompanyNumber, trust.CompanyNumber)
             .CreateMany(20).ToArray();
 
         var ratings = Fixture.Build<RagRating>()
@@ -134,7 +133,7 @@ public partial class WhenViewingSpending(SchoolBenchmarkingWebAppClient client) 
         return (page, trust, ratings, schools);
     }
 
-    private static void AssertPageLayout(IHtmlDocument page, Trust trust, RagRating[] ratings, School[] schools, string[] categories, string[] priorities)
+    private static void AssertPageLayout(IHtmlDocument page, Trust trust, RagRating[] ratings, TrustSchool[] schools, string[] categories, string[] priorities)
     {
         DocumentAssert.AssertPageUrl(page, Paths.TrustSpending(trust.CompanyNumber, categories, priorities).ToAbsolute());
         DocumentAssert.BackLink(page, "Back", Paths.TrustHome(trust.CompanyNumber).ToAbsolute());
@@ -196,7 +195,11 @@ public partial class WhenViewingSpending(SchoolBenchmarkingWebAppClient client) 
                 var school = schools.Single(s => s.SchoolName == name);
                 var rating = ratings.Where(r => r.URN == school.URN);
                 Assert.Contains(value, rating.Select(r => r.Value));
-                Assert.Contains(units, new[] { "per pupil", "per square metre" });
+                Assert.Contains(units, new[]
+                {
+                    "per pupil",
+                    "per square metre"
+                });
 
                 rowCount++;
             }

--- a/web/tests/Web.Tests/ViewModels/GivenATrustPlanningViewModel.cs
+++ b/web/tests/Web.Tests/ViewModels/GivenATrustPlanningViewModel.cs
@@ -1,0 +1,31 @@
+using AutoFixture;
+using Web.App.Domain;
+using Web.App.ViewModels;
+using Xunit;
+namespace Web.Tests.ViewModels;
+
+public class GivenATrustPlanningViewModel
+{
+    private readonly IEnumerable<FinancialPlan> _completePlans;
+    private readonly Fixture _fixture = new();
+    private readonly IEnumerable<FinancialPlan> _incompletePlans;
+    private readonly Trust _trust;
+
+    public GivenATrustPlanningViewModel()
+    {
+        _trust = _fixture.Create<Trust>();
+        _incompletePlans = _fixture.Build<FinancialPlan>().With(p => p.IsComplete, false).CreateMany();
+        _completePlans = _fixture.Build<FinancialPlan>().With(p => p.IsComplete, true).CreateMany();
+    }
+
+    [Fact]
+    public void WhenContainsCompletedPlans()
+    {
+        var result = new TrustPlanningViewModel(_trust, _completePlans.Concat(_incompletePlans).ToArray());
+
+        Assert.Equal(_trust.CompanyNumber, result.CompanyNumber);
+        Assert.Equal(_trust.TrustName, result.Name);
+        Assert.Equal(_trust.Schools, result.Schools);
+        Assert.Equal(_completePlans, result.Plans);
+    }
+}

--- a/web/tests/Web.Tests/ViewModels/GivenATrustSpendingViewModel.cs
+++ b/web/tests/Web.Tests/ViewModels/GivenATrustSpendingViewModel.cs
@@ -1,0 +1,123 @@
+using AutoFixture;
+using Web.App.Domain;
+using Web.App.ViewModels;
+using Xunit;
+namespace Web.Tests.ViewModels;
+
+public class GivenATrustSpendingViewModel
+{
+    private readonly string[] _categories = [Category.EducationalIct, Category.EducationalSupplies, Category.AdministrativeSupplies];
+    private readonly Fixture _fixture = new();
+    private readonly Trust _trust;
+
+    public GivenATrustSpendingViewModel()
+    {
+        _trust = _fixture.Create<Trust>();
+    }
+
+    [Fact]
+    public void WhenContainsHighPriority()
+    {
+        var (viewModel, schools) = BuildViewModel("high");
+
+        Assert.Equal(_trust.CompanyNumber, viewModel.CompanyNumber);
+        Assert.Equal(_trust.TrustName, viewModel.Name);
+        Assert.Equal(schools.Length, viewModel.NumberSchools);
+        Assert.Equal(_categories.Length, viewModel.CostCategories.Length);
+        Assert.True(viewModel.IsPriorityHigh);
+    }
+
+    [Fact]
+    public void WhenContainsRagRatingsByCategory()
+    {
+        var (viewModel, _) = BuildViewModel();
+
+        var resultsByCategory = viewModel.RatingsByCategory.ToList();
+
+        var administrativeSupplies = resultsByCategory.ElementAt(0);
+        Assert.Equal(_categories.ElementAt(2), administrativeSupplies.CostCategory);
+        Assert.Equal("red", administrativeSupplies.Statuses.ElementAt(0).Status);
+        Assert.Equal(["2"], administrativeSupplies.Statuses.ElementAt(0).Schools.Select(s => s.Urn));
+        Assert.Equal("green", administrativeSupplies.Statuses.ElementAt(1).Status);
+        Assert.Equal(["5", "8", "11", "14", "17", "20"], administrativeSupplies.Statuses.ElementAt(1).Schools.Select(s => s.Urn));
+
+        var educationalIct = resultsByCategory.ElementAt(1);
+        Assert.Equal(_categories.ElementAt(0), educationalIct.CostCategory);
+        Assert.Equal("amber", educationalIct.Statuses.ElementAt(0).Status);
+        Assert.Equal(["3"], educationalIct.Statuses.ElementAt(0).Schools.Select(s => s.Urn));
+        Assert.Equal("green", educationalIct.Statuses.ElementAt(1).Status);
+        Assert.Equal(["6", "9", "12", "15", "18"], educationalIct.Statuses.ElementAt(1).Schools.Select(s => s.Urn));
+
+        var educationalSupplies = resultsByCategory.ElementAt(2);
+        Assert.Equal(_categories.ElementAt(1), educationalSupplies.CostCategory);
+        Assert.Equal("red", educationalSupplies.Statuses.ElementAt(0).Status);
+        Assert.Equal(["1"], educationalSupplies.Statuses.ElementAt(0).Schools.Select(s => s.Urn));
+        Assert.Equal("amber", educationalSupplies.Statuses.ElementAt(1).Status);
+        Assert.Equal(["4"], educationalSupplies.Statuses.ElementAt(1).Schools.Select(s => s.Urn));
+        Assert.Equal("green", educationalSupplies.Statuses.ElementAt(2).Status);
+        Assert.Equal(["7", "10", "13", "16", "19"], educationalSupplies.Statuses.ElementAt(2).Schools.Select(s => s.Urn));
+    }
+
+    [Fact]
+    public void WhenContainsRagRatingsByPriority()
+    {
+        var (viewModel, _) = BuildViewModel();
+
+        var resultsByPriority = viewModel.RatingsByPriority.ToList();
+
+        var red = resultsByPriority.ElementAt(0);
+        Assert.Equal("red", red.Status);
+        Assert.Equal(_categories.ElementAt(1), red.Categories.ElementAt(0).Category);
+        Assert.Equal(["1"], red.Categories.ElementAt(0).Schools.Select(s => s.Urn));
+        Assert.Equal(_categories.ElementAt(2), red.Categories.ElementAt(1).Category);
+        Assert.Equal(["2"], red.Categories.ElementAt(1).Schools.Select(s => s.Urn));
+
+        var amber = resultsByPriority.ElementAt(1);
+        Assert.Equal("amber", amber.Status);
+        Assert.Equal(_categories.ElementAt(0), amber.Categories.ElementAt(0).Category);
+        Assert.Equal(["3"], amber.Categories.ElementAt(0).Schools.Select(s => s.Urn));
+        Assert.Equal(_categories.ElementAt(1), amber.Categories.ElementAt(1).Category);
+        Assert.Equal(["4"], amber.Categories.ElementAt(1).Schools.Select(s => s.Urn));
+
+        var green = resultsByPriority.ElementAt(2);
+        Assert.Equal("green", green.Status);
+        Assert.Equal(_categories.ElementAt(2), green.Categories.ElementAt(0).Category);
+        Assert.Equal(["5", "8", "11", "14", "17", "20"], green.Categories.ElementAt(0).Schools.Select(s => s.Urn));
+        Assert.Equal(_categories.ElementAt(0), green.Categories.ElementAt(1).Category);
+        Assert.Equal(["6", "9", "12", "15", "18"], green.Categories.ElementAt(1).Schools.Select(s => s.Urn));
+        Assert.Equal(_categories.ElementAt(1), green.Categories.ElementAt(2).Category);
+        Assert.Equal(["7", "10", "13", "16", "19"], green.Categories.ElementAt(2).Schools.Select(s => s.Urn));
+    }
+
+    private (TrustSpendingViewModel, TrustSchool[] schools) BuildViewModel(params string[] priorities)
+    {
+        var i = 0;
+        var schools = _fixture
+            .Build<TrustSchool>()
+            .With(s => s.URN, () =>
+            {
+                i++;
+                return i.ToString();
+            })
+            .CreateMany(20)
+            .ToArray();
+
+        var ratings = schools.Select(s =>
+        {
+            var j = int.Parse(s.URN!);
+            return new RagRating
+            {
+                URN = s.URN,
+                RAG = j < 3
+                    ? "red"
+                    : j < 5
+                        ? "amber"
+                        : "green",
+                Category = _categories.ElementAt(j % 3)
+            };
+        });
+
+        _trust.Schools = schools;
+        return (new TrustSpendingViewModel(_trust, ratings, _categories, priorities), schools);
+    }
+}

--- a/web/tests/Web.Tests/ViewModels/GivenATrustViewModel.cs
+++ b/web/tests/Web.Tests/ViewModels/GivenATrustViewModel.cs
@@ -86,20 +86,21 @@ public class GivenATrustViewModel
         Assert.Equal(expected, actual);
     }
 
-    private (TrustViewModel, List<School> schools) BuildViewModelForOverallPhase(params string[] overallPhases)
+    private (TrustViewModel, TrustSchool[] schools) BuildViewModelForOverallPhase(params string[] overallPhases)
     {
         var random = new Random();
         var schools = _fixture
-            .Build<School>()
+            .Build<TrustSchool>()
             .With(s => s.OverallPhase, () => overallPhases.ElementAt(random.Next(overallPhases.Length)))
             .CreateMany()
-            .ToList();
+            .ToArray();
 
         var ratings = schools.Select(s => new RagRating
         {
             URN = s.URN
         });
 
-        return (new TrustViewModel(_trust, _balance, schools, ratings), schools);
+        _trust.Schools = schools;
+        return (new TrustViewModel(_trust, _balance, ratings), schools);
     }
 }


### PR DESCRIPTION
### Context
[AB#230397](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/230397) [AB#229325](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/229325)

### Change proposed in this pull request
Perform single API call to obtain Trust and related part-School collection rather than require multiple API calls to achieve the same result.

### Guidance to review 
Build and run Platform and Web locally and then browse to Trust home/census/comparison. Visually, results should be identical before and after this change.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

