### PR TITLE
Replaced comparator set existence check on part-year status with explicit comparator set lookup

### DIFF
--- a/web/src/Web.App/Controllers/SchoolComparisonController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparisonController.cs
@@ -5,12 +5,12 @@ using Web.App.Attributes;
 using Web.App.Attributes.RequestTelemetry;
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Apis.Benchmark;
 using Web.App.Infrastructure.Apis.Establishment;
 using Web.App.Infrastructure.Apis.Insight;
 using Web.App.Infrastructure.Extensions;
 using Web.App.Services;
 using Web.App.ViewModels;
-
 namespace Web.App.Controllers;
 
 [Controller]
@@ -18,6 +18,7 @@ namespace Web.App.Controllers;
 public class SchoolComparisonController(
     IEstablishmentApi establishmentApi,
     IExpenditureApi expenditureApi,
+    IComparatorSetApi comparatorSetApi,
     ILogger<SchoolComparisonController> logger,
     IUserDataService userDataService)
     : Controller
@@ -36,9 +37,10 @@ public class SchoolComparisonController(
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.SchoolComparison(urn);
 
                 var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
-                var expenditure = await expenditureApi.School(urn).GetResultOrThrow<SchoolExpenditure>();
+                var expenditure = await expenditureApi.School(urn).GetResultOrDefault<SchoolExpenditure>();
+                var defaultComparatorSet = await comparatorSetApi.GetDefaultSchoolAsync(urn).GetResultOrDefault<SchoolComparatorSet>();
                 var userData = await userDataService.GetSchoolDataAsync(User, urn);
-                var viewModel = new SchoolComparisonViewModel(school, userData.ComparatorSet, userData.CustomData, expenditure);
+                var viewModel = new SchoolComparisonViewModel(school, userData.ComparatorSet, userData.CustomData, expenditure, defaultComparatorSet);
 
                 return View(viewModel);
             }

--- a/web/src/Web.App/ViewModels/SchoolComparisonViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolComparisonViewModel.cs
@@ -1,7 +1,12 @@
 ﻿using Web.App.Domain;
 namespace Web.App.ViewModels;
 
-public class SchoolComparisonViewModel(School school, string? userDefinedSetId = null, string? customDataId = null, SchoolExpenditure? expenditure = null)
+public class SchoolComparisonViewModel(
+    School school,
+    string? userDefinedSetId = null,
+    string? customDataId = null,
+    SchoolExpenditure? expenditure = null,
+    SchoolComparatorSet? defaultComparatorSet = null)
 {
     public string? Urn => school.URN;
     public string? Name => school.SchoolName;
@@ -9,4 +14,5 @@ public class SchoolComparisonViewModel(School school, string? userDefinedSetId =
     public string? UserDefinedSetId => userDefinedSetId;
     public string? CustomDataId => customDataId;
     public int? PeriodCoveredByReturn => expenditure?.PeriodCoveredByReturn;
+    public bool HasDefaultComparatorSet => defaultComparatorSet != null;
 }

--- a/web/src/Web.App/Views/SchoolComparison/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/Index.cshtml
@@ -3,8 +3,7 @@
     ViewData[ViewDataKeys.Title] = PageTitles.Comparison;
     var hasUserDefinedSet = !string.IsNullOrEmpty(Model.UserDefinedSetId);
     var hasCustomData = !string.IsNullOrEmpty(Model.CustomDataId);
-    var hasFinancialData = Model.PeriodCoveredByReturn == 12;
-    var hasMissingComparatorSet = !hasUserDefinedSet && !hasFinancialData;
+    var hasMissingComparatorSet = !hasUserDefinedSet && !Model.HasDefaultComparatorSet;
 }
 
 @if (Model is { PeriodCoveredByReturn: < 12 })

--- a/web/tests/Web.E2ETests/Features/School/CompareYourCosts.feature
+++ b/web/tests/Web.E2ETests/Features/School/CompareYourCosts.feature
@@ -1,8 +1,5 @@
 Feature: School compare your costs
 
