### PR TITLE
Inverted commentary on red RAGs for defined set of cost categories

### DIFF
--- a/web/src/Web.App/Domain/CostCategories.cs
+++ b/web/src/Web.App/Domain/CostCategories.cs
@@ -14,6 +14,8 @@ public class Category(decimal value)
     public const string CateringStaffServices = "Catering staff and supplies";
     public const string Other = "Other costs";
 
+    public static readonly string[] InvertRagValueCategories = [TeachingStaff, EducationalSupplies, EducationalIct];
+
     public decimal Value => value;
 
     public static string? FromSlug(string? slug)

--- a/web/src/Web.App/ViewModels/SchoolSpendingViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolSpendingViewModel.cs
@@ -64,3 +64,8 @@ public class CostsViewModel
     public bool HasIncompleteData { get; init; }
     public bool IsCustomData { get; set; }
 }
+
+public class RagRatingCommentaryViewModel
+{
+    public RagRating Rating { get; init; }
+}

--- a/web/src/Web.App/Views/School/Index.cshtml
+++ b/web/src/Web.App/Views/School/Index.cshtml
@@ -1,4 +1,3 @@
-@using Web.App.Domain
 @using Web.App.Extensions
 @using Web.App.TagHelpers
 @using Web.App.ViewModels
@@ -95,17 +94,11 @@
                                 {
                                     rating = new RatingViewModel(rating.PriorityTag?.Colour, rating.PriorityTag?.DisplayText)
                                 })
-                                Spends <strong>@rating.Value.ToCurrency(0)</strong> @rating.Unit — Spending is
-                                @if (rating.RAG == "red" && Category.InvertRagValueCategories.Contains(rating.Category))
+                                Spends <strong>@rating.Value.ToCurrency(0)</strong> @rating.Unit —
+                                @await Html.PartialAsync("_RagRatingCommentary", new RagRatingCommentaryViewModel
                                 {
-                                    @:lower than <strong>@((100 - rating.Percentile).ToPercent())</strong>
-                                }
-                                else
-                                {
-                                    @:higher than
-                                    <strong>@rating.Percentile.ToPercent()</strong>
-                                }
-                                of similar schools.
+                                    Rating = rating
+                                })
                             </p>
                         </div>
                     }

--- a/web/src/Web.App/Views/School/Index.cshtml
+++ b/web/src/Web.App/Views/School/Index.cshtml
@@ -1,3 +1,4 @@
+@using Web.App.Domain
 @using Web.App.Extensions
 @using Web.App.TagHelpers
 @using Web.App.ViewModels
@@ -8,7 +9,7 @@
 }
 
 @if (Model is { PeriodCoveredByReturn: < 12 })
-{ 
+{
     @await Html.PartialAsync("_IncompleteFinances")
 }
 
@@ -17,9 +18,12 @@
         <h1 class="govuk-heading-l govuk-!-margin-bottom-1">@Model.Name</h1>
         <p class="govuk-body">
             @Html.TrackedAnchor(
-            TrackedLinks.ChangeOrganisation,
-            Url.Action("Index", "FindOrganisation", new { method = OrganisationTypes.School }) ?? "",
-            "Change school")
+                TrackedLinks.ChangeOrganisation,
+                Url.Action("Index", "FindOrganisation", new
+                {
+                    method = OrganisationTypes.School
+                }) ?? "",
+                "Change school")
         </p>
     </div>
 </div>
@@ -91,7 +95,17 @@
                                 {
                                     rating = new RatingViewModel(rating.PriorityTag?.Colour, rating.PriorityTag?.DisplayText)
                                 })
-                                Spends <strong>@rating.Value.ToCurrency(0)</strong> @rating.Unit — Spending is higher than <strong>@rating.Percentile.ToPercent()</strong> of similar schools.
+                                Spends <strong>@rating.Value.ToCurrency(0)</strong> @rating.Unit — Spending is
+                                @if (rating.RAG == "red" && Category.InvertRagValueCategories.Contains(rating.Category))
+                                {
+                                    @:lower than <strong>@((100 - rating.Percentile).ToPercent())</strong>
+                                }
+                                else
+                                {
+                                    @:higher than
+                                    <strong>@rating.Percentile.ToPercent()</strong>
+                                }
+                                of similar schools.
                             </p>
                         </div>
                     }
@@ -146,4 +160,3 @@
       initAll()
     </script>
 }
-

--- a/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
@@ -1,18 +1,17 @@
-@using Web.App.Extensions
 @using Newtonsoft.Json
