### PR TITLE
fix: remove processing of 1-day Academies

### DIFF
--- a/data-pipeline/src/pipeline/comparator_sets.py
+++ b/data-pipeline/src/pipeline/comparator_sets.py
@@ -302,8 +302,7 @@ def _map_pupil_comparator_set(row: pd.Series) -> bool:
     """
     Whether to generate a pupil comparator set for the row in question.
 
-    For Academies, "1 day return" and "early transfer" should generated
-    comparator sets.
+    For Academies, "early transfer" should generate comparator sets.
 
     For partial-year data, financial and pupil data must be present.
 
@@ -312,7 +311,7 @@ def _map_pupil_comparator_set(row: pd.Series) -> bool:
     :param row: grouped data
     :return: whether to generate pupil comparator set
     """
-    if row.get("Is Day One Return") or row.get("Is Early Transfer"):
+    if row.get("Is Early Transfer"):
         return True
 
     if not row["Partial Years Present"]:
@@ -331,8 +330,7 @@ def _map_building_comparator_set(row: pd.Series) -> bool:
     """
     Whether to generate a building comparator set for the row.
 
-    For Academies, "1 day return" and "early transfer" should generated
-    comparator sets.
+    For Academies, "early transfer" should generated comparator sets.
 
     For partial-year data, financial, pupil and building data must be
     present.
@@ -342,7 +340,7 @@ def _map_building_comparator_set(row: pd.Series) -> bool:
     :param row: grouped data
     :return: whether to generate building comparator set
     """
-    if row.get("Is Day One Return") or row.get("Is Early Transfer"):
+    if row.get("Is Early Transfer"):
         return True
 
     if not row["Partial Years Present"]:

--- a/data-pipeline/src/pipeline/part_year/academies.py
+++ b/data-pipeline/src/pipeline/part_year/academies.py
@@ -3,20 +3,6 @@ import pandas as pd
 from src.pipeline import config
 
 
-def map_is_day_one_return(academies: pd.DataFrame) -> pd.DataFrame:
-    """
-    Whether an academy is a "1 day" return.
-
-    This is entirely based on the "ACADEMYTRUSTSTATUS" value.
-
-    :param academies: academy data
-    :return: updated data
-    """
-    academies["Is Day One Return"] = academies["ACADEMYTRUSTSTATUS"] == "1 day"
-
-    return academies
-
-
 def _is_early_transfer(row: pd.Series) -> bool:
     """
     Whether an row's "Date joined or opened if in period" value is

--- a/data-pipeline/src/pipeline/pre_processing.py
+++ b/data-pipeline/src/pipeline/pre_processing.py
@@ -403,6 +403,21 @@ def prepare_central_services_data(cs_path, current_year: int):
 
 
 def prepare_aar_data(aar_path, current_year: int):
+    """
+    Process Academies Accounts Return (AAR) data.
+
+    This processin includes:
+
+    - removal of any rows where URN is absent (often due to extraneous
+      rows in the input file)
+    - removal of "1 day" Academies (which indicate a transitioning
+      Academy for which there will be data elsewhere)
+    - TODO
+
+    :param aar_path: source from which data are to be read
+    :param current_year: year in question
+    :return: processed AAR data
+    """
     aar = pd.read_csv(
         aar_path,
         encoding="utf-8",
@@ -411,6 +426,7 @@ def prepare_aar_data(aar_path, current_year: int):
     )
 
     aar = aar[~aar["URN"].isna()]
+    aar = aar[~(aar["ACADEMYTRUSTSTATUS"] == "1 day")]
 
     if (current_year < 2023) or (
         "BNCH11123-BAI011-A (Academies - Income)" not in aar.columns
@@ -1042,7 +1058,6 @@ def map_academy_data(df: pd.DataFrame) -> pd.DataFrame:
     :param df: academy data
     :return: updated data
     """
-    df = part_year.academies.map_is_day_one_return(df)
     df = part_year.academies.map_is_early_transfer(df)
     df = part_year.academies.map_has_financial_data(df)
     df = part_year.academies.map_partial_year_present(df)

--- a/data-pipeline/tests/unit/comparator_sets/test_part_year.py
+++ b/data-pipeline/tests/unit/comparator_sets/test_part_year.py
@@ -4,30 +4,14 @@ import pytest
 from src.pipeline import comparator_sets
 
 