-    Background:
-        Given I am not logged in
-
     @ignore
     Scenario: Download total expenditure chart
         Given I am on compare your costs page for school with URN '777042'
@@ -54,31 +51,45 @@ Feature: School compare your costs
           | Test academy school 333 | Hampshire               | Free schools alternative provision | 190              | £1,179,475  |
         But save as image buttons are hidden
 
-    Scenario: Table view for total expenditure for school(s) with part-year data in custom comparator set
-        Given I am on compare your costs page for school with URN '777042'
-        And I have selected organisation '01: FBIT TEST - Community School (Open)' after logging in
-        And I have created a custom comparator set for '777042' containing
-          | Urn    |
-          | 777043 |
-          | 777045 |
-          | 990057 |
-          | 990127 |
-          | 990233 |
-          | 990411 |
+    Scenario: Table view for total expenditure for school(s) with part-year data
+        Given I am on compare your costs page for school with URN '777045'
         And table view is selected
         And the 'total expenditure' dimension is '£ per pupil'
         Then the following is shown for 'total expenditure'
-          | School name                                                                                                               | Local Authority        | School type         | Number of pupils | Amount  |
-          | Test academy school 273                                                                                                   | Kensington and Chelsea | Academy converter   | 114              | £13,051 |
-          | Test school 88                                                                                                            | Slough                 | Community school    | 134              | £9,916  |
-          | Test part year with pupil and without building comparator\n!\nWarning\nThis school only has 3 months of data available.   | Bromley                | Pupil referral unit | 260              | £9,068  |
-          | Test school 197                                                                                                           | Windsor and Maidenhead | Community school    | 167              | £9,050  |
-          | Test school 102                                                                                                           | Hammersmith and Fulham | Community school    | 212              | £7,487  |
-          | Test Part year school with pupil and builiding comparators\n!\nWarning\nThis school only has 10 months of data available. | Bracknell Forest       | Foundation school   | 214              | £7,470  |
-          | Test school 205                                                                                                           | Plymouth               | Community school    | 196              | £7,385  |
+          | School name                                                                                                               | Local Authority                   | School type                    | Number of pupils | Amount  |
+          | Test academy school 273                                                                                                   | Kensington and Chelsea            | Academy converter              | 114              | £13,051 |
+          | Test school 88                                                                                                            | Slough                            | Community school               | 134              | £9,916  |
+          | Test part year with pupil and without building comparator\n!\nWarning\nThis school only has 3 months of data available.   | Bromley                           | Pupil referral unit            | 260              | £9,068  |
+          | Test school 197                                                                                                           | Windsor and Maidenhead            | Community school               | 167              | £9,050  |
+          | Test academy school 470                                                                                                   | Waltham Forest                    | Academy 16-19 converter        | 167              | £9,050  |
+          | Test academy school 77                                                                                                    | Hartlepool                        | Academy converter              | 1040             | £9,023  |
+          | Test academy school 469                                                                                                   | Hillingdon                        | Free school 16 to 19           | 235              | £8,981  |
+          | Test school 198                                                                                                           | West Berkshire                    | Community school               | 174              | £8,882  |
+          | Test academy school 255                                                                                                   | Stockton-on-Tees                  | Academy converter              | 174              | £8,882  |
+          | Test school 181                                                                                                           | Dorset                            | Voluntary aided school         | 399              | £8,584  |
+          | Test school 87                                                                                                            | Reading                           | Foundation school              | 206              | £8,224  |
+          | Test school 124                                                                                                           | Newham                            | Voluntary aided school         | 769              | £8,089  |
+          | Test academy school 82                                                                                                    | Bournemouth, Christchurch & Poole | Academy converter              | 991              | £8,088  |
+          | Test academy school 53                                                                                                    | Salford                           | Free school                    | 407              | £8,028  |
+          | Test school 260                                                                                                           | Kingston upon Thames              | Community school               | 853              | £7,880  |
+          | Test academy school 450                                                                                                   | Surrey                            | Academy 16-19 converter        | 367              | £7,703  |
+          | Test Part year school with pupil and builiding comparators\n!\nWarning\nThis school only has 10 months of data available. | Bracknell Forest                  | Foundation school              | 214              | £7,470  |
+          | Test school 205                                                                                                           | Plymouth                          | Community school               | 196              | £7,385  |
+          | Test academy school 20                                                                                                    | Waltham Forest                    | Academy converter              | 449              | £7,356  |
+          | Test academy school 98                                                                                                    | Southwark                         | Academy converter              | 449              | £7,356  |
+          | Test academy school 244                                                                                                   | Islington                         | Academy converter              | 446              | £7,342  |
+          | Test school 68                                                                                                            | Derbyshire                        | Local authority nursery school | 339              | £7,318  |
+          | Test academy school 37                                                                                                    | North Lincolnshire                | Academy converter              | 339              | £7,318  |
+          | Test school 270                                                                                                           | Solihull                          | Voluntary aided school         | 230              | £7,281  |
+          | Test school 237                                                                                                           | City of London                    | Voluntary aided school         | 231              | £6,918  |
+          | Test academy school 465                                                                                                   | Enfield                           | Academy 16-19 converter        | 231              | £6,918  |
+          | Test academy school 375                                                                                                   | Reading                           | Academy special sponsor led    | 232              | £6,814  |
+          | Test school 132                                                                                                           | Solihull                          | Community school               | 418              | £6,676  |
+          | Test academy school 32                                                                                                    | Stockton-on-Tees                  | Academy converter              | 418              | £6,676  |
+          | Test academy school 160                                                                                                   | West Sussex                       | Academy special converter      | 190              | £6,208  |
 
