### PR TITLE
Removed dependency on `RevenueReserveCS` from Insight API

### DIFF
--- a/platform/src/apis/Platform.Api.Insight/Balance/BalanceModel.cs
+++ b/platform/src/apis/Platform.Api.Insight/Balance/BalanceModel.cs
@@ -13,7 +13,6 @@ public abstract record BalanceBaseModel
     public decimal? TotalIncomeCS { get; set; }
     public decimal? TotalExpenditureCS { get; set; }
     public decimal? InYearBalanceCS { get; set; }
-    public decimal? RevenueReserveCS { get; set; }
 }
 
 [ExcludeFromCodeCoverage]

--- a/platform/src/apis/Platform.Api.Insight/Balance/BalanceResponse.cs
+++ b/platform/src/apis/Platform.Api.Insight/Balance/BalanceResponse.cs
@@ -51,10 +51,8 @@ public static class BalanceResponseFactory
     {
         SchoolInYearBalance = CalcAmount(model.InYearBalance - model.InYearBalanceCS.GetValueOrDefault(), model, parameters),
         CentralInYearBalance = CalcAmount(model.InYearBalanceCS, model, parameters),
-        SchoolRevenueReserve = CalcAmount(model.RevenueReserve - model.RevenueReserveCS.GetValueOrDefault(), model, parameters),
-        CentralRevenueReserve = CalcAmount(model.RevenueReserveCS, model, parameters),
         InYearBalance = CalcTotal(model.InYearBalance, model.InYearBalanceCS.GetValueOrDefault(), model, parameters),
-        RevenueReserve = CalcTotal(model.RevenueReserve, model.RevenueReserveCS.GetValueOrDefault(), model, parameters)
+        RevenueReserve = CalcTotal(model.RevenueReserve, 0, model, parameters)
     };
 
     private static decimal? CalcTotal(decimal? value, decimal valueCentral, BalanceBaseModel model, BalanceParameters parameters)
@@ -101,8 +99,6 @@ public abstract record BalanceBaseResponse
 
     public decimal? SchoolInYearBalance { get; set; }
     public decimal? CentralInYearBalance { get; set; }
-    public decimal? SchoolRevenueReserve { get; set; }
-    public decimal? CentralRevenueReserve { get; set; }
     public decimal? InYearBalance { get; set; }
     public decimal? RevenueReserve { get; set; }
 }

--- a/platform/tests/Platform.ApiTests/Features/InsightBalance.feature
+++ b/platform/tests/Platform.ApiTests/Features/InsightBalance.feature
@@ -14,31 +14,29 @@
         Given a valid school balance request with urn '990000', dimension 'Actuals' and exclude central services = 'true'
         When I submit the insights balance request
         Then the school balance result should be ok and contain:
-          | Field                | Value                  |
-          | URN                  | 990000                 |
-          | SchoolName           | Test school 176        |
-          | SchoolType           | Voluntary aided school |
-          | LAName               | Bedford                |
-          | TotalPupils          | 418.00                 |
-          | SchoolInYearBalance  |                        |
-          | SchoolRevenueReserve |                        |
-          | InYearBalance        | 121827.00              |
-          | RevenueReserve       | 441008.00              |
+          | Field               | Value                  |
+          | URN                 | 990000                 |
+          | SchoolName          | Test school 176        |
+          | SchoolType          | Voluntary aided school |
+          | LAName              | Bedford                |
+          | TotalPupils         | 418.00                 |
+          | SchoolInYearBalance |                        |
+          | InYearBalance       | 121827.00              |
+          | RevenueReserve      | 441008.00              |
 
     Scenario: Sending a valid school balance request with dimension
         Given a valid school balance request with urn '990000', dimension 'Actuals' and exclude central services = ''
         When I submit the insights balance request
         Then the school balance result should be ok and contain:
-          | Field                | Value                  |
-          | URN                  | 990000                 |
-          | SchoolName           | Test school 176        |
-          | SchoolType           | Voluntary aided school |
-          | LAName               | Bedford                |
-          | TotalPupils          | 418.00                 |
-          | SchoolInYearBalance  | 121827.00              |
-          | SchoolRevenueReserve | 441008.00              |
-          | InYearBalance        | 121827.00              |
-          | RevenueReserve       | 441008.00              |
+          | Field               | Value                  |
+          | URN                 | 990000                 |
+          | SchoolName          | Test school 176        |
+          | SchoolType          | Voluntary aided school |
+          | LAName              | Bedford                |
+          | TotalPupils         | 418.00                 |
+          | SchoolInYearBalance | 121827.00              |
+          | InYearBalance       | 121827.00              |
+          | RevenueReserve      | 441008.00              |
 
     Scenario: Sending an invalid school balance request
         Given an invalid school balance request with urn '000000'
@@ -49,12 +47,12 @@
         Given a valid school balance history request with urn '990000'
         When I submit the insights balance request
         Then the school balance history result should be ok and contain:
-          | Year | Term         | URN    | SchoolInYearBalance | SchoolRevenueReserve | InYearBalance | RevenueReserve |
-          | 2018 | 2017 to 2018 | 990000 |                     |                      |               |                |
-          | 2019 | 2018 to 2019 | 990000 |                     |                      |               |                |
-          | 2020 | 2019 to 2020 | 990000 |                     |                      |               |                |
-          | 2021 | 2020 to 2021 | 990000 | 100522.00           | 79032.00             | 100522.00     | 79032.00       |
-          | 2022 | 2021 to 2022 | 990000 | 121827.00           | 441008.00            | 121827.00     | 441008.00      |
+          | Year | Term         | URN    | SchoolInYearBalance | InYearBalance | RevenueReserve |
+          | 2018 | 2017 to 2018 | 990000 |                     |               |                |
+          | 2019 | 2018 to 2019 | 990000 |                     |               |                |
+          | 2020 | 2019 to 2020 | 990000 |                     |               |                |
+          | 2021 | 2020 to 2021 | 990000 | 100522.00           | 100522.00     | 79032.00       |
+          | 2022 | 2021 to 2022 | 990000 | 121827.00           | 121827.00     | 441008.00      |
 
     Scenario: Sending a valid school balance query request
         Given a valid school balance query request with urns:
@@ -64,34 +62,32 @@
           | 990002 |
         When I submit the insights balance request
         Then the school balance query result should be ok and contain:
-          | URN    | SchoolInYearBalance | SchoolRevenueReserve | InYearBalance | RevenueReserve |
-          | 990000 | 121827.00           | 441008.00            | 121827.00     | 441008.00      |
-          | 990001 | -15635.00           | 317789.00            | -15635.00     | 317789.00      |
-          | 990002 | -44912.00           | 234559.00            | -44912.00     | 234559.00      |
+          | URN    | SchoolInYearBalance | InYearBalance | RevenueReserve |
+          | 990000 | 121827.00           | 121827.00     | 441008.00      |
+          | 990001 | -15635.00           | -15635.00     | 317789.00      |
+          | 990002 | -44912.00           | -44912.00     | 234559.00      |
 
     Scenario: Sending a valid trust balance request with dimension and exclude central services
         Given a valid trust balance request with company number '10192252', dimension 'Actuals' and exclude central services = 'true'
         When I submit the insights balance request
         Then the trust balance result should be ok and contain:
-          | Field                | Value                  |
-          | CompanyNumber        | 10192252               |
-          | TrustName            | Test Company/Trust  31 |
-          | SchoolInYearBalance  |                        |
-          | SchoolRevenueReserve |                        |
-          | InYearBalance        | 364946.00              |
-          | RevenueReserve       | 871095.00              |
+          | Field               | Value                  |
+          | CompanyNumber       | 10192252               |
+          | TrustName           | Test Company/Trust  31 |
+          | SchoolInYearBalance |                        |
+          | InYearBalance       | 364946.00              |
+          | RevenueReserve      | 871095.00              |
 
     Scenario: Sending a valid trust balance request with dimension
         Given a valid trust balance request with company number '10192252', dimension 'Actuals' and exclude central services = ''
         When I submit the insights balance request
         Then the trust balance result should be ok and contain:
-          | Field                | Value                  |
-          | CompanyNumber        | 10192252               |
-          | TrustName            | Test Company/Trust  31 |
-          | SchoolInYearBalance  | 364946.00              |
-          | SchoolRevenueReserve | 871095.00              |
-          | InYearBalance        | 364946.00              |
-          | RevenueReserve       | 871095.00              |
+          | Field               | Value                  |
+          | CompanyNumber       | 10192252               |
+          | TrustName           | Test Company/Trust  31 |
+          | SchoolInYearBalance | 364946.00              |
+          | InYearBalance       | 364946.00              |
+          | RevenueReserve      | 871095.00              |
 
     Scenario: Sending an invalid trust balance request
         Given an invalid trust balance request with company number '10000000'
@@ -102,8 +98,8 @@
         Given a valid trust balance history request with company number '10192252'
         When I submit the insights balance request
         Then the trust balance history result should be ok and contain:
-          | Year | Term         | CompanyNumber | SchoolInYearBalance | SchoolRevenueReserve | InYearBalance | RevenueReserve |
-          | 2022 | 2021 to 2022 | 10192252      | 364946.00           | 871095.00            | 364946.00     | 871095.00      |
+          | Year | Term         | CompanyNumber | SchoolInYearBalance | InYearBalance | RevenueReserve |
+          | 2022 | 2021 to 2022 | 10192252      | 364946.00           | 364946.00     | 871095.00      |
 
     Scenario: Sending a valid trust balance query request
         Given a valid trust balance query request with company numbers:
@@ -113,7 +109,7 @@
           | 10264735      |
         When I submit the insights balance request
         Then the trust balance query result should be ok and contain:
