### PR TITLE
fix: casing for PupilReferralUnit

### DIFF
--- a/web/src/Web.App/Domain/OverallPhaseTypes.cs
+++ b/web/src/Web.App/Domain/OverallPhaseTypes.cs
@@ -7,7 +7,7 @@ public static class OverallPhaseTypes
     public const string Primary = "Primary";
     public const string Secondary = "Secondary";
     public const string Special = "Special";
-    public const string PupilReferralUnit = "Pupil referral unit";
+    public const string PupilReferralUnit = "Pupil Referral Unit";
     public const string AllThrough = "All-through";
     public const string Nursery = "Nursery";
     public const string PostSixteen = "Post-16";

--- a/web/tests/Web.Tests/Infrastructure/Apis/Requests/GivenAPostSchoolComparatorsRequest.cs
+++ b/web/tests/Web.Tests/Infrastructure/Apis/Requests/GivenAPostSchoolComparatorsRequest.cs
@@ -77,7 +77,7 @@ public class GivenAPostSchoolComparatorsRequest
         "Pupil referral units"
     }, new[]
     {
-        "Pupil referral unit"
+        "Pupil Referral Unit"
     })]
     [InlineData(new[]
     {


### PR DESCRIPTION
### Context


### Change proposed in this pull request
Updates OverallPhaseTypes.PupilReferralUnit to correctly match the casing in the db 

### Guidance to review 
Ran locally to confirm LA homepage displaying correctly.

### Checklist (add/remove as appropriate)
- [ ] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