-@using Web.App.ViewModels
 @using Web.App.Domain
-
-@model CostsViewModel
+@using Web.App.Extensions
+@using Web.App.ViewModels
+@model Web.App.ViewModels.CostsViewModel
 
 @if (Model.Costs.Any())
 {
     var costs = Model.Costs.ToList();
-        
+
     @for (var i = 0; i < costs.Count; i++)
     {
         var category = costs[i];
-        
+
         var categoryToLower = category.Rating.Category switch
         {
             Category.Other => "other",
@@ -25,16 +24,35 @@
             : category.Rating.Category;
 
         var categoryUri = Model.IsCustomData
-            ? Url.Action("CustomData", "SchoolComparison", new { urn = Model.Urn })
-            : Url.Action("Index", "SchoolComparison", new { urn = Model.Urn });
+            ? Url.Action("CustomData", "SchoolComparison", new
+            {
+                urn = Model.Urn
+            })
+            : Url.Action("Index", "SchoolComparison", new
+            {
+                urn = Model.Urn
+            });
 
         <div class="govuk-grid-row govuk-!-margin-bottom-4"
              @(i == 0 ? $"id={Model.Id}" : "")>
             <div class="govuk-grid-column-two-thirds">
                 <h3 class="govuk-heading-s govuk-!-font-size-27">@categoryHeading</h3>
                 <p class="priority @category.Rating.PriorityTag?.Class govuk-body govuk-!-margin-bottom-0">
-                    @await Component.InvokeAsync("Tag", new { rating = new RatingViewModel(category.Rating.PriorityTag?.Colour, category.Rating.PriorityTag?.DisplayText) })
-                    Spending is higher than <strong>@category.Rating.Percentile.ToPercent()</strong> of similar schools.
+                    @await Component.InvokeAsync("Tag", new
+                    {
+                        rating = new RatingViewModel(category.Rating.PriorityTag?.Colour, category.Rating.PriorityTag?.DisplayText)
+                    })
+                    Spending is
+                    @if (category.Rating.RAG == "red" && Category.InvertRagValueCategories.Contains(category.Rating.Category))
+                    {
+                        @:lower than <strong>@((100 - category.Rating.Percentile).ToPercent())</strong>
+                    }
+                    else
+                    {
+                        @:higher than
+                        <strong>@category.Rating.Percentile.ToPercent()</strong>
+                    }
+                    of similar schools.
                 </p>
                 <div class="govuk-!-margin-bottom-2 composed-container"
                      data-spending-and-costs-composed

--- a/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
@@ -42,17 +42,10 @@
                     {
                         rating = new RatingViewModel(category.Rating.PriorityTag?.Colour, category.Rating.PriorityTag?.DisplayText)
                     })
-                    Spending is
-                    @if (category.Rating.RAG == "red" && Category.InvertRagValueCategories.Contains(category.Rating.Category))
+                    @await Html.PartialAsync("_RagRatingCommentary", new RagRatingCommentaryViewModel
                     {
-                        @:lower than <strong>@((100 - category.Rating.Percentile).ToPercent())</strong>
-                    }
-                    else
-                    {
-                        @:higher than
-                        <strong>@category.Rating.Percentile.ToPercent()</strong>
-                    }
-                    of similar schools.
+                        Rating = category.Rating
+                    })
                 </p>
                 <div class="govuk-!-margin-bottom-2 composed-container"
                      data-spending-and-costs-composed

--- a/web/src/Web.App/Views/Shared/_RagRatingCommentary.cshtml
+++ b/web/src/Web.App/Views/Shared/_RagRatingCommentary.cshtml
@@ -3,9 +3,9 @@
 @model Web.App.ViewModels.RagRatingCommentaryViewModel
 
 Spending is
-@if (Model.Rating.RAG == "red" && Category.InvertRagValueCategories.Contains(Model.Rating.Category))
+@if (Model.Rating.Percentile < 50 && Category.InvertRagValueCategories.Contains(Model.Rating.Category))
 {
-    @:lower than <strong>@((100 - Model.Rating.Percentile).ToPercent())</strong>
+    @:less than <strong>@((100 - Model.Rating.Percentile).ToPercent())</strong>
 }
 else
 {

--- a/web/src/Web.App/Views/Shared/_RagRatingCommentary.cshtml
+++ b/web/src/Web.App/Views/Shared/_RagRatingCommentary.cshtml
@@ -1,0 +1,15 @@
+@using Web.App.Domain
+@using Web.App.Extensions
+@model Web.App.ViewModels.RagRatingCommentaryViewModel
+
+Spending is
+@if (Model.Rating.RAG == "red" && Category.InvertRagValueCategories.Contains(Model.Rating.Category))
+{
+    @:lower than <strong>@((100 - Model.Rating.Percentile).ToPercent())</strong>
+}
+else
+{
+    @:higher than
+    <strong>@Model.Rating.Percentile.ToPercent()</strong>
+}
+of similar schools.

--- a/web/tests/Web.E2ETests/Features/School/SchoolHome.feature
+++ b/web/tests/Web.E2ETests/Features/School/SchoolHome.feature
@@ -44,6 +44,6 @@
         Given I am on school homepage for school with urn '777042'
         Then the RAG commentary for each priority category is
           | Name                                | Commentary                                                                               |
-          | Teaching and Teaching support staff | High priority Spends £6,315 per pupil — Spending is lower than 1% of similar schools.    |
+          | Teaching and Teaching support staff | High priority Spends £6,315 per pupil — Spending is higher than 99% of similar schools.  |
           | Non-educational support staff       | High priority Spends £845 per pupil — Spending is higher than 95.67% of similar schools. |
           | Administrative supplies             | High priority Spends £429 per pupil — Spending is higher than 99% of similar schools.    |

--- a/web/tests/Web.E2ETests/Features/School/SchoolHome.feature
+++ b/web/tests/Web.E2ETests/Features/School/SchoolHome.feature
@@ -39,3 +39,11 @@
         Given I am on part year school homepage for school with urn '777043'
         When I click on compare your costs
         Then the compare your costs page is displayed for part year
+
+    Scenario: Top priority categories have the correct RAG commentary
+        Given I am on school homepage for school with urn '777042'
+        Then the RAG commentary for each priority category is
+          | Name                                | Commentary                                                                               |
+          | Teaching and Teaching support staff | High priority Spends £6,315 per pupil — Spending is lower than 1% of similar schools.    |
+          | Non-educational support staff       | High priority Spends £845 per pupil — Spending is higher than 95.67% of similar schools. |
+          | Administrative supplies             | High priority Spends £429 per pupil — Spending is higher than 99% of similar schools.    |

--- a/web/tests/Web.E2ETests/Features/School/SpendingCosts.feature
+++ b/web/tests/Web.E2ETests/Features/School/SpendingCosts.feature
@@ -18,15 +18,15 @@
         Given I am on spending and costs page for school with URN '777042'
         Then the RAG commentary for each category is
           | Name                                | Commentary                                         |
-          | Teaching and Teaching support staff | Spending is lower than 1% of similar schools.      |
+          | Teaching and Teaching support staff | Spending is higher than 99% of similar schools.    |
           | Non-educational support staff       | Spending is higher than 95.67% of similar schools. |
           | Administrative supplies             | Spending is higher than 99% of similar schools.    |
-          | Educational supplies                | Spending is lower than 1% of similar schools.      |
+          | Educational supplies                | Spending is higher than 99% of similar schools.    |
           | Catering staff and supplies         | Spending is higher than 92.33% of similar schools. |
           | Premises staff and services         | Spending is higher than 99% of similar schools.    |
           | Other costs                         | Spending is higher than 89% of similar schools.    |
           | Utilities                           | Spending is higher than 39% of similar schools.    |
-          | Educational ICT                     | Spending is higher than 22.33% of similar schools. |
+          | Educational ICT                     | Spending is less than 77.67% of similar schools.   |
 
     Scenario Outline: Click on view all links for each chart
         Given I am on spending and costs page for school with URN '777042'

--- a/web/tests/Web.E2ETests/Features/School/SpendingCosts.feature
+++ b/web/tests/Web.E2ETests/Features/School/SpendingCosts.feature
@@ -1,31 +1,47 @@
 ﻿Feature: School spending and costs
 
+    Scenario: Categories in the correct priority order
+        Given I am on spending and costs page for school with URN '777042'
+        Then the priority order of charts is
+          | Name                                | Priority        |
+          | Teaching and Teaching support staff | High priority   |
+          | Non-educational support staff       | High priority   |
+          | Administrative supplies             | High priority   |
+          | Educational supplies                | High priority   |
+          | Catering staff and supplies         | High priority   |
+          | Premises staff and services         | High priority   |
+          | Other costs                         | High priority   |
+          | Utilities                           | Medium priority |
+          | Educational ICT                     | Medium priority |
+
+    Scenario: Categories have the correct RAG commentary
+        Given I am on spending and costs page for school with URN '777042'
+        Then the RAG commentary for each category is
+          | Name                                | Commentary                                         |
+          | Teaching and Teaching support staff | Spending is lower than 1% of similar schools.      |
+          | Non-educational support staff       | Spending is higher than 95.67% of similar schools. |
+          | Administrative supplies             | Spending is higher than 99% of similar schools.    |
+          | Educational supplies                | Spending is lower than 1% of similar schools.      |
+          | Catering staff and supplies         | Spending is higher than 92.33% of similar schools. |
+          | Premises staff and services         | Spending is higher than 99% of similar schools.    |
+          | Other costs                         | Spending is higher than 89% of similar schools.    |
+          | Utilities                           | Spending is higher than 39% of similar schools.    |
+          | Educational ICT                     | Spending is higher than 22.33% of similar schools. |
 
     Scenario Outline: Click on view all links for each chart
         Given I am on spending and costs page for school with URN '777042'
-        And the priority order of charts is
-          | Name                                       | Priority        |
-          | Teaching and Teaching support staff        | High priority   |
-          | Non-educational support staff | High priority   |
-          | Administrative supplies                    | High priority   |
-          | Educational supplies                       | High priority   |
-          | Catering staff and supplies                | High priority   |
-          | Premises staff and services                | High priority   |
-          | Other costs                                | High priority   |
-          | Utilities                                  | Medium priority |
-          | Educational ICT                            | Medium priority |
         When I click on view all '<CostCategory>' link
         Then I am directed to compare your costs page
         And the accordion '<CostCategory>'is expanded
 
         Examples:
-          | CostCategory                               |
-          |Teaching and Teaching support staff         |
-          | Non-educational support staff |
-          | Administrative supplies                    |
-          | Educational supplies                       |
-          | Catering staff and supplies                |
-          | Premises staff and services                |
-          | Other costs                                |
-          | Utilities                                  |
-          | Educational ICT                            |
+          | CostCategory                        |
+          | Teaching and Teaching support staff |
+          | Non-educational support staff       |
+          | Administrative supplies             |
+          | Educational supplies                |
+          | Catering staff and supplies         |
+          | Premises staff and services         |
+          | Other costs                         |
+          | Utilities                           |
+          | Educational ICT                     |

--- a/web/tests/Web.E2ETests/Pages/School/HomePage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/HomePage.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Playwright;
+using Xunit;
 namespace Web.E2ETests.Pages.School;
 
 public class HomePage(IPage page)
@@ -137,5 +138,17 @@ public class HomePage(IPage page)
     public async Task CookieBannerIsDisplayed()
     {
         await CookieBanner.ShouldBeVisible();
+    }
+
+    public async Task AssertRagCommentary(string categoryName, string commentary)
+    {
+        var categoryHeader = page.Locator("h4").And(page.GetByText(categoryName));
+        Assert.NotNull(categoryHeader);
+
+        var priority = categoryHeader.Locator("//following-sibling::p[1]");
+        Assert.NotNull(priority);
+
+        var text = await priority.InnerTextAsync();
+        Assert.Equal(commentary, text);
     }
 }

--- a/web/tests/Web.E2ETests/Pages/School/SpendingCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/SpendingCostsPage.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Playwright;
 using Xunit;
-
 namespace Web.E2ETests.Pages.School;
 
 public enum CostCategoryNames
@@ -20,9 +19,15 @@ public class SpendingCostsPage(IPage page)
 {
     private readonly string[] _h3Names =
     {
-        "Teaching and Teaching support staff", "Administrative supplies", "Catering staff and supplies",
-        "Educational ICT", "Educational supplies", "Non-educational support staff", "Other costs",
-        "Premises staff and services", "Utilities"
+        "Teaching and Teaching support staff",
+        "Administrative supplies",
+        "Catering staff and supplies",
+        "Educational ICT",
+        "Educational supplies",
+        "Non-educational support staff",
+        "Other costs",
+        "Premises staff and services",
+        "Utilities"
     };
 
     private ILocator PageH1Heading => page.Locator(Selectors.H1);
@@ -30,38 +35,68 @@ public class SpendingCostsPage(IPage page)
 
     private ILocator ComparatorSetDetails =>
         page.Locator(Selectors.GovDetailsSummaryText,
-            new PageLocatorOptions { HasText = "How we choose and compare similar schools" });
+            new PageLocatorOptions
+            {
+                HasText = "How we choose and compare similar schools"
+            });
 
     private ILocator PageH3Headings => page.Locator(Selectors.H3);
     private ILocator AllCharts => page.Locator(Selectors.ReactChartContainer);
     private ILocator AllChartsStats => page.Locator(Selectors.ReactChartStats);
 
     private ILocator TeachingAndTeachingSupplyStaffLink => page.Locator(Selectors.GovLink,
-        new PageLocatorOptions { HasText = "View all teaching and teaching support staff" });
+        new PageLocatorOptions
+        {
+            HasText = "View all teaching and teaching support staff"
+        });
 
     private ILocator AdministrativeSuppliesLink => page.Locator(Selectors.GovLink,
-        new PageLocatorOptions { HasText = "View all administrative supplies costs" });
+        new PageLocatorOptions
+        {
+            HasText = "View all administrative supplies costs"
+        });
 
     private ILocator CateringStaffAndServicesLink => page.Locator(Selectors.GovLink,
-        new PageLocatorOptions { HasText = "View all catering staff and supplies costs" });
+        new PageLocatorOptions
+        {
+            HasText = "View all catering staff and supplies costs"
+        });
 
     private ILocator EducationalIctLink => page.Locator(Selectors.GovLink,
-        new PageLocatorOptions { HasText = "View all Educational ICT costs" });
+        new PageLocatorOptions
+        {
+            HasText = "View all Educational ICT costs"
+        });
 
     private ILocator EducationalSuppliesLink => page.Locator(Selectors.GovLink,
-        new PageLocatorOptions { HasText = "View all educational supplies costs" });
+        new PageLocatorOptions
+        {
+            HasText = "View all educational supplies costs"
+        });
 
     private ILocator NonEducationalSupportStaffLink => page.Locator(Selectors.GovLink,
-        new PageLocatorOptions { HasText = "View all non-educational support staff" });
+        new PageLocatorOptions
+        {
+            HasText = "View all non-educational support staff"
+        });
 
     private ILocator OtherLink => page.Locator(Selectors.GovLink,
-        new PageLocatorOptions { HasText = "View all other costs" });
+        new PageLocatorOptions
+        {
+            HasText = "View all other costs"
+        });
 
     private ILocator PremisesStaffAndServicesLink => page.Locator(Selectors.GovLink,
-        new PageLocatorOptions { HasText = "View all premises staff and services costs" });
+        new PageLocatorOptions
+        {
+            HasText = "View all premises staff and services costs"
+        });
 
     private ILocator UtilitiesLink => page.Locator(Selectors.GovLink,
-        new PageLocatorOptions { HasText = "View all utilities" });
+        new PageLocatorOptions
+        {
+            HasText = "View all utilities"
+        });
 
     private ILocator PriorityTags => page.Locator($"{Selectors.MainContent} {Selectors.GovukTag}");
 
