### PR TITLE
fix: remove default-median values for columns

### DIFF
--- a/data-pipeline/src/pipeline/part_year/common.py
+++ b/data-pipeline/src/pipeline/part_year/common.py
@@ -10,19 +10,12 @@ def map_has_pupil_comparator_data(df: pd.DataFrame) -> pd.DataFrame:
 
     Specifically, this is the FSM and SEN data.
 
-    Note: "Number of pupils" is specifically excluded as this value is
-    previously set to the _median_ if absent.
-
     :param df: academy/school data
     :return: updated DataFrame
     """
-    pupil_comparator_columns = [
-        column
-        for column in set(
-            list(config.census_column_map.values()) + config.sen_generated_columns
-        )
-        if column != "Number of pupils"
-    ]
+    pupil_comparator_columns = list(
+        set(list(config.census_column_map.values()) + config.sen_generated_columns)
+    )
 
     df["Pupil Comparator Data Present"] = (
         ~df[pupil_comparator_columns].isna().all(axis=1)
@@ -40,17 +33,10 @@ def map_has_building_comparator_data(
 
     Specifically, this is the CDC data.
 
-    Note: "Total Internal Floor Area" is specifically excluded as this
-    value is previously set to the _median_ if absent.
-
     :param maintained_schools: maintained schools data
     :return: updated DataFrame
     """
-    building_comparator_columns = [
-        column
-        for column in config.cdc_generated_columns
-        if column != "Total Internal Floor Area"
-    ]
+    building_comparator_columns = list(config.cdc_generated_columns)
 
     maintained_schools["Building Comparator Data Present"] = (
         ~maintained_schools[building_comparator_columns].isna().all(axis=1)

--- a/data-pipeline/src/pipeline/pre_processing.py
+++ b/data-pipeline/src/pipeline/pre_processing.py
@@ -1,7 +1,5 @@
 import datetime
-import io
 import logging
-import struct
 from warnings import simplefilter
 
 import numpy as np
@@ -716,15 +714,6 @@ def build_academy_data(
 
     if ks4 is not None:
         academies = academies.merge(ks4, on="URN", how="left")
-
-    academies["Total Internal Floor Area"] = academies[
-        "Total Internal Floor Area"
-    ].fillna(academies["Total Internal Floor Area"].median())
-
-    # TODO: necessary for apportionment?
-    academies["Number of pupils"] = academies["Number of pupils"].fillna(
-        academies["Number of pupils"].median()
-    )
 
     academies["Overall Phase"] = academies.apply(
         lambda df: mappings.map_phase_type(


### PR DESCRIPTION
### Context

`Number of pupils` and `Total Internal Floor Area` should _not_ have default values where missing, to avoid misrepresenting data.

[AB#231997](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/231997)

### Change proposed in this pull request

- remove the code which sets missing values for `Number of pupils` and `Total Internal Floor Area` to the collective median.
- remove the part-year checks which previously ignored those columns (as they would always contain a value).

### Guidance to review 

Pipeline has been run locally and successfully created comparator sets for all Schools/Academies.

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

