### PR TITLE
feat: separate AAR, CFR, BFR processing

### DIFF
--- a/data-pipeline/README.md
+++ b/data-pipeline/README.md
@@ -189,7 +189,15 @@ To run the pipeline locally, follow these steps:
     Once the pipeline is running, start processing files placed in the `raw` container by adding the following message to the `data-pipeline-job-default-start` queue:
 
     ```json
-    {"type":"default","year":<year>}
+    {
+      "type": "default",
+      "runId": <year>,
+        "year": {
+            "aar": <year>,
+            "cfr": <year>,
+            "bfr": <year>
+        }
+    }
     ```
 
 > Note: There is a docker compose script that will start Azurite, SQL server, and the FBIT pipeline that can be run from the `docker` directory using

--- a/data-pipeline/src/pipeline/comparator_sets.py
+++ b/data-pipeline/src/pipeline/comparator_sets.py
@@ -378,8 +378,16 @@ def compute_distances(
         phase_pfi = np.array(row["Is PFI"])
         phase_boarding = np.array(row["Boarders (name)"])
         phase_regions = np.array(row["GOR (name)"])
-        pupil_include = ~np.array(row["Partial Years Present"]) & ~np.array(row["Did Not Submit"]) & np.array(row["Pupil Comparator Data Present"])
-        building_include = ~np.array(row["Partial Years Present"]) & ~np.array(row["Did Not Submit"]) & np.array(row["Building Comparator Data Present"])
+        pupil_include = (
+            ~np.array(row["Partial Years Present"])
+            & ~np.array(row["Did Not Submit"])
+            & np.array(row["Pupil Comparator Data Present"])
+        )
+        building_include = (
+            ~np.array(row["Partial Years Present"])
+            & ~np.array(row["Did Not Submit"])
+            & np.array(row["Building Comparator Data Present"])
+        )
 
         # TODO: compares ab/ba and aa.
         # compute best-set for each org. individually.
@@ -405,7 +413,7 @@ def compute_distances(
                 # note: single-element arrays are unpacked; in this
                 # case, do not produce a comparator-set.
                 if len(top_pupil_set_urns) == 1:
-                    logger.warning(
+                    logger.debug(
                         f"Unable to produce pupil comparator-set for URN: {urn}."
                     )
                     pupils.loc[urn] = np.array([])
@@ -426,7 +434,7 @@ def compute_distances(
                     include=building_include,
                 )
                 if len(top_building_set_urns) == 1:
-                    logger.warning(
+                    logger.debug(
                         f"Unable to produce building comparator-set for URN: {urn}."
                     )
                     buildings.loc[urn] = np.array([])

--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -204,22 +204,26 @@ def pre_process_cfo(run_type: str, year: int, run_id: str) -> pd.DataFrame:
     return cfo
 
 
-def pre_process_central_services(run_type: str, year: int, run_id: str) -> pd.DataFrame:
+def pre_process_central_services(
+    run_type: str, year: int, run_id: str
+) -> pd.DataFrame | None:
     logger.info(f"Building Central Services Data: {run_type}/{year}/aar_cs.csv")
 
-    academies_data = get_blob(
+    if academies_data := try_get_blob(
         raw_container, f"{run_type}/{year}/aar_cs.csv", encoding="utf-8"
-    )
+    ):
 
-    central_services = prepare_central_services_data(academies_data, year)
+        central_services = prepare_central_services_data(academies_data, year)
 
-    write_blob(
-        "pre-processed",
-        f"{run_type}/{run_id}/central_services.parquet",
-        central_services.to_parquet(),
-    )
+        write_blob(
+            "pre-processed",
+            f"{run_type}/{run_id}/central_services.parquet",
+            central_services.to_parquet(),
+        )
 
-    return central_services
+        return central_services
+
+    return None
 
 
 def pre_process_academies_data(

--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -66,62 +66,80 @@ ds_logger = logging.getLogger("distributed.utils_perf")
 ds_logger.setLevel(logging.ERROR)
 
 
-def pre_process_cdc(run_type: str, year: int) -> pd.DataFrame:
+def pre_process_cdc(run_type: str, year: int, run_id: str) -> pd.DataFrame:
     logger.info("Processing CDC Data")
+
     cdc_data = get_blob(raw_container, f"{run_type}/{year}/cdc.csv", encoding="utf-8")
+
     cdc = prepare_cdc_data(cdc_data, year)
-    write_blob("pre-processed", f"{run_type}/{year}/cdc.parquet", cdc.to_parquet())
+
+    write_blob("pre-processed", f"{run_type}/{run_id}/cdc.parquet", cdc.to_parquet())
 
     return cdc
 
 
-def pre_process_census(run_type, year) -> pd.DataFrame:
+def pre_process_census(run_type: str, year: int, run_id: str) -> pd.DataFrame:
     logger.info("Processing Census Data")
+
     workforce_census_data = get_blob(
         raw_container, f"{run_type}/{year}/census_workforce.xlsx"
     )
     pupil_census_data = get_blob(
         raw_container, f"{run_type}/{year}/census_pupils.csv", encoding="cp1252"
     )
+
     census = prepare_census_data(workforce_census_data, pupil_census_data)
+
     write_blob(
         "pre-processed",
-        f"{run_type}/{year}/census.parquet",
+        f"{run_type}/{run_id}/census.parquet",
         census.to_parquet(),
     )
 
     return census
 
 
-def pre_process_sen(run_type, year) -> pd.DataFrame:
+def pre_process_sen(run_type: str, year: int, run_id: str) -> pd.DataFrame:
     logger.info("Processing SEN Data")
+
     sen_data = get_blob(raw_container, f"{run_type}/{year}/sen.csv", encoding="cp1252")
+
     sen = prepare_sen_data(sen_data)
-    write_blob("pre-processed", f"{run_type}/{year}/sen.parquet", sen.to_parquet())
+
+    write_blob("pre-processed", f"{run_type}/{run_id}/sen.parquet", sen.to_parquet())
 
     return sen
 
 
-def pre_process_ks2(run_type, year) -> pd.DataFrame:
+def pre_process_ks2(run_type: str, year: int, run_id: str) -> pd.DataFrame:
     logger.info("Processing KS2 Data")
+
     ks2_data = try_get_blob(raw_container, f"{run_type}/{year}/ks2.xlsx")
+
     ks2 = prepare_ks2_data(ks2_data)
-    write_blob("pre-processed", f"{run_type}/{year}/ks2.parquet", ks2.to_parquet())
+
+    write_blob("pre-processed", f"{run_type}/{run_id}/ks2.parquet", ks2.to_parquet())
 
     return ks2
 
 
-def pre_process_ks4(run_type, year) -> pd.DataFrame:
+def pre_process_ks4(run_type: str, year: int, run_id: str) -> pd.DataFrame:
     logger.info("Processing KS4 Data")
+
     ks4_data = try_get_blob(raw_container, f"{run_type}/{year}/ks4.xlsx")
+
     ks4 = prepare_ks4_data(ks4_data)
-    write_blob("pre-processed", f"{run_type}/{year}/ks4.parquet", ks4.to_parquet())
+
+    write_blob("pre-processed", f"{run_type}/{run_id}/ks4.parquet", ks4.to_parquet())
 
     return ks4
 
 
-def pre_process_academy_ar(run_type, year) -> tuple[pd.DataFrame, pd.DataFrame]:
+def pre_process_academy_ar(
+    run_type: str, year: int, run_id: str
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     logger.info("Processing Academy AR Data")
+
     academy_ar_data = get_blob(
         raw_container, f"{run_type}/{year}/aar.csv", encoding="utf-8"
     )
@@ -130,46 +148,51 @@ def pre_process_academy_ar(run_type, year) -> tuple[pd.DataFrame, pd.DataFrame]:
 
     write_blob(
         "pre-processed",
-        f"{run_type}/{year}/aar.parquet",
+        f"{run_type}/{run_id}/aar.parquet",
         aar.to_parquet(),
     )
 
     return aar
 
 
-def pre_process_schools(run_type, year) -> pd.DataFrame:
+def pre_process_schools(run_type: str, year: int, run_id: str) -> pd.DataFrame:
     logger.info("Processing Schools Data")
+
     gias_data = get_blob(
         raw_container, f"{run_type}/{year}/gias.csv", encoding="cp1252"
     )
     gias_links_data = get_blob(
         raw_container, f"{run_type}/{year}/gias_links.csv", encoding="cp1252"
     )
+
     schools = prepare_schools_data(gias_data, gias_links_data)
+
     write_blob(
         "pre-processed",
-        f"{run_type}/{year}/schools.parquet",
+        f"{run_type}/{run_id}/schools.parquet",
         schools.to_parquet(),
     )
 
     return schools
 
 
-def pre_process_cfo(run_type, year) -> pd.DataFrame:
+def pre_process_cfo(run_type: str, year: int, run_id: str) -> pd.DataFrame:
     logger.info("Processing CFO Data")
+
     cfo_data = get_blob(raw_container, f"{run_type}/{year}/cfo.xlsx")
 
     cfo = build_cfo_data(cfo_data)
+
     write_blob(
         "pre-processed",
-        f"{run_type}/{year}/cfo.parquet",
+        f"{run_type}/{run_id}/cfo.parquet",
         cfo.to_parquet(),
     )
 
     return cfo
 
 
-def pre_process_central_services(run_type, year) -> pd.DataFrame:
+def pre_process_central_services(run_type: str, year: int, run_id: str) -> pd.DataFrame:
     logger.info("Building Central Services Data")
 
     academies_data = get_blob(
@@ -180,18 +203,23 @@ def pre_process_central_services(run_type, year) -> pd.DataFrame:
 
     write_blob(
         "pre-processed",
-        f"{run_type}/{year}/central_services.parquet",
+        f"{run_type}/{run_id}/central_services.parquet",
         central_services.to_parquet(),
     )
 
     return central_services
 
 
-def pre_process_academies_data(run_type, year, data_ref) -> pd.DataFrame:
+def pre_process_academies_data(
+    run_type: str,
+    run_id: str,
+    year: int,
+    data_ref: tuple,
+) -> pd.DataFrame:
     logger.info("Building Academy Set")
     schools, census, sen, cdc, aar, ks2, ks4, cfo, central_services = data_ref
 
-    logger.info(f"Processing AAR data - {year}.")
+    logger.info(f"Processing AAR data - {run_id} - {year}.")
 
     academies = build_academy_data(
         schools,
@@ -209,18 +237,23 @@ def pre_process_academies_data(run_type, year, data_ref) -> pd.DataFrame:
 
     write_blob(
         "pre-processed",
-        f"{run_type}/{year}/academies.parquet",
+        f"{run_type}/{run_id}/academies.parquet",
         academies.to_parquet(),
     )
 
     return academies
 
 
-def pre_process_maintained_schools_data(run_type, year, data_ref) -> pd.DataFrame:
+def pre_process_maintained_schools_data(
+    run_type: str,
+    run_id: str,
+    year: int,
+    data_ref: tuple,
+) -> pd.DataFrame:
     logger.info("Building Maintained School Set")
     schools, census, sen, cdc, aar, ks2, ks4, cfo, central_services = data_ref
 
-    logger.info(f"Processing CFR data - {year}.")
+    logger.info(f"Processing CFR data - {run_id} - {year}.")
 
     maintained_schools_data = get_blob(
         raw_container,
@@ -234,7 +267,7 @@ def pre_process_maintained_schools_data(run_type, year, data_ref) -> pd.DataFram
 
     write_blob(
         "pre-processed",
-        f"{run_type}/{year}/maintained_schools.parquet",
+        f"{run_type}/{run_id}/maintained_schools.parquet",
         maintained_schools.to_parquet(),
     )
 
@@ -243,14 +276,14 @@ def pre_process_maintained_schools_data(run_type, year, data_ref) -> pd.DataFram
 
 def pre_process_trust_data(
     run_type: str,
-    year: int,
+    run_id: str,
     academies: pd.DataFrame,
 ) -> pd.DataFrame:
     """
     Build and store Trust financial information.
 
     :param run_type: "default" or "custom"
-    :param year: year in question
+    :param run_id: unique identifer for data-writes
     :param academies: Academy financial information
     :return: Trust-level financial information
     """
@@ -260,7 +293,7 @@ def pre_process_trust_data(
 
     write_blob(
         "pre-processed",
-        f"{run_type}/{year}/trusts.parquet",
+        f"{run_type}/{run_id}/trusts.parquet",
         trusts.to_parquet(),
     )
 
@@ -453,6 +486,7 @@ def pre_process_bfr(run_id: str, year: int):
 
 def _get_ancillary_data(
     worker_client: Client,
+    run_id: str,
     year: int,
 ) -> tuple[pd.DataFrame]:
     """
@@ -461,6 +495,7 @@ def _get_ancillary_data(
     Note: `run_type` is _always_ "default".
 
     :param worker_client: Dask client
+    :param run_id: unique identifier (used for write target)
     :param year: financial year in question
     :return: tuple of supporting datasets
     """
@@ -469,15 +504,17 @@ def _get_ancillary_data(
     cdc, census, sen, ks2, ks4, aar, schools, cfo, central_services = (
         worker_client.gather(
             [
-                worker_client.submit(pre_process_cdc, run_type, year),
-                worker_client.submit(pre_process_census, run_type, year),
-                worker_client.submit(pre_process_sen, run_type, year),
-                worker_client.submit(pre_process_ks2, run_type, year),
-                worker_client.submit(pre_process_ks4, run_type, year),
-                worker_client.submit(pre_process_academy_ar, run_type, year),
-                worker_client.submit(pre_process_schools, run_type, year),
-                worker_client.submit(pre_process_cfo, run_type, year),
-                worker_client.submit(pre_process_central_services, run_type, year),
+                worker_client.submit(pre_process_cdc, run_type, year, run_id),
+                worker_client.submit(pre_process_census, run_type, year, run_id),
+                worker_client.submit(pre_process_sen, run_type, year, run_id),
+                worker_client.submit(pre_process_ks2, run_type, year, run_id),
+                worker_client.submit(pre_process_ks4, run_type, year, run_id),
+                worker_client.submit(pre_process_academy_ar, run_type, year, run_id),
+                worker_client.submit(pre_process_schools, run_type, year, run_id),
+                worker_client.submit(pre_process_cfo, run_type, year, run_id),
+                worker_client.submit(
+                    pre_process_central_services, run_type, year, run_id
+                ),
             ]
         )
     )
@@ -512,25 +549,32 @@ def pre_process_data(
     logger.info(f"Pre-processing data {run_type} - {run_id}")
 
     academy_data_ref = maintained_data_ref = _get_ancillary_data(
-        worker_client, aar_year
+        worker_client,
+        run_id,
+        aar_year,
     )
     if cfr_year != aar_year:
-        maintained_data_ref = _get_ancillary_data(worker_client, cfr_year)
+        maintained_data_ref = _get_ancillary_data(worker_client, run_id, cfr_year)
 
     academies, maintained_schools = worker_client.gather(
         [
             worker_client.submit(
-                pre_process_academies_data, run_type, aar_year, academy_data_ref
+                pre_process_academies_data,
+                run_type,
+                run_id,
+                aar_year,
+                academy_data_ref,
             ),
             worker_client.submit(
                 pre_process_maintained_schools_data,
                 run_type,
+                run_id,
                 cfr_year,
                 maintained_data_ref,
             ),
         ]
     )
-    trusts = pre_process_trust_data(run_type, aar_year, academies)
+    trusts = pre_process_trust_data(run_type, run_id, academies)
 
     pre_process_all_schools(
         run_type,

--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -191,6 +191,8 @@ def pre_process_academies_data(run_type, year, data_ref) -> pd.DataFrame:
     logger.info("Building Academy Set")
     schools, census, sen, cdc, aar, ks2, ks4, cfo, central_services = data_ref
 
+    logger.info(f"Processing AAR data - {year}.")
+
     academies = build_academy_data(
         schools,
         census,
@@ -218,14 +220,12 @@ def pre_process_maintained_schools_data(run_type, year, data_ref) -> pd.DataFram
     logger.info("Building Maintained School Set")
     schools, census, sen, cdc, aar, ks2, ks4, cfo, central_services = data_ref
 
+    logger.info(f"Processing CFR data - {year}.")
+
     maintained_schools_data = get_blob(
         raw_container,
         f"{run_type}/{year}/maintained_schools_master_list.csv",
         encoding="cp1252",
-    )
-
-    links_data = get_blob(
-        raw_container, f"{run_type}/{year}/gias_all_links.csv", encoding="cp1252"
     )
 
     maintained_schools = build_maintained_school_data(

--- a/data-pipeline/src/pipeline/message.py
+++ b/data-pipeline/src/pipeline/message.py
@@ -19,9 +19,24 @@ def get_message_type(message: dict) -> MessageType:
     """
     Determine the type of an incoming message.
 
-    TODO: `default` message format?
+    `default` messages will be of the form (including varying sources
+    for each data type):
 
-    User-defined comparator set message will be of the form:
+    ```json
+    {
+        "jobId": "24463424-9642-4314-bb55-45424af6e812",
+        "type": "default",
+        "runId": 2023,
+        "year": {
+            "aar": 2022,
+            "cfr": 2023,
+            "bfr": 2022
+        }
+    }
+    ```
+
+    User-defined comparator set message will be of the form (including
+    only a single source from which to retrieve data):
 
     ```json
     {
@@ -47,9 +62,9 @@ def get_message_type(message: dict) -> MessageType:
         "jobId": "79ca4d18-d065-4180-9e0d-10c9b3fdd1a8",
         "type": "custom-data",
         "runType": "custom",
-        "runId": "123",
-        "year": 2023,
-        "urn": "123",
+        "runId": "c321ef6a-3b1c-4ce2-8e32-0d0167bf2fa7",
+        "year": 2022,
+        "urn": "142875",
         "payload": {
             "kind": "CustomDataPayload",
             "administrativeSuppliesNonEducationalCosts": 0.0,

--- a/data-pipeline/src/pipeline/rag.py
+++ b/data-pipeline/src/pipeline/rag.py
@@ -247,7 +247,7 @@ def compute_rag(
                             ):
                                 yield r
                         else:
-                            logger.warning(
+                            logger.debug(
                                 f'Unable to compute rag for {cat_name} - {rag_settings["type"]} - {urn}'
                             )
                     if indx > 1 and indx % 1000 == 0:

--- a/documentation/features/6_Orchestrator.md
+++ b/documentation/features/6_Orchestrator.md
@@ -33,24 +33,30 @@ sequenceDiagram
     end
 
     Platform API->>data-pipeline-job-pending: Produce
-    Note over Platform API,data-pipeline-job-pending: Platform API generated message
+    Note over Platform API,data-pipeline-job-pending: Platform API generated message<br/>with the 'custom' message schema
     data-pipeline-job-pending-->>Orchestrator: Consume
     
     Developer->>data-pipeline-job-pending: Produce
-    Note over Developer,data-pipeline-job-pending: Manually generated message 
+    Note over Developer,data-pipeline-job-pending: Manually generated message <br/>with the 'default' message schema
     data-pipeline-job-pending-->>Orchestrator: Consume
 
-    alt is custom
+    alt is 'custom' message type
         Orchestrator->>data-pipeline-job-custom-start: Produce
         Data pipeline-->>data-pipeline-job-custom-start: Consume
-    else is default
+    else is 'default' message type
         Orchestrator->>data-pipeline-job-default-start: Produce
         Data pipeline-->>data-pipeline-job-default-start: Consume
+    else
+        Note right of Orchestrator: Exception
     end
 
     Data pipeline->>data-pipeline-job-finished: Produce
     data-pipeline-job-finished-->>Orchestrator: Consume
-    Orchestrator->>Orchestrator: Log completion
+    alt is 'custom' message type
+        Orchestrator->>Database: Update status
+    else is 'default' message type
+        Orchestrator->>Azure Search: Run indexers
+    end
 ```
 
 ## Configuration

--- a/platform/src/abstractions/Platform.Functions/Messages/PipelineFinishMessage.cs
+++ b/platform/src/abstractions/Platform.Functions/Messages/PipelineFinishMessage.cs
@@ -1,0 +1,13 @@
+﻿using System.Diagnostics.CodeAnalysis;
+// ReSharper disable ClassNeverInstantiated.Global
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+// ReSharper disable UnusedMember.Global
+namespace Platform.Functions.Messages;
+
+[ExcludeFromCodeCoverage]
+public record PipelineFinishMessage
+{
+    public string? JobId { get; set; }
+    public string? RunId { get; set; }
+    public bool Success { get; set; }
+}

--- a/platform/src/abstractions/Platform.Functions/Messages/PipelineMessagePayload.cs
+++ b/platform/src/abstractions/Platform.Functions/Messages/PipelineMessagePayload.cs
@@ -1,43 +1,9 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using JsonSubTypes;
 using Newtonsoft.Json;
-// ReSharper disable AutoPropertyCanBeMadeGetOnly.Global
-// ReSharper disable ClassNeverInstantiated.Global
-// ReSharper disable InconsistentNaming
-// ReSharper disable PropertyCanBeMadeInitOnly.Global
 // ReSharper disable UnusedAutoPropertyAccessor.Global
-// ReSharper disable UnusedMember.Global
 
-namespace Platform.Functions;
-
-[ExcludeFromCodeCoverage]
-public record PipelineFinishMessage
-{
-    public string? JobId { get; set; }
-    public string? RunId { get; set; }
-    public bool Success { get; set; }
-}
-
-[ExcludeFromCodeCoverage]
-public record PipelineStartMessage
-{
-    public string? JobId { get; set; } = Guid.NewGuid().ToString();
-
-    /// See
-    /// <see cref="PipelineJobType" />
-    /// for available values
-    public string? Type { get; set; } // Pipeline job type : default / comparator-set / custom-data
-
-    /// See
-    /// <see cref="PipelineRunType" />
-    /// for available values
-    public string? RunType { get; set; } // Data context : default / custom
-
-    public string? RunId { get; set; } // year or id for comparator-set / custom-data
-    public int? Year { get; set; } // Needed for when custom data or comparator set
-    public string? URN { get; set; }
-    public Payload? Payload { get; set; } // null for default
-}
+namespace Platform.Functions.Messages;
 
 [ExcludeFromCodeCoverage]
 [JsonConverter(typeof(JsonSubtypes), "Kind")]
@@ -106,17 +72,4 @@ public record CustomDataPayload : Payload
     public decimal? NonClassroomSupportStaffFTE { get; set; }
     public decimal? AuxiliaryStaffFTE { get; set; }
     public decimal? WorkforceHeadcount { get; set; }
-}
-
-public record PipelineRunType
-{
-    public const string Default = "default";
-    public const string Custom = "custom";
-}
-
-public record PipelineJobType
-{
-    public const string Default = "default";
-    public const string ComparatorSet = "comparator-set";
-    public const string CustomData = "custom-data";
 }

--- a/platform/src/abstractions/Platform.Functions/Messages/PipelinePendingMessage.cs
+++ b/platform/src/abstractions/Platform.Functions/Messages/PipelinePendingMessage.cs
@@ -1,0 +1,20 @@
+// ReSharper disable InconsistentNaming
+// ReSharper disable PropertyCanBeMadeInitOnly.Global
+namespace Platform.Functions.Messages;
+
+public record PipelinePendingMessage : PipelineStartMessage
+{
+    /// <summary>
+    ///     This property could be serialised to an <c>int</c> or a <c>string</c>
+    /// </summary>
+    public object? RunId { get; set; }
+
+    /// <summary>
+    ///     This property could be serialised to an <c>int</c> or a <see cref="PipelineMessageYears">PipelineMessageYears</see>
+    /// </summary>
+    public object? Year { get; set; }
+
+    public string? URN { get; set; }
+
+    public Payload? Payload { get; set; }
+}

--- a/platform/src/abstractions/Platform.Functions/Messages/PipelineStartCustomMessage.cs
+++ b/platform/src/abstractions/Platform.Functions/Messages/PipelineStartCustomMessage.cs
@@ -1,0 +1,43 @@
+using System.Diagnostics.CodeAnalysis;
+// ReSharper disable InconsistentNaming
+// ReSharper disable PropertyCanBeMadeInitOnly.Global
+namespace Platform.Functions.Messages;
+
+public record PipelineStartCustomMessage : PipelineStartMessage
+{
+    /// <summary>
+    ///     For the <c>custom</c> message, this is a year or a custom run GUID
+    /// </summary>
+    public string? RunId { get; set; }
+
+    public int? Year { get; set; }
+
+    public string? URN { get; set; }
+
+    public Payload? Payload { get; set; }
+
+    [SuppressMessage("Usage", "CA2208:Instantiate argument exceptions correctly")]
+    public static PipelineStartCustomMessage FromPending(PipelinePendingMessage input)
+    {
+        int? year;
+        if (input.Year != null && int.TryParse(input.Year.ToString(), out var parsed))
+        {
+            year = parsed;
+        }
+        else
+        {
+            throw new ArgumentException($"Unable to parse `{input.Year}` as `int`", nameof(PipelinePendingMessage.Year));
+        }
+
+        return new PipelineStartCustomMessage
+        {
+            JobId = input.JobId,
+            Type = input.Type,
+            RunType = input.RunType,
+            RunId = input.RunId?.ToString(),
+            Year = year,
+            URN = input.URN,
+            Payload = input.Payload
+        };
+    }
+}

--- a/platform/src/abstractions/Platform.Functions/Messages/PipelineStartDefaultMessage.cs
+++ b/platform/src/abstractions/Platform.Functions/Messages/PipelineStartDefaultMessage.cs
@@ -1,0 +1,57 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json.Linq;
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable PropertyCanBeMadeInitOnly.Global
+namespace Platform.Functions.Messages;
+
+public record PipelineStartDefaultMessage : PipelineStartMessage
+{
+    /// <summary>
+    ///     For the <c>default</c> message, this is a year
+    /// </summary>
+    public int? RunId { get; set; }
+
+    public PipelineMessageYears? Year { get; set; }
+
+    [SuppressMessage("Usage", "CA2208:Instantiate argument exceptions correctly")]
+    public static PipelineStartDefaultMessage FromPending(PipelinePendingMessage input)
+    {
+        int? runId = null;
+        if (input.RunId != null && int.TryParse(input.RunId.ToString(), out var parsed))
+        {
+            runId = parsed;
+        }
+
+        if (runId == null)
+        {
+            throw new ArgumentException($"Unable to parse `{input.RunId}` as `int`", nameof(PipelinePendingMessage.RunId));
+        }
+
+        PipelineMessageYears? year = null;
+        if (input.Year is JObject yearObj)
+        {
+            year = yearObj.ToObject<PipelineMessageYears>();
+        }
+
+        if (year == null)
+        {
+            throw new ArgumentException($"Unable to parse `{input.Year}` as `PipelineMessageYears`", nameof(PipelinePendingMessage.Year));
+        }
+
+        return new PipelineStartDefaultMessage
+        {
+            JobId = input.JobId,
+            Type = input.Type,
+            RunType = input.RunType,
+            RunId = runId,
+            Year = year
+        };
+    }
+}
+
+public record PipelineMessageYears
+{
+    public int? Aar { get; set; }
+    public int? Cfr { get; set; }
+    public int? Bfr { get; set; }
+}

--- a/platform/src/abstractions/Platform.Functions/Messages/PipelineStartMessage.cs
+++ b/platform/src/abstractions/Platform.Functions/Messages/PipelineStartMessage.cs
@@ -1,0 +1,39 @@
+// ReSharper disable ClassNeverInstantiated.Global
+// ReSharper disable PropertyCanBeMadeInitOnly.Global
+namespace Platform.Functions.Messages;
+
+public abstract record PipelineStartMessage
+{
+    public string? JobId { get; set; } = Guid.NewGuid().ToString();
+
+    /// See
+    /// <see cref="PipelineJobType" />
+    /// for available values:
+    /// <c>default</c>
+    /// |
+    /// <c>comparator-set</c>
+    /// |
+    /// <c>custom-data</c>
+    public string? Type { get; set; }
+
+    /// See
+    /// <see cref="PipelineRunType" />
+    /// for available values:
+    /// <c>default</c>
+    /// |
+    /// <c>custom</c>
+    public string? RunType { get; set; }
+}
+
+public record PipelineRunType
+{
+    public const string Default = "default";
+    public const string Custom = "custom";
+}
+
+public record PipelineJobType
+{
+    public const string Default = "default";
+    public const string ComparatorSet = "comparator-set";
+    public const string CustomData = "custom-data";
+}

--- a/platform/src/apis/Platform.Api.Benchmark/ComparatorSets/ComparatorSetsFunctions.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/ComparatorSets/ComparatorSetsFunctions.cs
@@ -9,8 +9,8 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Extensions.Logging;
 using Platform.Api.Benchmark.OpenApi;
 using Platform.Api.Benchmark.Responses;
-using Platform.Functions;
 using Platform.Functions.Extensions;
+using Platform.Functions.Messages;
 using Platform.Functions.OpenApi;
 namespace Platform.Api.Benchmark.ComparatorSets;
 
@@ -211,7 +211,7 @@ public class ComparatorSetsFunctions(IComparatorSetsService service, ILogger<Com
                         ComparatorSetUserData.PendingSchool(identifier, body.UserId, urn));
                     var year = await service.CurrentYearAsync();
 
-                    var message = new PipelineStartMessage
+                    var message = new PipelineStartCustomMessage
                     {
                         RunId = comparatorSet.RunId,
                         RunType = comparatorSet.RunType,

--- a/platform/src/apis/Platform.Api.Benchmark/ComparatorSets/ComparatorSetsService.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/ComparatorSets/ComparatorSetsService.cs
@@ -2,7 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Dapper;
 using Dapper.Contrib.Extensions;
-using Platform.Functions;
+using Platform.Functions.Messages;
 using Platform.Sql;
 namespace Platform.Api.Benchmark.ComparatorSets;
 

--- a/platform/src/apis/Platform.Api.Benchmark/CustomData/CustomDataFunctions.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/CustomData/CustomDataFunctions.cs
@@ -7,8 +7,8 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Extensions.Logging;
 using Platform.Api.Benchmark.Responses;
-using Platform.Functions;
 using Platform.Functions.Extensions;
+using Platform.Functions.Messages;
 using Platform.Functions.OpenApi;
 namespace Platform.Api.Benchmark.CustomData;
 
@@ -103,7 +103,7 @@ public class CustomDataFunctions(ILogger<CustomDataFunctions> logger, ICustomDat
 
                 var year = await service.CurrentYearAsync();
 
-                var message = new PipelineStartMessage
+                var message = new PipelineStartCustomMessage
                 {
                     RunId = data.Id,
                     RunType = PipelineRunType.Custom,

--- a/platform/src/apis/Platform.Api.Benchmark/CustomData/CustomDataRequest.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/CustomData/CustomDataRequest.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using Platform.Functions;
 using Platform.Functions.Extensions;
+using Platform.Functions.Messages;
 namespace Platform.Api.Benchmark.CustomData;
 
 [ExcludeFromCodeCoverage]

--- a/platform/src/apis/Platform.Api.Insight/BudgetForecast/BudgetForecastFunctions.cs
+++ b/platform/src/apis/Platform.Api.Insight/BudgetForecast/BudgetForecastFunctions.cs
@@ -9,8 +9,8 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using Platform.Api.Insight.OpenApi.Examples;
-using Platform.Functions;
 using Platform.Functions.Extensions;
+using Platform.Functions.Messages;
 using Platform.Functions.OpenApi;
 namespace Platform.Api.Insight.BudgetForecast;
 

--- a/platform/src/apis/Platform.Api.Insight/BudgetForecast/BudgetForecastReturnParameters.cs
+++ b/platform/src/apis/Platform.Api.Insight/BudgetForecast/BudgetForecastReturnParameters.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Platform.Functions;
+using Platform.Functions.Messages;
 namespace Platform.Api.Insight.BudgetForecast;
 
 public record BudgetForecastReturnParameters : QueryParameters

--- a/platform/src/apis/Platform.Api.Insight/MetricRagRatings/MetricRagRatingParameters.cs
+++ b/platform/src/apis/Platform.Api.Insight/MetricRagRatings/MetricRagRatingParameters.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Platform.Functions;
 using Platform.Functions.Extensions;
+using Platform.Functions.Messages;
 namespace Platform.Api.Insight.MetricRagRatings;
 
 public record MetricRagRatingParameters : QueryParameters

--- a/platform/src/apis/Platform.Api.Insight/MetricRagRatings/MetricRagRatingService.cs
+++ b/platform/src/apis/Platform.Api.Insight/MetricRagRatings/MetricRagRatingService.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Dapper;
-using Platform.Functions;
+using Platform.Functions.Messages;
 using Platform.Sql;
 namespace Platform.Api.Insight.MetricRagRatings;
 

--- a/platform/tests/Platform.Tests/Insight/MetricRagRatings/WhenMetricRagRatingParametersSetsValues.cs
+++ b/platform/tests/Platform.Tests/Insight/MetricRagRatings/WhenMetricRagRatingParametersSetsValues.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using Platform.Api.Insight.MetricRagRatings;
-using Platform.Functions;
+using Platform.Functions.Messages;
 using Xunit;
 namespace Platform.Tests.Insight.MetricRagRatings;
 

--- a/platform/tests/Platform.Tests/Orchestrator/Search/WhenPipelineStartCustomMessageCreatesFromPending.cs
+++ b/platform/tests/Platform.Tests/Orchestrator/Search/WhenPipelineStartCustomMessageCreatesFromPending.cs
@@ -1,0 +1,63 @@
+using AutoFixture;
+using Platform.Api.Benchmark.CustomData;
+using Platform.Functions.Messages;
+using Xunit;
+namespace Platform.Tests.Orchestrator.Search;
+
+public class WhenPipelineStartCustomMessageCreatesFromPending
+{
+    private readonly Fixture _fixture = new();
+
+    [Fact]
+    public void ShouldCreatePipelineStartCustomMessage()
+    {
+        var runId = Guid.NewGuid().ToString();
+        const string runType = PipelineRunType.Custom;
+        const string type = PipelineJobType.CustomData;
+        const string urn = nameof(urn);
+        const int year = 2024;
+        var payload = _fixture.Create<CustomDataRequest>().CreatePayload();
+
+        var input = new PipelinePendingMessage
+        {
+            RunId = runId,
+            RunType = runType,
+            Type = type,
+            URN = urn,
+            Year = year,
+            Payload = payload
+        };
+
+        var result = PipelineStartCustomMessage.FromPending(input);
+        Assert.Equal(runId, result.RunId);
+        Assert.Equal(runType, result.RunType);
+        Assert.Equal(type, result.Type);
+        Assert.Equal(urn, result.URN);
+        Assert.Equal(year, result.Year);
+        Assert.Equal(payload, result.Payload);
+    }
+
+    [Theory]
+    [InlineData("year", "Unable to parse `year` as `int` (Parameter 'Year')")]
+    public void ShouldNotCreatePipelineStartCustomMessageIfYearInWrongFormat(object? year, string expectedMessage)
+    {
+        var runId = Guid.NewGuid().ToString();
+        const string runType = PipelineRunType.Custom;
+        const string type = PipelineJobType.CustomData;
+        const string urn = nameof(urn);
+        var payload = _fixture.Create<CustomDataRequest>().CreatePayload();
+
+        var input = new PipelinePendingMessage
+        {
+            RunId = runId,
+            RunType = runType,
+            Type = type,
+            URN = urn,
+            Year = year,
+            Payload = payload
+        };
+
+        var exception = Assert.Throws<ArgumentException>(() => PipelineStartCustomMessage.FromPending(input));
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+}

--- a/platform/tests/Platform.Tests/Orchestrator/Search/WhenPipelineStartDefaultMessageCreatesFromPending.cs
+++ b/platform/tests/Platform.Tests/Orchestrator/Search/WhenPipelineStartDefaultMessageCreatesFromPending.cs
@@ -1,0 +1,49 @@
+using AutoFixture;
+using Newtonsoft.Json.Linq;
+using Platform.Functions.Messages;
+using Xunit;
+namespace Platform.Tests.Orchestrator.Search;
+
+public class WhenPipelineStartDefaultMessageCreatesFromPending
+{
+    private readonly Fixture _fixture = new();
+
+    [Fact]
+    public void ShouldCreatePipelineStartDefaultMessage()
+    {
+        const int runId = 2024;
+        const string type = PipelineJobType.Default;
+        var year = _fixture.Create<PipelineMessageYears>();
+
+        var input = new PipelinePendingMessage
+        {
+            RunId = runId,
+            Type = type,
+            Year = JObject.FromObject(year)
+        };
+
+        var result = PipelineStartDefaultMessage.FromPending(input);
+        Assert.Equal(runId, result.RunId);
+        Assert.Equal(type, result.Type);
+        Assert.Equal(year, result.Year);
+    }
+
+    [Theory]
+    [InlineData(2024, 2024, "Unable to parse `2024` as `PipelineMessageYears` (Parameter 'Year')")]
+    [InlineData(2024, null, "Unable to parse `` as `PipelineMessageYears` (Parameter 'Year')")]
+    [InlineData("runId", null, "Unable to parse `runId` as `int` (Parameter 'RunId')")]
+    [InlineData(null, null, "Unable to parse `` as `int` (Parameter 'RunId')")]
+    public void ShouldNotCreatePipelineStartDefaultMessageIfYearInWrongFormat(object? runId, object? year, string expectedMessage)
+    {
+        const string type = PipelineJobType.Default;
+        var input = new PipelinePendingMessage
+        {
+            RunId = runId,
+            Type = type,
+            Year = year
+        };
+
+        var exception = Assert.Throws<ArgumentException>(() => PipelineStartDefaultMessage.FromPending(input));
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+}


### PR DESCRIPTION
### Context

Allow for processing of Academy, Maintained and BFR data from different years/sources.

[AB#232974](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/232974)
[AB#239415](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/239415)

### Change proposed in this pull request

- update docs. for expected message format
- process ancillary files separately for Academies, Maintained and BFR
  - avoid separate processing if actually referencing the same source

### Guidance to review

Successfully ran locally with a `default` message:

```json
{
    "type": "default",
    "runId": 2023,
    "year": {
        "aar": 2023,
        "cfr": 2023,
        "bfr": 2023
    }
}
```

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] You have reviewed with UX/Design

