### PR TITLE
fix: correct Revenue Reserve calculations

### DIFF
--- a/data-pipeline/tests/unit/pre_processing/test_academies.py
+++ b/data-pipeline/tests/unit/pre_processing/test_academies.py
@@ -1,0 +1,66 @@
+import numpy as np
+import pandas as pd
+
+from src.pipeline import pre_processing
+
+
+def test_revenue_reservce_part_year_academy():
+    academies = pd.DataFrame(
+        [
+            {
+                "URN": 0,
+                "Trust UPIN": 0,  # Joining this Trust…
+                "Valid To": np.nan,
+                "Revenue reserve": 1.0,
+                "Number of pupils_pro_rata": 5.0,
+                "Total pupils in trust_pro_rata": 5.0,
+            },
+            {
+                "URN": 0,
+                "Trust UPIN": 1,  # …and leaving this.
+                "Valid To": True,
+                "Revenue reserve": 1.0,
+                "Number of pupils_pro_rata": 5.0,
+                "Total pupils in trust_pro_rata": 15.0,
+            },
+            {
+                "URN": 1,
+                "Trust UPIN": 1,
+                "Valid To": np.nan,
+                "Revenue reserve": 1.0,
+                "Number of pupils_pro_rata": 10.0,
+                "Total pupils in trust_pro_rata": 15.0,
+            },
+        ],
+        index=[0, 0, 1],
+    )
+    central_services = pd.DataFrame(
+        [
+            {
+                "Trust UPIN": 0,
+                "Revenue reserve": 10.0,
+            },
+            {
+                "Trust UPIN": 1,
+                "Revenue reserve": 20.0,
+            },
+        ]
+    )
+
+    result = pre_processing._trust_revenue_reserve(
+        academies,
+        central_services,
+    )
+
+    assert result[(result["URN"] == 0) & (result["Trust UPIN"] == 0)].at[
+        0, "Revenue reserve"
+    ] == 11.0 * (5.0 / 5.0)
+    assert (
+        result[(result["URN"] == 0) & (result["Trust UPIN"] == 1)].at[
+            1, "Revenue reserve"
+        ]
+        == 0.0
+    )
+    assert result[(result["URN"] == 1) & (result["Trust UPIN"] == 1)].at[
+        2, "Revenue reserve"
+    ] == 21.0 * (10.0 / 15.0)


### PR DESCRIPTION
### Context

Update "Revenue reserve" calculations as per ticket.

[AB#225541](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/225541)

### Change proposed in this pull request

- refactor to an isolated function
- derive Trust-level values from _final_ Academy values
- apportion the above based on pro-rata pupil basis

### Guidance to review 

`Revenue reserve_CS` is effectively defunct but as it's still in the DB as `RevenueReserveCS` I've zeroed it out to remove in the future.

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