-@pytest.mark.parametrize(
-    "series",
-    [
-        pd.Series({"Is Day One Return": True, "Is Early Transfer": False}),
-        pd.Series({"Is Day One Return": False, "Is Early Transfer": True}),
-        pd.Series({"Is Day One Return": True, "Is Early Transfer": True}),
-    ],
-)
-def test_academy_map_pupil_comparator_set_early(series: pd.Series):
-    result = comparator_sets._map_pupil_comparator_set(series)
+def test_academy_map_pupil_comparator_set_early():
+    result = comparator_sets._map_pupil_comparator_set({"Is Early Transfer": True})
 
     assert result is True
 
 
-@pytest.mark.parametrize(
-    "series",
-    [
-        pd.Series({"Is Day One Return": True, "Is Early Transfer": False}),
-        pd.Series({"Is Day One Return": False, "Is Early Transfer": True}),
-        pd.Series({"Is Day One Return": True, "Is Early Transfer": True}),
-    ],
-)
-def test_academy_map_building_comparator_set_early(series: pd.Series):
-    result = comparator_sets._map_building_comparator_set(series)
+def test_academy_map_building_comparator_set_early():
+    result = comparator_sets._map_building_comparator_set({"Is Early Transfer": True})
 
     assert result is True
 
@@ -38,7 +22,6 @@ def test_academy_map_building_comparator_set_early(series: pd.Series):
         pd.Series({"Partial Years Present": False}),
         pd.Series(
             {
-                "Is Day One Return": False,
                 "Is Early Transfer": False,
                 "Partial Years Present": False,
             }
@@ -57,7 +40,6 @@ def test_map_pupil_comparator_set_non_part_year(series: pd.Series):
         pd.Series({"Partial Years Present": False}),
         pd.Series(
             {
-                "Is Day One Return": False,
                 "Is Early Transfer": False,
                 "Partial Years Present": False,
             }

--- a/data-pipeline/tests/unit/part_year/test_map_academies.py
+++ b/data-pipeline/tests/unit/part_year/test_map_academies.py
@@ -4,24 +4,6 @@ import pandas as pd
 from src.pipeline import config, part_year
 
 
-def test_map_is_day_one_return():
-    df = pd.DataFrame(
-        {
-            "ACADEMYTRUSTSTATUS": [
-                "Existing",
-                "Existing",
-                "1 day",
-                "Closed",
-                "Existing",
-            ],
-        }
-    )
-
-    df = part_year.academies.map_is_day_one_return(df)
-
-    assert df["Is Day One Return"].to_list() == [False, False, True, False, False]
-
-
 def test_map_is_early_transfer():
     df = pd.DataFrame(
         {

--- a/data-pipeline/tests/unit/pre_processing/conftest.py
+++ b/data-pipeline/tests/unit/pre_processing/conftest.py
@@ -164,6 +164,7 @@ def aar_data() -> pd.DataFrame:
             "LA": [865, 845, 929, 731],
             "Estab": [5411, 4026, 4002, 4003],
             "ACADEMYUPIN": [111443, 111451, 111453, 111451],
+            "ACADEMYTRUSTSTATUS": ["Existing", "Existing", "Existing", "Existing"],
             "Company_Number": ["8146633", "8075785", "8146633", "8146633"],
             "Date joined or opened if in period:": [None, "01/05/2023", None, None],
             "Date left or closed if in period:": [None, "01/05/2023", None, None],

--- a/data-pipeline/tests/unit/pre_processing/test_aar.py
+++ b/data-pipeline/tests/unit/pre_processing/test_aar.py
@@ -10,6 +10,7 @@ def test_aar_data_has_correct_output_columns(prepared_aar_data: pd.DataFrame):
         "LA",
         "Estab",
         "Academy UPIN",
+        "ACADEMYTRUSTSTATUS",
         "Company Registration Number",
         "Date joined or opened if in period",
         "Date left or closed if in period",


### PR DESCRIPTION
### Context

- previously, they were specifically treated as non-part-year Academies.
- should be instead removed as their net effect is null.

[AB#231999](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/231999)

### Change proposed in this pull request

- removal of previous processing/testing of "1 day" academies
- specifically removing rows from the AAR data where `ACADEMYTRUSTSTATUS` is `1 day`

### Guidance to review 

- for Academies moving between Trusts, there will always be a second AAR row for the full academic year
- for closing Academies, the `1 day` row has no effect (i.e. no financial data, no apportionment)

### Checklist (add/remove as appropriate)

- [ ] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally

