### PR TITLE
fix: remove RevenueReserveCS

### DIFF
--- a/core-infrastructure/src/db/Core.Database/Scripts/055-RemoveRevenueReserveCs.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/055-RemoveRevenueReserveCs.sql
@@ -1,0 +1,14 @@
+IF EXISTS(SELECT *
+          FROM INFORMATION_SCHEMA.TABLES
+          WHERE table_name = 'Financial')
+    BEGIN
+       ALTER TABLE Financial DROP COLUMN RevenueReserveCS;
+    END
+
+
+IF EXISTS(SELECT *
+          FROM INFORMATION_SCHEMA.TABLES
+          WHERE table_name = 'TrustFinancial')
+    BEGIN
+       ALTER TABLE TrustFinancial DROP COLUMN RevenueReserveCS;
+    END

--- a/core-infrastructure/src/db/Core.Database/Scripts/056-RecreateTrustBalanceViews.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/056-RecreateTrustBalanceViews.sql
@@ -1,0 +1,42 @@
+ALTER VIEW TrustBalanceHistoric
+AS
+SELECT t.CompanyNumber,
+       t.TrustName,
+       f.RunId 'Year',
+       f.TotalPupils,
+       f.TotalIncome,
+       f.TotalExpenditure,
+       f.InYearBalance,
+       f.RevenueReserve,
+       f.TotalIncomeCS,
+       f.TotalExpenditureCS,
+       f.InYearBalanceCS
+  FROM Trust t
+  LEFT JOIN TrustFinancial f
+    ON t.CompanyNumber = f.CompanyNumber
+ CROSS JOIN (SELECT Value FROM Parameters p WHERE p.Name = 'LatestAARYear') y
+ WHERE f.RunType = 'default'
+   AND f.RunId BETWEEN y.Value - 5 AND y.Value
+
+GO
+
+
+ALTER VIEW TrustBalance
+AS
+SELECT t.CompanyNumber,
+       t.TrustName,
+       TotalPupils,
+       TotalIncome,
+       TotalExpenditure,
+       InYearBalance,
+       RevenueReserve,
+       TotalIncomeCS,
+       TotalExpenditureCS,
+       InYearBalanceCS
+ FROM Trust t
+ LEFT JOIN TrustFinancial f
+   ON t.CompanyNumber = f.CompanyNumber
+WHERE f.RunType = 'default'
+  AND f.RunId = (SELECT Value FROM Parameters WHERE Name = 'CurrentYear')
+
+GO

--- a/core-infrastructure/src/db/Core.Database/Scripts/057-RecreateSchoolBalanceViews.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/057-RecreateSchoolBalanceViews.sql
@@ -1,0 +1,56 @@
+ALTER VIEW SchoolBalanceHistoric AS
+SELECT s.URN,
+       s.Year,
+       s.TrustCompanyNumber,
+       f.TotalPupils,
+       f.TotalIncome,
+       f.TotalExpenditure,
+       f.InYearBalance,
+       f.RevenueReserve,
+       f.TotalIncomeCS,
+       f.TotalExpenditureCS,
+       f.InYearBalanceCS
+FROM (SELECT *
+      FROM School,
+           AARHistoryYears) s
+         LEFT OUTER JOIN Financial f ON s.Year = f.RunId AND f.URN = s.URN AND f.RunType = 'default'
+WHERE s.FinanceType = 'Academy'
+UNION
+SELECT s.URN,
+       s.Year,
+       s.TrustCompanyNumber,
+       f.TotalPupils,
+       f.TotalIncome,
+       f.TotalExpenditure,
+       f.InYearBalance,
+       f.RevenueReserve,
+       f.TotalIncomeCS,
+       f.TotalExpenditureCS,
+       f.InYearBalanceCS
+FROM (SELECT *
+      FROM School,
+           CFRHistoryYears) s
+         LEFT OUTER JOIN Financial f ON s.Year = f.RunId AND f.URN = s.URN AND f.RunType = 'default'
+WHERE s.FinanceType = 'Maintained'
+
+GO
+
+
+ALTER VIEW SchoolBalance AS
+    SELECT s.URN,
+           s.SchoolName,
+           s.SchoolType,
+           s.LAName,
+           s.TrustCompanyNumber,
+           f.PeriodCoveredByReturn,
+           f.TotalPupils,
+           f.TotalIncome,
+           f.TotalExpenditure,
+           f.InYearBalance,
+           f.RevenueReserve,
+           f.TotalIncomeCS,
+           f.TotalExpenditureCS,
+           f.InYearBalanceCS
+    FROM School s
+             LEFT JOIN CurrentDefaultFinancial f on f.URN = s.URN
+GO

