### PR TITLE
fix: exclude part-year orgs. from comparator-sets

### DIFF
--- a/data-pipeline/src/pipeline/comparator_sets.py
+++ b/data-pipeline/src/pipeline/comparator_sets.py
@@ -372,6 +372,8 @@ def compute_distances(
       distance calculations.
         - this may be skipped if an org. has only submitted
           partial-year data.
+        - orgs. are excluded from being in any comparator set if they
+          have only submitted part-year data.
 
     If `target_urn` is populated, only the org. in question is
     processed.
@@ -395,8 +397,7 @@ def compute_distances(
         phase_pfi = np.array(row["Is PFI"])
         phase_boarding = np.array(row["Boarders (name)"])
         phase_regions = np.array(row["GOR (name)"])
-        include_pupils = np.array(row["_GeneratePupilComparatorSet"])
-        include_buildings = np.array(row["_GenerateBuildingComparatorSet"])
+        include = ~np.array(row["Partial Years Present"])
 
         # TODO: compares ab/ba and aa.
         # compute best-set for each org. individually.
@@ -417,7 +418,7 @@ def compute_distances(
                     phase_boarding,
                     phase_regions,
                     distances=pupil_distances[idx],
-                    include=include_pupils,
+                    include=include,
                 )
                 # note: single-element arrays are unpacked; in this
                 # case, do not produce a comparator-set.
@@ -440,7 +441,7 @@ def compute_distances(
                     phase_boarding,
                     phase_regions,
                     building_distances[idx],
-                    include=include_buildings,
+                    include=include,
                 )
                 if len(top_building_set_urns) == 1:
                     logger.warning(

--- a/data-pipeline/tests/unit/comparator_sets/conftest.py
+++ b/data-pipeline/tests/unit/comparator_sets/conftest.py
@@ -35,9 +35,10 @@ def select_top_set_urns_defaults() -> dict:
     return {
         "urns": np.array(list(string.ascii_uppercase)),  # ["A"…"Z"]
         "pfi": np.array([True] * 26),  # [True, True…]
-        "boarding": np.array([True] * 26),  # [True, True…]
+        "boarding": np.array(["Boarding"] * 26),  # [True, True…]
         "regions": np.array(["A"] * 26),  # ["A"…"A"]
         "distances": np.array([0.01 * i for i in range(26)]),  # [0.0, 0.01…0.25]
         "base_set_size": 6,
         "final_set_size": 3,
+        "include": np.array([True] * 26),  # [True, True…]
     }

--- a/data-pipeline/tests/unit/comparator_sets/test_top_set_urns.py
+++ b/data-pipeline/tests/unit/comparator_sets/test_top_set_urns.py
@@ -5,124 +5,124 @@ import pytest
 
 from src.pipeline.comparator_sets import select_top_set_urns
 
-# @pytest.mark.parametrize(
-#     "local",
-#     [
-#         {
-#             "pfi": np.array([i % 2 == 0 for i in range(26)]),
-#             "boarding": np.array([i % 2 == 0 for i in range(26)]),
-#         },
-#         {
-#             "pfi": np.array([i % 2 == 0 for i in range(26)]),
-#             "boarding": np.array([i % 2 != 0 for i in range(26)]),
-#         },
-#         {
-#             "pfi": np.array([i % 2 != 0 for i in range(26)]),
-#             "boarding": np.array([i % 2 == 0 for i in range(26)]),
-#         },
-#         {
-#             "pfi": np.array([i % 2 != 0 for i in range(26)]),
-#             "boarding": np.array([i % 2 != 0 for i in range(26)]),
-#         },
-#     ],
-# )
-# def test_pfi_boarding(select_top_set_urns_defaults, local):
-#     """
-#     26 orgs. where every other org. is the same PFI/Boarding status as
-#     the first: this will reduce the base-set to ACEGIK.
-#
-#     All are in the same region: the final set should be ACE.
-#     """
-#     result = select_top_set_urns(
-#         index=1,
-#         **(select_top_set_urns_defaults | local),
-#     )
-#
-#     np.testing.assert_array_equal(
-#         result,
-#         np.array(["A", "C", "E"]),
-#     )
+
+@pytest.mark.parametrize(
+    "local",
+    [
+        {
+            "pfi": np.array([i % 2 == 0 for i in range(26)]),
+            "boarding": np.array(["Boarding" if i % 2 == 0 else "" for i in range(26)]),
+        },
+        {
+            "pfi": np.array([i % 2 == 0 for i in range(26)]),
+            "boarding": np.array(["Boarding" if i % 2 != 0 else "" for i in range(26)]),
+        },
+        {
+            "pfi": np.array([i % 2 != 0 for i in range(26)]),
+            "boarding": np.array(["Boarding" if i % 2 == 0 else "" for i in range(26)]),
+        },
+    ],
+    ids=[
+        "pfi_boarding",
+        "pfi_not_boarding",
+        "not_pfi_boarding",
+    ],
+)
+def test_pfi_boarding(select_top_set_urns_defaults, local):
+    """
+    26 orgs. where every other org. is the same PFI/Boarding status as
+    the first: this will reduce the base-set to ACEGIK.
+
+    All are in the same region: the final set should be ACE.
+    """
+    result = select_top_set_urns(
+        index=0,
+        **(select_top_set_urns_defaults | local),
+    )
+
+    print(result)
+    np.testing.assert_array_equal(
+        result,
+        np.array(["A", "C", "E"]),
+    )
 
 
-# def test_excludes_low_distance_region():
-#     """
-#     26 orgs. where every other org. is the same PFI/Boarding status:
-#     this will reduce the base-set to ACEGIK.
-#
-#     None in the top `base_set_size` are in the same region, reducing
-#     the potential final set to just A.
-#
-#     The final set should then be supplemented by the original set,
-#     ordered by distance-metric.
-#     """
-#     urns = np.array(list(string.ascii_uppercase))  # ["A"…"Z"]
-#     pfi = np.array([i % 2 == 0 for i in range(26)])  # [True, False, True…]
-#     boarding = np.array([i % 2 == 0 for i in range(26)])  # [True, False, True…]
-#     regions = np.array(["A"] + (["B"] * 24) + ["A"])  # ["A", "B"…"B", "A"]
-#     distances = np.array([0.01 * i for i in range(26)])  # [0.0, 0.01…0.25]
-#
-#     result = select_top_set_urns(
-#         index=0,
-#         urns=urns,
-#         pfi=pfi,
-#         boarding=boarding,
-#         regions=regions,
-#         distances=distances,
-#         base_set_size=6,
-#         final_set_size=3,
-#     )
-#
-#     np.testing.assert_array_equal(
-#         result,
-#         np.array(["A", "B", "C"]),
-#     )
-#
-#
-# def test_two_calls_to_top_set_urns():
-#     """
-#     26 orgs. where every other org. is the same PFI/Boarding status:
-#     this will reduce the base-set to ACEGIK.
-#
-#     None in the top `base_set_size` are in the same region, reducing
-#     the potential final set to just A.
-#
-#     The final set should then be supplemented by the original set,
-#     ordered by distance-metric.
-#     """
-#     urns = np.array(list(string.ascii_uppercase))  # ["A"…"Z"]
-#     pfi = np.array([i % 2 == 0 for i in range(26)])  # [True, False, True…]
-#     boarding = np.array([i % 2 == 0 for i in range(26)])  # [True, False, True…]
-#     regions = np.array(["A"] + (["B"] * 24) + ["A"])  # ["A", "B"…"B", "A"]
-#     distances = np.array([0.01 * i for i in range(26)])  # [0.0, 0.01…0.25]
-#
-#     resultA = select_top_set_urns(
-#         index=0,
-#         urns=urns,
-#         pfi=pfi,
-#         boarding=boarding,
-#         regions=regions,
-#         distances=distances,
-#         base_set_size=6,
-#         final_set_size=3,
-#     )
-#
-#     resultB = select_top_set_urns(
-#         index=0,
-#         urns=urns,
-#         pfi=pfi,
-#         boarding=boarding,
-#         regions=regions,
-#         distances=distances,
-#         base_set_size=6,
-#         final_set_size=3,
-#     )
-#
-#     np.testing.assert_array_equal(
-#         resultA,
-#         np.array(["A", "B", "C"]),
-#     )
-#
-#     np.testing.assert_array_equal(
-#         resultB,
-#         np.array(["A", "B", "C"]),
-#     )
+def test_not_pfi_not_boarding(select_top_set_urns_defaults):
+    """
+    If neither PFI nor boarding, the result should be ABC.
+    """
+    local = {
+        "pfi": np.array([i % 2 != 0 for i in range(26)]),
+        "boarding": np.array(["Boarding" if i % 2 != 0 else "" for i in range(26)]),
+    }
+    result = select_top_set_urns(
+        index=0,
+        **(select_top_set_urns_defaults | local),
+    )
+
+    print(result)
+    np.testing.assert_array_equal(
+        result,
+        np.array(["A", "B", "C"]),
+    )
+
+
+def test_excludes_low_distance_region():
+    """
+    26 orgs. where every other org. is the same PFI/Boarding status:
+    this will reduce the base-set to ACEGIK.
+
+    None in the top `base_set_size` are in the same region, reducing
+    the potential final set to just A.
+
+    The final set should then be supplemented by the original set,
+    ordered by distance-metric but prioritising PFI and boarding.
+    """
+    urns = np.array(list(string.ascii_uppercase))  # ["A"…"Z"]
+    pfi = np.array([i % 2 == 0 for i in range(26)])  # [True, False, True…]
+    boarding = np.array([i % 2 == 0 for i in range(26)])  # [True, False, True…]
+    regions = np.array(["A"] + (["B"] * 24) + ["A"])  # ["A", "B"…"B", "A"]
+    distances = np.array([0.01 * i for i in range(26)])  # [0.0, 0.01…0.25]
+    include = np.array([True] * 26)
+
+    result = select_top_set_urns(
+        index=0,
+        urns=urns,
+        pfi=pfi,
+        boarding=boarding,
+        regions=regions,
+        distances=distances,
+        include=include,
+        base_set_size=6,
+        final_set_size=3,
+    )
+
+    np.testing.assert_array_equal(
+        result,
+        np.array(["A", "C", "E"]),
+    )
+
+
+def test_excludes_non_included(select_top_set_urns_defaults):
+    """
+    26 orgs. where every other org. is the same PFI/Boarding status:
+    this will reduce the base-set to ACEGIK.
+
+    None in the top `base_set_size` are in `include`; only the final
+    URN should be included.
+    """
+    local = {
+        "pfi": np.array([i % 2 == 0 for i in range(26)]),
+        "boarding": np.array(["Boarding" if i % 2 == 0 else "" for i in range(26)]),
+        "include": np.array([True] + [False] * 24 + [True]),
+    }
+
+    result = select_top_set_urns(
+        index=0,
+        **(select_top_set_urns_defaults | local),
+    )
+
+    np.testing.assert_array_equal(
+        result,
+        np.array(["A", "Z"]),
+    )


### PR DESCRIPTION
### Context

Any org. for which there is only part-year data cannot appear in the comparator-set of another org.

[AB#231998](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/231998)

### Change proposed in this pull request

- remove previous logic which only restricted the omission of part-year orgs. based on whether they would themselves create a pupil/building comparator-set.
- replace this with a restriction based purely on part-year data being present.
- restore the tests for this particular function.

### Guidance to review 

I've validated this locally by running the pipeline and verifying that all URNs for which there are part-year data _do not_ appear in the pupil/building comparator sets for non-part-year orgs. (note: part-year orgs. _can_ create their own comparator-sets and will appear therein: this is an important distinction).

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally

