### PR TITLE
fix: retain Trust Revenue reserve column

### DIFF
--- a/data-pipeline/src/pipeline/pre_processing.py
+++ b/data-pipeline/src/pipeline/pre_processing.py
@@ -751,7 +751,7 @@ def _trust_revenue_reserve(
         * academies["Number of pupils_pro_rata"]
     ).fillna(0.0)
 
-    return academies.drop(columns=["Trust Revenue reserve"])
+    return academies
 
 
 def build_academy_data(


### PR DESCRIPTION
### Context

This was removed due to the recent `Revenue reserve` changes. However, BFR requires this.

[AB#225541](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/225541)

### Change proposed in this pull request

Retain the `Trust Revenue reserve` column.

### Guidance to review 

As a result of the recent changes, `Trust Revenue reserve` is the "sum of `Revenue reserve` for all Academies which ended the year in the Trust" _plus_ the "Central Services `Revenue reserve` for that Trust".

i.e. this is the value which is later apportioned to each Academy in the Trust.

Is this correct for BFR?

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

