### PR TITLE
Added Cost Category commentary and guidance

### DIFF
--- a/web/src/Web.App/Constants/PageTitles.cs
+++ b/web/src/Web.App/Constants/PageTitles.cs
@@ -73,4 +73,5 @@ public static class PageTitles
     public const string TrustComparatorsRevert = "Remove all your trusts?";
     public const string TrustToTrustHome = "Benchmark spending for this trust";
     public const string ForecastAndRisks = "Forecast and risks";
+    public const string CostCategories = "Cost category breakdown";
 }

--- a/web/src/Web.App/Controllers/StaticContentController.cs
+++ b/web/src/Web.App/Controllers/StaticContentController.cs
@@ -53,4 +53,8 @@ public class StaticContentController : Controller
         ViewData[ViewDataKeys.UseJsBackLink] = true;
         return View();
     }
+
+    [HttpGet]
+    [Route("guidance/cost-categories")]
+    public IActionResult CostCategories() => View();
 }

--- a/web/src/Web.App/Domain/CostCategories.cs
+++ b/web/src/Web.App/Domain/CostCategories.cs
@@ -81,11 +81,15 @@ public abstract class CostCategory(RagRating rating)
     public RagRating Rating => rating;
 
     public ReadOnlyDictionary<string, Category> Values => _values.AsReadOnly();
