### PR TITLE
Automation runbook to copy from one storage container to another

### DIFF
--- a/core-infrastructure/terraform/automation.tf
+++ b/core-infrastructure/terraform/automation.tf
@@ -12,10 +12,6 @@ resource "azurerm_automation_account" "automation" {
   public_network_access_enabled = var.environment == "development" ? true : false
 }
 
-data "local_file" "backup-database-script" {
-  filename = "${path.module}/scripts/backup-database.ps1"
-}
-
 resource "azurerm_automation_schedule" "daily-schedule" {
   name                    = "${var.environment-prefix}-daily-schedule"
   resource_group_name     = azurerm_resource_group.resource-group.name
@@ -25,6 +21,10 @@ resource "azurerm_automation_schedule" "daily-schedule" {
 
   # begin schedule from midnight tomorrow (UTC)
   start_time = formatdate("YYYY-MM-DD'T'00:00:00+00:00", timeadd(timestamp(), "24h"))
+}
+
+data "local_file" "backup-database-script" {
+  filename = "${path.module}/scripts/backup-database.ps1"
 }
 
 resource "azurerm_automation_runbook" "backup-database-runbook" {
@@ -60,6 +60,46 @@ resource "azurerm_automation_job_schedule" "backup-database-runbook-daily-schedu
     storagekeysecret       = azurerm_key_vault_secret.backup-storage-key.name
     containername          = azurerm_storage_container.pipeline-database-backup.name
     expiryseconds          = 604800
+  }
+}
+
+data "local_file" "backup-container-script" {
+  filename = "${path.module}/scripts/backup-container.ps1"
+}
+
+resource "azurerm_automation_runbook" "backup-raw-data-runbook" {
+  name                    = "${var.environment-prefix}-backup-raw-data"
+  location                = azurerm_resource_group.resource-group.location
+  resource_group_name     = azurerm_resource_group.resource-group.name
+  automation_account_name = azurerm_automation_account.automation.name
+  log_verbose             = "true"
+  log_progress            = "true"
+  description             = "Performs a backup of the given container to the specified blob storage container"
+  runbook_type            = "PowerShell72"
+  tags                    = local.common-tags
+  content                 = data.local_file.backup-container-script.content
+}
+
+resource "azurerm_automation_job_schedule" "backup-raw-data-runbook-daily-schedule" {
+  resource_group_name     = azurerm_resource_group.resource-group.name
+  automation_account_name = azurerm_automation_account.automation.name
+  runbook_name            = azurerm_automation_runbook.backup-raw-data-runbook.name
+  schedule_name           = azurerm_automation_schedule.daily-schedule.name
+
+  # Due to a bug in the implementation of Runbooks in Azure, the parameter names need to be specified in lowercase only. 
+  # https://github.com/Azure/azure-sdk-for-go/issues/4780
+  parameters = {
+    subscriptionname         = data.azurerm_subscription.current.display_name
+    resourcegroup            = azurerm_resource_group.resource-group.name
+    keyvaultname             = azurerm_key_vault.key-vault.name
+    sourcestorageaccountname = azurerm_storage_account.data.name
+    sourcestoragekeysecret   = azurerm_key_vault_secret.data-storage-key.name
+    sourcecontainername      = azurerm_storage_container.pipeline-raw-data.name
+    targetstorageaccountname = azurerm_storage_account.backup.name
+    targetstoragekeysecret   = azurerm_key_vault_secret.backup-storage-key.name
+    targetcontainername      = azurerm_storage_container.pipeline-raw-data-backup.name
+    targetfoldertimestamp    = true
+    expiryseconds            = 604800
   }
 }
 

