### PR TITLE
Improved handling of invalid comparator sets due to missing source data

### DIFF
--- a/web/Web.sln.DotSettings
+++ b/web/Web.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/HtmlFormatter/KeepWhiteSpacesInsideTags/@EntryValue">pre,textarea,a</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ASD/@EntryIndexedValue">ASD</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=FTE/@EntryIndexedValue">FTE</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=HI/@EntryIndexedValue">HI</s:String>

--- a/web/src/Web.App/ViewComponents/ComparatorSetDetailsViewComponent.cs
+++ b/web/src/Web.App/ViewComponents/ComparatorSetDetailsViewComponent.cs
@@ -1,12 +1,8 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Web.App.ViewModels.Components;
-
 namespace Web.App.ViewComponents;
 
 public class ComparatorSetDetailsViewComponent : ViewComponent
 {
-    public IViewComponentResult Invoke(string identifier, bool hasUserDefinedSet, bool hasCustomData, ComparatorSetType type = ComparatorSetType.Costs)
-    {
-        return View(new ComparatorSetDetailsViewModel(identifier, hasUserDefinedSet, hasCustomData, type));
-    }
+    public IViewComponentResult Invoke(string identifier, bool hasUserDefinedSet, bool hasCustomData, bool hasMissingComparatorSet = false, ComparatorSetType type = ComparatorSetType.Costs) => View(new ComparatorSetDetailsViewModel(identifier, hasUserDefinedSet, hasCustomData, hasMissingComparatorSet, type));
 }

--- a/web/src/Web.App/ViewModels/Components/ComparatorSetDetailsViewModel.cs
+++ b/web/src/Web.App/ViewModels/Components/ComparatorSetDetailsViewModel.cs
@@ -1,10 +1,11 @@
 ﻿namespace Web.App.ViewModels.Components;
 
-public class ComparatorSetDetailsViewModel(string identifier, bool hasUserDefinedSet, bool hasCustomData, ComparatorSetType type)
+public class ComparatorSetDetailsViewModel(string identifier, bool hasUserDefinedSet, bool hasCustomData, bool hasMissingComparatorSet, ComparatorSetType type)
 {
     public string Identifier => identifier;
     public bool HasUserDefinedSet => hasUserDefinedSet;
     public bool HasCustomData => hasCustomData;
+    public bool HasMissingComparatorSet => hasMissingComparatorSet;
     public ComparatorSetType Type => type;
 }
 
@@ -13,4 +14,3 @@ public enum ComparatorSetType
     Costs,
     Workforce
 }
-

--- a/web/src/Web.App/ViewModels/SchoolCensusViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolCensusViewModel.cs
@@ -1,12 +1,12 @@
 ﻿using Web.App.Domain;
-
 namespace Web.App.ViewModels;
 
-public class SchoolCensusViewModel(School school, string? userDefinedSetId = null, string? customDataId = null)
+public class SchoolCensusViewModel(School school, string? userDefinedSetId = null, string? customDataId = null, Census? census = null)
 {
     public string? Urn => school.URN;
     public string? Name => school.SchoolName;
     public bool IsPartOfTrust => school.IsPartOfTrust;
     public string? UserDefinedSetId => userDefinedSetId;
     public string? CustomDataId => customDataId;
+    public decimal? TotalPupils => census?.TotalPupils;
 }

--- a/web/src/Web.App/ViewModels/SchoolComparisonViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolComparisonViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using Web.App.Domain;
-
 namespace Web.App.ViewModels;
 
 public class SchoolComparisonViewModel(School school, string? userDefinedSetId = null, string? customDataId = null, SchoolExpenditure? expenditure = null)
@@ -9,5 +8,5 @@ public class SchoolComparisonViewModel(School school, string? userDefinedSetId =
     public bool IsPartOfTrust => school.IsPartOfTrust;
     public string? UserDefinedSetId => userDefinedSetId;
     public string? CustomDataId => customDataId;
-    public int? PeriodCoveredByReturn => expenditure.PeriodCoveredByReturn;
+    public int? PeriodCoveredByReturn => expenditure?.PeriodCoveredByReturn;
 }

--- a/web/src/Web.App/Views/SchoolCensus/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolCensus/Index.cshtml
@@ -2,39 +2,53 @@
 @model Web.App.ViewModels.SchoolCensusViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.Census;
+    var hasUserDefinedSet = !string.IsNullOrEmpty(Model.UserDefinedSetId);
+    var hasCustomData = !string.IsNullOrEmpty(Model.CustomDataId);
+    var hasCensusData = Model.TotalPupils.GetValueOrDefault() > 0;
+    var hasMissingComparatorSet = !hasUserDefinedSet && !hasCensusData;
 }
 
 @await Component.InvokeAsync("EstablishmentHeading", new
 {
-    title = ViewData[ViewDataKeys.Title], 
-    name = Model.Name, 
-    id = Model.Urn, 
+    title = ViewData[ViewDataKeys.Title],
+    name = Model.Name,
+    id = Model.Urn,
     kind = OrganisationTypes.School
 })
 
-@await Component.InvokeAsync("DataSource", new
+@if (!hasMissingComparatorSet)
 {
-    organisationType = OrganisationTypes.School,
-    sourceType = DataSourceTypes.Census,
-    additionText = new[] { "Benchmark your pupil and workforce data against similar schools." }
-})
+    @await Component.InvokeAsync("DataSource", new
+    {
+        organisationType = OrganisationTypes.School,
+        sourceType = DataSourceTypes.Census,
+        additionText = new[]
+        {
+            "Benchmark your pupil and workforce data against similar schools."
+        }
+    })
+}
 
 @await Component.InvokeAsync("ComparatorSetDetails", new
 {
-    identifier = Model.Urn, 
-    hasUserDefinedSet = !string.IsNullOrEmpty(Model.UserDefinedSetId), 
-    hasCustomData = !string.IsNullOrEmpty(Model.CustomDataId),
+    identifier = Model.Urn,
+    hasUserDefinedSet,
+    hasCustomData,
+    hasMissingComparatorSet,
     type = ComparatorSetType.Workforce
 })
 
-<div id="compare-your-census" data-type="@OrganisationTypes.School" data-id="@Model.Urn"></div>
+@if (!hasMissingComparatorSet)
+{
+    <div id="compare-your-census" data-type="@OrganisationTypes.School" data-id="@Model.Urn"></div>
+}
 
 @await Component.InvokeAsync("SchoolFinanceTools", new
 {
-    identifier = Model.Urn, 
+    identifier = Model.Urn,
     tools = new[]
     {
-        FinanceTools.FinancialPlanning, 
+        FinanceTools.FinancialPlanning,
         FinanceTools.CompareYourCosts
     }
 })

--- a/web/src/Web.App/Views/SchoolComparison/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/Index.cshtml
@@ -1,46 +1,53 @@
 ﻿@model Web.App.ViewModels.SchoolComparisonViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.Comparison;
-}
-
-@if (Model is { PeriodCoveredByReturn: < 12 })
-{
-@await Html.PartialAsync("_IncompleteFinances")
+    var hasUserDefinedSet = !string.IsNullOrEmpty(Model.UserDefinedSetId);
+    var hasCustomData = !string.IsNullOrEmpty(Model.CustomDataId);
+    var hasFinancialData = Model.PeriodCoveredByReturn == 12;
+    var hasMissingComparatorSet = !hasUserDefinedSet && !hasFinancialData;
 }
 
 @await Component.InvokeAsync("EstablishmentHeading", new
 {
-    title = ViewData[ViewDataKeys.Title], 
-    name = Model.Name, 
-    id = Model.Urn, 
+    title = ViewData[ViewDataKeys.Title],
+    name = Model.Name,
+    id = Model.Urn,
     kind = OrganisationTypes.School
 })
 
