### PR TITLE
feat: update Federation handling for Maintained Schools

### DIFF
--- a/data-pipeline/src/pipeline/input_schemas.py
+++ b/data-pipeline/src/pipeline/input_schemas.py
@@ -60,6 +60,7 @@ gias_links = {
 maintained_schools_master_list_index_col = "URN"
 maintained_schools_master_list = {
     "URN": "Int64",
+    "School Name": "string",
     "LAEstab": "string",
     "Phase": "string",
     "Overall Phase": "string",

--- a/data-pipeline/tests/unit/pre_processing/conftest.py
+++ b/data-pipeline/tests/unit/pre_processing/conftest.py
@@ -688,7 +688,8 @@ def maintained_schools_master_list():
     return pd.DataFrame(
         {
             "URN": [100150, 100152, 100153, 100154],
-            "LAEstab": ["20136154", "2026005", "2026006", "2026007"],
+            "School Name": ["A", "B", "C", "D"],
+            "LAEstab": [20136154, 2026005, 2026006, 2026007],
             "Phase": [
                 "Infant and junior",
                 "Infant and junior",
@@ -705,7 +706,7 @@ def maintained_schools_master_list():
             "Period covered by return (months)": [11, 18, 4, 11],
             "Did Not Supply flag": [0, 0, 1, 0],
             "Federation": ["No", "Lead School", "No", "Yes"],
-            "Lead school in federation": [0, 0, 0, 1],
+            "Lead school in federation": [20136154, 0, 0, 20136154],
             "Urban  Rural": [
                 "Urban major conurbation",
                 "Urban major conurbation",

--- a/data-pipeline/tests/unit/pre_processing/test_maintained_schools.py
+++ b/data-pipeline/tests/unit/pre_processing/test_maintained_schools.py
@@ -1,5 +1,6 @@
 import datetime
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -192,12 +193,9 @@ def test_calc_catering_net_costs():
     assert actual["Catering staff and supplies_Net Costs"] == -500
 
 
-# Waiting on actual confirmation of federation logic.
-# def test_federation_mapping(maintained_schools_master_list: pd.DataFrame, gias_group_links_csv: StringIO):
-#     (hard_federations, soft_federations) = pre_processing.build_federations_data(gias_group_links_csv, maintained_schools_master_list)
-#
-#     actual = maintained_schools.apply_federation_mapping(maintained_schools_master_list, hard_federations, soft_federations)
-#
-#     print(hard_federations)
-#     print(soft_federations)
-#     assert actual.columns.isin(["Federation Name"]).any()
+def test_federation_mapping(maintained_schools_master_list: pd.DataFrame):
+    actual = maintained_schools.join_federations(maintained_schools_master_list)
+
+    # Beware: `nan != nan`
+    assert list(actual["Federation Name"].fillna(0)) == ["A", 0, 0, "A"]
+    assert list(actual["Federation Lead School URN"].fillna(0)) == [100150.0, 0, 0, 100150.0]


### PR DESCRIPTION
### Context

Handling of Federations has changed: the previous hard-/soft-Federation distinction has been dropped and data can be derived entirely on `LAEstab`/`Lead school in federation` values.

[AB#232745](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/232745)

### Change proposed in this pull request

- previous hard-/soft-Federation logic has been deprecated
- each Maintained School instead references the lead-School in its Federation (where present)
  - Federation data can be derived based on this value

### Guidance to review 

Successfully ran locally and populated `FederationLeadURN` and `FederationLeadName` as expected.

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] You have reviewed with UX/Design