--- a/core-infrastructure/terraform/scripts/backup-container.ps1
+++ b/core-infrastructure/terraform/scripts/backup-container.ps1
@@ -1,0 +1,127 @@
+<#
+    .SYNOPSIS
+        Backup a Blob storage container to another Blob storage location.
+ 
+    .DESCRIPTION
+        Copies files from a storage container to another storage container as a timestamped backup.
+
+    .PARAMETER SubscriptionName
+        The Azure Subscription name where the storage accounts exists to backup.
+ 
+    .PARAMETER ResourceGroup
+        The resource group name where the storage accounts exists to backup.
+ 
+    .PARAMETER KeyVaultName
+        The key vault name where secrets may be resolved from.
+
+    .PARAMETER SourceStorageAccountName
+        The StorageAccount that contains the files to back up. 
+
+    .PARAMETER SourceStorageKeySecret
+        Key Vault secret name coresponding to the source storage account access key.
+ 
+    .PARAMETER SourceContainerName
+        The StorageAccount container name that contains the files to back up.
+ 
+    .PARAMETER TargetStorageAccountName
+        The StorageAccount that should hold the backed up files. 
+
+    .PARAMETER TargetStorageKeySecret
+        Key Vault secret name coresponding to the target storage account access key.
+ 
+    .PARAMETER TargetContainerName
+        The StorageAccount container name that should hold the backed up files.
+
+    .PARAMETER TargetFolderName
+        The container folder name that should hold the backed up files.
+
+    .PARAMETER ExpirySeconds
+        Specifies expiry period in seconds assigned to the files stored in blob storage.
+#>
+
+Param (
+    [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()]
+    [String] $SubscriptionName,
+    [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()]
+    [String] $ResourceGroup,
+    [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()]
+    [String] $KeyVaultName,
+    [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()]
+    [String] $SourceStorageAccountName,
+    [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()]
+    [String] $SourceStorageKeySecret,
+    [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()]
+    [String] $SourceContainerName,
+    [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()]
+    [String] $TargetStorageAccountName,
+    [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()]
+    [String] $TargetStorageKeySecret,
+    [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()]
+    [String] $TargetContainerName,
+    [Parameter(Mandatory = $false)][ValidateNotNullOrEmpty()]
+    [Boolean] $TargetFolderTimestamp,
+    [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()]
+    [Int32] $ExpirySeconds
+)
+
+# Connect to Azure with system-assigned managed identity
+Connect-AzAccount -Identity
+
+# Set context
+$sourceStorageKey = Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name $SourceStorageKeySecret -AsPlainText
+$targetStorageKey = Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name $TargetStorageKeySecret -AsPlainText
+$sourceStorageContext = New-AzStorageContext -StorageAccountName $SourceStorageAccountName -StorageAccountKey $sourceStorageKey -Protocol Https
+$targetStorageContext = New-AzStorageContext -StorageAccountName $TargetStorageAccountName -StorageAccountKey $targetStorageKey -Protocol Https
+$timestamp = Get-Date -UFormat "%Y-%m-%d_%H-%M-%S"
+
+# below is based on https://stackoverflow.com/a/43777258/504477
+$blobs = Get-AzStorageBlob -Context $sourceStorageContext -Container $SourceContainerName
+$copiedBlobs = @()
+foreach ($Blob in $blobs) {
+    $blobName = $Blob.Name
+    if ($TargetFolderTimestamp -eq $True) {
+        $targetBlobName = "$timestamp/$blobName"
+    } 
+    
+    Write-Output "Copying $SourceContainerName/$blobName to $targetContainerName/$targetBlobName"
+    $blobCopy = Start-AzStorageBlobCopy -Context $sourceStorageContext -SrcContainer $SourceContainerName -SrcBlob $blobName -DestContext $targetStorageContext -DestContainer $SourceContainerName -DestBlob $TargetBlobName
+    $copiedBlobs += $blobCopy
+}
+
+# Start-AzStorageBlobCopy is asynchronous, so need to poll state until all are successful 
+$completeBlobs = @()
+while ($completeBlobs.Length -lt $copiedBlobs.Length) {
+    Start-Sleep -Seconds 60
+
+    foreach ($copiedBlob in $copiedBlobs) {
+        [Microsoft.Azure.Storage.Blob.CopyState] $copyState
+
+        try {
+            $copyState = $copiedBlob | Get-AzStorageBlobCopyState -ErrorAction stop
+        }
+        catch {
+            if ($completeBlobs -notcontains $copiedBlob) {
+                $completeBlobs += $copiedBlob
+            }
+
+            Write-Output $("Unable to determine blob copy state of $($copiedBlob.Name). $($_.Exception.Message)")
+            Write-Verbose $_.ScriptStackTrace
+        }
+
+        if ($null -ne $copyState) {
+            $message = $copyState.Source.AbsolutePath + " " + $copyState.Status + " {0:N2}%" -f (($copyState.BytesCopied / $copyState.TotalBytes) * 100) 
+            Write-Verbose $message
+        }
+
+        # wait until copy complete and then update the properties, otherwise content length is set to zero
+        if (($copyState.BytesCopied -ge $copyState.TotalBytes) -and ($completeBlobs -notcontains $copiedBlob)) {
+            $completeBlobs += $copiedBlob
+            $blob = Get-AzStorageBlob -Container $targetContainerName -Blob $copiedBlob.Name -Context $targetStorageContext
+            $blob.ICloudBlob.Properties.CacheControl = "max-age=$ExpirySeconds"
+            $blob.ICloudBlob.SetProperties()
+            Write-Verbose $("Updated properties for $($copiedBlob.Name)")
+        }
+    }
+
+    Write-Output $("Completed blobs: $($completeBlobs.Length)/$($copiedBlobs.Length)")
+}