-@await Component.InvokeAsync("DataSource", new
+@if (!hasMissingComparatorSet)
 {
-    organisationType = OrganisationTypes.School,
-    sourceType = DataSourceTypes.Spending,
-    isPartOfTrust = Model.IsPartOfTrust, 
-    additionText = new[] { "Benchmark your spending against similar schools." }
-})
+    @await Component.InvokeAsync("DataSource", new
+    {
+        organisationType = OrganisationTypes.School,
+        sourceType = DataSourceTypes.Spending,
+        isPartOfTrust = Model.IsPartOfTrust,
+        additionText = new[]
+        {
+            "Benchmark your spending against similar schools."
+        }
+    })
+}
 
 @await Component.InvokeAsync("ComparatorSetDetails", new
 {
-    identifier = Model.Urn, 
-    hasUserDefinedSet = !string.IsNullOrEmpty(Model.UserDefinedSetId), 
-    hasCustomData = !string.IsNullOrEmpty(Model.CustomDataId)
+    identifier = Model.Urn,
+    hasUserDefinedSet,
+    hasCustomData,
+    hasMissingComparatorSet
 })
 
-<div id="compare-your-costs" data-type="@OrganisationTypes.School" data-id="@Model.Urn">
-    
-</div>
+@if (!hasMissingComparatorSet)
+{
+    <div id="compare-your-costs" data-type="@OrganisationTypes.School" data-id="@Model.Urn"></div>
+}
 
 @await Component.InvokeAsync("SchoolFinanceTools", new
 {
-    identifier = Model.Urn, 
+    identifier = Model.Urn,
     tools = new[]
     {
-        FinanceTools.FinancialPlanning, 
+        FinanceTools.FinancialPlanning,
         FinanceTools.BenchmarkCensus
     }
 })

--- a/web/src/Web.App/Views/Shared/Components/ComparatorSetDetails/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/ComparatorSetDetails/Default.cshtml
@@ -2,61 +2,74 @@
 @using Web.App.ViewModels.Components
 @model Web.App.ViewModels.Components.ComparatorSetDetailsViewModel
 