@@ -78,18 +113,22 @@ public class SpendingCostsPage(IPage page)
     }
 
 
-    public async Task CheckOrderOfCharts(List<string[]> expectedOrder)
+    public async Task AssertOrderOfCharts(List<string[]> expectedOrder)
     {
         var actualOrder = new List<string[]>();
         var chartNames = await GetCategoryNames();
         var priorityTags = await PriorityTags.AllAsync();
-        for (int i = 0; i < chartNames.Count; i++)
+        for (var i = 0; i < chartNames.Count; i++)
         {
             if (i < priorityTags.Count)
             {
                 var chartName = chartNames[i];
                 var priorityTag = await priorityTags[i].TextContentAsync() ?? string.Empty;
-                var chartDetails = new[] { chartName, priorityTag.Trim() };
+                var chartDetails = new[]
+                {
+                    chartName,
+                    priorityTag.Trim()
+                };
                 actualOrder.Add(chartDetails);
             }
             else
@@ -99,6 +138,18 @@ public class SpendingCostsPage(IPage page)
             }
         }
         Assert.Equal(expectedOrder, actualOrder);
+    }
+
+    public async Task AssertRagCommentary(string categoryName, string commentary)
+    {
+        var categoryHeader = page.Locator("h3").And(page.GetByText(categoryName));
+        Assert.NotNull(categoryHeader);
+
+        var priority = categoryHeader.Locator("//following-sibling::p[1]");
+        Assert.NotNull(priority);
+
+        var text = await priority.InnerTextAsync();
+        Assert.EndsWith(commentary, text);
     }
 
     public async Task<CompareYourCostsPage> ClickOnLink(CostCategoryNames costCategory)