--- a/data-pipeline/src/pipeline/config.py
+++ b/data-pipeline/src/pipeline/config.py
@@ -746,7 +746,6 @@ trust_db_projections = {
     "Total Income_CS": "TotalIncomeCS",
     "Total Expenditure_CS": "TotalExpenditureCS",
     "In year balance_CS": "InYearBalanceCS",
-    "Revenue reserve_CS": "RevenueReserveCS",
     "Income_Total grant funding_CS": "TotalGrantFundingCS",
     "Income_Total self generated funding_CS": "TotalSelfGeneratedFundingCS",
     "Income_Direct grants_CS": "DirectGrantsCS",

--- a/data-pipeline/src/pipeline/database.py
+++ b/data-pipeline/src/pipeline/database.py
@@ -350,7 +350,6 @@ def insert_financial_data(run_type: str, year: str, df: pd.DataFrame):
         "Total Income_CS": "TotalIncomeCS",
         "Total Expenditure_CS": "TotalExpenditureCS",
         "In year balance_CS": "InYearBalanceCS",
-        "Revenue reserve_CS": "RevenueReserveCS",
         "Income_Total grant funding_CS": "TotalGrantFundingCS",
         "Income_Total self generated funding_CS": "TotalSelfGeneratedFundingCS",
         "Income_Direct grants_CS": "DirectGrantsCS",

--- a/data-pipeline/src/pipeline/pre_processing.py
+++ b/data-pipeline/src/pipeline/pre_processing.py
@@ -269,8 +269,11 @@ def prepare_central_services_data(cs_path, current_year: int):
                 "BNCH11123-BTI011-A (MAT Central services - Income)"
             ] = central_services_financial["BNCHBAI061 (Coronavirus Govt Funding)"]
 
-    central_services_financial["Income_Direct revenue finance"] = central_services_financial[
-        "BNCH21707 (Direct revenue financing (Revenue contributions to capital))"]
+    central_services_financial["Income_Direct revenue finance"] = (
+        central_services_financial[
+            "BNCH21707 (Direct revenue financing (Revenue contributions to capital))"
+        ]
+    )
 
     central_services_financial["Income_Total grant funding"] = (
         central_services_financial["BNCH11110T (EFA Revenue Grants)"]
@@ -436,7 +439,9 @@ def prepare_aar_data(aar_path, current_year: int):
     ):
         aar["BNCH11123-BAI011-A (Academies - Income)"] = 0.0
 
-    aar["Income_Direct revenue finance"] = aar["BNCH21707 (Direct revenue financing (Revenue contributions to capital))"]
+    aar["Income_Direct revenue finance"] = aar[
+        "BNCH21707 (Direct revenue financing (Revenue contributions to capital))"
+    ]
 
     aar["Income_Total grant funding"] = (
         aar["BNCH11110T (EFA Revenue Grants)"]
@@ -1037,8 +1042,6 @@ def build_academy_data(
     ] - academies["Income_Catering services_CS"].fillna(0.0)
 
     academies = _trust_revenue_reserve(academies, central_services)
-    # TODO: `Revenue reserve_CS` to be removed.
-    academies["Revenue reserve_CS"] = 0.0
 
     academies["Company Registration Number"] = academies[
         "Company Registration Number"


### PR DESCRIPTION
### Context

`RevenueReserveCS` no longer required; removed from dependant layers in #1459 and #1463.

[AB#225541](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/225541)

### Change proposed in this pull request

- no longer persist `RevenueReserveCs` to the DB in the data-pipeline
- remove column from financial tables

### Guidance to review 

…

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [ ] You have tested by running locally
- [ ] You have reviewed with UX/Design