-    Scenario: Benchmarking for school(s) with part-year data does not display comparators
-        Given I am on compare your costs page for part year school with URN '777045'
+    Scenario: Benchmarking for school with missing comparators does not display comparators
+        Given I am on compare your costs page for missing comparator school with URN '990754'
         Then the benchmarking charts are not displayed
 
     Scenario: Show all should expand all sections
@@ -111,14 +122,10 @@ Feature: School compare your costs
           | School type      | Community school |
           | Number of pupils | 114              |
 
-    Scenario: View additional details upon hover for part-year school in custom comparator set
+    Scenario: View additional details upon hover for part-year school
         Given I am on compare your costs page for part year school with URN '777045'
-        And I have selected organisation '01: FBIT TEST - Community School (Open)' after logging in
-        And I have created a custom comparator set for '777045' containing
-          | Urn    |
-          | 777042 |
         And the 'total expenditure' dimension is '£ per pupil'
-        When I hover over the nth chart bar 0
+        When I hover over the nth chart bar 2
         Then additional information is displayed
         And additional information contains
           | Item             | Value               |
@@ -127,15 +134,11 @@ Feature: School compare your costs
           | Number of pupils | 260                 |
         And additional information shows part year warning for 3 months
 
-    Scenario: Warning icon displayed in chart for part-year school in custom comparator set
+    Scenario: Warning icon displayed in chart for part-year school
         Given I am on compare your costs page for part year school with URN '777045'
-        And I have selected organisation '01: FBIT TEST - Community School (Open)' after logging in
-        And I have created a custom comparator set for '777045' containing
-          | Urn    |
-          | 777042 |
         And the 'total expenditure' dimension is '£ per pupil'
-        Then the nth chart bar 0 displays the establishment name 'Test part year with pupil and without building comparator'
-        And the nth chart bar 0 displays the warning icon
+        Then the nth chart bar 2 displays the establishment name 'Test part year with pupil and without building comparator'
+        And the nth chart bar 2 displays the warning icon
 
     Scenario: Clicking school name in chart directs to homepage
         Given I am on compare your costs page for school with URN '777042'