+
+    public abstract string[] SubCategories { get; }
     public abstract void Add(string urn, SchoolExpenditure expenditure);
 }
 
 public class AdministrativeSupplies(RagRating rating) : CostCategory(rating)
 {
+    public override string[] SubCategories => SubCostCategories.AdministrativeSupplies.SubCategories;
+
     public override void Add(string urn, SchoolExpenditure expenditure)
     {
         this[urn] = new Category(expenditure.AdministrativeSuppliesCosts ?? 0);
@@ -94,6 +98,8 @@ public class AdministrativeSupplies(RagRating rating) : CostCategory(rating)
 
 public class CateringStaffServices(RagRating rating) : CostCategory(rating)
 {
+    public override string[] SubCategories => SubCostCategories.CateringStaffServices.SubCategories;
+
     public override void Add(string urn, SchoolExpenditure expenditure)
     {
         this[urn] = new Category(expenditure.TotalGrossCateringCosts ?? 0);
@@ -102,6 +108,8 @@ public class CateringStaffServices(RagRating rating) : CostCategory(rating)
 
 public class EducationalIct(RagRating rating) : CostCategory(rating)
 {
+    public override string[] SubCategories => SubCostCategories.EducationalIct.SubCategories;
+
     public override void Add(string urn, SchoolExpenditure expenditure)
     {
         this[urn] = new Category(expenditure.LearningResourcesIctCosts ?? 0);
@@ -110,6 +118,8 @@ public class EducationalIct(RagRating rating) : CostCategory(rating)
 
 public class EducationalSupplies(RagRating rating) : CostCategory(rating)
 {
+    public override string[] SubCategories => SubCostCategories.EducationalSupplies.SubCategories;
+
     public override void Add(string urn, SchoolExpenditure expenditure)
     {
         this[urn] = new Category(expenditure.TotalEducationalSuppliesCosts ?? 0);
@@ -118,6 +128,8 @@ public class EducationalSupplies(RagRating rating) : CostCategory(rating)
 
 public class NonEducationalSupportStaff(RagRating rating) : CostCategory(rating)
 {
+    public override string[] SubCategories => SubCostCategories.NonEducationalSupportStaff.SubCategories;
+
     public override void Add(string urn, SchoolExpenditure expenditure)
     {
         this[urn] = new Category(expenditure.TotalNonEducationalSupportStaffCosts ?? 0);
@@ -126,6 +138,8 @@ public class NonEducationalSupportStaff(RagRating rating) : CostCategory(rating)
 
 public class TeachingStaff(RagRating rating) : CostCategory(rating)
 {
+    public override string[] SubCategories => SubCostCategories.TeachingStaff.SubCategories;
+
     public override void Add(string urn, SchoolExpenditure expenditure)
     {
         this[urn] = new Category(expenditure.TotalTeachingSupportStaffCosts ?? 0);
@@ -134,6 +148,8 @@ public class TeachingStaff(RagRating rating) : CostCategory(rating)
 
 public class Other(RagRating rating) : CostCategory(rating)
 {
+    public override string[] SubCategories => SubCostCategories.Other.SubCategories;
+
     public override void Add(string urn, SchoolExpenditure expenditure)
     {
         this[urn] = new Category(expenditure.TotalOtherCosts ?? 0);
@@ -142,6 +158,8 @@ public class Other(RagRating rating) : CostCategory(rating)
 
 public class PremisesStaffServices(RagRating rating) : CostCategory(rating)
 {
+    public override string[] SubCategories => SubCostCategories.PremisesStaffServices.SubCategories;
+
     public override void Add(string urn, SchoolExpenditure expenditure)
     {
         this[urn] = new Category(expenditure.TotalPremisesStaffServiceCosts ?? 0);
@@ -150,6 +168,7 @@ public class PremisesStaffServices(RagRating rating) : CostCategory(rating)
 
 public class Utilities(RagRating rating) : CostCategory(rating)
 {
+    public override string[] SubCategories => SubCostCategories.Utilities.SubCategories;
 
     public override void Add(string urn, SchoolExpenditure expenditure)
     {
@@ -238,5 +257,107 @@ public static class CategoryBuilder
         }
 
         return categories.Pupil.Concat(categories.Area);
+    }
+}
+
+public static class SubCostCategories
+{
+    public static class TeachingStaff
+    {
+        public const string TeachingStaffCosts = "Teaching staff";
+        public const string SupplyTeachingStaffCosts = "Supply teaching staff";
+        public const string AgencySupplyTeachingStaffCosts = "Agency supply teaching staff";
+        public const string EducationSupportStaffCosts = "Education support staff";
+        public const string EducationalConsultancyCosts = "Educational consultancy";
+
+        public static string[] SubCategories { get; } = [TeachingStaffCosts, SupplyTeachingStaffCosts, AgencySupplyTeachingStaffCosts, EducationSupportStaffCosts, EducationalConsultancyCosts];
+    }
+
+    public static class NonEducationalSupportStaff
+    {
+        public const string AdministrativeClericalStaffCosts = "Administrative and clerical staff";
+        public const string AuditorsCosts = "Auditor costs";
+        public const string OtherStaffCosts = "Other staff";
+        public const string ProfessionalServicesNonCurriculumCosts = "Professional services (non-curriculum)";
+
+        public static string[] SubCategories { get; } = [AdministrativeClericalStaffCosts, AuditorsCosts, OtherStaffCosts, ProfessionalServicesNonCurriculumCosts];
+    }
+
+    public static class EducationalSupplies
+    {
+        public const string ExaminationFeesCosts = "Examination fees";
+        public const string LearningResourcesNonIctCosts = "Learning resources (not ICT equipment)";
+
+        public static string[] SubCategories { get; } = [ExaminationFeesCosts, LearningResourcesNonIctCosts];
+    }
+
+    public static class EducationalIct
+    {
+        public const string LearningResourcesIctCosts = "ICT learning resources";
+
+        public static string[] SubCategories { get; } = [LearningResourcesIctCosts];
+    }
+
+    public static class PremisesStaffServices
+    {
+        public const string CleaningCaretakingCosts = "Cleaning and caretaking";
+        public const string MaintenancePremisesCosts = "Maintenance of premises";
+        public const string OtherOccupationCosts = "Other occupation costs";
+        public const string PremisesStaffCosts = "Premises staff";
+
+        public static string[] SubCategories { get; } = [CleaningCaretakingCosts, MaintenancePremisesCosts, OtherOccupationCosts, PremisesStaffCosts];
+    }
+
+    public static class Utilities
+    {
+        public const string EnergyCosts = "Energy";
+        public const string WaterSewerageCosts = "Water and sewerage";
+
+        public static string[] SubCategories { get; } = [EnergyCosts, WaterSewerageCosts];
+    }
+
+    public static class AdministrativeSupplies
+    {
+        public const string AdministrativeSuppliesCosts = "Administrative supplies (non-educational)";
+
+        public static string[] SubCategories { get; } = [AdministrativeSuppliesCosts];
+    }
+
+    public static class CateringStaffServices
+    {
+        public const string CateringStaffCosts = "Catering staff";
+        public const string CateringSuppliesCosts = "Catering supplies";
+
+        public static string[] SubCategories { get; } = [CateringStaffCosts, CateringSuppliesCosts];
+    }
+
+    public static class Other
+    {
+        public const string DirectRevenueFinancingCosts = "Direct revenue financing";
+        public const string GroundsMaintenanceCosts = "Grounds maintenance";
+        public const string IndirectEmployeeExpenses = "Indirect employee expenses";
+        public const string InterestChargesLoanBank = "Interest charges for loan and bank";
+        public const string OtherInsurancePremiumsCosts = "Other insurance premiums";
+        public const string PrivateFinanceInitiativeCharges = "Private Finance Initiative (PFI) charges";
+        public const string RentRatesCosts = "Rent and rates";
+        public const string SpecialFacilitiesCosts = "Special facilities";
+        public const string StaffDevelopmentTrainingCosts = "Staff development and training";
+        public const string StaffRelatedInsuranceCosts = "Staff-related insurance";
+        public const string SupplyTeacherInsurableCosts = "Supply teacher insurance";
+
+        public static string[] SubCategories { get; } =
+        [
+            DirectRevenueFinancingCosts,
+            GroundsMaintenanceCosts,
+            IndirectEmployeeExpenses,
+            InterestChargesLoanBank,
+            OtherInsurancePremiumsCosts,
+            PrivateFinanceInitiativeCharges,
+            RentRatesCosts,
+            SpecialFacilitiesCosts,
+            StaffDevelopmentTrainingCosts,
+            StaffRelatedInsuranceCosts,
+            SupplyTeacherInsurableCosts
+        ];
     }
 }

--- a/web/src/Web.App/Extensions/StringExtensions.cs
+++ b/web/src/Web.App/Extensions/StringExtensions.cs
@@ -115,6 +115,22 @@ public static partial class StringExtensions
         return "a";
     }
 
+    public static string ToLower(this string source, bool persistInitials)
+    {
+        if (!persistInitials)
+        {
+            return source.ToLower();
+        }
+
+        var matches = NonInitialsWords().Matches(source);
+        foreach (Match match in matches)
+        {
+            source = source.Replace(match.Value, match.Value.ToLower());
+        }
+
+        return source;
+    }
+
     public static string ToSlug(this string source)
     {
         if (string.IsNullOrWhiteSpace(source))
@@ -129,7 +145,7 @@ public static partial class StringExtensions
             .ToLower();
     }
 
-    public static string Replace(this string source, Regex regex, string replacement)
+    private static string Replace(this string source, Regex regex, string replacement)
         => string.IsNullOrWhiteSpace(source) ? source : regex.Replace(source, replacement);
 
     [GeneratedRegex("[^a-z0-9\\-]", RegexOptions.IgnoreCase, "en-GB")]
@@ -137,4 +153,7 @@ public static partial class StringExtensions
 
     [GeneratedRegex("\\s+")]
     private static partial Regex WhitespaceRegex();
+
+    [GeneratedRegex(@"\w+\b(?<!\b[A-Z]{2,})")]
+    private static partial Regex NonInitialsWords();
 }

--- a/web/src/Web.App/ViewModels/FinancialDataCustomDataViewModel.cs
+++ b/web/src/Web.App/ViewModels/FinancialDataCustomDataViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Web.App.Attributes;
+using Web.App.Domain;
 
 // ReSharper disable UnusedAutoPropertyAccessor.Global
 
@@ -48,139 +49,139 @@ public record FinancialDataCustomDataViewModel : IFinancialDataCustomDataViewMod
 {
     // Administrative supplies
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.AdministrativeSuppliesCosts)]
+    [Display(Name = SubCostCategories.AdministrativeSupplies.AdministrativeSuppliesCosts)]
     public decimal? AdministrativeSuppliesCosts { get; init; }
 
     // Catering
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.CateringStaffCosts)]
+    [Display(Name = SubCostCategories.CateringStaffServices.CateringStaffCosts)]
     public decimal? CateringStaffCosts { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.CateringSuppliesCosts)]
+    [Display(Name = SubCostCategories.CateringStaffServices.CateringSuppliesCosts)]
     public decimal? CateringSuppliesCosts { get; init; }
 
     // Educational supplies
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.ExaminationFeesCosts)]
+    [Display(Name = SubCostCategories.EducationalSupplies.ExaminationFeesCosts)]
     public decimal? ExaminationFeesCosts { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.LearningResourcesNonIctCosts)]
+    [Display(Name = SubCostCategories.EducationalSupplies.LearningResourcesNonIctCosts)]
     public decimal? LearningResourcesNonIctCosts { get; init; }
 
     // IT
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.LearningResourcesIctCosts)]
+    [Display(Name = SubCostCategories.EducationalIct.LearningResourcesIctCosts)]
     public decimal? LearningResourcesIctCosts { get; init; }
 
     // Non-educational support staff
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.AdministrativeClericalStaffCosts)]
+    [Display(Name = SubCostCategories.NonEducationalSupportStaff.AdministrativeClericalStaffCosts)]
     public decimal? AdministrativeClericalStaffCosts { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.AuditorsCosts)]
+    [Display(Name = SubCostCategories.NonEducationalSupportStaff.AuditorsCosts)]
     public decimal? AuditorsCosts { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.OtherStaffCosts)]
