### PR TITLE
fix: remove semicolons in migrations

### DIFF
--- a/core-infrastructure/src/db/Core.Database/Scripts/014-RebuildFinancialTable.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/014-RebuildFinancialTable.sql
@@ -5,7 +5,7 @@ IF EXISTS(SELECT *
         DROP TABLE dbo.Financial
     END;
 
-GO;
+GO
 
 IF NOT EXISTS(SELECT *
               FROM INFORMATION_SCHEMA.TABLES

--- a/core-infrastructure/src/db/Core.Database/Scripts/024-RebuildFinancialTableCentralServices.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/024-RebuildFinancialTableCentralServices.sql
@@ -5,7 +5,7 @@ IF EXISTS(SELECT *
         DROP TABLE dbo.Financial
     END;
 
-GO;
+GO
 
 IF NOT EXISTS(SELECT *
               FROM INFORMATION_SCHEMA.TABLES


### PR DESCRIPTION
Trailing semicolons causing failures during local migrations:

```sh
../core-infrastructure/src/db/Core.Database/Scripts/014-RebuildFinancialTable.sql
Msg 102, Level 15, State 1, Server f4594901140e, Line 8
Incorrect syntax near 'GO'.
```