@@ -229,3 +232,15 @@ Feature: School compare your costs
           | Test school 149         | Barnsley                | Pupil referral unit                | 232              | £41,903  |
           | Test academy school 12  | Hounslow                | Academy sponsor led                | 232              | £41,903  |
           | Test academy school 466 | Haringey                | Academy 16-19 converter            | 232              | £41,903  |
+
+    Scenario Outline: View comparators for part year school
+        Given I am on compare your costs page for part year school with URN '<URN>'
+        When I click on sets of similar school link
+        Then I am taken to comparators page
+        And pupil cost comparators are <PupilComparators>
+        And building cost comparators are <BuildingComparators>
+
+        Examples:
+          | URN    | PupilComparators | BuildingComparators |
+          | 777043 | not null         | not null            |
+          | 777045 | not null         | null                |

--- a/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
@@ -85,12 +85,19 @@ public class CompareYourCostsPage(IPage page)
     private ILocator AdditionalDetailsPopUps => page.Locator(Selectors.AdditionalDetailsPopUps);
     private ILocator SchoolLinksInCharts => page.Locator(Selectors.SchoolNamesLinksInCharts);
 
-    public async Task IsDisplayed(bool isPartYear = false)
+    public async Task IsDisplayed(bool isPartYear = false, bool isMissingComparatorSet = false)
     {
         await PageH1Heading.ShouldBeVisible();
         //await Breadcrumbs.ShouldBeVisible();
 
-        if (!isPartYear)
+        if (isPartYear)
+        {
+            await IncompleteFinancialBanner.First.ShouldBeVisible();
+            await IncompleteFinancialBanner.First.ShouldContainText(
+                "This school doesn't have a complete set of financial data for this period.");
+        }
+
+        if (!isMissingComparatorSet)
         {
             await SaveImageTotalExpenditure.ShouldBeVisible();
             await TotalExpenditureDimension.ShouldBeVisible();
@@ -108,9 +115,6 @@ public class CompareYourCostsPage(IPage page)
             return;
         }
 
-        await IncompleteFinancialBanner.First.ShouldBeVisible();
-        await IncompleteFinancialBanner.First.ShouldContainText(
-            "This school doesn't have a complete set of financial data for this period.");
         await IncompleteFinancialBanner.Last.ShouldContainText(
             "There isn't enough information available to create a set of similar schools.");
     }

--- a/web/tests/Web.E2ETests/Steps/School/CompareYourCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/CompareYourCostsSteps.cs
@@ -43,6 +43,17 @@ public class CompareYourCostsSteps(PageDriver driver)
         await _comparisonPage.IsDisplayed(true);
     }
 
+    [Given("I am on compare your costs page for missing comparator school with URN '(.*)'")]
+    public async Task GivenIAmOnCompareYourCostsPageForMissingComparatorSchoolWithURN(string urn)
+    {
+        var url = CompareYourCostsUrl(urn);
+        var page = await driver.Current;
+        await page.GotoAndWaitForLoadAsync(url);
+
+        _comparisonPage = new CompareYourCostsPage(page);
+        await _comparisonPage.IsDisplayed(false, true);
+    }
+
     [When("I click on save as image for '(.*)'")]
     public async Task WhenIClickOnSaveAsImageFor(string chartName)
     {

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -393,6 +393,13 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         return this;
     }
 
+    public BenchmarkingWebAppClient SetupComparatorSet(School school, SchoolComparatorSet? comparatorSet)
+    {
+        ComparatorSetApi.Reset();
+        ComparatorSetApi.Setup(api => api.GetDefaultSchoolAsync(school.URN!)).ReturnsAsync(ApiResult.Ok(comparatorSet));
+        return this;
+    }
+
     // public BenchmarkingWebAppClient SetupBenchmarkWithNotFound()
     // {
     //     FinancialPlanApi.Reset();

