### PR TITLE
chore: Removed `SetType` from comparator set/RAG

### DIFF
--- a/platform/src/apis/Platform.Api.Benchmark/ComparatorSets/ComparatorSet.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/ComparatorSets/ComparatorSet.cs
@@ -9,7 +9,6 @@ namespace Platform.Api.Benchmark.ComparatorSets;
 public record ComparatorSetSchool
 {
     public string? URN { get; set; }
-    public string? SetType { get; set; }
 
     public ComparatorSetIds? Pupil { get; set; }
     public ComparatorSetIds? Building { get; set; }

--- a/platform/src/apis/Platform.Api.Benchmark/ComparatorSets/ComparatorSetsService.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/ComparatorSets/ComparatorSetsService.cs
@@ -3,14 +3,13 @@ using System.Threading.Tasks;
 using Dapper;
 using Dapper.Contrib.Extensions;
 using Platform.Sql;
-
 namespace Platform.Api.Benchmark.ComparatorSets;
 
 public interface IComparatorSetsService
 {
     Task<string> CurrentYearAsync();
-    Task<ComparatorSetSchool?> DefaultSchoolAsync(string urn, string setType = "unmixed");
-    Task<ComparatorSetSchool?> CustomSchoolAsync(string runId, string urn, string setType = "unmixed");
+    Task<ComparatorSetSchool?> DefaultSchoolAsync(string urn);
+    Task<ComparatorSetSchool?> CustomSchoolAsync(string runId, string urn);
     Task UpsertUserDefinedSchoolAsync(ComparatorSetUserDefinedSchool comparatorSet);
     Task<ComparatorSetUserDefinedSchool?> UserDefinedSchoolAsync(string urn, string identifier, string runType = "default");
     Task UpsertUserDataAsync(ComparatorSetUserData userData);
@@ -38,23 +37,31 @@ public class ComparatorSetsService : IComparatorSetsService
         return await conn.QueryFirstAsync<string>(sql);
     }
 
-    public async Task<ComparatorSetSchool?> DefaultSchoolAsync(string urn, string setType)
+    public async Task<ComparatorSetSchool?> DefaultSchoolAsync(string urn)
     {
         const string paramSql = "SELECT Value from Parameters where Name = 'CurrentYear'";
-        const string setSql = "SELECT * from ComparatorSet where RunType = 'default' AND RunId = @RunId AND SetType = @SetType AND URN = @URN";
+        const string setSql = "SELECT * from ComparatorSet where RunType = 'default' AND RunId = @RunId AND URN = @URN";
 
         using var conn = await _dbFactory.GetConnection();
         var year = await conn.QueryFirstAsync<string>(paramSql);
-        var parameters = new { URN = urn, RunId = year, SetType = setType };
+        var parameters = new
+        {
+            URN = urn,
+            RunId = year
+        };
         return await conn.QueryFirstOrDefaultAsync<ComparatorSetSchool>(setSql, parameters);
     }
 
-    public async Task<ComparatorSetSchool?> CustomSchoolAsync(string runId, string urn, string setType)
+    public async Task<ComparatorSetSchool?> CustomSchoolAsync(string runId, string urn)
     {
-        const string setSql = "SELECT * from ComparatorSet where RunType = 'custom' AND RunId = @RunId AND SetType = @SetType AND URN = @URN";
+        const string setSql = "SELECT * from ComparatorSet where RunType = 'custom' AND RunId = @RunId AND URN = @URN";
 
         using var conn = await _dbFactory.GetConnection();
-        var parameters = new { URN = urn, RunId = runId, SetType = setType };
+        var parameters = new
+        {
+            URN = urn,
+            RunId = runId
+        };
         return await conn.QueryFirstOrDefaultAsync<ComparatorSetSchool>(setSql, parameters);
     }
 
@@ -62,7 +69,12 @@ public class ComparatorSetsService : IComparatorSetsService
     {
         const string sql = "SELECT * from UserDefinedSchoolComparatorSet where URN = @URN AND RunId = @RunId AND RunType = @RunType";
 
-        var parameters = new { comparatorSet.URN, comparatorSet.RunId, comparatorSet.RunType };
+        var parameters = new
+        {
+            comparatorSet.URN,
+            comparatorSet.RunId,
+            comparatorSet.RunType
+        };
 
         using var conn = await _dbFactory.GetConnection();
         var existing = await conn.QueryFirstOrDefaultAsync<ComparatorSetUserDefinedSchool>(sql, parameters);
@@ -84,7 +96,12 @@ public class ComparatorSetsService : IComparatorSetsService
     public async Task<ComparatorSetUserDefinedSchool?> UserDefinedSchoolAsync(string urn, string identifier, string runType = "default")
     {
         const string sql = "SELECT * from UserDefinedSchoolComparatorSet where URN = @URN AND RunId = @RunId AND RunType = @RunType";
-        var parameters = new { URN = urn, RunId = identifier, RunType = runType };
+        var parameters = new
+        {
+            URN = urn,
+            RunId = identifier,
+            RunType = runType
+        };
 
         using var conn = await _dbFactory.GetConnection();
         return await conn.QueryFirstOrDefaultAsync<ComparatorSetUserDefinedSchool>(sql, parameters);
@@ -94,7 +111,10 @@ public class ComparatorSetsService : IComparatorSetsService
     {
         const string sql = "SELECT * from UserData where Id = @Id";
 
-        var parameters = new { userData.Id };
+        var parameters = new
+        {
+            userData.Id
+        };
 
         using var conn = await _dbFactory.GetConnection();
         var existing = await conn.QueryFirstOrDefaultAsync<ComparatorSetUserData>(sql, parameters);
@@ -117,7 +137,10 @@ public class ComparatorSetsService : IComparatorSetsService
     public async Task DeleteSchoolAsync(ComparatorSetUserDefinedSchool comparatorSet)
     {
         const string sql = "UPDATE UserData SET Status = 'removed' where Id = @Id";
-        var parameters = new { Id = comparatorSet.RunId };
+        var parameters = new
+        {
+            Id = comparatorSet.RunId
+        };
 
         using var connection = await _dbFactory.GetConnection();
         using var transaction = connection.BeginTransaction();
@@ -131,7 +154,10 @@ public class ComparatorSetsService : IComparatorSetsService
     public async Task DeleteTrustAsync(ComparatorSetUserDefinedTrust comparatorSet)
     {
         const string sql = "UPDATE UserData SET Status = 'removed' where Id = @Id";
-        var parameters = new { Id = comparatorSet.RunId };
+        var parameters = new
+        {
+            Id = comparatorSet.RunId
+        };
 
         using var connection = await _dbFactory.GetConnection();
         using var transaction = connection.BeginTransaction();
@@ -145,7 +171,12 @@ public class ComparatorSetsService : IComparatorSetsService
     public async Task<ComparatorSetUserDefinedTrust?> UserDefinedTrustAsync(string companyNumber, string identifier, string runType = "default")
     {
         const string sql = "SELECT * from UserDefinedTrustComparatorSet where CompanyNumber = @CompanyNumber AND RunId = @RunId AND RunType = @RunType";
-        var parameters = new { CompanyNumber = companyNumber, RunId = identifier, RunType = runType };
+        var parameters = new
+        {
+            CompanyNumber = companyNumber,
+            RunId = identifier,
+            RunType = runType
+        };
 
         using var conn = await _dbFactory.GetConnection();
         return await conn.QueryFirstOrDefaultAsync<ComparatorSetUserDefinedTrust>(sql, parameters);
@@ -155,7 +186,12 @@ public class ComparatorSetsService : IComparatorSetsService
     {
         const string sql = "SELECT * from UserDefinedTrustComparatorSet where CompanyNumber = @CompanyNumber AND RunId = @RunId AND RunType = @RunType";
 
-        var parameters = new { comparatorSet.CompanyNumber, comparatorSet.RunId, comparatorSet.RunType };
+        var parameters = new
+        {
+            comparatorSet.CompanyNumber,
+            comparatorSet.RunId,
+            comparatorSet.RunType
+        };
 
         using var conn = await _dbFactory.GetConnection();
         var existing = await conn.QueryFirstOrDefaultAsync<ComparatorSetUserDefinedTrust>(sql, parameters);

--- a/platform/src/apis/Platform.Api.Benchmark/OpenApi/ComparatorSetSchoolOpenApiType.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/OpenApi/ComparatorSetSchoolOpenApiType.cs
@@ -6,18 +6,17 @@
 namespace Platform.Api.Benchmark.OpenApi;
 
 /// <summary>
-/// <see cref="ComparatorSets.ComparatorSetSchool" />
+///     <see cref="ComparatorSets.ComparatorSetSchool" />
 /// </summary>
 internal interface IComparatorSetSchool
 {
     string? URN { get; }
-    string? SetType { get; }
     List<string>? Pupil { get; }
     List<string>? Building { get; }
 }
 
 /// <summary>
-/// <see cref="ComparatorSets.ComparatorSetUserDefinedSchool" />
+///     <see cref="ComparatorSets.ComparatorSetUserDefinedSchool" />
 /// </summary>
 internal interface IComparatorSetUserDefinedSchool
 {
@@ -28,7 +27,7 @@ internal interface IComparatorSetUserDefinedSchool
 }
 
 /// <summary>
-/// <see cref="ComparatorSets.ComparatorSetUserDefinedTrust" />
+///     <see cref="ComparatorSets.ComparatorSetUserDefinedTrust" />
 /// </summary>
 internal interface IComparatorSetUserDefinedTrust
 {

--- a/platform/src/apis/Platform.Api.Insight/MetricRagRatings/MetricRagRatingParameters.cs
+++ b/platform/src/apis/Platform.Api.Insight/MetricRagRatings/MetricRagRatingParameters.cs
@@ -1,19 +1,14 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Platform.Functions;
 using Platform.Functions.Extensions;
-
 namespace Platform.Api.Insight.MetricRagRatings;
 
 public record MetricRagRatingParameters : QueryParameters
 {
     public string DataContext { get; set; } = "default";
-    public string SetType { get; set; } = "unmixed";
 
     public override void SetValues(IQueryCollection query)
     {
-        var setType = query["setType"].ToString();
-
-        SetType = setType is "mixed" or "unmixed" ? setType : "unmixed";
         DataContext = query.ToBool("useCustomData") ? "custom" : "default";
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/MetricRagRatings/MetricRagRatingService.cs
+++ b/platform/src/apis/Platform.Api.Insight/MetricRagRatings/MetricRagRatingService.cs
@@ -8,15 +8,15 @@ namespace Platform.Api.Insight.MetricRagRatings;
 public interface IMetricRagRatingsService
 {
     Task<IEnumerable<MetricRagRating>> QueryAsync(string[] urns, string[] categories, string[] statuses,
-        string runType = "default", string setType = "unmixed", bool includeSubCategories = false);
+        string runType = "default", bool includeSubCategories = false);
 
-    Task<IEnumerable<MetricRagRating>> UserDefinedAsync(string identifier, string runType = "default", string setType = "unmixed", bool includeSubCategories = false);
+    Task<IEnumerable<MetricRagRating>> UserDefinedAsync(string identifier, string runType = "default", bool includeSubCategories = false);
 }
 
 public class MetricRagRatingsService(IDatabaseFactory dbFactory) : IMetricRagRatingsService
 {
     public async Task<IEnumerable<MetricRagRating>> QueryAsync(string[] urns, string[] categories, string[] statuses,
-        string runType = "default", string setType = "unmixed", bool includeSubCategories = false)
+        string runType = "default", bool includeSubCategories = false)
     {
         const string paramSql = "SELECT Value from Parameters where Name = 'CurrentYear'";
 
@@ -25,12 +25,11 @@ public class MetricRagRatingsService(IDatabaseFactory dbFactory) : IMetricRagRat
 
         var builder = new SqlBuilder();
         var template = builder.AddTemplate("SELECT * from MetricRAG /**where**/");
-        builder.Where("RunType = @RunType AND RunId = @RunId AND SetType = @SetType AND URN IN @URNS",
+        builder.Where("RunType = @RunType AND RunId = @RunId AND URN IN @URNS",
             new
             {
                 RunType = runType,
                 RunId = year,
-                SetType = setType,
                 URNS = urns
             });
 
@@ -59,18 +58,17 @@ public class MetricRagRatingsService(IDatabaseFactory dbFactory) : IMetricRagRat
     }
 
     public async Task<IEnumerable<MetricRagRating>> UserDefinedAsync(string identifier, string runType = "default",
-        string setType = "unmixed", bool includeSubCategories = false)
+        bool includeSubCategories = false)
     {
         using var conn = await dbFactory.GetConnection();
 
         var builder = new SqlBuilder();
         var template = builder.AddTemplate("SELECT * from MetricRAG /**where**/");
-        builder.Where("RunType = @RunType AND RunId = @RunId AND SetType = @SetType",
+        builder.Where("RunType = @RunType AND RunId = @RunId",
             new
             {
                 RunType = runType,
-                RunId = identifier,
-                SetType = setType
+                RunId = identifier
             });
 
         if (!includeSubCategories)

--- a/platform/src/apis/Platform.Api.Insight/MetricRagRatings/MetricRagRatingsFunctions.cs
+++ b/platform/src/apis/Platform.Api.Insight/MetricRagRatings/MetricRagRatingsFunctions.cs
@@ -17,7 +17,6 @@ public class MetricRagRatingsFunctions(IMetricRagRatingsService service, ILogger
     [OpenApiOperation(nameof(UserDefinedAsync), "Metric RAG Ratings")]
     [OpenApiParameter("identifier", Type = typeof(string), Required = true)]
     [OpenApiParameter("useCustomData", In = ParameterLocation.Query, Description = "Sets whether or not to use custom data context", Type = typeof(bool))]
-    [OpenApiParameter("setType", In = ParameterLocation.Query, Description = "Comparator set type", Type = typeof(string))]
     [OpenApiSecurityHeader]
     [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(MetricRagRating[]))]
     [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
@@ -43,7 +42,7 @@ public class MetricRagRatingsFunctions(IMetricRagRatingsService service, ILogger
         {
             try
             {
-                var result = await service.UserDefinedAsync(identifier, queryParams.DataContext, queryParams.SetType);
+                var result = await service.UserDefinedAsync(identifier, queryParams.DataContext);
                 return await req.CreateJsonResponseAsync(result);
             }
             catch (Exception e)

--- a/platform/tests/Platform.ApiTests/Features/InsightMetricRagRatings.feature
+++ b/platform/tests/Platform.ApiTests/Features/InsightMetricRagRatings.feature
@@ -1,11 +1,11 @@
 ﻿Feature: Insights metric rag ratings endpoints
-    
+
     Scenario: Sending a valid user defined metric rag rating request with default options
-        Given a valid user defined metric rag rating with runId 'some-user-defined-id', useCustomData '' and setType ''
+        Given a valid user defined metric rag rating with runId 'some-user-defined-id', useCustomData ''
         When I submit the metric rag rating request
         Then the metric rag rating result should be ok and contain:
           | URN | Category | SubCategory | Value | Mean | DiffMean | PercentDiff | Percentile | Decile | RAG |
-          
+
     Scenario: Sending a valid default metric rag rating request with default options
         Given a valid default metric rag rating with categories '' and statuses '' for urns:
           | Urn    |
@@ -34,7 +34,7 @@
           | URN    | Category                    | SubCategory | Value  | Mean   | DiffMean | PercentDiff | Percentile | Decile | RAG |
           | 777042 | Administrative supplies     | Total       | 429.07 | 47.78  | 381.28   | 88.86       | 99.00      | 9.00   | red |
           | 777042 | Catering staff and supplies | Total       | 362.59 | 173.19 | 189.40   | 52.23       | 92.33      | 9.00   | red |
-          
+
     Scenario: Sending a valid default metric rag rating request with status
         Given a valid default metric rag rating with categories '' and statuses 'amber' for urns:
           | Urn    |

--- a/platform/tests/Platform.ApiTests/Steps/InsightMetricRagRatingSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/InsightMetricRagRatingSteps.cs
@@ -10,12 +10,12 @@ public class MetricRagRatingsBalanceSteps(InsightApiDriver api)
 {
     private const string MetricRagRatingsKey = "metric-rag-ratings";
 
-    [Given("a valid user defined metric rag rating with runId '(.*)', useCustomData '(.*)' and setType '(.*)'")]
-    public void GivenAValidUserDefinedMetricRagRatingWithRunIdUseCustomDataAndSetType(string runId, string useCustomData, string setType)
+    [Given("a valid user defined metric rag rating with runId '(.*)', useCustomData '(.*)'")]
+    public void GivenAValidUserDefinedMetricRagRatingWithRunIdUseCustomData(string runId, string useCustomData)
     {
         api.CreateRequest(MetricRagRatingsKey, new HttpRequestMessage
         {
-            RequestUri = new Uri($"/api/metric-rag/{runId}?useCustomData={useCustomData}&setType={setType}", UriKind.Relative),
+            RequestUri = new Uri($"/api/metric-rag/{runId}?useCustomData={useCustomData}", UriKind.Relative),
             Method = HttpMethod.Get
         });
     }

--- a/platform/tests/Platform.Tests/Benchmark/WhenFunctionReceivesGetComparatorSetRequest.cs
+++ b/platform/tests/Platform.Tests/Benchmark/WhenFunctionReceivesGetComparatorSetRequest.cs
@@ -2,7 +2,6 @@ using System.Net;
 using Moq;
 using Platform.Api.Benchmark.ComparatorSets;
 using Xunit;
-
 namespace Platform.Tests.Benchmark;
 
 public class WhenFunctionReceivesGetComparatorSetRequest : ComparatorSetsFunctionsTestBase
@@ -11,7 +10,7 @@ public class WhenFunctionReceivesGetComparatorSetRequest : ComparatorSetsFunctio
     public async Task DefaultShouldBeOkOnValidRequest()
     {
         Service
-            .Setup(d => d.DefaultSchoolAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(d => d.DefaultSchoolAsync(It.IsAny<string>()))
             .ReturnsAsync(new ComparatorSetSchool());
 
         var response =
@@ -25,7 +24,7 @@ public class WhenFunctionReceivesGetComparatorSetRequest : ComparatorSetsFunctio
     public async Task DefaultShouldBe500OnError()
     {
         Service
-            .Setup(d => d.DefaultSchoolAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(d => d.DefaultSchoolAsync(It.IsAny<string>()))
             .Throws(new Exception());
 
         var response = await Functions
@@ -39,7 +38,7 @@ public class WhenFunctionReceivesGetComparatorSetRequest : ComparatorSetsFunctio
     public async Task CustomShouldBeOkOnValidRequest()
     {
         Service
-            .Setup(d => d.CustomSchoolAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(d => d.CustomSchoolAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync(new ComparatorSetSchool());
 
         var response =
@@ -53,7 +52,7 @@ public class WhenFunctionReceivesGetComparatorSetRequest : ComparatorSetsFunctio
     public async Task CustomShouldBe500OnError()
     {
         Service
-            .Setup(d => d.CustomSchoolAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(d => d.CustomSchoolAsync(It.IsAny<string>(), It.IsAny<string>()))
             .Throws(new Exception());
 
         var response = await Functions

--- a/platform/tests/Platform.Tests/Insight/MetricRagRatings/WhenBudgetForecastServiceQueriesAsync.cs
+++ b/platform/tests/Platform.Tests/Insight/MetricRagRatings/WhenBudgetForecastServiceQueriesAsync.cs
@@ -35,14 +35,13 @@ public class WhenMetricRagRatingsServiceQueriesAsync
     }
 
     [Theory]
-    [InlineData("1,2,3", "4,5,6", "7,8,9", "runType", "setType", false, "SELECT * from MetricRAG WHERE RunType = @RunType AND RunId = @RunId AND SetType = @SetType AND URN IN @URNS AND SubCategory = 'Total' AND Category IN @categories AND RAG IN @statuses")]
-    [InlineData("1,2,3", null, null, "runType", "setType", true, "SELECT * from MetricRAG WHERE RunType = @RunType AND RunId = @RunId AND SetType = @SetType AND URN IN @URNS")]
+    [InlineData("1,2,3", "4,5,6", "7,8,9", "runType", false, "SELECT * from MetricRAG WHERE RunType = @RunType AND RunId = @RunId AND URN IN @URNS AND SubCategory = 'Total' AND Category IN @categories AND RAG IN @statuses")]
+    [InlineData("1,2,3", null, null, "runType", true, "SELECT * from MetricRAG WHERE RunType = @RunType AND RunId = @RunId AND URN IN @URNS")]
     public async Task ShouldQueryAsyncWhenQueryAsync(
         string urns,
         string? categories,
         string? statuses,
         string runType,
-        string setType,
         bool includeSubCategories,
         string expectedSql)
     {
@@ -64,7 +63,7 @@ public class WhenMetricRagRatingsServiceQueriesAsync
             .Callback((string sql, object? param) =>
             {
                 actualSql = sql;
-                actualParam = TestDatabase.GetDictionaryFromDynamicParameters(param, "RunType", "RunId", "SetType", "URNS", "categories", "statuses");
+                actualParam = TestDatabase.GetDictionaryFromDynamicParameters(param, "RunType", "RunId", "URNS", "categories", "statuses");
             })
             .ReturnsAsync(results);
 
@@ -74,7 +73,6 @@ public class WhenMetricRagRatingsServiceQueriesAsync
             categories?.Split(",") ?? [],
             statuses?.Split(",") ?? [],
             runType,
-            setType,
             includeSubCategories);
 
         // assert
@@ -88,9 +86,6 @@ public class WhenMetricRagRatingsServiceQueriesAsync
             },
             {
                 "RunId", year
-            },
-            {
-                "SetType", setType
             },
             {
                 "URNS", urns.Split(",")
@@ -109,9 +104,9 @@ public class WhenMetricRagRatingsServiceQueriesAsync
     }
 
     [Theory]
-    [InlineData("identifier", "runType", "setType", false, "SELECT * from MetricRAG WHERE RunType = @RunType AND RunId = @RunId AND SetType = @SetType AND SubCategory = 'Total'")]
-    [InlineData("identifier", "runType", "setType", true, "SELECT * from MetricRAG WHERE RunType = @RunType AND RunId = @RunId AND SetType = @SetType")]
-    public async Task ShouldQueryAsyncWhenUserDefinedAsync(string identifier, string runType, string setType, bool includeSubCategories, string expectedSql)
+    [InlineData("identifier", "runType", false, "SELECT * from MetricRAG WHERE RunType = @RunType AND RunId = @RunId AND SubCategory = 'Total'")]
+    [InlineData("identifier", "runType", true, "SELECT * from MetricRAG WHERE RunType = @RunType AND RunId = @RunId")]
+    public async Task ShouldQueryAsyncWhenUserDefinedAsync(string identifier, string runType, bool includeSubCategories, string expectedSql)
     {
         // arrange
         var results = new List<MetricRagRating>
@@ -126,12 +121,12 @@ public class WhenMetricRagRatingsServiceQueriesAsync
             .Callback((string sql, object? param) =>
             {
                 actualSql = sql;
-                actualParam = TestDatabase.GetDictionaryFromDynamicParameters(param, "RunType", "RunId", "SetType");
+                actualParam = TestDatabase.GetDictionaryFromDynamicParameters(param, "RunType", "RunId");
             })
             .ReturnsAsync(results);
 
         // act
-        var actual = await _service.UserDefinedAsync(identifier, runType, setType, includeSubCategories);
+        var actual = await _service.UserDefinedAsync(identifier, runType, includeSubCategories);
 
         // assert
         Assert.Equal(results, actual);
@@ -144,9 +139,6 @@ public class WhenMetricRagRatingsServiceQueriesAsync
             },
             {
                 "RunId", identifier
-            },
-            {
-                "SetType", setType
             }
         };
 

--- a/platform/tests/Platform.Tests/Insight/MetricRagRatings/WhenMetricRagRatingParametersSetsValues.cs
+++ b/platform/tests/Platform.Tests/Insight/MetricRagRatings/WhenMetricRagRatingParametersSetsValues.cs
@@ -7,18 +7,14 @@ namespace Platform.Tests.Insight.MetricRagRatings;
 public class WhenMetricRagRatingParametersSetsValues
 {
     [Theory]
-    [InlineData("mixed", "true", "mixed", "custom")]
-    [InlineData("unmixed", "true", "unmixed", "custom")]
-    [InlineData("mixed", "false", "mixed", "default")]
-    [InlineData(null, null, "unmixed", "default")]
-    public void ShouldSetValuesFromIQueryCollection(string? setType, string? useCustomData, string expectedSetType, string expectedDataContext)
+    [InlineData("true", "custom")]
+    [InlineData("false", "default")]
+    [InlineData(null, "default")]
+    public void ShouldSetValuesFromIQueryCollection(string? useCustomData, string expectedDataContext)
     {
         var parameters = new MetricRagRatingParameters();
         var query = new QueryCollection(new Dictionary<string, StringValues>
         {
-            {
-                "setType", setType
-            },
             {
                 "useCustomData", useCustomData
             }
@@ -26,7 +22,6 @@ public class WhenMetricRagRatingParametersSetsValues
 
         parameters.SetValues(query);
 
-        Assert.Equal(expectedSetType, parameters.SetType);
         Assert.Equal(expectedDataContext, parameters.DataContext);
     }
 }

--- a/web/src/Web.App/Infrastructure/Apis/Insight/MetricRagRatingApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Insight/MetricRagRatingApi.cs
@@ -9,8 +9,7 @@ public class MetricRagRatingApi(HttpClient httpClient, string? key = default) : 
 
     public async Task<ApiResult> UserDefinedAsync(string identifier)
     {
-        var query = new ApiQuery().AddIfNotNull("setType", "mixed");
-        return await GetAsync($"{Api.MetricRagRating.Single(identifier)}{query.ToQueryString()}");
+        return await GetAsync($"{Api.MetricRagRating.Single(identifier)}");
     }
 
     public async Task<ApiResult> CustomAsync(string identifier)


### PR DESCRIPTION
### Context
AB#233103 AB#232973

### Change proposed in this pull request
Removed `SetType` from comparator set/RAG rating models and queries in API.

### Guidance to review 
See related PR #1471 for more details.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

