### PR TITLE
Set automation runbook runtime environment to PowerShell 7.2

### DIFF
--- a/core-infrastructure/terraform/automation.tf
+++ b/core-infrastructure/terraform/automation.tf
@@ -35,7 +35,7 @@ resource "azurerm_automation_runbook" "backup-database-runbook" {
   log_verbose             = "true"
   log_progress            = "true"
   description             = "Performs a backup of the given database to the specified blob storage container"
-  runbook_type            = "PowerShell"
+  runbook_type            = "PowerShell72"
   tags                    = local.common-tags
   content                 = data.local_file.backup-database-script.content
 }


### PR DESCRIPTION
### Context
[AB#232850](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/232850) [AB#231298](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/231298)

### Change proposed in this pull request
As a follow-up to #1451, ensures the correct runtime environment is assigned to the automation runbook.

### Guidance to review 
Testing was done against the `PowerShell-7.2` runtime environment in the `d12` feature environment but this version was not being provisioned via TF. This should get everything in sync and resolve the errors observed in `d01` and `t01` at the last scheduled trigger.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~~Your code builds clean without any errors or warnings~~
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