-<div class="govuk-grid-row govuk-!-margin-bottom-3">
-    <div class="govuk-grid-column-two-thirds">
-
+<div class="govuk-grid-row govuk-!-margin-bottom-6">
+    <div class="govuk-grid-column-full">
         @if (Model.HasUserDefinedSet)
         {
-        <p class="govuk-body">
-            You are now comparing with your chosen schools.
-        </p>
-
-        <feature name="@FeatureFlags.UserDefinedComparators">
-            <p class="govuk-body govuk-!-margin-bottom-0">
-                <a class="govuk-link govuk-link--no-visited-state"
-                   href="@Url.Action("UserDefined", "SchoolComparators", new { urn = Model.Identifier })">
-                    Change your similar schools
-                </a>
-            </p>
-        </feature>
-        }
-        else if (Model.HasCustomData){
-        <p class="govuk-body">
-            <a class="govuk-link govuk-link--no-visited-state"
-               href="@Url.Action("Index", "SchoolComparators", new { urn = Model.Identifier })">
-                We've chosen 2 sets of similar schools
-            </a> to benchmark this school's spending against.
-        </p>
-        <feature name="@FeatureFlags.CustomData">
             <p class="govuk-body">
-                The information displayed is the originally reported data, not the customised data that was provided.
+                You are now comparing with your chosen schools.
             </p>
 
-            <p class="govuk-body govuk-!-margin-bottom-0">
+            <feature name="@FeatureFlags.UserDefinedComparators">
+                <p class="govuk-body govuk-!-margin-bottom-0">
+                    <a class="govuk-link govuk-link--no-visited-state"
+                       href="@Url.Action("UserDefined", "SchoolComparators", new { urn = Model.Identifier })">
+                        Change your similar schools
+                    </a>
+                </p>
+            </feature>
+        }
+        else if (Model.HasCustomData)
+        {
+            <p class="govuk-body">
                 <a class="govuk-link govuk-link--no-visited-state"
-                   id="custom-data-link"
-                       href="@Url.Action("CustomData", "School", new { urn = Model.Identifier })">
-                    View custom data set
-                </a>
+                   href="@Url.Action("Index", "SchoolComparators", new { urn = Model.Identifier })">
+                    We've chosen 2 sets of similar schools
+                </a> to benchmark this school's spending against.
             </p>
+            <feature name="@FeatureFlags.CustomData">
+                <p class="govuk-body">
+                    The information displayed is the originally reported data, not the customised data that was provided.
+                </p>
+
+                <p class="govuk-body govuk-!-margin-bottom-0">
+                    <a class="govuk-link govuk-link--no-visited-state"
+                       id="custom-data-link"
+                       href="@Url.Action("CustomData", "School", new { urn = Model.Identifier })">
+                        View custom data set
+                    </a>
+                </p>
             </feature>
         }
         else
         {
             if (Model.Type == ComparatorSetType.Workforce)
             {
-                <p class="govuk-body">
-                    <a class="govuk-link govuk-link--no-visited-state"
-                       href="@Url.Action("Workforce", "SchoolComparators", new { urn = Model.Identifier })">
-                        We've chosen this set of similar schools
-                    </a> to benchmark this school's pupil and workforce data against.
-                </p>
+                if (Model.HasMissingComparatorSet)
+                {
+                    <div class="govuk-warning-text">
+                        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                        <strong class="govuk-warning-text__text">
+                            <span class="govuk-visually-hidden">Warning</span>
+                            There isn't enough information available to create a set of similar schools.
+                        </strong>
+                    </div>
+                }
+                else
+                {
+                    <p class="govuk-body">
+                        <a class="govuk-link govuk-link--no-visited-state"
+                           href="@Url.Action("Workforce", "SchoolComparators", new { urn = Model.Identifier })">
+                            We've chosen this set of similar schools</a>
+                        to benchmark this school's pupil and workforce data against.
+                    </p>
+                }
 
                 <feature name="@FeatureFlags.UserDefinedComparators">
                     <p class="govuk-body">
                         <a class="govuk-link govuk-link--no-visited-state"
                            href="@Url.Action("Index", "SchoolComparatorsCreate", new { urn = Model.Identifier })">
-                            Choose a new or saved set of your own schools
+                            Create or save your own set of schools to benchmark against
                         </a>
                     </p>
                 </feature>
@@ -72,18 +85,31 @@
             }
             else
             {
-                <p class="govuk-body">
-                    <a class="govuk-link govuk-link--no-visited-state"
-                       href="@Url.Action("Index", "SchoolComparators", new { urn = Model.Identifier })">
-                        We've chosen 2 sets of similar schools
-                    </a> to benchmark this school's spending against.
-                </p>
+                if (Model.HasMissingComparatorSet)
+                {
+                    <div class="govuk-warning-text">
+                        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                        <strong class="govuk-warning-text__text">
+                            <span class="govuk-visually-hidden">Warning</span>
+                            There isn't enough information available to create a set of similar schools.
+                        </strong>
+                    </div>
+                }
+                else
+                {
+                    <p class="govuk-body">
+                        <a class="govuk-link govuk-link--no-visited-state"
+                           href="@Url.Action("Index", "SchoolComparators", new { urn = Model.Identifier })">
+                            We've chosen 2 sets of similar schools</a>
+                        to benchmark this school's spending against.
+                    </p>
+                }
 
                 <feature name="@FeatureFlags.UserDefinedComparators">
                     <p class="govuk-body">
                         <a class="govuk-link govuk-link--no-visited-state"
                            href="@Url.Action("Index", "SchoolComparatorsCreate", new { urn = Model.Identifier })">
-                            Choose a new or saved set of your own schools
+                            Create or save your own set of schools to benchmark against
                         </a>
                     </p>
                 </feature>

--- a/web/tests/Web.E2ETests/Extensions/PageExtensions.cs
+++ b/web/tests/Web.E2ETests/Extensions/PageExtensions.cs
@@ -1,12 +1,51 @@
 using Microsoft.Playwright;
-
 namespace Web.E2ETests;
 
 public static class PageExtensions
 {
+    private static ILocator SignInLink(this IPage page) => page.Locator(Selectors.SignInLink);
+    private static ILocator SignOutLink(this IPage page) => page.Locator(Selectors.SignOutLink);
+
     public static async Task GotoAndWaitForLoadAsync(this IPage page, string url)
     {
         await page.GotoAsync(url);
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
     }
+
+    public static async Task SignInWithOrganisation(this IPage page, string organisation, bool authGuard = false)
+    {
+        if (!authGuard)
+        {
+            if (await page.IsSignedIn())
+            {
+                return;
+            }
+
+            await page.SignInLink().ClickAsync();
+        }
+
+        await page.Locator("input[id='username']").Fill(TestConfiguration.LoginEmail);
+        await page.Locator("button[type='submit']").Click();
+        await page.Locator("h1:text-is('Enter your password')").CheckVisible();
+        await page.Locator("input[id='password']").Fill(TestConfiguration.LoginPassword);
+        await page.Locator("button[type='submit']").Click();
+        await page.Locator("label", new PageLocatorOptions
+        {
+            HasTextString = organisation
+        }).Check();
+        await page.Locator("input[type='submit']").Click();
+
+        await page.SignOutLink().IsVisibleAsync();
+    }
+
+    public static async Task SignOut(this IPage page)
+    {
+        if (await page.SignOutLink().IsVisibleAsync())
+        {
+            await page.SignOutLink().ClickAsync();
+            await page.WaitForURLAsync($"{TestConfiguration.ServiceUrl}/");
+        }
+    }
+
+    private static async Task<bool> IsSignedIn(this IPage page) => !await page.SignInLink().IsVisibleAsync() && await page.SignOutLink().IsVisibleAsync();
 }

--- a/web/tests/Web.E2ETests/Features/School/BenchmarkCensus.feature
+++ b/web/tests/Web.E2ETests/Features/School/BenchmarkCensus.feature
@@ -1,5 +1,8 @@
 ﻿Feature: School benchmark pupil and workforce data
 
+    Background:
+        Given I am not logged in
+
     Scenario: Download school workforce chart
         Given I am on census page for school with URN '777042'
         When I click on save as image for 'school workforce'
@@ -52,13 +55,17 @@
           | non class room support staff | total, headcount per FTE, percentage of workforce, pupils per staff role |
           | auxiliary staff              | total, headcount per FTE, percentage of workforce, pupils per staff role |
           | school workforce headcount   | total, pupils per staff role                                             |
-        
+
     Scenario: View additional details upon hover
         Given I am on census page for school with URN '777042'
         When I hover over a chart bar
         Then additional information is displayed
-        
-     Scenario: Clicking school name in chart directs to homepage
+
+    Scenario: Clicking school name in chart directs to homepage
         Given I am on census page for school with URN '777042'
         When I select the school name on the chart
         Then I am navigated to selected school home page
+
+    Scenario: Benchmarking for school(s) with missing census data does not display comparators
+        Given I am on census page for part year school with URN '990754'
+        Then the benchmarking charts are not displayed

--- a/web/tests/Web.E2ETests/Features/School/CompareYourCosts.feature
+++ b/web/tests/Web.E2ETests/Features/School/CompareYourCosts.feature
@@ -1,5 +1,8 @@
 Feature: School compare your costs
 
+    Background:
+        Given I am not logged in
+
     @ignore
     Scenario: Download total expenditure chart
         Given I am on compare your costs page for school with URN '777042'
@@ -49,48 +52,34 @@ Feature: School compare your costs
           | Test school 263         | Redbridge               | Community school                   | 114              | £1,487,825  |
           | Test academy school 435 | Bradford                | Academy sponsor led                | 204              | £1,424,986  |
           | Test academy school 333 | Hampshire               | Free schools alternative provision | 190              | £1,179,475  |
-
-
-
-
         But save as image buttons are hidden
 
-    Scenario: Table view for total expenditure for school(s) with part-year data
-        Given I am on compare your costs page for school with URN '777045'
+    Scenario: Table view for total expenditure for school(s) with part-year data in custom comparator set
+        Given I am on compare your costs page for school with URN '777042'
+        And I have selected organisation '01: FBIT TEST - Community School (Open)' after logging in
+        And I have created a custom comparator set for '777042' containing
+          | Urn    |
+          | 777043 |
+          | 777045 |
+          | 990057 |
+          | 990127 |
+          | 990233 |
+          | 990411 |
         And table view is selected
         And the 'total expenditure' dimension is '£ per pupil'
         Then the following is shown for 'total expenditure'
-          | School name                                                                                                               | Local Authority                   | School type                    | Number of pupils | Amount  |
-          | Test academy school 273                                                                                                   | Kensington and Chelsea            | Academy converter              | 114              | £13,051 |
-          | Test school 88                                                                                                            | Slough                            | Community school               | 134              | £9,916  |
-          | Test part year with pupil and without building comparator\n!\nWarning\nThis school only has 3 months of data available.   | Bromley                           | Pupil referral unit            | 260              | £9,068  |
-          | Test school 197                                                                                                           | Windsor and Maidenhead            | Community school               | 167              | £9,050  |
-          | Test academy school 470                                                                                                   | Waltham Forest                    | Academy 16-19 converter        | 167              | £9,050  |
-          | Test academy school 77                                                                                                    | Hartlepool                        | Academy converter              | 1040             | £9,023  |
-          | Test academy school 469                                                                                                   | Hillingdon                        | Free school 16 to 19           | 235              | £8,981  |
-          | Test school 198                                                                                                           | West Berkshire                    | Community school               | 174              | £8,882  |
-          | Test academy school 255                                                                                                   | Stockton-on-Tees                  | Academy converter              | 174              | £8,882  |
-          | Test school 181                                                                                                           | Dorset                            | Voluntary aided school         | 399              | £8,584  |
-          | Test school 87                                                                                                            | Reading                           | Foundation school              | 206              | £8,224  |
-          | Test school 124                                                                                                           | Newham                            | Voluntary aided school         | 769              | £8,089  |
-          | Test academy school 82                                                                                                    | Bournemouth, Christchurch & Poole | Academy converter              | 991              | £8,088  |
-          | Test academy school 53                                                                                                    | Salford                           | Free school                    | 407              | £8,028  |
-          | Test school 260                                                                                                           | Kingston upon Thames              | Community school               | 853              | £7,880  |
-          | Test academy school 450                                                                                                   | Surrey                            | Academy 16-19 converter        | 367              | £7,703  |
-          | Test Part year school with pupil and builiding comparators\n!\nWarning\nThis school only has 10 months of data available. | Bracknell Forest                  | Foundation school              | 214              | £7,470  |
-          | Test school 205                                                                                                           | Plymouth                          | Community school               | 196              | £7,385  |
-          | Test academy school 20                                                                                                    | Waltham Forest                    | Academy converter              | 449              | £7,356  |
-          | Test academy school 98                                                                                                    | Southwark                         | Academy converter              | 449              | £7,356  |
-          | Test academy school 244                                                                                                   | Islington                         | Academy converter              | 446              | £7,342  |
-          | Test school 68                                                                                                            | Derbyshire                        | Local authority nursery school | 339              | £7,318  |
-          | Test academy school 37                                                                                                    | North Lincolnshire                | Academy converter              | 339              | £7,318  |
-          | Test school 270                                                                                                           | Solihull                          | Voluntary aided school         | 230              | £7,281  |
-          | Test school 237                                                                                                           | City of London                    | Voluntary aided school         | 231              | £6,918  |
-          | Test academy school 465                                                                                                   | Enfield                           | Academy 16-19 converter        | 231              | £6,918  |
-          | Test academy school 375                                                                                                   | Reading                           | Academy special sponsor led    | 232              | £6,814  |
-          | Test school 132                                                                                                           | Solihull                          | Community school               | 418              | £6,676  |
-          | Test academy school 32                                                                                                    | Stockton-on-Tees                  | Academy converter              | 418              | £6,676  |
-          | Test academy school 160                                                                                                   | West Sussex                       | Academy special converter      | 190              | £6,208  |
+          | School name                                                                                                               | Local Authority        | School type         | Number of pupils | Amount  |
+          | Test academy school 273                                                                                                   | Kensington and Chelsea | Academy converter   | 114              | £13,051 |
+          | Test school 88                                                                                                            | Slough                 | Community school    | 134              | £9,916  |
+          | Test part year with pupil and without building comparator\n!\nWarning\nThis school only has 3 months of data available.   | Bromley                | Pupil referral unit | 260              | £9,068  |
+          | Test school 197                                                                                                           | Windsor and Maidenhead | Community school    | 167              | £9,050  |
+          | Test school 102                                                                                                           | Hammersmith and Fulham | Community school    | 212              | £7,487  |
+          | Test Part year school with pupil and builiding comparators\n!\nWarning\nThis school only has 10 months of data available. | Bracknell Forest       | Foundation school   | 214              | £7,470  |
+          | Test school 205                                                                                                           | Plymouth               | Community school    | 196              | £7,385  |
+
+    Scenario: Benchmarking for school(s) with part-year data does not display comparators
+        Given I am on compare your costs page for part year school with URN '777045'
+        Then the benchmarking charts are not displayed
 
     Scenario: Show all should expand all sections
         Given I am on compare your costs page for school with URN '777042'
@@ -122,10 +111,14 @@ Feature: School compare your costs
           | School type      | Community school |
           | Number of pupils | 114              |
 
-    Scenario: View additional details upon hover for part-year school
-        Given I am on compare your costs page for school with URN '777045'
+    Scenario: View additional details upon hover for part-year school in custom comparator set
+        Given I am on compare your costs page for part year school with URN '777045'
+        And I have selected organisation '01: FBIT TEST - Community School (Open)' after logging in
+        And I have created a custom comparator set for '777045' containing
+          | Urn    |
+          | 777042 |
         And the 'total expenditure' dimension is '£ per pupil'
-        When I hover over the nth chart bar 2
+        When I hover over the nth chart bar 0
         Then additional information is displayed
         And additional information contains
           | Item             | Value               |
@@ -134,11 +127,15 @@ Feature: School compare your costs
           | Number of pupils | 260                 |
         And additional information shows part year warning for 3 months
 
-    Scenario: Warning icon displayed in chart for part-year school
-        Given I am on compare your costs page for school with URN '777045'
+    Scenario: Warning icon displayed in chart for part-year school in custom comparator set
+        Given I am on compare your costs page for part year school with URN '777045'
+        And I have selected organisation '01: FBIT TEST - Community School (Open)' after logging in
+        And I have created a custom comparator set for '777045' containing
+          | Urn    |
+          | 777042 |
         And the 'total expenditure' dimension is '£ per pupil'
-        Then the nth chart bar 2 displays the establishment name 'Test part year with pupil and without building comparator'
-        And the nth chart bar 2 displays the warning icon
+        Then the nth chart bar 0 displays the establishment name 'Test part year with pupil and without building comparator'
+        And the nth chart bar 0 displays the warning icon
 
     Scenario: Clicking school name in chart directs to homepage
         Given I am on compare your costs page for school with URN '777042'
@@ -232,16 +229,3 @@ Feature: School compare your costs
           | Test school 149         | Barnsley                | Pupil referral unit                | 232              | £41,903  |
           | Test academy school 12  | Hounslow                | Academy sponsor led                | 232              | £41,903  |
           | Test academy school 466 | Haringey                | Academy 16-19 converter            | 232              | £41,903  |
-
-    Scenario Outline: View comparators for part year school
-        Given I am on compare your costs page for part year school with URN '<URN>'
-        When I click on sets of similar school link
-        Then I am taken to comparators page
-        And pupil cost comparators are <PupilComparators>
-        And building cost comparators are <BuildingComparators>
-
-        Examples:
-          | URN    | PupilComparators | BuildingComparators |
-          | 777043 | not null         | not null            |
-          | 777044 | null             | null                |
-          | 777045 | not null         | null                |

--- a/web/tests/Web.E2ETests/Features/School/CreateComparators.feature
+++ b/web/tests/Web.E2ETests/Features/School/CreateComparators.feature
@@ -1,0 +1,27 @@
+Feature: School create comparator set
+
+    Background:
+        Given I am on create comparators page for school with URN '777042'
+        And I have selected organisation '01: FBIT TEST - Community School (Open)' after logging in
+
+    Scenario: Can view create comparator set page
+        When I click continue
+        Then the create comparators by page is displayed
+
+    Scenario: Can move to create comparator set by characteristic page
+        When I click continue
+        And I select the option By Characteristic and click continue
+        Then the create comparators by characteristic page is displayed
+
+    Scenario: Can move to create comparator set by name page
+        When I click continue
+        And I select the option By Name and click continue
+        Then the create comparators by name page is displayed
+
+    Scenario: Can create comparator set by name
+        When I click continue
+        And I select the option By Name and click continue
+        And I select the school with urn '777045' from suggester
+        And I click the choose school button
+        And I click the create set button
+        Then the school home page is displayed

--- a/web/tests/Web.E2ETests/Features/School/SchoolHome.feature
+++ b/web/tests/Web.E2ETests/Features/School/SchoolHome.feature
@@ -1,5 +1,8 @@
 ﻿Feature: School homepage
 
+    Background:
+        Given I am not logged in
+
     Scenario: Go to contact details page
         Given I am on school homepage for school with urn '777042'
         When I click on school details
@@ -13,7 +16,7 @@
     Scenario: Go to curriculum and financial planning page
         Given I am on school homepage for school with urn '777042'
         When I click on curriculum and financial planning
-        Then the curriculum and financial planning page is displayed
+        Then the curriculum and financial planning page is displayed after logging in with organisation '01: FBIT TEST - Community School (Open)'
 
     Scenario: Go to benchmark census data page
         Given I am on school homepage for school with urn '777042'
@@ -47,7 +50,7 @@
           | Teaching and Teaching support staff | High priority Spends £6,315 per pupil — Spending is higher than 99% of similar schools.  |
           | Non-educational support staff       | High priority Spends £845 per pupil — Spending is higher than 95.67% of similar schools. |
           | Administrative supplies             | High priority Spends £429 per pupil — Spending is higher than 99% of similar schools.    |
-          
+
     Scenario: RAG guidance is displayed
         Given I am on school homepage for school with urn '777042'
         Then the RAG guidance is visible

--- a/web/tests/Web.E2ETests/Keyboard.cs
+++ b/web/tests/Web.E2ETests/Keyboard.cs
@@ -1,0 +1,7 @@
+namespace Web.E2ETests;
+
+public static class Keyboard
+{
+    public const string ArrowDownKey = "ArrowDown";
+    public const string EnterKey = "Enter";
+}

--- a/web/tests/Web.E2ETests/Pages/FindOrganisationPage.cs
+++ b/web/tests/Web.E2ETests/Pages/FindOrganisationPage.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Playwright;
-
 namespace Web.E2ETests.Pages;
 
 public enum OrganisationTypes
@@ -10,14 +9,15 @@ public enum OrganisationTypes
 
 public class FindOrganisationPage(IPage page)
 {
-    private const string ArrowDownKey = "ArrowDown";
-    private const string EnterKey = "Enter";
     private ILocator PageH1Heading => page.Locator(Selectors.H1);
     private ILocator OrganisationsTypeRadios => page.Locator(Selectors.GovRadios);
     private ILocator SchoolSearchInputField => page.Locator(Selectors.SchoolSearchInput);
 
     private ILocator ContinueButton =>
-        page.Locator(Selectors.GovButton, new PageLocatorOptions { HasText = "Continue" });
+        page.Locator(Selectors.GovButton, new PageLocatorOptions
+        {
+            HasText = "Continue"
+        });
 
     private ILocator SchoolRadioButton => page.Locator(Selectors.SchoolRadio);
     private ILocator SchoolSuggestionsDropdown => page.Locator(Selectors.SchoolSuggestDropdown);
@@ -37,8 +37,8 @@ public class FindOrganisationPage(IPage page)
 
     public async Task SelectItemFromSuggester()
     {
-        await SchoolSearchInputField.PressAsync(ArrowDownKey);
-        await page.Keyboard.PressAsync(EnterKey);
+        await SchoolSearchInputField.PressAsync(Keyboard.ArrowDownKey);
+        await page.Keyboard.PressAsync(Keyboard.EnterKey);
     }
 
     public async Task<School.HomePage> ClickContinue()

--- a/web/tests/Web.E2ETests/Pages/School/BenchmarkCensusPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/BenchmarkCensusPage.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Playwright;
 using Xunit;
-
 namespace Web.E2ETests.Pages.School;
 
 public enum CensusChartNames
@@ -33,17 +32,29 @@ public class BenchmarkCensusPage(IPage page)
     private ILocator SaveImageSchoolWorkforce => page.Locator(Selectors.SchoolWorkforceSaveAsImage);
 
     private ILocator SaveAsImageButtons =>
-        page.Locator(Selectors.Button, new PageLocatorOptions { HasText = "Save" });
+        page.Locator(Selectors.Button, new PageLocatorOptions
+        {
+            HasText = "Save"
+        });
 
     private ILocator ComparatorSetDetails =>
         page.Locator(Selectors.GovLink,
-            new PageLocatorOptions { HasText = "We've chosen this set of similar schools" });
+            new PageLocatorOptions
+            {
+                HasText = "We've chosen this set of similar schools"
+            });
 
     private ILocator CustomComparatorLink => page.Locator(Selectors.GovLink,
-        new PageLocatorOptions { HasText = "Choose a new or saved set of your own schools" });
+        new PageLocatorOptions
+        {
+            HasText = "Create or save your own set of schools to benchmark against"
+        });
 
     private ILocator CustomDataLink => page.Locator(Selectors.GovLink,
-        new PageLocatorOptions { HasText = "Change the data for this school" });
+        new PageLocatorOptions
+        {
+            HasText = "Change the data for this school"
+        });
 
     private ILocator ChartBars => page.Locator(Selectors.ChartBars);
     private ILocator AdditionalDetailsPopUps => page.Locator(Selectors.AdditionalDetailsPopUps);