--- a/web/tests/Web.E2ETests/Steps/School/HomeSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/HomeSteps.cs
@@ -2,21 +2,20 @@
 using Web.E2ETests.Drivers;
 using Web.E2ETests.Pages.School;
 using Xunit;
-
 namespace Web.E2ETests.Steps.School;
 
 [Binding]
 [Scope(Feature = "School homepage")]
 public class HomeSteps(PageDriver driver)
 {
-    private HomePage? _schoolHomePage;
-    private DetailsPage? _schoolDetailsPage;
+    private BenchmarkCensusPage? _benchmarkCensusPage;
+    private CommercialResourcesPage? _commercialResourcesPage;
     private CompareYourCostsPage? _compareYourCostsPage;
     private CurriculumFinancialPlanningPage? _curriculumAndFinancialPlanningPage;
-    private BenchmarkCensusPage? _benchmarkCensusPage;
-    private SpendingCostsPage? _spendingCostsPage;
-    private CommercialResourcesPage? _commercialResourcesPage;
     private HistoricDataPage? _historicDataPage;
+    private DetailsPage? _schoolDetailsPage;
+    private HomePage? _schoolHomePage;
+    private SpendingCostsPage? _spendingCostsPage;
 
     [Given("I am on school homepage for school with urn '(.*)'")]
     public async Task GivenIAmOnSchoolHomepageForSchoolWithUrn(string urn)
@@ -98,7 +97,10 @@ public class HomeSteps(PageDriver driver)
             await page.Locator("h1:text-is('Enter your password')").CheckVisible();
             await page.Locator("input[id='password']").Fill(TestConfiguration.LoginPassword);
             await page.Locator("button[type='submit']").Click();
-            await page.Locator("label", new PageLocatorOptions { HasTextString = "01: FBIT TEST - Community School (Open)" }).Check();
+            await page.Locator("label", new PageLocatorOptions
+            {
+                HasTextString = "01: FBIT TEST - Community School (Open)"
+            }).Check();
             await page.Locator("input[type='submit']").Click();
         }
         else
