### PR TITLE
fix: consistent log format for timestamps

### DIFF
--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -495,7 +495,7 @@ def pre_process_data(worker_client, run_type, year):
     pre_process_bfr(run_type, year)
 
     time_taken = time.time() - start_time
-    logger.info(f"Pre-processing data done in {time_taken} seconds")
+    logger.info(f"Pre-processing data done in {time_taken:,.2f} seconds")
 
     return time_taken
 
@@ -586,7 +586,7 @@ def pre_process_custom_data(
     )
 
     time_taken = time.time() - start_time
-    logger.info(f"Pre-processing data done in {time_taken} seconds")
+    logger.info(f"Pre-processing data done in {time_taken:,.2f} seconds")
 
     return time_taken
 
@@ -687,7 +687,7 @@ def compute_comparator_sets(
     )
 
     time_taken = time.time() - start_time
-    logger.info(f"Computing comparators sets done in {time_taken} seconds")
+    logger.info(f"Computing comparators sets done in {time_taken:,.2f} seconds")
 
     return time_taken
 
@@ -786,7 +786,7 @@ def run_compute_rag(
     )
 
     time_taken = time.time() - start_time
-    logger.info(f"Computing RAG done in {time_taken} seconds")
+    logger.info(f"Computing RAG done in {time_taken:,.2f} seconds")
 
     return time_taken
 


### PR DESCRIPTION
### Context

For no other reason that it bothers me seeing `Computing RAG done in 989.3214044570923 seconds` in the logs.

### Change proposed in this pull request

make sure all time-related logs are comma-formatted and restricted to 2 decimal places.

### Guidance to review 

In no way a priority, just a formatting change for the logs.

### Checklist (add/remove as appropriate)

- [ ] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] You have reviewed with UX/Design