@@ -173,6 +184,19 @@ public class BenchmarkCensusPage(IPage page)
     {
         await SchoolLinksInCharts.First.Click();
         return new HomePage(page);
+    }
+
+    public async Task AreComparisonChartsAndTablesDisplayed(bool displayed = true)
+    {
+        var locator = page.Locator(Selectors.ComparisonChartsAndTables);
+        if (displayed)
+        {
+            await locator.ShouldBeVisible();
+        }
+        else
+        {
+            await locator.ShouldNotBeVisible();
+        }
     }
 
     private ILocator ChartDimensionDropdown(CensusChartNames chartName)

--- a/web/tests/Web.E2ETests/Pages/School/BenchmarkCensusPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/BenchmarkCensusPage.cs
@@ -59,19 +59,28 @@ public class BenchmarkCensusPage(IPage page)
     private ILocator ChartBars => page.Locator(Selectors.ChartBars);
     private ILocator AdditionalDetailsPopUps => page.Locator(Selectors.AdditionalDetailsPopUps);
     private ILocator SchoolLinksInCharts => page.Locator(Selectors.SchoolNamesLinksInCharts);
+    private ILocator IncompleteFinancialBanner => page.Locator(Selectors.GovWarning);
 
-    public async Task IsDisplayed()
+    public async Task IsDisplayed(bool isPartYear = false)
     {
         await PageH1Heading.ShouldBeVisible();
-        //await Breadcrumbs.ShouldBeVisible();
-        await ViewAsTableRadio.ShouldBeVisible().ShouldBeChecked(false);
-        await ViewAsChartRadio.ShouldBeVisible().ShouldBeChecked();
-        await ComparatorSetDetails.ShouldBeVisible();
-        await CustomComparatorLink.ShouldBeVisible();
-        await CustomDataLink.ShouldBeVisible();
 
-        await AreSaveAsImageButtonsDisplayed();
-        await AreChartsDisplayed();
+        if (!isPartYear)
+        {
+            await ViewAsTableRadio.ShouldBeVisible().ShouldBeChecked(false);
+            await ViewAsChartRadio.ShouldBeVisible().ShouldBeChecked();
+            await ComparatorSetDetails.ShouldBeVisible();
+            await CustomComparatorLink.ShouldBeVisible();
+            await CustomDataLink.ShouldBeVisible();
+
+            await AreSaveAsImageButtonsDisplayed();
+            await AreChartsDisplayed();
+            return;
+        }
+
+        await IncompleteFinancialBanner.First.ShouldBeVisible();
+        await IncompleteFinancialBanner.First.ShouldContainText(
+            "There isn't enough information available to create a set of similar schools.");
     }
 
     public async Task ClickSaveAsImage(CensusChartNames chartName)