--- a/core-infrastructure/terraform/scripts/backup-database.ps1
+++ b/core-infrastructure/terraform/scripts/backup-database.ps1
@@ -8,7 +8,7 @@
     .PARAMETER SubscriptionName
         The Azure Subscription name where the databases exists to backup.
  
-    .PARAMETER SourceResourceGroupName
+    .PARAMETER ResourceGroup
         The resource group name where the source database exists to backup.
  
     .PARAMETER KeyVaultName
@@ -68,7 +68,7 @@ Param (
 Connect-AzAccount -Identity
 
 # Set context
-$bacpacFileName = "$DatabaseName-$(Get-Date -UFormat "%Y-%m-%d_%H-%m-%S").bacpac"
+$bacpacFileName = "$DatabaseName-$(Get-Date -UFormat "%Y-%m-%d_%H-%M-%S").bacpac"
 $databaseUsername = Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name $DatabaseUsernameSecret -AsPlainText
 $databasePassword = Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name $DatabasePasswordSecret -AsPlainText
 $storageKey = Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name $StorageKeySecret -AsPlainText

--- a/core-infrastructure/terraform/storage.tf
+++ b/core-infrastructure/terraform/storage.tf
@@ -74,6 +74,15 @@ resource "azurerm_key_vault_secret" "data-storage-connection-string" {
   depends_on   = [azurerm_key_vault_access_policy.terraform_sp_access]
 }
 
+resource "azurerm_key_vault_secret" "data-storage-key" {
+  #checkov:skip=CKV_AZURE_41:See ADO backlog AB#206511
+  name         = "data-storage-key"
+  value        = azurerm_storage_account.data.primary_access_key
+  key_vault_id = azurerm_key_vault.key-vault.id
+  content_type = "token"
+  depends_on   = [azurerm_key_vault_access_policy.terraform_sp_access]
+}
+
 resource "azurerm_monitor_diagnostic_setting" "storage-account-data-queue" {
   name                       = "${azurerm_storage_account.data.name}-queue-logs"
   target_resource_id         = "${azurerm_storage_account.data.id}/queueServices/default/"
@@ -151,6 +160,12 @@ resource "azurerm_storage_account" "backup" {
 resource "azurerm_storage_container" "pipeline-database-backup" {
   #checkov:skip=CKV2_AZURE_21:See ADO backlog AB#206507
   name                 = "database"
+  storage_account_name = azurerm_storage_account.backup.name
+}
+
+resource "azurerm_storage_container" "pipeline-raw-data-backup" {
+  #checkov:skip=CKV2_AZURE_21:See ADO backlog AB#206507
+  name                 = "raw"
   storage_account_name = azurerm_storage_account.backup.name
 }
 


### PR DESCRIPTION
### Context
AB#232949 AB#231790

### Change proposed in this pull request
New runbook on a daily schedule that runs PowerShell to copy all blobs from one container to another, within a timestamped folder. Expiry set on all blob properties.

### Guidance to review 
AzCopy was unable to be used here due to issues around SAS tokens. Verbose logging has been added should help identify where issues may occur. This has been deployed to and run on `d12` feature environment.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~~Your code builds clean without any errors or warnings~~
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

