### PR TITLE
Updated comparator set existence check to include empty as well as missing comparator sets

### DIFF
--- a/web/src/Web.App/ViewModels/SchoolComparisonViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolComparisonViewModel.cs
@@ -14,5 +14,7 @@ public class SchoolComparisonViewModel(
     public string? UserDefinedSetId => userDefinedSetId;
     public string? CustomDataId => customDataId;
     public int? PeriodCoveredByReturn => expenditure?.PeriodCoveredByReturn;
-    public bool HasDefaultComparatorSet => defaultComparatorSet != null;
+    public bool HasDefaultComparatorSet => defaultComparatorSet != null
+                                           && (defaultComparatorSet.Building.Any(b => !string.IsNullOrWhiteSpace(b))
+                                               || defaultComparatorSet.Pupil.Any(p => !string.IsNullOrWhiteSpace(p)));
 }

--- a/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingComparison.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingComparison.cs
@@ -5,7 +5,6 @@ using AngleSharp.XPath;
 using AutoFixture;
 using Web.App.Domain;
 using Xunit;
-
 namespace Web.Integration.Tests.Pages.Schools;
 
 public class WhenViewingComparison(SchoolBenchmarkingWebAppClient client)
@@ -98,7 +97,9 @@ public class WhenViewingComparison(SchoolBenchmarkingWebAppClient client)
             .With(x => x.FinanceType, financeType)
             .Create();
 
-        var comparatorSet = Fixture.Create<SchoolComparatorSet>();
+        var comparatorSet = Fixture.Build<SchoolComparatorSet>()
+            .With(x => x.Building, ["building"])
+            .Create();
 
         var page = await Client.SetupEstablishment(school)
             .SetupInsights()

--- a/web/tests/Web.Tests/ViewModels/GivenASchoolComparisonViewModel.cs
+++ b/web/tests/Web.Tests/ViewModels/GivenASchoolComparisonViewModel.cs
@@ -39,7 +39,30 @@ public class GivenASchoolComparisonViewModel
                 null, false
             },
             {
-                new SchoolComparatorSet(), true
+                new SchoolComparatorSet(), false
+            },
+            {
+                new SchoolComparatorSet
+                {
+                    Building = [string.Empty],
+                    Pupil = [string.Empty]
+
+                },
+                false
+            },
+            {
+                new SchoolComparatorSet
+                {
+                    Building = ["building"]
+                },
+                true
+            },
+            {
+                new SchoolComparatorSet
+                {
+                    Pupil = ["pupil"]
+                },
+                true
             }
         };
 


### PR DESCRIPTION
### Context
[AB#233725](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/233725) [AB#230616](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/230616)

### Change proposed in this pull request
Follow-up to #1489 following additional QA

### Guidance to review 
Validate the following scenarios in `d01`:
1. Part year submission + no comparator set => banner + mock up: `100885`, `146059`
1. Full submission + no comparator set => mock up: `133545`
1. Part year submission + with comparator set => banner + normal: `147069`, `105296`, `105296`
1. Full submission + with comparator set => normal: `100000`, `145956`

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