-          | CompanyNumber | TrustName               | SchoolInYearBalance | SchoolRevenueReserve | InYearBalance | RevenueReserve |
-          | 10249712      | Test Company/Trust  229 | -381267.00          | 49358.00             | -381267.00    | 49358.00       |
-          | 10259334      | Test Company/Trust  157 | 598442.00           | 1301815.00           | 598442.00     | 1301815.00     |
-          | 10264735      | Test Company/Trust  262 | -220633.00          | -297118.00           | -220633.00    | -297118.00     |
+          | CompanyNumber | TrustName               | SchoolInYearBalance | InYearBalance | RevenueReserve |
+          | 10249712      | Test Company/Trust  229 | -381267.00          | -381267.00    | 49358.00       |
+          | 10259334      | Test Company/Trust  157 | 598442.00           | 598442.00     | 1301815.00     |
+          | 10264735      | Test Company/Trust  262 | -220633.00          | -220633.00    | -297118.00     |

--- a/platform/tests/Platform.Tests/Insight/Balance/BalanceResponseFactoryCreate/Assertions.cs
+++ b/platform/tests/Platform.Tests/Insight/Balance/BalanceResponseFactoryCreate/Assertions.cs
@@ -14,8 +14,6 @@ public static class Assertions
     internal static void AssertRevenueReserve(BalanceBaseResponse expected, BalanceBaseResponse response)
     {
         AssertEqual(nameof(BalanceBaseResponse.RevenueReserve), expected.RevenueReserve, response.RevenueReserve);
-        AssertEqual(nameof(BalanceBaseResponse.SchoolRevenueReserve), expected.SchoolRevenueReserve, response.SchoolRevenueReserve);
-        AssertEqual(nameof(BalanceBaseResponse.CentralRevenueReserve), expected.CentralRevenueReserve, response.CentralRevenueReserve);
     }
 
     private static void AssertEqual(string field, decimal? expected, decimal? actual) =>

--- a/platform/tests/Platform.Tests/Insight/Balance/BalanceResponseFactoryCreate/BalanceTestData.json
+++ b/platform/tests/Platform.Tests/Insight/Balance/BalanceResponseFactoryCreate/BalanceTestData.json
@@ -10,6 +10,5 @@
   "TotalExpenditureCS": 1700000,
   "InYearBalance": 980000,
   "InYearBalanceCS": 870000,
-  "RevenueReserve": 830000,
-  "RevenueReserveCS": 630000
+  "RevenueReserve": 830000
 }

--- a/platform/tests/Platform.Tests/Insight/Balance/BalanceResponseFactoryCreate/TotalBalanceTestData.json
+++ b/platform/tests/Platform.Tests/Insight/Balance/BalanceResponseFactoryCreate/TotalBalanceTestData.json
@@ -4,7 +4,7 @@
     "ExcludeCentralServices": true,
     "Expected": {
       "InYearBalance": 110000,
-      "RevenueReserve": 200000
+      "RevenueReserve": 830000
     }
   },
   {
@@ -12,7 +12,7 @@
     "ExcludeCentralServices": true,
     "Expected": {
       "InYearBalance": 36.67,
-      "RevenueReserve": 66.67
+      "RevenueReserve": 276.67
     }
   },
   {
@@ -20,7 +20,7 @@
     "ExcludeCentralServices": true,
     "Expected": {
       "InYearBalance": 1100,
-      "RevenueReserve": 2000
+      "RevenueReserve": 8300
     }
   },
   {
@@ -28,7 +28,7 @@
     "ExcludeCentralServices": true,
     "Expected": {
       "InYearBalance": 110,
-      "RevenueReserve": 200
+      "RevenueReserve": 830
     }
   },
   {
@@ -38,9 +38,7 @@
       "InYearBalance": 980000,
       "SchoolInYearBalance": 110000,
       "CentralInYearBalance": 870000,
-      "RevenueReserve": 830000,
-      "SchoolRevenueReserve": 200000,
-      "CentralRevenueReserve": 630000
+      "RevenueReserve": 830000
     }
   },
   {
@@ -50,9 +48,7 @@
       "InYearBalance": 98,
       "SchoolInYearBalance": 11,
       "CentralInYearBalance": 87,
-      "RevenueReserve": 83,
-      "SchoolRevenueReserve": 20,
-      "CentralRevenueReserve": 63
+      "RevenueReserve": 83
     }
   },
   {
@@ -62,9 +58,7 @@
       "InYearBalance": 49,
       "SchoolInYearBalance": 5.5,
       "CentralInYearBalance": 43.5,
-      "RevenueReserve": 41.5,
-      "SchoolRevenueReserve": 10,
-      "CentralRevenueReserve": 31.5
+      "RevenueReserve": 41.5
     }
   },
   {
@@ -74,9 +68,7 @@
       "InYearBalance": 980,
       "SchoolInYearBalance": 110,
       "CentralInYearBalance": 870,
-      "RevenueReserve": 830,
-      "SchoolRevenueReserve": 200,
-      "CentralRevenueReserve": 630
+      "RevenueReserve": 830
     }
   },
   {


### PR DESCRIPTION
### Context
[AB#232578](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/232578) [AB#225541](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/225541)

### Change proposed in this pull request
As a follow-up to #1459, also remove unused fields from response models.

### Guidance to review 
Expected output should be covered by unit/API tests, but Swagger UI could also be used to validate output models and values at http://localhost:7071/api/swagger/ui

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