--- a/web/tests/Web.E2ETests/Pages/School/Comparators/ComparatorsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/Comparators/ComparatorsPage.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Playwright;
 using Xunit;
-
-namespace Web.E2ETests.Pages.School;
+namespace Web.E2ETests.Pages.School.Comparators;
 
 public class ComparatorsPage(IPage page)
 {
@@ -15,6 +14,7 @@ public class ComparatorsPage(IPage page)
     private ILocator BuildingCostTab => page.Locator(Selectors.BuildingCostCategoriesTab);
     private ILocator RunningCostComparators => page.Locator(Selectors.Table).First.Locator("tr");
     private ILocator BuildingCostComparators => page.Locator(Selectors.Table).Nth(1).Locator("tr");
+
     public async Task IsDisplayed()
     {
         await PageH1Heading.ShouldBeVisible();
@@ -23,13 +23,7 @@ public class ComparatorsPage(IPage page)
         await BuildingCostTab.ShouldBeVisible();
     }
 
-    public async Task CheckRunningCostComparators(bool isPresent)
-    {
-        Assert.Equal(isPresent ? 31 : 1, await RunningCostComparators.Count());
-    }
+    public async Task CheckRunningCostComparators(bool isPresent) => Assert.Equal(isPresent ? 31 : 1, await RunningCostComparators.Count());
 
-    public async Task CheckBuildingCostComparators(bool isPresent)
-    {
-        Assert.Equal(isPresent ? 31 : 1, await BuildingCostComparators.Count());
-    }
+    public async Task CheckBuildingCostComparators(bool isPresent) => Assert.Equal(isPresent ? 31 : 1, await BuildingCostComparators.Count());
 }

