### PR TITLE
chore: adds retention policies to db

### DIFF
--- a/core-infrastructure/terraform/databases.tf
+++ b/core-infrastructure/terraform/databases.tf
@@ -122,6 +122,15 @@ resource "azurerm_mssql_database" "sql-db" {
     storage_account_access_key = azurerm_storage_account.sql-log-storage.primary_access_key
     retention_days             = 120
   }
+
+  short_term_retention_policy {
+    backup_interval_in_hours = 24
+    retention_days           = 7
+  }
+
+  long_term_retention_policy {
+    weekly_retention = "P52W"
+  }
 }
 
 resource "azurerm_mssql_database_extended_auditing_policy" "db-audit-policy" {


### PR DESCRIPTION
### Context
[AB#231299](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/231299) - [AB#233110](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/233110)

### Change proposed in this pull request
adds `short_term_retention_policy` and `long_term_retention_policy` to the `azurerm_mssql_database` resource.

### Guidance to review 
Appears Differential backup frequency and PITR retention already default to our desired values but set explicitly in the terraform anyway. Validated in `d16` and Weekly LTR shows 52 weeks as required.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] You have reviewed with UX/Design

