### PR TITLE
feat: remove processing of mixed datasets

### DIFF
--- a/core-infrastructure/src/db/Core.Database/Scripts/059-RemoveSetType.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/059-RemoveSetType.sql
@@ -1,0 +1,21 @@
+DELETE FROM ComparatorSet WHERE SetType = 'mixed' AND RunType = 'default';
+
+IF EXISTS(SELECT *
+          FROM INFORMATION_SCHEMA.TABLES
+          WHERE table_name = 'ComparatorSet')
+    BEGIN
+       ALTER TABLE ComparatorSet DROP CONSTRAINT PK_ComparatorSet;
+       ALTER TABLE ComparatorSet DROP COLUMN SetType;
+       ALTER TABLE ComparatorSet ADD CONSTRAINT PK_ComparatorSet PRIMARY KEY (RunType, RunId, URN);
+    END
+
+DELETE FROM MetricRAG WHERE SetType = 'mixed' AND RunType = 'default';
+
+IF EXISTS(SELECT *
+          FROM INFORMATION_SCHEMA.TABLES
+          WHERE table_name = 'MetricRAG')
+    BEGIN
+       ALTER TABLE MetricRAG DROP CONSTRAINT PK_MetricRAG;
+       ALTER TABLE MetricRAG DROP COLUMN SetType;
+       ALTER TABLE MetricRAG ADD CONSTRAINT PK_MetricRAG PRIMARY KEY (RunType, RunId, URN, Category, SubCategory);
+    END

