### PR TITLE
Replaced hard-coded app settings in Web app service with Key Vault references

### DIFF
--- a/pipelines/destroy/release.yaml
+++ b/pipelines/destroy/release.yaml
@@ -36,11 +36,11 @@ parameters:
       - No
 
 variables:
-  Version.BranchRevision: $[counter(variables['Build.SourceBranchName'], 0)]
+  Environment.Name: ${{ parameters.environment }}
+  Version.BranchRevision: $[counter(variables['Environment.Name'], 100)]
   Version.FeatureEnvironment: ${{ parameters.featureEnvironment }}
   Version.BuildNumber: 0.$(Version.FeatureEnvironment).$(Version.BranchRevision)
   Version.BuildVersion: $(Version.BuildNumber)
-  Environment.Name: ${{ parameters.environment }}
   Pipeline.Environment: 'destroy'
   Subscription: 's198d.azdo-deployment'
   ShouldDestroy: $[eq('${{ parameters.areYouSure }}', 'Yes')]

--- a/pipelines/feature/release.yaml
+++ b/pipelines/feature/release.yaml
@@ -29,11 +29,11 @@ parameters:
       - 19
 
 variables:
-  Version.BranchRevision: $[counter(variables['Build.SourceBranchName'], 0)]
+  Environment.Name: ${{ parameters.environment }}
+  Version.BranchRevision: $[counter(variables['Environment.Name'], 100)]
   Version.FeatureEnvironment: ${{ parameters.featureEnvironment }}
   Version.BuildNumber: 0.$(Version.FeatureEnvironment).$(Version.BranchRevision)
   Version.BuildVersion: $(Version.BuildNumber)
-  Environment.Name: ${{ parameters.environment }}
   Pipeline.Environment: 'feature'
   Subscription: 's198d.azdo-deployment'
   WorkingDir.Core: 'core-infrastructure'
@@ -69,7 +69,7 @@ stages:
               echo "##vso[build.addbuildtag]Environment $(Version.FeatureEnvironment)"
 
               branchRevision=$(Version.BranchRevision)
-              echo "##vso[task.setvariable variable=Version_FrontEnd;isOutput=true]0.$(Version.FeatureEnvironment).$((branchRevision + 1))-$environmentPrefix.0"
+              echo "##vso[task.setvariable variable=Version_FrontEnd;isOutput=true]$(Version.BuildNumber)-$environmentPrefix.0"
             displayName: 'Set release build number'
             name: outputVars
 
@@ -173,26 +173,16 @@ stages:
     dependsOn: [ BuildNumber, BuildPlatform ]
     displayName: 'Front-end : Build and Publish'
     variables: 
-      environmentPrefix: $[ stageDependencies.BuildNumber.SetBuildNumber.outputs['outputVars.Environment_Prefix'] ]
+      frontEndVersion: $[ stageDependencies.BuildNumber.SetBuildNumber.outputs['outputVars.Version_FrontEnd'] ]
     jobs:
       - job: BuildAndRPublishFrontEnd
         displayName: 'Build and publish'
         steps:
           - task: Npm@1
             displayName: 'Update version number'
-            continueOnError: false
             inputs:
               command: 'custom'
-              customCommand: 'version $(Version.BuildNumber)'
-              workingDir: $(WorkingDir.FrontEnd)
-              verbose: false
-
-          - task: Npm@1
-            displayName: 'Update pre-release version number'
-            continueOnError: false
-            inputs:
-              command: 'custom'
-              customCommand: 'version prerelease -preid=$(environmentPrefix)'
+              customCommand: 'version $(frontEndVersion)'
               workingDir: $(WorkingDir.FrontEnd)
               verbose: false
 

--- a/web/terraform/README.md
+++ b/web/terraform/README.md
@@ -35,6 +35,11 @@ No modules.
 | [azurerm_cosmosdb_sql_container.session-cache-container](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_sql_container) | resource |
 | [azurerm_cosmosdb_sql_database.session-cache-database](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_sql_database) | resource |
 | [azurerm_cosmosdb_sql_role_assignment.app-service-cache](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_sql_role_assignment) | resource |
+| [azurerm_key_vault_access_policy.keyvault_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_secret.data-web-storage-connection-string](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.dfe-signin-api-secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.dfe-signin-client-secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.session-cache-account-connection-string](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_monitor_diagnostic_setting.front-door-analytics](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_resource_group.resource-group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_service_plan.education-benchmarking-asp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_plan) | resource |

--- a/web/terraform/cache.tf
+++ b/web/terraform/cache.tf
@@ -54,3 +54,11 @@ resource "azurerm_cosmosdb_sql_role_assignment" "app-service-cache" {
   # see https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-setup-rbac#built-in-role-definitions
   role_definition_id = "${azurerm_cosmosdb_account.session-cache-account.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
 }
+
+resource "azurerm_key_vault_secret" "session-cache-account-connection-string" {
+  #checkov:skip=CKV_AZURE_41:See ADO backlog AB#232052
+  name         = "session-cache-account-connection-string"
+  value        = "AccountEndpoint=${azurerm_cosmosdb_account.session-cache-account.endpoint}"
+  key_vault_id = data.azurerm_key_vault.key-vault.id
+  content_type = "connection-string"
+}

--- a/web/terraform/storage.tf
+++ b/web/terraform/storage.tf
@@ -52,3 +52,11 @@ resource "azurerm_storage_container" "return-container" {
   name                 = "returns"
   storage_account_name = azurerm_storage_account.data-source-storage.name
 }
+
+resource "azurerm_key_vault_secret" "data-web-storage-connection-string" {
+  #checkov:skip=CKV_AZURE_41:See ADO backlog AB#232052
+  name         = "data-web-storage-connection-string"
+  value        = azurerm_storage_account.data-source-storage.primary_connection_string
+  key_vault_id = data.azurerm_key_vault.key-vault.id
+  content_type = "connection-string"
+}


### PR DESCRIPTION
### Context
[AB#231984](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/231984) [AB#230754](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/230754)

### Change proposed in this pull request
Also fixed Feature pipeline versioning to not generate conflicts when publishing front-end-components.

### Guidance to review 
This has been pushed out to the `d12` feature environment. The Kudu tool may be used to validate the resolved configuration settings. At Web app service level the Key Vault references for any secrets should be used instead. To validate the underlying values, self-assign permission to Key Vault via Access Policies.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~~Your code builds clean without any errors or warnings~~
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