@@ -167,5 +169,15 @@ public class HomeSteps(PageDriver driver)
     {
         Assert.NotNull(_historicDataPage);
         await _historicDataPage.IsDisplayed();
+    }
+
+    [Then("the RAG commentary for each priority category is")]
+    public async Task ThenTheRagCommentaryForEachPriorityCategoryIs(DataTable table)
+    {
+        Assert.NotNull(_schoolHomePage);
+        foreach (var row in table.Rows)
+        {
+            await _schoolHomePage.AssertRagCommentary(row["Name"], row["Commentary"]);
+        }
     }
 }

--- a/web/tests/Web.E2ETests/Steps/School/SpendingCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/SpendingCostsSteps.cs
@@ -21,8 +21,8 @@ public class SpendingCostsSteps(PageDriver driver)
         await _spendingCostsPage.IsDisplayed();
     }
 
-    [Given("the priority order of charts is")]
-    public async Task GivenThePriorityOrderOfChartsIs(DataTable table)
+    [Then("the priority order of charts is")]
+    public async Task ThenThePriorityOrderOfChartsIs(DataTable table)
     {
         Assert.NotNull(_spendingCostsPage);
         var expectedOrder = new List<string[]>();
@@ -36,7 +36,17 @@ public class SpendingCostsSteps(PageDriver driver)
             expectedOrder.Add(chartPriorityArray);
         }
 
-        await _spendingCostsPage.CheckOrderOfCharts(expectedOrder);
+        await _spendingCostsPage.AssertOrderOfCharts(expectedOrder);
+    }
+
+    [Then("the RAG commentary for each category is")]
+    public async Task ThenTheRagCommentaryForEachCategoryIs(DataTable table)
+    {
+        Assert.NotNull(_spendingCostsPage);
+        foreach (var row in table.Rows)
+        {
+            await _spendingCostsPage.AssertRagCommentary(row["Name"], row["Commentary"]);
+        }
     }
 
     [When("I click on view all '(.*)' link")]


### PR DESCRIPTION
### Context
[AB#230746](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/230746) [AB#230538](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/230538)

### Change proposed in this pull request
For the following Cost Categories and if High priority RAG displayed, invert the commentary:
- Teaching and Teaching support staff
- Educational supplies
- Educational ICT

### Guidance to review 
Change may be validated on School home and School spending priorities pages. Sample URNs for schools that should display the updated content: 
- 131251
- 140575

Categories not listed above, or are otherwise not marked as High priority should be unaffected.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