--- a/data-pipeline/src/pipeline/database.py
+++ b/data-pipeline/src/pipeline/database.py
@@ -74,10 +74,13 @@ def upsert(
         cnx.execute(sqlalchemy.text(f"DROP TABLE IF EXISTS {temp_table}"))
 
 
-def insert_comparator_set(run_type: str, set_type: str, run_id: str, df: pd.DataFrame):
+def insert_comparator_set(
+    run_type: str,
+    run_id: str,
+    df: pd.DataFrame,
+):
     write_frame = df[["Pupil", "Building"]].copy()
     write_frame["RunType"] = run_type
-    write_frame["SetType"] = set_type
     write_frame["RunId"] = str(run_id)
     write_frame["Pupil"] = write_frame["Pupil"].map(lambda x: json.dumps(x.tolist()))
     write_frame["Building"] = write_frame["Building"].map(
@@ -87,14 +90,14 @@ def insert_comparator_set(run_type: str, set_type: str, run_id: str, df: pd.Data
     upsert(
         write_frame,
         "ComparatorSet",
-        keys=["RunType", "RunId", "URN", "SetType"],
+        keys=["RunType", "RunId", "URN"],
     )
     logger.info(
-        f"Wrote {len(write_frame)} rows to comparator set {run_type} - {set_type} - {run_id}"
+        f"Wrote {len(write_frame)} rows to comparator set {run_type} - {run_id}"
     )
 
 
-def insert_metric_rag(run_type: str, set_type: str, run_id: str, df: pd.DataFrame):
+def insert_metric_rag(run_type: str, run_id: str, df: pd.DataFrame):
     write_frame = df[
         [
             "Category",
@@ -110,19 +113,17 @@ def insert_metric_rag(run_type: str, set_type: str, run_id: str, df: pd.DataFram
     ].copy()
     write_frame["RunType"] = run_type
     write_frame["RunId"] = str(run_id)
-    write_frame["SetType"] = set_type
 
     upsert(
         write_frame,
         "MetricRAG",
-        keys=["RunType", "RunId", "SetType", "URN", "Category", "SubCategory"],
+        keys=["RunType", "RunId", "URN", "Category", "SubCategory"],
         dtype={
             "RunType": sqlalchemy.types.VARCHAR(length=50),
             "RunId": sqlalchemy.types.VARCHAR(length=50),
             "URN": sqlalchemy.types.VARCHAR(length=6),
             "Category": sqlalchemy.types.VARCHAR(length=50),
             "SubCategory": sqlalchemy.types.VARCHAR(length=50),
-            "SetType": sqlalchemy.types.VARCHAR(length=50),
             "Value": sqlalchemy.types.Numeric(16, 2),
             "Mean": sqlalchemy.types.Numeric(16, 2),
             "DiffMean": sqlalchemy.types.Numeric(16, 2),
@@ -132,9 +133,7 @@ def insert_metric_rag(run_type: str, set_type: str, run_id: str, df: pd.DataFram
             "RAG": sqlalchemy.types.VARCHAR(length=10),
         },
     )
-    logger.info(
-        f"Wrote {len(write_frame)} rows to metric rag {run_type} - {set_type} - {run_id}"
-    )
+    logger.info(f"Wrote {len(write_frame)} rows to metric rag {run_type} - {run_id}")
 
 
 def insert_schools_and_local_authorities(run_type: str, year: str, df: pd.DataFrame):

--- a/documentation/data/2_Models.md
+++ b/documentation/data/2_Models.md
@@ -261,7 +261,6 @@ It is also key to note that within the service, metrics such as "cost per pupil"
 |     gias| URN  |     URN    |URN  |    |
 |     N/A - defined in pipeline run |   |   Category     | Category  |    |
 |     N/A - defined in pipeline run |   |    Subcategory    | Subcategory  |    |
-|     N/A - defined in pipeline run |   |        | SetType  |  SetType may take values such as: unmixed or mixed  |
 |     N/A - computed |   |    Value    | Value  | The numerical value for the specific Category, for a given URN  |
 |     N/A - computed |   |    Mean    | Mean  | Computed from the mean of a series of Category values for a comparator set  |
 |     N/A - computed |   |    DiffMean    | DiffMean  | Computed as the difference between the Value for a given URN and the Mean for the entire comparator set, for a given Catagory |
@@ -279,7 +278,6 @@ It is also key to note that within the service, metrics such as "cost per pupil"
 |     N/A - defined in pipeline run |   |        | RunType  |    |
 |     N/A - defined in pipeline run |   |        | RunId  |    |
 |     gias| URN  |     URN    |URN  |    |
-|     N/A - defined in pipeline run |   |        | SetType  |  SetType may take values such as: unmixed or mixed  |
 |     N/A - computed |   |    Pupil    | Pupil  | A comparator set list of URNs for the top 30 schools determined by the pupil characteristic euclidean distance caluclation outlined in `3_Data-Processing` |
 |     N/A - computed |   |    Building    | Building  | A comparator set list of URNs for the top 30 schools determined by the building characteristic euclidean distance caluclation outlined in `3_Data-Processing`   |
 

--- a/documentation/data/3_Processing.md
+++ b/documentation/data/3_Processing.md
@@ -458,7 +458,7 @@ The currently configured mappings can be found [here](https://github.com/DFE-Dig
 
 Once all of the processing is complete the data is stored in the platform database so that it is available to query from reporting engines and the FBIT front end. The schema for this data consists of the following tables
 
-> Note: The RunType, RunID, SetType are metadata fields that allow the front end and other tools to identify which pipeline run that the data has been derived from. 
+> Note: The RunType, RunID are metadata fields that allow the front end and other tools to identify which pipeline run that the data has been derived from. 
 
 ```mermaid
 classDiagram
@@ -469,7 +469,6 @@ class ComparatorSet {
    nvarchar(50) RunType
    nvarchar(50) RunId
    nvarchar(6) URN
-   nvarchar(50) SetType
 }
 class FinancialPlan {
    nvarchar(max) Input
@@ -500,7 +499,6 @@ class MetricRAG {
    nvarchar(6) URN
    nvarchar(50) Category
    nvarchar(50) SubCategory
-   nvarchar(50) SetType
 }
 class School {
    nvarchar(255) SchoolName


### PR DESCRIPTION
### Context

"Mixed" datasets are no longer required and comparator-set/RAG processing thereof can be removed.

Note: the "all-schools" data, however, is being retained as this is useful in later processing.

[AB#232973](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/232973)

### Change proposed in this pull request

- remove generation of comparator-sets and RAG for mixed datasets
- remove references to mixed/unmixed data throughout
- remove `SetType` from all DB tables and associated constraints
- remove references to `SetType` from docs.

### Guidance to review 

Note: this can't be merged until the API/UI is updated to accommodate these changes (#233103).

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] You have reviewed with UX/Design