+    [Display(Name = SubCostCategories.NonEducationalSupportStaff.OtherStaffCosts)]
     public decimal? OtherStaffCosts { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.ProfessionalServicesNonCurriculumCosts)]
+    [Display(Name = SubCostCategories.NonEducationalSupportStaff.ProfessionalServicesNonCurriculumCosts)]
     public decimal? ProfessionalServicesNonCurriculumCosts { get; init; }
 
     // Premises and services
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.CleaningCaretakingCosts)]
+    [Display(Name = SubCostCategories.PremisesStaffServices.CleaningCaretakingCosts)]
     public decimal? CleaningCaretakingCosts { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.MaintenancePremisesCosts)]
+    [Display(Name = SubCostCategories.PremisesStaffServices.MaintenancePremisesCosts)]
     public decimal? MaintenancePremisesCosts { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.OtherOccupationCosts)]
+    [Display(Name = SubCostCategories.PremisesStaffServices.OtherOccupationCosts)]
     public decimal? OtherOccupationCosts { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.PremisesStaffCosts)]
+    [Display(Name = SubCostCategories.PremisesStaffServices.PremisesStaffCosts)]
     public decimal? PremisesStaffCosts { get; init; }
 
     // Teaching and teaching support
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.AgencySupplyTeachingStaffCosts)]
+    [Display(Name = SubCostCategories.TeachingStaff.AgencySupplyTeachingStaffCosts)]
     public decimal? AgencySupplyTeachingStaffCosts { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.EducationSupportStaffCosts)]
+    [Display(Name = SubCostCategories.TeachingStaff.EducationSupportStaffCosts)]
     public decimal? EducationSupportStaffCosts { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.EducationalConsultancyCosts)]
+    [Display(Name = SubCostCategories.TeachingStaff.EducationalConsultancyCosts)]
     public decimal? EducationalConsultancyCosts { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.SupplyTeachingStaffCosts)]
+    [Display(Name = SubCostCategories.TeachingStaff.SupplyTeachingStaffCosts)]
     public decimal? SupplyTeachingStaffCosts { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.TeachingStaffCosts)]
+    [Display(Name = SubCostCategories.TeachingStaff.TeachingStaffCosts)]
     public decimal? TeachingStaffCosts { get; init; }
 
     // Utilities
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.EnergyCosts)]
+    [Display(Name = SubCostCategories.Utilities.EnergyCosts)]
     public decimal? EnergyCosts { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.WaterSewerageCosts)]
+    [Display(Name = SubCostCategories.Utilities.WaterSewerageCosts)]
     public decimal? WaterSewerageCosts { get; init; }
 
     // Other costs
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.DirectRevenueFinancingCosts)]
+    [Display(Name = SubCostCategories.Other.DirectRevenueFinancingCosts)]
     public decimal? DirectRevenueFinancingCosts { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.GroundsMaintenanceCosts)]
+    [Display(Name = SubCostCategories.Other.GroundsMaintenanceCosts)]
     public decimal? GroundsMaintenanceCosts { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.IndirectEmployeeExpenses)]
+    [Display(Name = SubCostCategories.Other.IndirectEmployeeExpenses)]
     public decimal? IndirectEmployeeExpenses { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.InterestChargesLoanBank)]
+    [Display(Name = SubCostCategories.Other.InterestChargesLoanBank)]
     public decimal? InterestChargesLoanBank { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.OtherInsurancePremiumsCosts)]
+    [Display(Name = SubCostCategories.Other.OtherInsurancePremiumsCosts)]
     public decimal? OtherInsurancePremiumsCosts { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.PrivateFinanceInitiativeCharges)]
+    [Display(Name = SubCostCategories.Other.PrivateFinanceInitiativeCharges)]
     public decimal? PrivateFinanceInitiativeCharges { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.RentRatesCosts)]
+    [Display(Name = SubCostCategories.Other.RentRatesCosts)]
     public decimal? RentRatesCosts { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.SpecialFacilitiesCosts)]
+    [Display(Name = SubCostCategories.Other.SpecialFacilitiesCosts)]
     public decimal? SpecialFacilitiesCosts { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.StaffDevelopmentTrainingCosts)]
+    [Display(Name = SubCostCategories.Other.StaffDevelopmentTrainingCosts)]
     public decimal? StaffDevelopmentTrainingCosts { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.StaffRelatedInsuranceCosts)]
+    [Display(Name = SubCostCategories.Other.StaffRelatedInsuranceCosts)]
     public decimal? StaffRelatedInsuranceCosts { get; init; }
 
     [PositiveNumericValue]
-    [Display(Name = SchoolCustomDataViewModelTitles.SupplyTeacherInsurableCosts)]
+    [Display(Name = SubCostCategories.Other.SupplyTeacherInsurableCosts)]
     public decimal? SupplyTeacherInsurableCosts { get; init; }
 
     // Totals

