### PR TITLE
Set chart bar colour for 'other' part-year schools in a comparator set

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -99,8 +99,8 @@
       data-id="02387916"
       data-phases='["Secondary","Primary","Post-16"]'
     ></div>-->
-    <!--<div id="compare-your-costs" data-type="school" data-id="143996"></div>-->
-    <div id="historic-data" data-type="school" data-id="990095"></div>
+    <div id="compare-your-costs" data-type="school" data-id="143996"></div>
+    <!--<div id="historic-data" data-type="school" data-id="990095"></div>-->
     <!--<div
       id="compare-your-costs"
       data-type="local-authority"

--- a/front-end-components/src/index.css
+++ b/front-end-components/src/index.css
@@ -129,6 +129,11 @@
 }
 
 .recharts-wrapper .chart-cell.chart-cell-part-year {
+  stroke: var(--warning-colour-bg);
+  fill: var(--warning-colour-bg);
+}
+
+.recharts-wrapper .chart-cell.chart-cell-part-year.chart-cell-highlight {
   stroke: var(--warning-colour);
   fill: var(--warning-colour);
 }


### PR DESCRIPTION
### Context
[AB#230801](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/230801) [AB#230800](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/230800)

### Guidance to review 
Locate a benchmark page for a school with comparators that are part-year to validate the change. e.g. URN `143996`

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~~Your code builds clean without any errors or warnings~~
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