--- a/web/tests/Web.E2ETests/Pages/School/Comparators/CreateComparatorsByCharacteristicPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/Comparators/CreateComparatorsByCharacteristicPage.cs
@@ -1,0 +1,16 @@
+using Microsoft.Playwright;
+namespace Web.E2ETests.Pages.School.Comparators;
+
+public class CreateComparatorsByCharacteristicPage(IPage page) : ICreateComparatorsByPage
+{
+    private ILocator PageH1Heading => page.Locator(Selectors.H1,
+        new PageLocatorOptions
+        {
+            HasText = "Choose characteristics to find matching schools"
+        });
+
+    public async Task IsDisplayed()
+    {
+        await PageH1Heading.ShouldBeVisible();
+    }
+}

--- a/web/tests/Web.E2ETests/Pages/School/Comparators/CreateComparatorsByNamePage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/Comparators/CreateComparatorsByNamePage.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Playwright;
+namespace Web.E2ETests.Pages.School.Comparators;
+
+public class CreateComparatorsByNamePage(IPage page) : ICreateComparatorsByPage
+{
+    private ILocator PageH1Heading => page.Locator(Selectors.H1,
+        new PageLocatorOptions
+        {
+            HasText = "Choose schools to benchmark against"
+        });
+
+    private ILocator SchoolSearchInputField => page.Locator(Selectors.SchoolSearchInput);
+    private ILocator SchoolSuggestionsDropdown => page.Locator(Selectors.SchoolSuggestDropdown);
+    private ILocator ChooseSchoolButton => page.Locator("#choose-school");
+    private ILocator CreateSetButton => page.Locator("#create-set");
+
+    public async Task IsDisplayed()
+    {
+        await PageH1Heading.ShouldBeVisible();
+    }
+
+    public async Task TypeIntoSchoolSearchBox(string text)
+    {
+        await SchoolSearchInputField.PressSequentially(text);
+        await SchoolSuggestionsDropdown.ShouldBeVisible();
+    }
+
+    public async Task SelectItemFromSuggester()
+    {
+        await SchoolSearchInputField.PressAsync(Keyboard.ArrowDownKey);
+        await page.Keyboard.PressAsync(Keyboard.EnterKey);
+    }
+
+    public async Task ClickChooseSchoolButton()
+    {
+        await ChooseSchoolButton.ClickAsync();
+    }
+
+    public async Task<HomePage> ClickCreateSetButton()
+    {
+        await CreateSetButton.ShouldBeVisible();
+        await CreateSetButton.ClickAsync();
+        await page.WaitForURLAsync(u => u.EndsWith("?comparator-generated=true"));
+        return new HomePage(page);
+    }
+}

--- a/web/tests/Web.E2ETests/Pages/School/Comparators/CreateComparatorsByPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/Comparators/CreateComparatorsByPage.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.Playwright;
+namespace Web.E2ETests.Pages.School.Comparators;
+
+public enum ComparatorsByTypes
+{
+    Name,
+    Characteristic
+}
+
+public class CreateComparatorsByPage(IPage page)
+{
+    private ILocator PageH1Heading => page.Locator(Selectors.H1,
+        new PageLocatorOptions
+        {
+            HasText = "How do you want to choose your set of schools?"
+        });
+
+    private ILocator ComparatorsByRadios => page.Locator(Selectors.GovRadios);
+
+    private ILocator ContinueButton => page.Locator(Selectors.GovButton,
+        new PageLocatorOptions
+        {
+            HasText = "Continue"
+        });
+    private ILocator NameRadioButton => page.Locator(".govuk-radios__input#by-name");
+    private ILocator CharacteristicRadioButton => page.Locator(".govuk-radios__input#by-characteristic");
+
+    public async Task IsDisplayed()
+    {
+        await PageH1Heading.ShouldBeVisible();
+        await ComparatorsByRadios.ShouldBeVisible();
+    }
+
+    public async Task SelectComparatorsBy(ComparatorsByTypes type)
+    {
+        var radioButton = type switch
+        {
+            ComparatorsByTypes.Name => NameRadioButton,
+            ComparatorsByTypes.Characteristic => CharacteristicRadioButton,
+            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+        };
+        await radioButton.Check();
+    }
+
+    public async Task<ICreateComparatorsByPage> ClickContinue(ComparatorsByTypes type)
+    {
+        await ContinueButton.ClickAsync();
+        if (type == ComparatorsByTypes.Characteristic)
+        {
+            return new CreateComparatorsByCharacteristicPage(page);
+        }
+
+        return new CreateComparatorsByNamePage(page);
+    }
+}

--- a/web/tests/Web.E2ETests/Pages/School/Comparators/CreateComparatorsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/Comparators/CreateComparatorsPage.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Playwright;
+namespace Web.E2ETests.Pages.School.Comparators;
+
+public class CreateComparatorsPage(IPage page)
+{
+    private ILocator PageH1Heading => page.Locator(Selectors.H1,
+        new PageLocatorOptions
+        {
+            HasText = "Choose your own set of schools"
+        });
+
+    private ILocator ContinueButton => page.Locator(Selectors.GovButton,
+        new PageLocatorOptions
+        {
+            HasText = "Continue"
+        });
+
+    public async Task IsDisplayed()
+    {
+        await PageH1Heading.ShouldBeVisible();
+    }
+
+    public async Task SignIn(string organisation)
+    {
+        await page.SignInWithOrganisation(organisation);
+    }
+
+    public async Task<CreateComparatorsByPage> ClickContinue()
+    {
+        await ContinueButton.ClickAsync();
+        return new CreateComparatorsByPage(page);
+    }
+}

--- a/web/tests/Web.E2ETests/Pages/School/Comparators/ICreateComparatorsByPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/Comparators/ICreateComparatorsByPage.cs
@@ -1,0 +1,6 @@
+namespace Web.E2ETests.Pages.School.Comparators;
+
+public interface ICreateComparatorsByPage
+{
+    Task IsDisplayed();
+}

--- a/web/tests/Web.E2ETests/Pages/School/HomePage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/HomePage.cs
@@ -52,14 +52,14 @@ public class HomePage(IPage page)
     private ILocator CookieBanner => page.Locator(Selectors.CookieBanner);
     private ILocator RagGuidance => page.Locator("#rag-guidance");
 
-    public async Task IsDisplayed(bool isPartYear = false, string? trustName = null)
+    public async Task IsDisplayed(bool isPartYear = false, string? trustName = null, bool isUserDefinedComparator = false)
     {
         await PageH1Heading.ShouldBeVisible();
         //await Breadcrumbs.ShouldBeVisible();
         await ChangeSchoolLink.ShouldBeVisible().ShouldHaveAttribute("href", "/find-organisation?method=school");
 
         List<string> expectedH2Texts = ["Benchmarking and planning tools", "Resources"];
-        if (!isPartYear)
+        if (!isPartYear && !isUserDefinedComparator)
         {
             expectedH2Texts.Insert(0, "Spending priorities for this school");
         }
@@ -81,17 +81,20 @@ public class HomePage(IPage page)
         await SchoolDetailsLink.ShouldBeVisible();
         await DataSourcesAndInterpretation.ShouldBeVisible();
         await FindWaysToSpendLessLink.ShouldBeVisible();
-        if (!isPartYear)
-        {
 
+        if (!isPartYear && !isUserDefinedComparator)
+        {
             await SpendingPrioritiesLink.ShouldBeVisible();
         }
         else
         {
             await SpendingPrioritiesLink.ShouldNotBeVisible();
-            await IncompleteFinancialBanner.ShouldBeVisible();
-        }
 
+            if (isPartYear)
+            {
+                await IncompleteFinancialBanner.ShouldBeVisible();
+            }
+        }
     }
 
     public async Task<DetailsPage> ClickSchoolDetails()