--- a/web/src/Web.App/ViewModels/SchoolCustomDataChangeViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolCustomDataChangeViewModel.cs
@@ -16,7 +16,7 @@ public class SchoolCustomDataChangeViewModel(
         "Cost",
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.AdministrativeSuppliesCosts,
+            Title = SubCostCategories.AdministrativeSupplies.AdministrativeSuppliesCosts,
             Name = nameof(SchoolCustomDataViewModel.AdministrativeSuppliesCosts),
             Current = CurrentValues.AdministrativeSuppliesCosts,
             Custom = CustomInput.AdministrativeSuppliesCosts
@@ -28,14 +28,14 @@ public class SchoolCustomDataChangeViewModel(
         "Cost",
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.CateringStaffCosts,
+            Title = SubCostCategories.CateringStaffServices.CateringStaffCosts,
             Name = nameof(SchoolCustomDataViewModel.CateringStaffCosts),
             Current = CurrentValues.CateringStaffCosts,
             Custom = CustomInput.CateringStaffCosts
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.CateringSuppliesCosts,
+            Title = SubCostCategories.CateringStaffServices.CateringSuppliesCosts,
             Name = nameof(SchoolCustomDataViewModel.CateringSuppliesCosts),
             Current = CurrentValues.CateringSuppliesCosts,
             Custom = CustomInput.CateringSuppliesCosts
@@ -47,14 +47,14 @@ public class SchoolCustomDataChangeViewModel(
         "Cost",
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.ExaminationFeesCosts,
+            Title = SubCostCategories.EducationalSupplies.ExaminationFeesCosts,
             Name = nameof(SchoolCustomDataViewModel.ExaminationFeesCosts),
             Current = CurrentValues.ExaminationFeesCosts,
             Custom = CustomInput.ExaminationFeesCosts
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.LearningResourcesNonIctCosts,
+            Title = SubCostCategories.EducationalSupplies.LearningResourcesNonIctCosts,
             Name = nameof(SchoolCustomDataViewModel.LearningResourcesNonIctCosts),
             Current = CurrentValues.LearningResourcesNonIctCosts,
             Custom = CustomInput.LearningResourcesNonIctCosts
@@ -66,7 +66,7 @@ public class SchoolCustomDataChangeViewModel(
         "Cost",
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.LearningResourcesIctCosts,
+            Title = SubCostCategories.EducationalIct.LearningResourcesIctCosts,
             Name = nameof(SchoolCustomDataViewModel.LearningResourcesIctCosts),
             Current = CurrentValues.LearningResourcesIctCosts,
             Custom = CustomInput.LearningResourcesIctCosts
@@ -78,28 +78,28 @@ public class SchoolCustomDataChangeViewModel(
         "Cost",
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.AdministrativeClericalStaffCosts,
+            Title = SubCostCategories.NonEducationalSupportStaff.AdministrativeClericalStaffCosts,
             Name = nameof(SchoolCustomDataViewModel.AdministrativeClericalStaffCosts),
             Current = CurrentValues.AdministrativeClericalStaffCosts,
             Custom = CustomInput.AdministrativeClericalStaffCosts
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.AuditorsCosts,
+            Title = SubCostCategories.NonEducationalSupportStaff.AuditorsCosts,
             Name = nameof(SchoolCustomDataViewModel.AuditorsCosts),
             Current = CurrentValues.AuditorsCosts,
             Custom = CustomInput.AuditorsCosts
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.OtherStaffCosts,
+            Title = SubCostCategories.NonEducationalSupportStaff.OtherStaffCosts,
             Name = nameof(SchoolCustomDataViewModel.OtherStaffCosts),
             Current = CurrentValues.OtherStaffCosts,
             Custom = CustomInput.OtherStaffCosts
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.ProfessionalServicesNonCurriculumCosts,
+            Title = SubCostCategories.NonEducationalSupportStaff.ProfessionalServicesNonCurriculumCosts,
             Name = nameof(SchoolCustomDataViewModel.ProfessionalServicesNonCurriculumCosts),
             Current = CurrentValues.ProfessionalServicesNonCurriculumCosts,
             Custom = CustomInput.ProfessionalServicesNonCurriculumCosts
@@ -111,28 +111,28 @@ public class SchoolCustomDataChangeViewModel(
         "Cost",
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.CleaningCaretakingCosts,
+            Title = SubCostCategories.PremisesStaffServices.CleaningCaretakingCosts,
             Name = nameof(SchoolCustomDataViewModel.CleaningCaretakingCosts),
             Current = CurrentValues.CleaningCaretakingCosts,
             Custom = CustomInput.CleaningCaretakingCosts
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.MaintenancePremisesCosts,
+            Title = SubCostCategories.PremisesStaffServices.MaintenancePremisesCosts,
             Name = nameof(SchoolCustomDataViewModel.MaintenancePremisesCosts),
             Current = CurrentValues.MaintenancePremisesCosts,
             Custom = CustomInput.MaintenancePremisesCosts
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.OtherOccupationCosts,
+            Title = SubCostCategories.PremisesStaffServices.OtherOccupationCosts,
             Name = nameof(SchoolCustomDataViewModel.OtherOccupationCosts),
             Current = CurrentValues.OtherOccupationCosts,
             Custom = CustomInput.OtherOccupationCosts
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.PremisesStaffCosts,
+            Title = SubCostCategories.PremisesStaffServices.PremisesStaffCosts,
             Name = nameof(SchoolCustomDataViewModel.PremisesStaffCosts),
             Current = CurrentValues.PremisesStaffCosts,
             Custom = CustomInput.PremisesStaffCosts
@@ -144,35 +144,35 @@ public class SchoolCustomDataChangeViewModel(
         "Cost",
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.AgencySupplyTeachingStaffCosts,
+            Title = SubCostCategories.TeachingStaff.AgencySupplyTeachingStaffCosts,
             Name = nameof(SchoolCustomDataViewModel.AgencySupplyTeachingStaffCosts),
             Current = CurrentValues.AgencySupplyTeachingStaffCosts,
             Custom = CustomInput.AgencySupplyTeachingStaffCosts
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.EducationSupportStaffCosts,
+            Title = SubCostCategories.TeachingStaff.EducationSupportStaffCosts,
             Name = nameof(SchoolCustomDataViewModel.EducationSupportStaffCosts),
             Current = CurrentValues.EducationSupportStaffCosts,
             Custom = CustomInput.EducationSupportStaffCosts
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.EducationalConsultancyCosts,
+            Title = SubCostCategories.TeachingStaff.EducationalConsultancyCosts,
             Name = nameof(SchoolCustomDataViewModel.EducationalConsultancyCosts),
             Current = CurrentValues.EducationalConsultancyCosts,
             Custom = CustomInput.EducationalConsultancyCosts
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.SupplyTeachingStaffCosts,
+            Title = SubCostCategories.TeachingStaff.SupplyTeachingStaffCosts,
             Name = nameof(SchoolCustomDataViewModel.SupplyTeachingStaffCosts),
             Current = CurrentValues.SupplyTeachingStaffCosts,
             Custom = CustomInput.SupplyTeachingStaffCosts
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.TeachingStaffCosts,
+            Title = SubCostCategories.TeachingStaff.TeachingStaffCosts,
             Name = nameof(SchoolCustomDataViewModel.TeachingStaffCosts),
             Current = CurrentValues.TeachingStaffCosts,
             Custom = CustomInput.TeachingStaffCosts
@@ -183,14 +183,14 @@ public class SchoolCustomDataChangeViewModel(
         "Cost",
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.EnergyCosts,
+            Title = SubCostCategories.Utilities.EnergyCosts,
             Name = nameof(SchoolCustomDataViewModel.EnergyCosts),
             Current = CurrentValues.EnergyCosts,
             Custom = CustomInput.EnergyCosts
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.WaterSewerageCosts,
+            Title = SubCostCategories.Utilities.WaterSewerageCosts,
             Name = nameof(SchoolCustomDataViewModel.WaterSewerageCosts),
             Current = CurrentValues.WaterSewerageCosts,
             Custom = CustomInput.WaterSewerageCosts
@@ -201,77 +201,77 @@ public class SchoolCustomDataChangeViewModel(
         "Cost",
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.DirectRevenueFinancingCosts,
+            Title = SubCostCategories.Other.DirectRevenueFinancingCosts,
             Name = nameof(SchoolCustomDataViewModel.DirectRevenueFinancingCosts),
             Current = CurrentValues.DirectRevenueFinancingCosts,
             Custom = CustomInput.DirectRevenueFinancingCosts
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.GroundsMaintenanceCosts,
+            Title = SubCostCategories.Other.GroundsMaintenanceCosts,
             Name = nameof(SchoolCustomDataViewModel.GroundsMaintenanceCosts),
             Current = CurrentValues.GroundsMaintenanceCosts,
             Custom = CustomInput.GroundsMaintenanceCosts
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.IndirectEmployeeExpenses,
+            Title = SubCostCategories.Other.IndirectEmployeeExpenses,
             Name = nameof(SchoolCustomDataViewModel.IndirectEmployeeExpenses),
             Current = CurrentValues.IndirectEmployeeExpenses,
             Custom = CustomInput.IndirectEmployeeExpenses
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.InterestChargesLoanBank,
+            Title = SubCostCategories.Other.InterestChargesLoanBank,
             Name = nameof(SchoolCustomDataViewModel.InterestChargesLoanBank),
             Current = CurrentValues.InterestChargesLoanBank,
             Custom = CustomInput.InterestChargesLoanBank
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.OtherInsurancePremiumsCosts,
+            Title = SubCostCategories.Other.OtherInsurancePremiumsCosts,
             Name = nameof(SchoolCustomDataViewModel.OtherInsurancePremiumsCosts),
             Current = CurrentValues.OtherInsurancePremiumsCosts,
             Custom = CustomInput.OtherInsurancePremiumsCosts
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.PrivateFinanceInitiativeCharges,
+            Title = SubCostCategories.Other.PrivateFinanceInitiativeCharges,
             Name = nameof(SchoolCustomDataViewModel.PrivateFinanceInitiativeCharges),
             Current = CurrentValues.PrivateFinanceInitiativeCharges,
             Custom = CustomInput.PrivateFinanceInitiativeCharges
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.RentRatesCosts,
+            Title = SubCostCategories.Other.RentRatesCosts,
             Name = nameof(SchoolCustomDataViewModel.RentRatesCosts),
             Current = CurrentValues.RentRatesCosts,
             Custom = CustomInput.RentRatesCosts
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.SpecialFacilitiesCosts,
+            Title = SubCostCategories.Other.SpecialFacilitiesCosts,
             Name = nameof(SchoolCustomDataViewModel.SpecialFacilitiesCosts),
             Current = CurrentValues.SpecialFacilitiesCosts,
             Custom = CustomInput.SpecialFacilitiesCosts
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.StaffDevelopmentTrainingCosts,
+            Title = SubCostCategories.Other.StaffDevelopmentTrainingCosts,
             Name = nameof(SchoolCustomDataViewModel.StaffDevelopmentTrainingCosts),
             Current = CurrentValues.StaffDevelopmentTrainingCosts,
             Custom = CustomInput.StaffDevelopmentTrainingCosts
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.StaffRelatedInsuranceCosts,
+            Title = SubCostCategories.Other.StaffRelatedInsuranceCosts,
             Name = nameof(SchoolCustomDataViewModel.StaffRelatedInsuranceCosts),
             Current = CurrentValues.StaffRelatedInsuranceCosts,
             Custom = CustomInput.StaffRelatedInsuranceCosts
         },
         new SchoolCustomDataValueViewModel
         {
-            Title = SchoolCustomDataViewModelTitles.SupplyTeacherInsurableCosts,
+            Title = SubCostCategories.Other.SupplyTeacherInsurableCosts,
             Name = nameof(SchoolCustomDataViewModel.SupplyTeacherInsurableCosts),
             Current = CurrentValues.SupplyTeacherInsurableCosts,
             Custom = CustomInput.SupplyTeacherInsurableCosts

--- a/web/src/Web.App/ViewModels/SchoolCustomDataViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolCustomDataViewModel.cs
@@ -152,38 +152,6 @@ public record SchoolCustomDataViewModel : IFinancialDataCustomDataViewModel, INo
 
 public static class SchoolCustomDataViewModelTitles
 {
-    public const string AdministrativeSuppliesCosts = "Administrative supplies (non-educational)";
-    public const string CateringStaffCosts = "Catering staff";
-    public const string CateringSuppliesCosts = "Catering supplies";
-    public const string ExaminationFeesCosts = "Examination fees";
-    public const string LearningResourcesNonIctCosts = "Learning resources (not ICT equipment)";
-    public const string LearningResourcesIctCosts = "ICT learning resources";
-    public const string AdministrativeClericalStaffCosts = "Administrative and clerical staff";
-    public const string AuditorsCosts = "Auditor costs";
-    public const string OtherStaffCosts = "Other staff";
-    public const string ProfessionalServicesNonCurriculumCosts = "Professional services (non-curriculum)";
-    public const string CleaningCaretakingCosts = "Cleaning and caretaking";
-    public const string MaintenancePremisesCosts = "Maintenance of premises";
-    public const string OtherOccupationCosts = "Other occupation costs";
-    public const string PremisesStaffCosts = "Premises staff";
-    public const string AgencySupplyTeachingStaffCosts = "Agency supply teaching staff";
-    public const string EducationSupportStaffCosts = "Education support staff";
-    public const string EducationalConsultancyCosts = "Educational consultancy";
-    public const string SupplyTeachingStaffCosts = "Supply teaching staff";
-    public const string TeachingStaffCosts = "Teaching staff";
-    public const string EnergyCosts = "Energy";
-    public const string WaterSewerageCosts = "Water and sewerage";
-    public const string DirectRevenueFinancingCosts = "Direct revenue financing";
-    public const string GroundsMaintenanceCosts = "Grounds maintenance";
-    public const string IndirectEmployeeExpenses = "Indirect employee expenses";
-    public const string InterestChargesLoanBank = "Interest charges for loan and bank";
-    public const string OtherInsurancePremiumsCosts = "Other insurance premiums";
-    public const string PrivateFinanceInitiativeCharges = "Private Finance Initiative (PFI) charges";
-    public const string RentRatesCosts = "Rent and rates";
-    public const string SpecialFacilitiesCosts = "Special facilities";
-    public const string StaffDevelopmentTrainingCosts = "Staff development and training";
-    public const string StaffRelatedInsuranceCosts = "Staff-related insurance";
-    public const string SupplyTeacherInsurableCosts = "Supply teacher insurance";
     public const string TotalIncome = "Total income";
     public const string TotalExpenditure = "Total spending";
     public const string RevenueReserve = "Revenue reserve";

--- a/web/src/Web.App/Views/SchoolSpending/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/Index.cshtml
@@ -1,5 +1,4 @@
 ﻿@using Web.App.ViewModels
-
 @model Web.App.ViewModels.SchoolSpendingViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.Spending;
@@ -33,22 +32,25 @@
         <div class="govuk-grid-column-two-thirds">
             <h2 class="govuk-heading-m govuk-!-font-size-36">Priority cost categories</h2>
             <p class="govuk-body">This shows where spending is different to similar schools.</p>
+            <p class="govuk-body">
+                <a href="@Url.ActionLink("CostCategories", "StaticContent")" class="govuk-link" rel="noreferrer noopener" target="_blank" id="cost-categories-guidance">View more details on cost categories (opens in new tab)</a>
+            </p>
         </div>
     </div>
-    
+
     @await Html.PartialAsync("_Costs", new CostsViewModel
     {
         Costs = Model.HighPriorityCosts,
         Id = "high-priority",
         Urn = Model.Urn
     })
-    
+
     @await Html.PartialAsync("_Costs", new CostsViewModel
     {
         Costs = Model.MediumPriorityCosts,
         Id = "medium-priority",
         Urn = Model.Urn
-    })    
+    })
 }
 
 @if (Model.LowPriorityCosts.Any())
@@ -59,11 +61,11 @@
             <p class="govuk-body">This shows where spending is close to similar schools.</p>
         </div>
     </div>
-    
+
     @await Html.PartialAsync("_Costs", new CostsViewModel
     {
         Costs = Model.LowPriorityCosts,
         Id = "low-priority",
         Urn = Model.Urn
-    }) 
+    })
 }

--- a/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
@@ -12,10 +12,6 @@
     {
         var category = costs[i];
 
-        var categoryToLower = category.Rating.Category == Category.EducationalIct
-            ? "Educational ICT"
-            : category.Rating.Category?.ToLower();
-
         var categoryHeading = category.Rating.Category == Category.NonEducationalSupportStaff
             ? "Non-educational support staff"
             : category.Rating.Category;
@@ -58,8 +54,25 @@
                          data-stats="@SchoolSpendingViewModel.Stats(category.Rating).ToJson(Formatting.None)"
                          data-has-incomplete-data="@Model.HasIncompleteData">
                     </div>
-                    <p class="govuk-body">
-                        <a href="@categoryUri#@category.Rating.CostCategoryAnchorId" class="govuk-link govuk-link--no-visited-state">View all @categoryToLower costs</a>
+                    <p class="govuk-body category-commentary">
+                        <a href="@categoryUri#@category.Rating.CostCategoryAnchorId" class="govuk-link govuk-link--no-visited-state">View all @category.Rating.Category?.ToLower(true) costs</a>@(category.SubCategories.Any() ? ". " : string.Empty)
+                        @if (category.SubCategories.Any())
+                        {
+                            @:This includes
+                            for (var j = 0; j < category.SubCategories.Length; j++)
+                            {
+                                var subCategory = category.SubCategories.ElementAt(j).ToLower(true);
+                                if (j < category.SubCategories.Length - 2)
+                                {
+                                    subCategory = $"{subCategory}, ";
+                                }
+                                else if (j == category.SubCategories.Length - 1)
+                                {
+                                    subCategory = $"{(category.SubCategories.Length > 1 ? "and " : string.Empty)} {subCategory}.";
+                                }
+                                <span>@subCategory</span>
+                            }
+                        }
                     </p>
                 </div>
                 <div class="govuk-grid-column-one-third">

--- a/web/src/Web.App/Views/StaticContent/CostCategories.cshtml
+++ b/web/src/Web.App/Views/StaticContent/CostCategories.cshtml
@@ -1,0 +1,107 @@
+﻿@using Web.App.Domain
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.CostCategories;
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <h1 class="govuk-heading-l">Cost category breakdown</h1>
+
+        <p class="govuk-body">
+            The table details what is included within each cost category:
+        </p>
+
+        <table class="govuk-table">
+            <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden">What is included within each cost category</caption>
+            <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Cost category</th>
+                <th scope="col" class="govuk-table__header">Categories included</th>
+            </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+            @await Html.PartialAsync("_CategoryAndSubCategoryRow", new ViewDataDictionary(ViewData)
+            {
+                {
+                    "Category", Category.TeachingStaff
+                },
+                {
+                    "SubCostCategories", SubCostCategories.TeachingStaff.SubCategories
+                }
+            })
+            @await Html.PartialAsync("_CategoryAndSubCategoryRow", new ViewDataDictionary(ViewData)
+            {
+                {
+                    "Category", Category.NonEducationalSupportStaff
+                },
+                {
+                    "SubCostCategories", SubCostCategories.NonEducationalSupportStaff.SubCategories
+                }
+            })
+            @await Html.PartialAsync("_CategoryAndSubCategoryRow", new ViewDataDictionary(ViewData)
+            {
+                {
+                    "Category", Category.EducationalSupplies
+                },
+                {
+                    "SubCostCategories", SubCostCategories.EducationalSupplies.SubCategories
+                }
+            })
+            @await Html.PartialAsync("_CategoryAndSubCategoryRow", new ViewDataDictionary(ViewData)
+            {
+                {
+                    "Category", Category.EducationalIct
+                },
+                {
+                    "SubCostCategories", SubCostCategories.EducationalIct.SubCategories
+                }
+            })
+            @await Html.PartialAsync("_CategoryAndSubCategoryRow", new ViewDataDictionary(ViewData)
+            {
+                {
+                    "Category", Category.PremisesStaffServices
+                },
+                {
+                    "SubCostCategories", SubCostCategories.PremisesStaffServices.SubCategories
+                }
+            })
+            @await Html.PartialAsync("_CategoryAndSubCategoryRow", new ViewDataDictionary(ViewData)
+            {
+                {
+                    "Category", Category.Utilities
+                },
+                {
+                    "SubCostCategories", SubCostCategories.Utilities.SubCategories
+                }
+            })
+            @await Html.PartialAsync("_CategoryAndSubCategoryRow", new ViewDataDictionary(ViewData)
+            {
+                {
+                    "Category", Category.AdministrativeSupplies
+                },
+                {
+                    "SubCostCategories", SubCostCategories.AdministrativeSupplies.SubCategories
+                }
+            })
+            @await Html.PartialAsync("_CategoryAndSubCategoryRow", new ViewDataDictionary(ViewData)
+            {
+                {
+                    "Category", Category.CateringStaffServices
+                },
+                {
+                    "SubCostCategories", SubCostCategories.CateringStaffServices.SubCategories
+                }
+            })
+            @await Html.PartialAsync("_CategoryAndSubCategoryRow", new ViewDataDictionary(ViewData)
+            {
+                {
+                    "Category", Category.Other
+                },
+                {
+                    "SubCostCategories", SubCostCategories.Other.SubCategories
+                }
+            })
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/web/src/Web.App/Views/StaticContent/_CategoryAndSubCategoryRow.cshtml
+++ b/web/src/Web.App/Views/StaticContent/_CategoryAndSubCategoryRow.cshtml
@@ -1,0 +1,16 @@
+@using Web.App.Extensions
+@{
+    var category = ViewData["Category"] as string ?? string.Empty;
+    var subCostCategories = ViewData["SubCostCategories"] as string[] ?? [];
+}
+<tr class="govuk-table__row" id="sub-categories-@category.ToSlug()">
+    <td class="govuk-table__cell">@category</td>
+    <td class="govuk-table__cell">
+        <ul class="govuk-list govuk-list--bullet">
+            @foreach (var subCostCategory in subCostCategories)
+            {
+                <li>@subCostCategory.ToLower(true)</li>
+            }
+        </ul>
+    </td>
+</tr>

--- a/web/tests/Web.E2ETests/Features/CostCategoriesGuidance.feature
+++ b/web/tests/Web.E2ETests/Features/CostCategoriesGuidance.feature
@@ -1,0 +1,38 @@
+﻿Feature: Cost categories guidance
+
+    Scenario: Sub categories are displayed on guidance page
+        Given I am on cost categories guidance page
+        Then the sub categories for each category are
+          | Category                                   | Sub-category                              |
+          | Teaching and Teaching support staff        | teaching staff                            |
+          | Teaching and Teaching support staff        | supply teaching staff                     |
+          | Teaching and Teaching support staff        | agency supply teaching staff              |
+          | Teaching and Teaching support staff        | education support staff                   |
+          | Teaching and Teaching support staff        | educational consultancy                   |
+          | Non-educational support staff and services | administrative and clerical staff         |
+          | Non-educational support staff and services | auditor costs                             |
+          | Non-educational support staff and services | other staff                               |
+          | Non-educational support staff and services | professional services (non-curriculum)    |
+          | Educational supplies                       | examination fees                          |
+          | Educational supplies                       | learning resources (not ICT equipment)    |
+          | Educational ICT                            | ICT learning resources                    |
+          | Premises staff and services                | cleaning and caretaking                   |
+          | Premises staff and services                | maintenance of premises                   |
+          | Premises staff and services                | other occupation costs                    |
+          | Premises staff and services                | premises staff                            |
+          | Utilities                                  | energy                                    |
+          | Utilities                                  | water and sewerage                        |
+          | Administrative supplies                    | administrative supplies (non-educational) |
+          | Catering staff and supplies                | catering staff                            |
+          | Catering staff and supplies                | catering supplies                         |
+          | Other costs                                | direct revenue financing                  |
+          | Other costs                                | grounds maintenance                       |
+          | Other costs                                | indirect employee expenses                |
+          | Other costs                                | interest charges for loan and bank        |
+          | Other costs                                | other insurance premiums                  |
+          | Other costs                                | private finance initiative (PFI) charges  |
+          | Other costs                                | rent and rates                            |
+          | Other costs                                | special facilities                        |
+          | Other costs                                | staff development and training            |
+          | Other costs                                | staff-related insurance                   |
+          | Other costs                                | supply teacher insurance                  |

--- a/web/tests/Web.E2ETests/Features/School/SpendingCosts.feature
+++ b/web/tests/Web.E2ETests/Features/School/SpendingCosts.feature
@@ -49,6 +49,19 @@
           | Utilities                           | Water, wastewater and ancillary services 2                          |
           | Educational ICT                     | Print market place                                                  |
 
+    Scenario: Categories have the correct category commentary
+        Given I am on spending and costs page for school with URN '777042'
+        Then the category commentary is
+          | Name                                | Commentary                                                                                                                                                                                  |
+          | Teaching and Teaching support staff | View all teaching and teaching support staff costs. This includes teaching staff, supply teaching staff, agency supply teaching staff, education support staff and educational consultancy. |
+          | Non-educational support staff       | View all non-educational support staff and services costs. This includes administrative and clerical staff, auditor costs, other staff and professional services (non-curriculum).          |
+          | Administrative supplies             | View all administrative supplies costs. This includes administrative supplies (non-educational).                                                                                            |
+          | Educational supplies                | View all educational supplies costs. This includes examination fees and learning resources (not ICT equipment).                                                                             |
+          | Catering staff and supplies         | View all catering staff and supplies costs. This includes catering staff and catering supplies.                                                                                             |
+          | Premises staff and services         | View all premises staff and services costs. This includes cleaning and caretaking, maintenance of premises, other occupation costs and premises staff.                                      |
+          | Utilities                           | View all utilities costs. This includes energy and water and sewerage.                                                                                                                      |
+          | Educational ICT                     | View all educational ICT costs. This includes ICT learning resources.                                                                                                                       |
+
     Scenario Outline: Click on view all links for each chart
         Given I am on spending and costs page for school with URN '777042'
         When I click on view all '<CostCategory>' link

--- a/web/tests/Web.E2ETests/Features/School/SpendingCosts.feature
+++ b/web/tests/Web.E2ETests/Features/School/SpendingCosts.feature
@@ -78,3 +78,8 @@
           | Premises staff and services         |
           | Utilities                           |
           | Educational ICT                     |
+
+    Scenario Outline: Click on View more details on cost categories link
+        Given I am on spending and costs page for school with URN '777042'
+        When I click on View more details on cost categories link
+        Then I am directed to cost categories guidance page

--- a/web/tests/Web.E2ETests/Pages/CostCategoriesGuidancePage.cs
+++ b/web/tests/Web.E2ETests/Pages/CostCategoriesGuidancePage.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Playwright;
+using Xunit;
+namespace Web.E2ETests.Pages;
+
+public class CostCategoriesGuidancePage(IPage page) : BasePage(page)
+{
+    public override async Task IsDisplayed()
+    {
+        await PageH1Heading.ShouldBeVisible();
+    }
+
+    public async Task AssertSubCategories(string category, string[] subCategories)
+    {
+        var categoryRow = page.Locator($"[id^=sub-categories-{category.ToSlug()}]");
+        await categoryRow.IsVisibleAsync();
+
+        var bullets = await categoryRow.Locator("ul li").AllTextContentsAsync();
+        Assert.Equal(subCategories, bullets);
+    }
+}

--- a/web/tests/Web.E2ETests/Pages/School/SpendingCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/SpendingCostsPage.cs
@@ -153,11 +153,20 @@ public class SpendingCostsPage(IPage page)
 
     public async Task AssertCommercialResources(string categoryName, string[] commercialResources)
     {
-        var categorySection = page.Locator($"#spending-priorities-{categoryName.ToSlug()}");
+        var categorySection = page.Locator($"[id^=spending-priorities-{categoryName.ToSlug()}]");
         await categorySection.IsVisibleAsync();
 
         var resources = await categorySection.Locator("ul li").AllTextContentsAsync();
         Assert.Equal(commercialResources, resources.Select(r => r.Replace("Opens in a new window", string.Empty).Trim()));
+    }
+
+    public async Task AssertCategoryCommentary(string categoryName, string commentary)
+    {
+        var categorySection = page.Locator($"[id^=spending-priorities-{categoryName.ToSlug()}]");
+        await categorySection.IsVisibleAsync();
+
+        var categoryCommentary = await categorySection.Locator(".category-commentary").InnerTextAsync();
+        Assert.Equal(commentary, categoryCommentary);
     }
 
     public async Task<CompareYourCostsPage> ClickOnLink(CostCategoryNames costCategory)

--- a/web/tests/Web.E2ETests/Pages/School/SpendingCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/SpendingCostsPage.cs
@@ -188,6 +188,13 @@ public class SpendingCostsPage(IPage page)
         return new CompareYourCostsPage(page);
     }
 
+    public async Task<CostCategoriesGuidancePage> ClickOnCostCategoriesGuidanceLink()
+    {
+        await page.Locator("#cost-categories-guidance").ClickAsync();
+        await page.BringToFrontAsync();
+        return new CostCategoriesGuidancePage(page);
+    }
+
     private async Task<List<string>> GetCategoryNames()
     {
         var h3Elements = await PageH3Headings.AllAsync();

--- a/web/tests/Web.E2ETests/Steps/CostCategoriesGuidanceSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/CostCategoriesGuidanceSteps.cs
@@ -1,0 +1,50 @@
+﻿using Web.E2ETests.Drivers;
+using Web.E2ETests.Pages;
+using Xunit;
+namespace Web.E2ETests.Steps;
+
+[Binding]
+[Scope(Feature = "Cost categories guidance")]
+public class CostCategoriesGuidanceSteps(PageDriver driver)
+{
+    private CostCategoriesGuidancePage? _costCategoriesGuidancePage;
+
+    [Given("I am on cost categories guidance page")]
+    public async Task GivenIAmOnCostCategoriesGuidancePage()
+    {
+        var url = CostCategoriesGuidanceUrl();
+        var page = await driver.Current;
+        await page.GotoAndWaitForLoadAsync(url);
+
+        _costCategoriesGuidancePage = new CostCategoriesGuidancePage(page);
+        await _costCategoriesGuidancePage.IsDisplayed();
+    }
+
+    [Then("the sub categories for each category are")]
+    public async Task ThenTheSubCategoriesForEachCategoryAre(DataTable table)
+    {
+        Assert.NotNull(_costCategoriesGuidancePage);
+
+        var categories = new Dictionary<string, List<string>>();
+        foreach (var row in table.Rows)
+        {
+            if (!categories.TryGetValue(row["Category"], out var value))
+            {
+                value = [];
+                categories.Add(row["Category"], value);
+            }
+
+            if (!string.IsNullOrWhiteSpace(row["Sub-category"]))
+            {
+                value.Add(row["Sub-category"]);
+            }
+        }
+
+        foreach (var row in categories)
+        {
+            await _costCategoriesGuidancePage.AssertSubCategories(row.Key, row.Value.ToArray());
+        }
+    }
+
+    private static string CostCategoriesGuidanceUrl() => $"{TestConfiguration.ServiceUrl}/guidance/cost-categories";
+}

--- a/web/tests/Web.E2ETests/Steps/School/SpendingCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/SpendingCostsSteps.cs
@@ -75,6 +75,16 @@ public class SpendingCostsSteps(PageDriver driver)
         }
     }
 
+    [Then("the category commentary is")]
+    public async Task ThenTheCategoryCommentaryIs(DataTable table)
+    {
+        Assert.NotNull(_spendingCostsPage);
+        foreach (var row in table.Rows)
+        {
+            await _spendingCostsPage.AssertCategoryCommentary(row["Name"], row["Commentary"]);
+        }
+    }
+
     [When("I click on view all '(.*)' link")]
     public async Task WhenIClickOnViewAllLink(string linkToClick)
     {

--- a/web/tests/Web.E2ETests/Steps/School/SpendingCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/SpendingCostsSteps.cs
@@ -1,4 +1,5 @@
 ﻿using Web.E2ETests.Drivers;
+using Web.E2ETests.Pages;
 using Web.E2ETests.Pages.School;
 using Xunit;
 namespace Web.E2ETests.Steps.School;
@@ -8,6 +9,7 @@ namespace Web.E2ETests.Steps.School;
 public class SpendingCostsSteps(PageDriver driver)
 {
     private CompareYourCostsPage? _compareYourCostsPage;
+    private CostCategoriesGuidancePage? _costCategoriesGuidancePage;
     private SpendingCostsPage? _spendingCostsPage;
 
     [Given(@"I am on spending and costs page for school with URN '(.*)'")]
@@ -92,6 +94,13 @@ public class SpendingCostsSteps(PageDriver driver)
         _compareYourCostsPage = await _spendingCostsPage.ClickOnLink(CostCategoryFromFriendlyName(linkToClick));
     }
 
+    [When("I click on View more details on cost categories link")]
+    public async Task WhenIClickOnViewMoreDetailsOnCostCategoriesLink()
+    {
+        Assert.NotNull(_spendingCostsPage);
+        _costCategoriesGuidancePage = await _spendingCostsPage.ClickOnCostCategoriesGuidanceLink();
+    }
+
     [Then("I am directed to compare your costs page")]
     public async Task ThenIAmDirectedToCompareYourCostsPage()
     {
@@ -105,6 +114,14 @@ public class SpendingCostsSteps(PageDriver driver)
         Assert.NotNull(_compareYourCostsPage);
         await _compareYourCostsPage.IsSectionVisible(ChartNameFromFriendlyName(chartName), true, "Hide", "chart");
     }
+
+    [Then("I am directed to cost categories guidance page")]
+    public async Task ThenIAmDirectedToCostCategoriesGuidancePage()
+    {
+        Assert.NotNull(_costCategoriesGuidancePage);
+        await _costCategoriesGuidancePage.IsDisplayed();
+    }
+
     private static string SpendingCostsUrl(string urn) =>
         $"{TestConfiguration.ServiceUrl}/school/{urn}/spending-and-costs";
 

--- a/web/tests/Web.Tests/Extensions/GivenAString.cs
+++ b/web/tests/Web.Tests/Extensions/GivenAString.cs
@@ -12,4 +12,19 @@ public class GivenAString
         var result = source.ToSlug();
         Assert.Equal(expected, result);
     }
+
+    [Theory]
+    [InlineData("Educational ICT", true, "educational ICT")]
+    [InlineData("Educational ICT", false, "educational ict")]
+    [InlineData("ICT Learning Resources", true, "ICT learning resources")]
+    [InlineData("ICT Learning Resources", false, "ict learning resources")]
+    [InlineData("Learning Resources (not ICT equipment)", true, "learning resources (not ICT equipment)")]
+    [InlineData("Learning Resources (not ICT equipment)", false, "learning resources (not ict equipment)")]
+    [InlineData("Cleaning and Caretaking", true, "cleaning and caretaking")]
+    [InlineData("Cleaning and Caretaking", false, "cleaning and caretaking")]
+    public void ReturnsLoweredCasedWhenToLowerIsCalled(string source, bool persistInitials, string expected)
+    {
+        var result = source.ToLower(persistInitials);
+        Assert.Equal(expected, result);
+    }
 }


### PR DESCRIPTION
### Context
[AB#232099](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/232099) [AB#230876](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/230876)

### Change proposed in this pull request
Added cost category commentary to School Spending Priorities page
Refactored definitions of sub-cost categories in a few places
Added `ToLower()` `string` extension method
Added cost categories guidance page and link from School Spending Priorities page

### Guidance to review 
View the Spending Priorities page for any school. Additional commentary should be available below each summary chart on the  priority categories. Under the first page `<h2>` there is also an additional link that opens in a new tab that displays additional guidance.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

