### PR TITLE
Reinstated 'part year' banner on School Comparison page

### DIFF
--- a/web/src/Web.App/Views/SchoolComparison/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/Index.cshtml
@@ -7,6 +7,11 @@
     var hasMissingComparatorSet = !hasUserDefinedSet && !hasFinancialData;
 }
 
+@if (Model is { PeriodCoveredByReturn: < 12 })
+{
+    @await Html.PartialAsync("_IncompleteFinances")
+}
+
 @await Component.InvokeAsync("EstablishmentHeading", new
 {
     title = ViewData[ViewDataKeys.Title],

--- a/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
@@ -110,6 +110,8 @@ public class CompareYourCostsPage(IPage page)
 
         await IncompleteFinancialBanner.First.ShouldBeVisible();
         await IncompleteFinancialBanner.First.ShouldContainText(
+            "This school doesn't have a complete set of financial data for this period.");
+        await IncompleteFinancialBanner.Last.ShouldContainText(
             "There isn't enough information available to create a set of similar schools.");
     }
 


### PR DESCRIPTION
### Context
[AB#233614](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/233614) [AB#230616](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/230616)

### Change proposed in this pull request
Part-reverts a change from #1482.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] You have reviewed with UX/Design

