### PR TITLE
bugfix: only show schools that are in current submission

### DIFF
--- a/platform/src/apis/Platform.Api.Establishment/LocalAuthorities/LocalAuthoritiesService.cs
+++ b/platform/src/apis/Platform.Api.Establishment/LocalAuthorities/LocalAuthoritiesService.cs
@@ -31,7 +31,7 @@ public class LocalAuthoritiesService(ISearchConnection<LocalAuthority> searchCon
             return null;
         }
 
-        const string schoolsSql = "SELECT URN, SchoolName, OverallPhase from School where LaCode = @Code AND FinanceType = 'Maintained'";
+        const string schoolsSql = "SELECT URN, SchoolName, OverallPhase FROM School WHERE LaCode = @Code AND FinanceType = 'Maintained' AND URN IN (SELECT URN FROM CurrentDefaultFinancial)";
         var schools = await conn.QueryAsync<School>(schoolsSql, parameters);
         return LocalAuthorityResponseFactory.Create(localAuthority, schools);
     }

--- a/platform/src/apis/Platform.Api.Establishment/Trusts/TrustsService.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Trusts/TrustsService.cs
@@ -31,7 +31,7 @@ public class TrustsService(ISearchConnection<Trust> searchConnection, IDatabaseF
             return null;
         }
 
-        const string schoolsSql = "SELECT URN, SchoolName, OverallPhase from School where TrustCompanyNumber = @CompanyNumber";
+        const string schoolsSql = "SELECT URN, SchoolName, OverallPhase from School where TrustCompanyNumber = @CompanyNumber AND URN IN (SELECT URN FROM CurrentDefaultFinancial)";
         var schools = await conn.QueryAsync<School>(schoolsSql, parameters);
         return TrustResponseFactory.Create(trust, schools);
     }

--- a/web/src/Web.App/Controllers/Api/CensusProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/CensusProxyController.cs
@@ -128,22 +128,16 @@ public class CensusProxyController(
 
     private async Task<string[]> GetTrustSet(string id, string? phase)
     {
-        var query = new ApiQuery()
-            .AddIfNotNull("companyNumber", id)
-            .AddIfNotNull("phase", phase);
-
-        var result = await establishmentApi.QuerySchools(query).GetResultOrThrow<IEnumerable<School>>();
-        return result.Select(x => x.URN).OfType<string>().ToArray();
+        var trust = await establishmentApi.GetTrust(id).GetResultOrThrow<Trust>();
+        var schools = trust.Schools.Where(x => x.OverallPhase == phase);
+        return schools.Select(x => x.URN).OfType<string>().ToArray();
     }
 
     private async Task<string[]> GetLocalAuthoritySet(string id, string? phase)
     {
-        var query = new ApiQuery()
-            .AddIfNotNull("laCode", id)
-            .AddIfNotNull("phase", phase);
-
-        var result = await establishmentApi.QuerySchools(query).GetResultOrThrow<IEnumerable<School>>();
-        return result.Select(x => x.URN).OfType<string>().ToArray();
+        var la = await establishmentApi.GetLocalAuthority(id).GetResultOrThrow<LocalAuthority>();
+        var schools = la.Schools.Where(x => x.OverallPhase == phase);
+        return schools.Select(x => x.URN).OfType<string>().ToArray();
     }
 
     private static ApiQuery BuildApiQuery(string? category = null, string? dimension = null, IEnumerable<string>? urns = null)

--- a/web/src/Web.App/Controllers/Api/ExpenditureProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/ExpenditureProxyController.cs
@@ -157,11 +157,8 @@ public class ExpenditureProxyController(
 
     private async Task<IActionResult> LocalAuthorityExpenditure(string id, string? phase, string? category, string? dimension, bool? excludeCentralServices)
     {
-        var query = new ApiQuery()
-            .AddIfNotNull("laCode", id)
-            .AddIfNotNull("phase", phase);
-
-        var schools = await establishmentApi.QuerySchools(query).GetResultOrThrow<IEnumerable<School>>();
+        var la = await establishmentApi.GetLocalAuthority(id).GetResultOrThrow<LocalAuthority>();
+        var schools = la.Schools.Where(x => x.OverallPhase == phase);
         var result = await expenditureApi
             .QuerySchools(BuildQuery(schools.Select(x => x.URN).OfType<string>(), "urns", category, dimension, excludeCentralServices))
             .GetResultOrThrow<SchoolExpenditure[]>();
@@ -170,10 +167,8 @@ public class ExpenditureProxyController(
 
     private async Task<IActionResult> TrustExpenditure(string id, string? phase, string? category, string? dimension, bool? excludeCentralServices)
     {
-        var query = new ApiQuery()
-            .AddIfNotNull("companyNumber", id)
-            .AddIfNotNull("phase", phase);
-        var schools = await establishmentApi.QuerySchools(query).GetResultOrThrow<IEnumerable<School>>();
+        var trust = await establishmentApi.GetTrust(id).GetResultOrThrow<Trust>();
+        var schools = trust.Schools.Where(x => x.OverallPhase == phase);
         var result = await expenditureApi
             .QuerySchools(BuildQuery(schools.Select(x => x.URN).OfType<string>(), "urns", category, dimension, excludeCentralServices))
             .GetResultOrThrow<SchoolExpenditure[]>();


### PR DESCRIPTION
### Context
[AB#228225](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/228225) ([AB#232583](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/232583))

### Change proposed in this pull request
Only show schools in the current submission when viewing LA and/or Trust

### Guidance to review 
Include any useful information needed to review this change. Include any dependencies that are required for this change. 

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