--- a/web/tests/Web.E2ETests/Pages/Trust/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/Trust/CompareYourCostsPage.cs
@@ -211,7 +211,7 @@ public class CompareYourCostsPage(IPage page)
 
     public async Task<School.HomePage> PressEnterKey()
     {
-        await page.Keyboard.PressAsync("Enter");
+        await page.Keyboard.PressAsync(Keyboard.EnterKey);
         return new School.HomePage(page);
     }
 

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -55,6 +55,7 @@ public static class Selectors
     public const string Table = "table";
     public const string Button = "button";
 
+    public const string ComparisonChartsAndTables = "#compare-your-costs";
     public const string ComparisonTables = "#compare-your-costs table.govuk-table";
 
     public const string TotalExpenditureSaveAsImage = "xpath=//*[@id='compare-your-costs']/div[2]/div[2]/button";
@@ -142,4 +143,7 @@ public static class Selectors
     public const string ChartTooltips = ".recharts-tooltip-wrapper";
     public const string RunningCostCategoriesTab = "#tab_running";
     public const string BuildingCostCategoriesTab = "#tab_building";
+
+    public const string SignInLink = "header a.app-signin:text-is('Sign in')";
+    public const string SignOutLink = "header a.app-signin:text-is('Sign out')";
 }

--- a/web/tests/Web.E2ETests/Steps/School/CreateComparatorsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/CreateComparatorsSteps.cs
@@ -1,0 +1,123 @@
+using Web.E2ETests.Drivers;
+using Web.E2ETests.Pages.School;
+using Web.E2ETests.Pages.School.Comparators;
+using Xunit;
+namespace Web.E2ETests.Steps.School;
+
+[Binding]
+[Scope(Feature = "School create comparator set")]
+public class CreateComparatorsSteps(PageDriver driver)
+{
+    private CreateComparatorsByCharacteristicPage? _createComparatorsByCharacteristicPage;
+    private CreateComparatorsByNamePage? _createComparatorsByNamePage;
+    private CreateComparatorsByPage? _createComparatorsByPage;
+    private CreateComparatorsPage? _createComparatorsPage;
+    private HomePage? _schoolHomepage;
+
+    [Given("I am on create comparators page for school with URN '(.*)'")]
+    public async Task GivenIAmOnCreateComparatorsPageForSchoolWithURN(string urn)
+    {
+        var url = CreateComparatorsUrl(urn);
+        var page = await driver.Current;
+        await page.GotoAndWaitForLoadAsync(url);
+
+        _createComparatorsPage = new CreateComparatorsPage(page);
+        await _createComparatorsPage.IsDisplayed();
+    }
+
+    [Given("I have selected organisation '(.*)' after logging in")]
+    public async Task GivenIHaveSelectedOrganisationAfterLoggingIn(string organisation)
+    {
+        Assert.NotNull(_createComparatorsPage);
+        await _createComparatorsPage.SignIn(organisation);
+    }
+
+    [When("I click continue")]
+    public async Task WhenIClickContinue()
+    {
+        Assert.NotNull(_createComparatorsPage);
+        _createComparatorsByPage = await _createComparatorsPage.ClickContinue();
+    }
+
+    [When("I select the option By Characteristic and click continue")]
+    public async Task WhenISelectTheOptionByCharacteristicAndClickContinue()
+    {
+        await SelectTheOptionByAndClickContinue(ComparatorsByTypes.Characteristic);
+    }
+
+    [When("I select the option By Name and click continue")]
+    public async Task WhenISelectTheOptionByNameAndClickContinue()
+    {
+        await SelectTheOptionByAndClickContinue(ComparatorsByTypes.Name);
+    }
+
+    [When("I select the school with urn '(.*)' from suggester")]
+    public async Task WhenISelectTheSchoolWithUrnFromSuggester(string urn)
+    {
+        Assert.NotNull(_createComparatorsByNamePage);
+        await _createComparatorsByNamePage.TypeIntoSchoolSearchBox(urn);
+        await _createComparatorsByNamePage.SelectItemFromSuggester();
+    }
+
+    [When("I click the choose school button")]
+    public async Task WhenIClickTheChooseSchoolButton()
+    {
+        Assert.NotNull(_createComparatorsByNamePage);
+        await _createComparatorsByNamePage.ClickChooseSchoolButton();
+    }
+
+    [When("I click the create set button")]
+    public async Task WhenIClickTheCreateSetButton()
+    {
+        Assert.NotNull(_createComparatorsByNamePage);
+        _schoolHomepage = await _createComparatorsByNamePage.ClickCreateSetButton();
+    }
+
+    [Then("the create comparators by page is displayed")]
+    public async Task ThenTheCreateComparatorsByPageIsDisplayed()
+    {
+        Assert.NotNull(_createComparatorsByPage);
+        await _createComparatorsByPage.IsDisplayed();
+    }
+
+    [Then("the create comparators by characteristic page is displayed")]
+    public async Task ThenTheCreateComparatorsByCharacteristicPageIsDisplayed()
+    {
+        Assert.NotNull(_createComparatorsByCharacteristicPage);
+        await _createComparatorsByCharacteristicPage.IsDisplayed();
+    }
+
+    [Then("the create comparators by name page is displayed")]
+    public async Task ThenTheCreateComparatorsByNamePageIsDisplayed()
+    {
+        Assert.NotNull(_createComparatorsByNamePage);
+        await _createComparatorsByNamePage.IsDisplayed();
+    }
+
+    [Then("the school home page is displayed")]
+    public async Task ThenTheSchoolHomePageIsDisplayed()
+    {
+        Assert.NotNull(_schoolHomepage);
+        await _schoolHomepage.IsDisplayed(isUserDefinedComparator: true);
+    }
+
+    private async Task SelectTheOptionByAndClickContinue(ComparatorsByTypes type)
+    {
+        Assert.NotNull(_createComparatorsByPage);
+        await _createComparatorsByPage.SelectComparatorsBy(type);
+        _createComparatorsByNamePage = null;
+        _createComparatorsByCharacteristicPage = null;
+
+        if (type == ComparatorsByTypes.Characteristic)
+        {
+            _createComparatorsByCharacteristicPage = await _createComparatorsByPage.ClickContinue(type) as CreateComparatorsByCharacteristicPage;
+        }
+        else
+        {
+            _createComparatorsByNamePage = await _createComparatorsByPage.ClickContinue(type) as CreateComparatorsByNamePage;
+        }
+    }
+
+    private static string CreateComparatorsUrl(string urn) => $"{TestConfiguration.ServiceUrl}/school/{urn}/comparators/create";
+    internal static string CreateComparatorsByNameUrl(string urn) => $"{CreateComparatorsUrl(urn)}/by/name";
+}

--- a/web/tests/Web.E2ETests/Steps/School/FinancialPlanningSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/FinancialPlanningSteps.cs
@@ -1,19 +1,16 @@
-﻿using Microsoft.Playwright;
-using Reqnroll;
-using Web.E2ETests.Drivers;
+﻿using Web.E2ETests.Drivers;
 using Web.E2ETests.Pages.School.CurriculumFinancialPlanningSteps;
 using Xunit;
