### PR TITLE
Sync Key Vault references after deploying App Services

### DIFF
--- a/pipelines/common/app-service-settings-refresh.yaml
+++ b/pipelines/common/app-service-settings-refresh.yaml
@@ -1,0 +1,56 @@
+parameters:
+  - name: subscription
+    type: string
+    default: ''
+  - name: resourceGroup
+    type: string
+    default: ''
+  - name: resources
+    type: object
+    default: 
+    - name: '' # Azure resource name
+      alias: '' # used for output variable and task name (alpha and underscores only permitted)
+  - name: dependsOn
+    type: object
+    default: []
+
+jobs:
+  - job: GetResourceIds
+    displayName: Get Resource Ids
+    dependsOn: ${{ parameters.dependsOn }}
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+    - checkout: none
+
+    - ${{ each resource in parameters.resources }}:
+      - task: AzureCLI@1
+        name: "AzureCli_${{ resource.alias }}"
+        displayName: 'Get Azure Resource Id for ${{ resource.alias }}'
+        inputs:
+          azureSubscription: ${{ parameters.subscription }}
+          scriptLocation: inlineScript
+          inlineScript: |
+            resourceId=$(az resource show --name ${{ resource.name }} --resource-group ${{ parameters.resourceGroup }} --resource-type Microsoft.Web/sites --query "id" -o tsv 2>nul)
+            echo "Resource Id '$resourceId' resolved for '${{ resource.name }}'"
+            echo "##vso[task.setvariable variable=Resource_Id;isOutput=true]$resourceId"
+
+  - job: SyncKeyVaultReferences
+    displayName: Sync Key Vault references
+    dependsOn: [ GetResourceIds ]
+    variables: 
+      - ${{ each resource in parameters.resources }}:
+        - name: "${{ resource.alias }}"
+          value: $[ replace(dependencies.GetResourceIds.outputs['AzureCli_${{ resource.alias }}.Resource_Id'], '/subscriptions/', 'subscriptions/') ]
+    pool: server
+    steps:
+    
+    - ${{ each resource in parameters.resources }}:
+      - task: InvokeRESTAPI@1
+        name: 'InvokeRestApi_${{ resource.alias }}'
+        displayName: 'Invoke REST API for ${{ resource.alias }}'
+        inputs:
+          connectionType: 'connectedServiceNameARM'
+          azureServiceConnection: ${{ parameters.subscription }}
+          method: POST
+          urlSuffix: "$(${{ resource.alias }})/config/configreferences/appsettings/refresh?api-version=2022-03-01"

--- a/pipelines/platform/deployment.yaml
+++ b/pipelines/platform/deployment.yaml
@@ -114,3 +114,20 @@ jobs:
                 slotName: production
                 appSettings: '-WEBSITE_RUN_FROM_PACKAGE 1'
                 deploymentMethod: 'runFromPackage'
+
+  - template: ../common/app-service-settings-refresh.yaml
+    parameters:
+      subscription: ${{ parameters.subscription }}
+      resourceGroup: '${{ parameters.environmentPrefix }}-ebis-platform'
+      resources: 
+        - name: '${{ parameters.environmentPrefix }}-ebis-benchmark-fa'
+          alias: 'benchmark'
+        - name: '${{ parameters.environmentPrefix }}-ebis-insight-fa'
+          alias: 'insight'
+        - name: '${{ parameters.environmentPrefix }}-ebis-establishment-fa'
+          alias: 'establishment'
+        - name: '${{ parameters.environmentPrefix }}-ebis-orchestrator-fa'
+          alias: 'orchestrator'
+        - name: '${{ parameters.environmentPrefix }}-ebis-clean-up-fa'
+          alias: 'cleanup'
+      dependsOn: [ PlatformDeployment ]

--- a/pipelines/web/deployment.yaml
+++ b/pipelines/web/deployment.yaml
@@ -43,3 +43,12 @@ jobs:
                 packageForLinux: '${{ parameters.workspaceDir }}/web/Web.App.zip'
                 enableCustomDeployment: true
                 DeploymentType: 'zipDeploy'
+
+  - template: ../common/app-service-settings-refresh.yaml
+    parameters:
+      subscription: ${{ parameters.subscription }}
+      resourceGroup: '${{ parameters.environmentPrefix }}-ebis-web'
+      resources: 
+        - name: '${{ parameters.environmentPrefix }}-education-benchmarking'
+          alias: 'web'
+      dependsOn: [ WebDeployment ]


### PR DESCRIPTION
### Context
[AB#234535](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/234535) [AB#229479](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/229479)

### Change proposed in this pull request
Instead of waiting up to 24 hours for unversioned Key Vault references to be updated on App Services, use [Azure Rest API to refresh](https://stackoverflow.com/a/79014000/504477) during Platform and Web deployments. 

### Guidance to review 
Deployed to and tested in `d11` feature environment. Responses received successfully from `POST`s to the `.../config/configreferences/appsettings/refresh` endpoints, e.g.:

```json
{
  "value": [
    {
      "id": ".../config/configreferences/appsettings/Apis__Benchmark__Key",
      "name": "Apis__Benchmark__Key",
      "type": "Microsoft.Web/sites/config/configreferences",
      "location": "West Europe",
      "properties": {
        "reference": "@Microsoft.KeyVault(SecretUri=https://s198d11-ebis-keyvault.vault.azure.net/secrets/benchmark-host-key)",
        "status": "Resolved",
        "vaultName": "s198d11-ebis-keyvault",
        "secretName": "benchmark-host-key",
        "identityType": "SystemAssigned",
        "details": "Reference has been successfully resolved.",
        "activeVersion": null
      }
    },
    ...
  ]
}
```

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