--- a/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingComparison.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingComparison.cs
@@ -98,10 +98,13 @@ public class WhenViewingComparison(SchoolBenchmarkingWebAppClient client)
             .With(x => x.FinanceType, financeType)
             .Create();
 
+        var comparatorSet = Fixture.Create<SchoolComparatorSet>();
+
         var page = await Client.SetupEstablishment(school)
             .SetupInsights()
             .SetupExpenditure(school)
             .SetupUserData()
+            .SetupComparatorSet(school, comparatorSet)
             .Navigate(Paths.SchoolComparison(school.URN));
 
         return (page, school);

--- a/web/tests/Web.Tests/ViewModels/GivenASchoolComparisonViewModel.cs
+++ b/web/tests/Web.Tests/ViewModels/GivenASchoolComparisonViewModel.cs
@@ -1,0 +1,94 @@
+using AutoFixture;
+using Web.App.Domain;
+using Web.App.ViewModels;
+using Xunit;
+namespace Web.Tests.ViewModels;
+
+public class GivenASchoolComparisonViewModel
+{
+    private readonly Fixture _fixture = new();
+    private readonly School _school;
+
+    public GivenASchoolComparisonViewModel()
+    {
+        _school = _fixture.Create<School>();
+    }
+
+    public static TheoryData<SchoolExpenditure?, int?> ExpenditureInput =>
+        new()
+        {
+            {
+                null, null
+            },
+            {
+                new SchoolExpenditure(), null
+            },
+            {
+                new SchoolExpenditure
+                {
+                    PeriodCoveredByReturn = 12
+                },
+                12
+            }
+        };
+
+    public static TheoryData<SchoolComparatorSet?, bool> ComparatorSetInput =>
+        new()
+        {
+            {
+                null, false
+            },
+            {
+                new SchoolComparatorSet(), true
+            }
+        };
+
+    [Fact]
+    public void WhenContainsSchool()
+    {
+
+        var vm = new SchoolComparisonViewModel(_school);
+
+        Assert.Equal(_school.URN, vm.Urn);
+        Assert.Equal(_school.SchoolName, vm.Name);
+        Assert.Equal(_school.IsPartOfTrust, vm.IsPartOfTrust);
+    }
+
+    [Fact]
+    public void WhenContainsUserDefinedSetId()
+    {
+        var userDefinedSetId = _fixture.Create<string>();
+
+        var vm = new SchoolComparisonViewModel(_school, userDefinedSetId);
+
+        Assert.Equal(userDefinedSetId, vm.UserDefinedSetId);
+    }
+
+    [Fact]
+    public void WhenContainsCustomDataId()
+    {
+        var customDataId = _fixture.Create<string>();
+
+        var vm = new SchoolComparisonViewModel(_school, null, customDataId);
+
+        Assert.Equal(customDataId, vm.CustomDataId);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExpenditureInput))]
+    public void WhenContainsExpenditure(SchoolExpenditure? expenditure, int? expected)
+    {
+        var vm = new SchoolComparisonViewModel(_school, null, null, expenditure);
+
+        Assert.Equal(expected, vm.PeriodCoveredByReturn);
+    }
+
+    [Theory]
+    [MemberData(nameof(ComparatorSetInput))]
+    public void WhenContainsDefaultComparatorSet(SchoolComparatorSet? defaultComparatorSet, bool expected)
+    {
+        var vm = new SchoolComparisonViewModel(_school, null, null, null, defaultComparatorSet);
+
+        Assert.Equal(expected, vm.HasDefaultComparatorSet);
+    }
+}


### PR DESCRIPTION
### Context
[AB#233725](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/233725) [AB#230616](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/230616)

### Change proposed in this pull request
Also partially reverts E2E changes originally made in #1482 by removing user defined comparator set creation outside the `School create comparator set` feature. This will prevent a race condition on the current 'active' comparators for the same test school which was causing recent pipeline runs to fail.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

