### PR TITLE
Added RAG guidance to Spending Priorities on School Homepage

### DIFF
--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -28,10 +28,7 @@
   background-color: govuk-tint(govuk-colour("dark-grey"), 85%);
   margin-top: -2px;
   margin-bottom: -3px;
-  padding-top: 2px;
-  padding-right: 8px;
-  padding-bottom: 3px;
-  padding-left: 8px;
+  padding: 2px 8px 3px;
   text-decoration: none;
   overflow-wrap: break-word;
 }
@@ -48,28 +45,39 @@
 .priority {
   margin-bottom: 14px;
   border-left: none;
+
+  &.high {
+    border: 1px solid $rag-red-colour;
+
+    .govuk-tag {
+      border-color: $rag-red-colour;
+    }
+  }
+
+  &.medium, &.low {
+    border: 1px solid $govuk-border-colour;
+  }
+
+  &.medium {
+    .govuk-tag {
+      border-color: $govuk-border-colour;
+    }
+  }
+
+  &.low {
+    .govuk-tag {
+      border-color: $govuk-border-colour;
+    }
+  }
 }
 
-.priority.high {
-  border: 1px solid $rag-red-colour;
-}
+.priority-wrapper {
+  border: 2px solid $govuk-border-colour;
 
-.priority.high .govuk-tag {
-  border-color: $rag-red-colour;
+  &.high {
+    border-color: $rag-red-colour;
+  }
 }
-
-.priority.medium, .priority.low {
-  border: 1px solid $govuk-border-colour;
-}
-
-.priority.medium .govuk-tag {
-  border-color: $govuk-border-colour;
-}
-
-.priority.low .govuk-tag {
-  border-color: $govuk-border-colour;
-}
-
 
 .app-tag--red {
   background-color: $rag-red-colour;
@@ -92,14 +100,27 @@ p.priority .govuk-tag {
   margin: 0 10px 0 0;
 }
 
-.top-categories div {
-  background-color: #EEEFEF;
-  padding: 20px;
-  margin-bottom: 20px;
-}
+.top-categories {
+  div {
+    background-color: #EEEFEF;
+    padding: 20px;
+    margin-bottom: 20px;
+  }
 
-.top-categories .priority {
-  margin-bottom: 0;
+  .priority {
+    margin-bottom: 0;
+  }
+
+  &.school-home-priorities {
+    .priority {
+      border: 0;
+
+      .govuk-tag {
+        border: 0;
+        margin-bottom: 4px;
+      }
+    }
+  }
 }
 
 .priority-guidance {

--- a/web/src/Web.App/Views/School/Index.cshtml
+++ b/web/src/Web.App/Views/School/Index.cshtml
@@ -84,10 +84,15 @@
             @if (Model.Ratings.Any())
             {
                 <h3 class="govuk-heading-s">Top spending priorities</h3>
-                <div class="top-categories">
+            }
+        </div>
+        @if (Model.Ratings.Any())
+        {
+            <div class="govuk-grid-column-one-half">
+                <div class="top-categories school-home-priorities">
                     @foreach (var rating in Model.Ratings)
                     {
-                        <div>
+                        <div class="priority-wrapper @rating.PriorityTag?.Class">
                             <h4 class="govuk-heading-s">@rating.Category</h4>
                             <p class="priority @rating.PriorityTag?.Class govuk-body">
                                 @await Component.InvokeAsync("Tag", new
@@ -103,13 +108,29 @@
                         </div>
                     }
                 </div>
-            }
-
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-0">
-                <a href="@Url.Action("Index", "SchoolSpending", new { urn = Model.Urn })" class="govuk-link govuk-link--no-visited-state">
-                    View all spending priorities for this school
-                </a>
-            </h3>
+            </div>
+        }
+        <div class="govuk-grid-column-one-half govuk-body" id="rag-guidance">
+            <p>
+                Red, amber and green (RAG) priority ratings are shown to give an indication of the spending compared to
+                similar schools.
+            </p>
+            <p>
+                The rating is not an indication of performance. It is used to display if spending is significantly
+                more or less than similar schools. This does not consider any individual spending strategies which might
+                apply.
+            </p>
+            <p>
+                The ratings are intended for schools and trusts to identify potential areas to help them make
+                informed spending decisions.
+            </p>
+            <p>
+                <strong>
+                    <a href="@Url.Action("Index", "SchoolSpending", new { urn = Model.Urn })" class="govuk-link govuk-link--no-visited-state">
+                        View all spending priorities for this school
+                    </a>
+                </strong>
+            </p>
         </div>
     </div>
 }

--- a/web/tests/Web.E2ETests/Features/School/SchoolHome.feature
+++ b/web/tests/Web.E2ETests/Features/School/SchoolHome.feature
@@ -47,3 +47,7 @@
           | Teaching and Teaching support staff | High priority Spends £6,315 per pupil — Spending is higher than 99% of similar schools.  |
           | Non-educational support staff       | High priority Spends £845 per pupil — Spending is higher than 95.67% of similar schools. |
           | Administrative supplies             | High priority Spends £429 per pupil — Spending is higher than 99% of similar schools.    |
+          
+    Scenario: RAG guidance is displayed
+        Given I am on school homepage for school with urn '777042'
+        Then the RAG guidance is visible

--- a/web/tests/Web.E2ETests/Pages/School/HomePage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/HomePage.cs
@@ -50,6 +50,7 @@ public class HomePage(IPage page)
         });
 
     private ILocator CookieBanner => page.Locator(Selectors.CookieBanner);
+    private ILocator RagGuidance => page.Locator("#rag-guidance");
 
     public async Task IsDisplayed(bool isPartYear = false, string? trustName = null)
     {
@@ -150,5 +151,10 @@ public class HomePage(IPage page)
 
         var text = await priority.InnerTextAsync();
         Assert.Equal(commentary, text);
+    }
+
+    public async Task AssertRagGuidance()
+    {
+        await RagGuidance.ShouldBeVisible();
     }
 }

--- a/web/tests/Web.E2ETests/Steps/School/HomeSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/HomeSteps.cs
@@ -181,4 +181,11 @@ public class HomeSteps(PageDriver driver)
             await _schoolHomePage.AssertRagCommentary(row["Name"], row["Commentary"]);
         }
     }
+
+    [Then("the RAG guidance is visible")]
+    public async Task ThenTheRagGuidanceIsVisible()
+    {
+        Assert.NotNull(_schoolHomePage);
+        await _schoolHomePage.AssertRagGuidance();
+    }
 }


### PR DESCRIPTION
### Context
[AB#232097](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/232097) [AB#230874](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/230874)

### Change proposed in this pull request
Added guidance copy as per designs. 
Formatting adjustments to priority panels on school home page only.

### Guidance to review 
View a school homepage to see the guidance and reformatted priority panels. Priority panels and RAG tags on other pages should not be affected by this change.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