-
 namespace Web.E2ETests.Steps.School;
 
 [Binding]
 [Scope(Feature = "School curriculum and financial planning")]
 public class FinancialPlanningSteps(PageDriver driver)
 {
-    private StartPage? _startPage;
     private HelpPage? _helpPage;
-    private SelectYearPage? _selectYearPage;
     private PrePopulatedDataPage? _prePopulatedDataPage;
+    private SelectYearPage? _selectYearPage;
+    private StartPage? _startPage;
 
     [Given("I am on start page for school with URN '(.*)'")]
     public async Task GivenIAmOnStartPageForSchoolWithUrn(string urn)
@@ -120,7 +117,7 @@ public class FinancialPlanningSteps(PageDriver driver)
     }*/
 
     [Given("I have selected organisation '(.*)' after logging in for school with URN '(.*)'")]
-    public async Task GivenIAmLoggedInForSchoolWithUrn(string organisation, string urn)
+    public async Task GivenIHaveSelectedOrganisationAfterLoggingInForSchoolWithURN(string organisation, string urn)
     {
         var url = CfpLandingUrl(urn);
         var page = await driver.Current;
@@ -132,18 +129,11 @@ public class FinancialPlanningSteps(PageDriver driver)
         }
         else if (await page.Locator("h1:text-is('Access the DfE Sign-in service')").CheckVisible())
         {
-            // Login required
-            await page.Locator("input[id='username']").Fill(TestConfiguration.LoginEmail);
-            await page.Locator("button[type='submit']").Click();
-            await page.Locator("h1:text-is('Enter your password')").CheckVisible();
-            await page.Locator("input[id='password']").Fill(TestConfiguration.LoginPassword);
-            await page.Locator("button[type='submit']").Click();
-            await page.Locator("label", new PageLocatorOptions { HasTextString = organisation }).Check();
-            await page.Locator("input[type='submit']").Click();
+            await page.SignInWithOrganisation(organisation, true);
         }
         else
         {
-            throw new Exception($"Unexpected page state encountered while trying to access the login page. Neither 'Curriculum and financial planning (CFP)' nor 'Access the DfE Sign-in service' page was detected.");
+            throw new Exception("Unexpected page state encountered while trying to access the login page. Neither 'Curriculum and financial planning (CFP)' nor 'Access the DfE Sign-in service' page was detected.");
         }
     }
 
@@ -164,6 +154,4 @@ public class FinancialPlanningSteps(PageDriver driver)
     private static string HelpUrl(string urn) => $"{TestConfiguration.ServiceUrl}/school/{urn}/financial-planning/create/help";
     private static string SelectYearUrl(string urn) => $"{TestConfiguration.ServiceUrl}/school/{urn}/financial-planning/create/select-year";
     private static string CfpLandingUrl(string urn) => $"{TestConfiguration.ServiceUrl}/school/{urn}/financial-planning";
-
-
 }

--- a/web/tests/Web.E2ETests/Steps/School/HomeSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/HomeSteps.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Playwright;
-using Reqnroll;
-using Web.E2ETests.Drivers;
+﻿using Web.E2ETests.Drivers;
 using Web.E2ETests.Pages.School;
 using Xunit;
 namespace Web.E2ETests.Steps.School;
@@ -17,6 +15,13 @@ public class HomeSteps(PageDriver driver)
     private DetailsPage? _schoolDetailsPage;
     private HomePage? _schoolHomePage;
     private SpendingCostsPage? _spendingCostsPage;
+
+    [Given("I am not logged in")]
+    public async Task GivenIAmNotLoggedIn()
+    {
+        var page = await driver.Current;
+        await page.SignOut();
+    }
 
     [Given("I am on school homepage for school with urn '(.*)'")]
     public async Task GivenIAmOnSchoolHomepageForSchoolWithUrn(string urn)
@@ -82,8 +87,8 @@ public class HomeSteps(PageDriver driver)
         _curriculumAndFinancialPlanningPage = await _schoolHomePage.ClickFinancialPlanning();
     }
 
-    [Then("the curriculum and financial planning page is displayed")]
-    public async Task ThenTheCurriculumAndFinancialPlanningPageIsDisplayed()
+    [Then("the curriculum and financial planning page is displayed after logging in with organisation '(.*)'")]
+    public async Task ThenTheCurriculumAndFinancialPlanningPageIsDisplayedAfterLoggingInWithOrganisation(string organisation)
     {
         var page = await driver.Current;
         if (await page.Locator("h1:text-is('Curriculum and financial planning (CFP)')").CheckVisible())
@@ -92,25 +97,14 @@ public class HomeSteps(PageDriver driver)
         }
         else if (await page.Locator("h1:text-is('Access the DfE Sign-in service')").CheckVisible())
         {
-            // Login required
-            await page.Locator("input[id='username']").Fill(TestConfiguration.LoginEmail);
-            await page.Locator("button[type='submit']").Click();
-            await page.Locator("h1:text-is('Enter your password')").CheckVisible();
-            await page.Locator("input[id='password']").Fill(TestConfiguration.LoginPassword);
-            await page.Locator("button[type='submit']").Click();
-            await page.Locator("label", new PageLocatorOptions
-            {
-                HasTextString = "01: FBIT TEST - Community School (Open)"
-            }).Check();
-            await page.Locator("input[type='submit']").Click();
+            await page.SignInWithOrganisation(organisation, true);
         }
         else
         {
-            throw new Exception($"Unexpected page state encountered while trying to access the login page. Neither 'Curriculum and financial planning (CFP)' nor 'Access the DfE Sign-in service' page was detected.");
+            throw new Exception("Unexpected page state encountered while trying to access the login page. Neither 'Curriculum and financial planning (CFP)' nor 'Access the DfE Sign-in service' page was detected.");
         }
         Assert.NotNull(_curriculumAndFinancialPlanningPage);
         await _curriculumAndFinancialPlanningPage.IsDisplayed();
-
     }
 
     [When("I click on benchmark census data")]

--- a/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingCensus.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingCensus.cs
@@ -8,8 +8,16 @@ using Xunit;
 
 namespace Web.Integration.Tests.Pages.Schools;
 
-public class WhenViewingCensus(SchoolBenchmarkingWebAppClient client) : PageBase<SchoolBenchmarkingWebAppClient>(client)
+public class WhenViewingCensus : PageBase<SchoolBenchmarkingWebAppClient>
 {
+    private readonly Census _census;
+
+    public WhenViewingCensus(SchoolBenchmarkingWebAppClient client) : base(client)
+    {
+        _census = Fixture.Build<Census>()
+            .Create();
+    }
+
     [Theory]
     [InlineData(EstablishmentTypes.Academies)]
     [InlineData(EstablishmentTypes.Maintained)]
@@ -107,6 +115,7 @@ public class WhenViewingCensus(SchoolBenchmarkingWebAppClient client) : PageBase
             .SetupInsights()
             .SetupExpenditure(school)
             .SetupUserData()
+            .SetupCensus(school, _census)
             .Navigate(Paths.SchoolCensus(school.URN));
 
         return (page, school);


### PR DESCRIPTION
### Context
[AB#233231](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/233231) [AB#230616](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/230616)

### Change proposed in this pull request
Prevent rendering of benchmark charts on financials/census data if they cannot be generated due to part-year/missing census respectively. Large impact on E2E tests due to the inability to directly view a part-year school's comparators any more. Additional coverage to allow custom comparator set to be created that includes part year school(s) so the chart and table formatting assertions can remain.

### Guidance to review 
Test benchmarking for a combination of schools with/out part-year or missing census data to view the new banner.
Configure and run the E2E tests locally against `d02` to validate all of the above.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

