### PR TITLE
Amended GitHub Action trigger that creates a PR from security scan documentation results

### DIFF
--- a/.github/workflows/updated-documentation-pr.yml
+++ b/.github/workflows/updated-documentation-pr.yml
@@ -3,14 +3,28 @@ name: Pull Request on documentation tag
 on:
   push:
     tags:        
-      - 'doc/**'
+      - "doc/**"
 jobs:
   create-pull-request:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get Branch
+        run: |
+          raw=$(git branch -r --contains ${{ github.ref }})
+          branch=$(echo $raw | cut -c 8-)
+          echo "BRANCH=$branch" >> $GITHUB_ENV
+          echo "Branch is $branch"
+
       - name: Create Pull Request
-        run: gh pr create -B main -H ${{ github.ref_name }} --title 'Updated documentation' --draft
+        run: |
+          buildId=$(echo "${{ github.ref }}" | cut -c 15-)
+          gh pr create -B main -H ${{ env.BRANCH }} --title "Updated documentation" --body "Includes artifact(s) from Azure DevOps Pipeline build [$buildId](https://dfe-ssp.visualstudio.com/s198-DfE-Benchmarking-service/_build/results?buildId=$buildId)"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pipelines/common/push-repo-artifacts.yaml
+++ b/pipelines/common/push-repo-artifacts.yaml
@@ -33,7 +33,7 @@ steps:
 
   - script: |
       git add .
-      git commit -m "${{ parameters.CommitTag }}: ${{ parameters.CommitMessage }} [skip ci]"
+      git commit -m "${{ parameters.CommitTag }}: ${{ parameters.CommitMessage }}"
       git tag -a ${{ parameters.CommitTag }}/$(Build.BuildId) -m "Tagged with build ID for GitHub Actions trigger"
       git push --atomic origin "refs/heads/${{ parameters.BranchName }}" ${{ parameters.CommitTag }}/$(Build.BuildId)
     displayName: 'Commit changes'


### PR DESCRIPTION
### Context
[AB#231171](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/231171) [AB#229428](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/229428) 

### Change proposed in this pull request
As a follow-up to #1452, fixed GitHub Action that is triggered by a specific tag push in order to automatically submit a pull request.

### Guidance to review 
Validated within branch, but once merged to `main` triggering a new security scan against Web or Platform should conclude with the PR being created based on intermediate pipelines.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~~Your code builds clean without any errors or warnings~~
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

