### PR TITLE
fix: skip RAG processing for empty comparator-sets

### DIFF
--- a/data-pipeline/src/pipeline/rag.py
+++ b/data-pipeline/src/pipeline/rag.py
@@ -234,7 +234,7 @@ def compute_rag(
                             if rag_settings["type"] == "Pupil"
                             else building_urns
                         )
-                        if set_urns is not None:
+                        if set_urns is not None and len(set_urns) > 0:
                             comparator_set = df[df.index.isin(set_urns)]
 
                             for r in compute_category_rag(


### PR DESCRIPTION
- if the comparator-set is empty, no RAG calculations can be made
- this is already skipped for part-year data but this may occur in other circumstances.