### PR TITLE
Strip unexpected characters from 'web' security scan results

### DIFF
--- a/.github/workflows/updated-documentation-pr.yml
+++ b/.github/workflows/updated-documentation-pr.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Create Pull Request
         run: |
           buildId=$(echo "${{ github.ref }}" | cut -c 15-)
-          gh pr create -B main -H ${{ env.BRANCH }} --title "Updated documentation" --body "Includes artifact(s) from Azure DevOps Pipeline build [$buildId](https://dfe-ssp.visualstudio.com/s198-DfE-Benchmarking-service/_build/results?buildId=$buildId)"
+          gh pr create -B main -H ${{ env.BRANCH }} --title "Updated documentation from build $buildId artifacts" --body "Includes artifact(s) from Azure DevOps Pipeline build [$buildId](https://dfe-ssp.visualstudio.com/s198-DfE-Benchmarking-service/_build/results?buildId=$buildId)" --label "documentation"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pipelines/platform/security-scan.yaml
+++ b/pipelines/platform/security-scan.yaml
@@ -134,5 +134,6 @@ jobs:
           CommitMessage: 'Updated platform security scan documentation'
           CommitTag: 'doc'
           PostProcessScript: |
-            find . -type f -name "*.md" -exec sh -c 'echo "\\\newpage" >> "$1"' _ {} \;
+            find . -type f \( -wholename "./benchmark/*.md" -o -wholename "./establishment/*.md" -o -wholename "./insight/*.md" \) -exec sh -c 'echo "\\\newpage" >> "$1"' _ {} \;
+            find . -type f \( -wholename "./benchmark/*.md" -o -wholename "./establishment/*.md" -o -wholename "./insight/*.md" \) -exec mv '{}' . \;
           TargetPath: 'documentation/quality-assurance/security-scan-reports'

--- a/pipelines/web/security-scan.yaml
+++ b/pipelines/web/security-scan.yaml
@@ -7,7 +7,7 @@ variables:
   - name: 'cacheKey'
     value: $[format('{0:yyyyMMdd}', pipeline.startTime)]
   - name: 'ShouldPublish'
-    value: true #donotpush! $[and(eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne(variables['Build.Reason'], 'PullRequest'))]
+    value: $[and(eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne(variables['Build.Reason'], 'PullRequest'))]
 
 trigger: none
 
@@ -115,5 +115,7 @@ jobs:
           CommitMessage: 'Updated web security scan documentation'
           CommitTag: 'doc'
           PostProcessScript: |
-            find . -type f -name "*.md" -exec sh -c 'echo "\\\newpage" >> "$1"' _ {} \;
+            find . -type f -wholename "./web/*.md" -exec sh -c 'sed -i -E "s/Other Info: \`[^\`]+\`/Other Info: \`\`/g" "$1"' _ {} \;
+            find . -type f -wholename "./web/*.md" -exec sh -c 'echo "\\\newpage" >> "$1"' _ {} \;
+            mv -f web/*.md .
           TargetPath: 'documentation/quality-assurance/security-scan-reports'


### PR DESCRIPTION
### Context
[AB#231848](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/231848) [AB#229428](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/229428) 

### Change proposed in this pull request
Also move downloaded build artifacts into parent folder before committing.
Accidentally pushed condition on 'web' security scan pipeline also reverted.

### Guidance to review 
Validated within branch to correctly remove unexpected characters from 'web' security scan as well as move files to the 'flattened' location. Full run of documentation pipeline not yet executed, but the modified `.md` file looks like it should be accepted now.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~~Your code builds clean without any errors or warnings~~
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

