### PR TITLE
Removed dependency on `schoolRevenueReserve` and `centralRevenueReserve` from front-end

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -92,14 +92,14 @@
       ></div>
       <button type="submit">Submit</button>
     </form>-->
-    <!--<div id="compare-your-trust" data-id="07465701"></div>-->
+    <div id="compare-your-trust" data-id="09617166"></div>
     <!--<div
       id="compare-your-costs"
       data-type="trust"
       data-id="02387916"
       data-phases='["Secondary","Primary","Post-16"]'
     ></div>-->
-    <div id="compare-your-costs" data-type="school" data-id="143996"></div>
+    <!--<div id="compare-your-costs" data-type="school" data-id="143996"></div>-->
     <!--<div id="historic-data" data-type="school" data-id="990095"></div>-->
     <!--<div
       id="compare-your-costs"

--- a/front-end-components/src/components/charts/table-chart/component.tsx
+++ b/front-end-components/src/components/charts/table-chart/component.tsx
@@ -122,20 +122,22 @@ export const TableChart: React.FC<
                         valueUnit,
                       })}
                     </td>
-                    {breakdown === BreakdownInclude && (
-                      <>
-                        <td className="govuk-table__cell table-cell-value">
-                          {fullValueFormatter(schoolValue, {
-                            valueUnit,
-                          })}
-                        </td>
-                        <td className="govuk-table__cell table-cell-value">
-                          {fullValueFormatter(centralValue, {
-                            valueUnit,
-                          })}
-                        </td>
-                      </>
-                    )}
+                    {breakdown === BreakdownInclude &&
+                      schoolValue !== undefined &&
+                      centralValue !== undefined && (
+                        <>
+                          <td className="govuk-table__cell table-cell-value">
+                            {fullValueFormatter(schoolValue, {
+                              valueUnit,
+                            })}
+                          </td>
+                          <td className="govuk-table__cell table-cell-value">
+                            {fullValueFormatter(centralValue, {
+                              valueUnit,
+                            })}
+                          </td>
+                        </>
+                      )}
                   </>
                 ) : (
                   <td className="govuk-table__cell table-cell-value">

--- a/front-end-components/src/components/charts/trust-data-tooltip/component.tsx
+++ b/front-end-components/src/components/charts/trust-data-tooltip/component.tsx
@@ -40,7 +40,9 @@ export function TrustDataTooltip<
         </tr>
       </thead>
       <tbody className="govuk-table__body">
-        {breakdown === BreakdownInclude ? (
+        {breakdown === BreakdownInclude &&
+        schoolValue !== undefined &&
+        centralValue !== undefined ? (
           <>
             <tr className="govuk-table__row">
               <th scope="row" className="govuk-table__header">

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/types.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/types.tsx
@@ -29,6 +29,10 @@ export type HorizontalBarChartWrapperData<
   dataPoints: (TData &
     (
       | { value: number }
-      | { totalValue: number; schoolValue: number; centralValue: number }
+      | {
+          totalValue: number;
+          schoolValue: number | undefined;
+          centralValue: number | undefined;
+        }
     ))[];
 };

--- a/front-end-components/src/services/types.tsx
+++ b/front-end-components/src/services/types.tsx
@@ -295,10 +295,7 @@ type BalanceBase = {
 
 type TrustBalanceBase = BalanceBase & {
   schoolInYearBalance: number;
-  schoolRevenueReserve: number;
-
   centralInYearBalance: number;
-  centralRevenueReserve: number;
 };
 
 export type SchoolBalance = BalanceBase & {

--- a/front-end-components/src/views/compare-your-trust/partials/balance.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/balance.tsx
@@ -56,12 +56,7 @@ export const Balance: React.FC<{
 
   const revenueReserveChartData: HorizontalBarChartWrapperData<BalanceData> =
     useMemo(() => {
-      const tableHeadings = [
-        "Trust name",
-        `Total ${dimension.heading}`,
-        `School ${dimension.heading}`,
-        `Central ${dimension.heading}`,
-      ];
+      const tableHeadings = ["Trust name", `Total ${dimension.heading}`];
 
       return {
         dataPoints:
@@ -70,8 +65,8 @@ export const Balance: React.FC<{
                 return {
                   ...trust,
                   totalValue: trust.revenueReserve ?? 0,
-                  schoolValue: trust.schoolRevenueReserve ?? 0,
-                  centralValue: trust.centralRevenueReserve ?? 0,
+                  schoolValue: undefined,
+                  centralValue: undefined,
                   type: "balance",
                 };
               })

--- a/platform/src/apis/Platform.Api.Insight/BudgetForecast/BudgetForecastResponse.cs
+++ b/platform/src/apis/Platform.Api.Insight/BudgetForecast/BudgetForecastResponse.cs
@@ -40,7 +40,6 @@ public static class BudgetForecastReturnsResponseFactory
     }
 }
 
-[ExcludeFromCodeCoverage]
 public record BudgetForecastReturnResponse
 {
     public int? Year { get; set; }
@@ -50,7 +49,7 @@ public record BudgetForecastReturnResponse
     public decimal? ActualTotalPupils { get; set; }
 
     public decimal? Variance => Forecast.HasValue && Actual.HasValue ? Actual - Forecast : null;
-    public decimal? PercentVariance => Forecast.HasValue && Actual.HasValue ? 100 - Forecast / Actual * 100 : null;
+    public decimal? PercentVariance => Forecast.HasValue && Actual.GetValueOrDefault() != default ? 100 - Forecast / Actual * 100 : null;
     public string? VarianceStatus => PercentVariance switch
     {
         < -10 => "AR significantly below forecast",

--- a/platform/tests/Platform.Tests/Insight/BudgetForecast/WhenBudgetForecastReturnsResponseFactoryCreatesResponse.cs
+++ b/platform/tests/Platform.Tests/Insight/BudgetForecast/WhenBudgetForecastReturnsResponseFactoryCreatesResponse.cs
@@ -175,4 +175,119 @@ public class WhenBudgetForecastReturnsResponseFactoryCreatesResponse
         // assert
         Assert.Equal(status, actual.VarianceStatus);
     }
+
+    [Fact]
+    public void ShouldBuildResponseModelForEdgeCaseValues()
+    {
+        // arrange
+        var bfr = new BudgetForecastReturnModel[]
+        {
+            new()
+            {
+                Year = 2020,
+                Value = 1_002,
+                TotalPupils = 2_002
+            },
+            new()
+            {
+                Year = 2021,
+                Value = 1_003,
+                TotalPupils = 2_003
+            },
+            new()
+            {
+                Year = 2022,
+                Value = 1_011,
+                TotalPupils = 2_011
+            },
+            new()
+            {
+                Year = 2023,
+                Value = -1_012,
+                TotalPupils = 2_012
+            },
+            new()
+            {
+                Year = 2024,
+                Value = null,
+                TotalPupils = 2_013
+            },
+            new()
+            {
+                Year = 2025,
+                Value = 0,
+                TotalPupils = 2_014
+            }
+        };
+
+        var ar = new ActualReturnModel[]
+        {
+            new()
+            {
+                Year = 2020,
+                Value = -1_007,
+                TotalPupils = 2_002
+            },
+            new()
+            {
+                Year = 2021,
+                Value = null,
+                TotalPupils = 2_003
+            },
+            new()
+            {
+                Year = 2022,
+                Value = 0,
+                TotalPupils = 2_011
+            }
+        };
+
+        // act
+        var actual = BudgetForecastReturnsResponseFactory.CreateForDefaultRunType(bfr, ar);
+
+        // assert
+        var year2020 = actual.ElementAt(0);
+        Assert.Equal(2020, year2020.Year);
+        Assert.Equal(-1_007, year2020.Actual);
+        Assert.Equal(1_002, year2020.Forecast);
+        Assert.Equal(-2_009, year2020.Variance);
+        Assert.Equal("199.503", year2020.PercentVariance.GetValueOrDefault().ToString("0.000"));
+        Assert.Equal("AR significantly above forecast", year2020.VarianceStatus);
+
+        var year2021 = actual.ElementAt(1);
+        Assert.Equal(2021, year2021.Year);
+        Assert.Null(year2021.Actual);
+        Assert.Equal(1_003, year2021.Forecast);
+        Assert.Null(year2021.Variance);
+        Assert.Equal("0.000", year2021.PercentVariance.GetValueOrDefault().ToString("0.000"));
+        Assert.Null(year2021.VarianceStatus);
+
+        var year2022 = actual.ElementAt(2);
+        Assert.Equal(2022, year2022.Year);
+        Assert.Equal(0, year2022.Actual);
+        Assert.Equal(1_011, year2022.Forecast);
+        Assert.Equal(-1_011, year2022.Variance);
+        Assert.Null(year2022.VarianceStatus);
+
+        var year2023 = actual.ElementAt(3);
+        Assert.Equal(2023, year2023.Year);
+        Assert.Null(year2023.Actual);
+        Assert.Equal(-1_012, year2023.Forecast);
+        Assert.Null(year2023.Variance);
+        Assert.Null(year2023.PercentVariance);
+
+        var year2024 = actual.ElementAt(4);
+        Assert.Equal(2024, year2024.Year);
+        Assert.Null(year2024.Actual);
+        Assert.Null(year2024.Forecast);
+        Assert.Null(year2024.Variance);
+        Assert.Null(year2024.PercentVariance);
+
+        var year2025 = actual.ElementAt(5);
+        Assert.Equal(2025, year2025.Year);
+        Assert.Null(year2025.Actual);
+        Assert.Equal(0, year2025.Forecast);
+        Assert.Null(year2025.Variance);
+        Assert.Null(year2025.PercentVariance);
+    }
 }

--- a/web/tests/Web.A11yTests/AuthPageBase.cs
+++ b/web/tests/Web.A11yTests/AuthPageBase.cs
@@ -12,8 +12,9 @@ public abstract partial class AuthPageBase(ITestOutputHelper testOutputHelper, W
         // Sign in using credentials set in config
         var page = await webDriver.GetPage($"{ServiceUrl}/sign-in", HttpStatusCode.OK);
         await page.Locator("#username").FillAsync(TestConfiguration.Authentication.Username);
+        await page.Locator("button").GetByText("Next").ClickAsync();
         await page.Locator("#password").FillAsync(TestConfiguration.Authentication.Password);
-        await page.GetByText("Sign in").ClickAsync();
+        await page.Locator("button").GetByText("Sign in").ClickAsync();
         await page.WaitForURLAsync(SelectOrganisation());
         await page.Locator("#organisation").Locator("input[type='radio']").First.ClickAsync();
         await page.GetByText("Continue").ClickAsync();

--- a/web/tests/Web.A11yTests/Pages/Schools/Comparators/WhenViewingComparatorsByName.cs
+++ b/web/tests/Web.A11yTests/Pages/Schools/Comparators/WhenViewingComparatorsByName.cs
@@ -31,7 +31,7 @@ public class WhenViewingComparatorsByName(ITestOutputHelper testOutputHelper, We
     public async Task ValidationErrorThenThereAreNoAccessibilityIssues()
     {
         await GoToPage();
-        await Page.Locator("button[type='submit']").ClickAsync();
+        await Page.Locator("main button[type='submit']").ClickAsync();
         await EvaluatePage(_context);
     }
 
@@ -43,7 +43,7 @@ public class WhenViewingComparatorsByName(ITestOutputHelper testOutputHelper, We
         await Page.Locator("#school-input__listbox.autocomplete__menu--visible").WaitForAsync();
         await Page.Keyboard.DownAsync("ArrowDown");
         await Page.Keyboard.DownAsync("Enter");
-        await Page.Locator("button[type='submit']").ClickAsync();
+        await Page.Locator("main button[type='submit']").ClickAsync();
         await EvaluatePage(_context);
     }
 }

--- a/web/tests/Web.A11yTests/Pages/Schools/Comparators/WhenViewingComparatorsRevert.cs
+++ b/web/tests/Web.A11yTests/Pages/Schools/Comparators/WhenViewingComparatorsRevert.cs
@@ -16,7 +16,7 @@ public class WhenViewingComparatorsRevert(ITestOutputHelper testOutputHelper, We
         await Page.Locator("#school-input__listbox.autocomplete__menu--visible").WaitForAsync();
         await Page.Keyboard.DownAsync("ArrowDown");
         await Page.Keyboard.DownAsync("Enter");
-        await Page.Locator("button[type='submit']").ClickAsync();
+        await Page.Locator("main button[type='submit']").ClickAsync();
         await Page.Locator("#create-set").WaitForAsync();
         await Page.Locator("#create-set").ClickAsync();
         await Page.WaitForURLAsync("**/submit");

--- a/web/tests/Web.A11yTests/Pages/Schools/Comparators/WhenViewingComparatorsSubmit.cs
+++ b/web/tests/Web.A11yTests/Pages/Schools/Comparators/WhenViewingComparatorsSubmit.cs
@@ -16,7 +16,7 @@ public class WhenViewingComparatorsSubmit(ITestOutputHelper testOutputHelper, We
         await Page.Locator("#school-input__listbox.autocomplete__menu--visible").WaitForAsync();
         await Page.Keyboard.DownAsync("ArrowDown");
         await Page.Keyboard.DownAsync("Enter");
-        await Page.Locator("button[type='submit']").ClickAsync();
+        await Page.Locator("main button[type='submit']").ClickAsync();
         await Page.Locator("#create-set").WaitForAsync();
         await Page.Locator("#create-set").ClickAsync();
         await Page.WaitForURLAsync("**/submit");

--- a/web/tests/Web.A11yTests/Pages/Trust/Comparators/WhenViewingComparators.cs
+++ b/web/tests/Web.A11yTests/Pages/Trust/Comparators/WhenViewingComparators.cs
@@ -16,7 +16,7 @@ public class WhenViewingComparators(ITestOutputHelper testOutputHelper, WebDrive
         await Page.Locator("#trust-input__listbox.autocomplete__menu--visible").WaitForAsync();
         await Page.Keyboard.DownAsync("ArrowDown");
         await Page.Keyboard.DownAsync("Enter");
-        await Page.Locator("button[type='submit']").ClickAsync();
+        await Page.Locator("main button[type='submit']").ClickAsync();
         await Page.Locator("#create-set").WaitForAsync();
         await Page.Locator("#create-set").ClickAsync();
         await Page.WaitForURLAsync("**/comparators?comparator-generated=true");

--- a/web/tests/Web.A11yTests/Pages/Trust/Comparators/WhenViewingComparatorsRevert.cs
+++ b/web/tests/Web.A11yTests/Pages/Trust/Comparators/WhenViewingComparatorsRevert.cs
@@ -16,12 +16,13 @@ public class WhenViewingComparatorsRevert(ITestOutputHelper testOutputHelper, We
         await Page.Locator("#trust-input__listbox.autocomplete__menu--visible").WaitForAsync();
         await Page.Keyboard.DownAsync("ArrowDown");
         await Page.Keyboard.DownAsync("Enter");
-        await Page.Locator("button[type='submit']").ClickAsync();
+        await Page.Locator("main button[type='submit']").ClickAsync();
         await Page.Locator("#create-set").WaitForAsync();
         await Page.Locator("#create-set").ClickAsync();
         await Page.WaitForURLAsync("**/submit");
-        await Page.Locator("#revert-set").WaitForAsync();
-        await Page.Locator("#revert-set").ClickAsync();
+        await Page.GetByText("View and change your set of trusts").ClickAsync();
+        await Page.GetByText("Change your set of trusts").ClickAsync();
+        await Page.GetByText("Remove all your choices").ClickAsync();
         await Page.WaitForURLAsync("**/revert");
         await EvaluatePage();
     }

--- a/web/tests/Web.A11yTests/Pages/Trust/Comparators/WhenViewingComparatorsSubmit.cs
+++ b/web/tests/Web.A11yTests/Pages/Trust/Comparators/WhenViewingComparatorsSubmit.cs
@@ -16,7 +16,7 @@ public class WhenViewingComparatorsSubmit(ITestOutputHelper testOutputHelper, We
         await Page.Locator("#trust-input__listbox.autocomplete__menu--visible").WaitForAsync();
         await Page.Keyboard.DownAsync("ArrowDown");
         await Page.Keyboard.DownAsync("Enter");
-        await Page.Locator("button[type='submit']").ClickAsync();
+        await Page.Locator("main button[type='submit']").ClickAsync();
         await Page.Locator("#create-set").WaitForAsync();
         await Page.Locator("#create-set").ClickAsync();
         await Page.WaitForURLAsync("**/submit");


### PR DESCRIPTION
### Context
[AB#232577](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/232577) [AB#225541](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/225541)

### Change proposed in this pull request
Also fixed Trust A11y tests, including `DivideByZeroException` in `BudgetForecastReturnResponse`.

### Guidance to review 
View/create a new trust-to-trust comparator set and open the 'Balance' tab. The Revenue Reserve should only show 'totals' rather than central/school split.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

