### PR TITLE
Post alerts to Teams channel

### DIFF
--- a/support-analytics/terraform/README.md
+++ b/support-analytics/terraform/README.md
@@ -21,6 +21,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [azurerm_api_connection.teams-api-connection](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_connection) | resource |
 | [azurerm_log_analytics_query_pack.query-pack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_query_pack) | resource |
 | [azurerm_log_analytics_query_pack_query.custom-data-funnel](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_query_pack_query) | resource |
 | [azurerm_log_analytics_query_pack_query.custom-pipeline-runs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_query_pack_query) | resource |
@@ -60,14 +61,12 @@ No modules.
 | [azurerm_log_analytics_saved_search.get-users](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_saved_search.get-waf-blocked-requests](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_saved_search.get-waf-logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
+| [azurerm_logic_app_action_custom.condition-post-teams](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
+| [azurerm_logic_app_action_custom.initialise-affected-resource](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
+| [azurerm_logic_app_trigger_http_request.http-trigger](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_trigger_http_request) | resource |
+| [azurerm_logic_app_workflow.alert-teams](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_workflow) | resource |
 | [azurerm_monitor_action_group.service-support-action](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
 | [azurerm_monitor_metric_alert.availability-alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
-| [azurerm_monitor_metric_alert.benchmark_api_error_alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
-| [azurerm_monitor_metric_alert.cpu_alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
-| [azurerm_monitor_metric_alert.establishment_api_error_alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
-| [azurerm_monitor_metric_alert.insight_api_error_alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
-| [azurerm_monitor_metric_alert.memory_alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
-| [azurerm_monitor_metric_alert.web_app_error_alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_smart_detector_alert_rule.dependency-performance-degradation-detector](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_smart_detector_alert_rule) | resource |
 | [azurerm_monitor_smart_detector_alert_rule.exception-volume-changed-detector](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_smart_detector_alert_rule) | resource |
 | [azurerm_monitor_smart_detector_alert_rule.failure-anomalies-detector](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_smart_detector_alert_rule) | resource |
@@ -102,13 +101,9 @@ No modules.
 | [azurerm_application_insights.application-insights](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/application_insights) | data source |
 | [azurerm_client_config.client](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_log_analytics_workspace.application-insights-workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |
-| [azurerm_service_plan.web-app-service-plan](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/service_plan) | data source |
+| [azurerm_managed_api.teams-api](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/managed_api) | data source |
 | [azurerm_storage_account.data](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
-| [azurerm_windows_function_app.benchmark-api](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/windows_function_app) | data source |
-| [azurerm_windows_function_app.establishment-api](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/windows_function_app) | data source |
-| [azurerm_windows_function_app.insight-api](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/windows_function_app) | data source |
-| [azurerm_windows_web_app.web-app-service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/windows_web_app) | data source |
 
 ## Inputs
 
@@ -120,6 +115,8 @@ No modules.
 | <a name="input_environment-prefix"></a> [environment-prefix](#input\_environment-prefix) | n/a | `any` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | n/a | `any` | n/a | yes |
 | <a name="input_support-alert-email"></a> [support-alert-email](#input\_support-alert-email) | n/a | `any` | n/a | yes |
+| <a name="input_teams-channel-id"></a> [teams-channel-id](#input\_teams-channel-id) | n/a | `any` | n/a | yes |
+| <a name="input_teams-team-id"></a> [teams-team-id](#input\_teams-team-id) | n/a | `any` | n/a | yes |
 | <a name="input_trackedEvents"></a> [trackedEvents](#input\_trackedEvents) | n/a | `list(string)` | <pre>[<br>  "gias-school-details",<br>  "commercial-resource",<br>  "guidance-resource",<br>  "data-source",<br>  "organisation",<br>  "service-banner",<br>  "change-organisation",<br>  "survey"<br>]</pre> | no |
 
 ## Outputs

--- a/support-analytics/terraform/action-group.tf
+++ b/support-analytics/terraform/action-group.tf
@@ -1,0 +1,18 @@
+resource "azurerm_monitor_action_group" "service-support-action" {
+  name                = "Service support"
+  resource_group_name = azurerm_resource_group.resource-group.name
+  short_name          = "Support"
+  tags                = local.common-tags
+
+  email_receiver {
+    name                    = "send-to-support"
+    email_address           = var.support-alert-email
+    use_common_alert_schema = true
+  }
+
+  webhook_receiver {
+    name                    = "send-to-teams"
+    service_uri             = azurerm_logic_app_trigger_http_request.http-trigger.callback_url
+    use_common_alert_schema = true
+  }
+}

--- a/support-analytics/terraform/logic-app.tf
+++ b/support-analytics/terraform/logic-app.tf
@@ -1,0 +1,245 @@
+resource "azurerm_logic_app_workflow" "alert-teams" {
+  name                = "${var.environment-prefix}-ebis-alert-teams"
+  location            = azurerm_resource_group.resource-group.location
+  resource_group_name = azurerm_resource_group.resource-group.name
+  tags                = local.common-tags
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  workflow_parameters = {
+    Environment = jsonencode({
+      type         = "String"
+      defaultValue = ""
+      description  = "The environment from which the alert has been triggered"
+    })
+    TeamId = jsonencode({
+      type         = "String"
+      defaultValue = ""
+      description  = "The GUID corresponding to the Team to post the alert to in Teams"
+    })
+    ChannelId = jsonencode({
+      type         = "String"
+      defaultValue = ""
+      description  = "The GUID corresponding to the Channel to post the alert to in Teams"
+    })
+    "$connections" = jsonencode({
+      type         = "Object"
+      defaultValue = {}
+    })
+  }
+
+  parameters = {
+    Environment = "${var.environment-prefix}"
+    TeamId      = "${var.teams-team-id}"
+    ChannelId   = "${var.teams-channel-id}"
+
+    "$connections" = jsonencode({
+      teams = {
+        id             = data.azurerm_managed_api.teams-api.id
+        connectionId   = azurerm_api_connection.teams-api-connection.id
+        connectionName = "teams"
+      }
+    })
+  }
+}
+
+# https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-logic-apps?tabs=send-teams-message
+resource "azurerm_logic_app_trigger_http_request" "http-trigger" {
+  name         = "When_an_alert_HTTP_request_is_received"
+  logic_app_id = azurerm_logic_app_workflow.alert-teams.id
+
+  schema = <<SCHEMA
+{
+    "type": "object",
+    "properties": {
+        "schemaId": {
+            "type": "string"
+        },
+        "data": {
+            "type": "object",
+            "properties": {
+                "essentials": {
+                    "type": "object",
+                    "properties": {
+                        "alertId": {
+                            "type": "string"
+                        },
+                        "alertRule": {
+                            "type": "string"
+                        },
+                        "severity": {
+                            "type": "string"
+                        },
+                        "signalType": {
+                            "type": "string"
+                        },
+                        "monitorCondition": {
+                            "type": "string"
+                        },
+                        "monitoringService": {
+                            "type": "string"
+                        },
+                        "alertTargetIDs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "originAlertId": {
+                            "type": "string"
+                        },
+                        "firedDateTime": {
+                            "type": "string"
+                        },
+                        "resolvedDateTime": {
+                            "type": "string"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "essentialsVersion": {
+                            "type": "string"
+                        },
+                        "alertContextVersion": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "alertContext": {
+                    "type": "object",
+                    "properties": {}
+                }
+            }
+        }
+    }
+}
+SCHEMA
+
+}
+
+resource "azurerm_logic_app_action_custom" "initialise-affected-resource-ids" {
+  name         = "Initialize_variable"
+  logic_app_id = azurerm_logic_app_workflow.alert-teams.id
+
+  body = <<BODY
+{
+    "runAfter": {},
+    "type": "InitializeVariable",
+    "inputs": {
+        "variables": [
+            {
+                "name": "AffectedResourceIds",
+                "type": "array",
+                "value": "@split(triggerBody()?['data']?['essentials']?['alertTargetIDs'][0], '/')"
+            }
+        ]
+    }
+}
+BODY
+
+}
+
+# https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-common-schema#sample-alert-payload
+resource "azurerm_logic_app_action_custom" "condition-post-teams" {
+  name         = "Condition"
+  logic_app_id = azurerm_logic_app_workflow.alert-teams.id
+
+  depends_on = [
+    azurerm_logic_app_action_custom.initialise-affected-resource-ids
+  ]
+
+  body = <<BODY
+{
+    "actions": {
+        "Post_resolved_message_in_a_channel": {
+            "type": "ApiConnection",
+            "inputs": {
+                "host": {
+                    "connection": {
+                        "name": "@parameters('$connections')['teams']['connectionId']"
+                    }
+                },
+                "method": "post",
+                "body": {
+                    "recipient": {
+                        "groupId": "@{parameters('TeamId')}",
+                        "channelId": "@{parameters('ChannelId')}"
+                    },
+                    "messageBody": "<p class=\"editor-paragraph\">✅ Alert <strong>@{triggerBody()?['data']?['essentials']?['alertRule']}</strong> was <strong>@{triggerBody()?['data']?['essentials']?['monitorCondition']}</strong> at @{triggerBody()?['data']?['essentials']?['firedDateTime']} in <strong>@{parameters('Environment')}</strong></p><br><p class=\"editor-paragraph\"><a href=\"https://portal.azure.com/#blade/Microsoft_Azure_Monitoring_Alerts/AlertDetails.ReactView/alertId/%2fsubscriptions%2f@{variables('AffectedResourceIds')[2]}%2fresourceGroups%2f@{variables('AffectedResourceIds')[4]}%2fproviders%2fMicrosoft.AlertsManagement%2falerts%2f@{triggerBody()?['data']?['essentials']?['alertId']}\" class=\"editor-link\">View the alert in Azure Monitor</a></p>"
+                },
+                "path": "/beta/teams/conversation/message/poster/Flow bot/location/@{encodeURIComponent('Channel')}"
+            }
+        }
+    },
+    "runAfter": {
+        "${azurerm_logic_app_action_custom.initialise-affected-resource-ids.name}": [
+            "Succeeded"
+        ]
+    },
+    "else": {
+        "actions": {
+            "Post_fired_message_in_a_channel": {
+                "type": "ApiConnection",
+                "inputs": {
+                    "host": {
+                        "connection": {
+                            "name": "@parameters('$connections')['teams']['connectionId']"
+                        }
+                    },
+                    "method": "post",
+                    "body": {
+                        "recipient": {
+                            "groupId": "@{parameters('TeamId')}",
+                            "channelId": "@{parameters('ChannelId')}"
+                        },
+                        "messageBody": "<p class=\"editor-paragraph\">🚨 Alert <strong>@{triggerBody()?['data']?['essentials']?['alertRule']}</strong> with severity <strong>@{triggerBody()?['data']?['essentials']?['severity']}</strong> was <strong>@{triggerBody()?['data']?['essentials']?['monitorCondition']}</strong> at @{triggerBody()?['data']?['essentials']?['firedDateTime']} in <strong>@{parameters('Environment')}</strong></p><br><p class=\"editor-paragraph\"><a href=\"https://portal.azure.com/#blade/Microsoft_Azure_Monitoring_Alerts/AlertDetails.ReactView/alertId/%2fsubscriptions%2f@{variables('AffectedResourceIds')[2]}%2fresourceGroups%2f@{variables('AffectedResourceIds')[4]}%2fproviders%2fMicrosoft.AlertsManagement%2falerts%2f@{triggerBody()?['data']?['essentials']?['alertId']}\" class=\"editor-link\">View the alert in Azure Monitor</a></p>"
+                    },
+                    "path": "/beta/teams/conversation/message/poster/Flow bot/location/@{encodeURIComponent('Channel')}"
+                }
+            }
+        }
+    },
+    "expression": {
+        "and": [
+            {
+                "equals": [
+                    "@triggerBody()?['data']?['essentials']?['monitorCondition']",
+                    "Resolved"
+                ]
+            }
+        ]
+    },
+    "type": "If"
+}
+
+BODY
+
+}
+
+data "azurerm_managed_api" "teams-api" {
+  name     = "teams"
+  location = azurerm_resource_group.resource-group.location
+}
+
+# This will create the API connection, but not actually perform authorisation for the `teams`
+# managed API. This must be handled as an interactive event via Azure Portal by selecting:
+#
+#  General > Edit API connection > Authorize
+#
+# and then logging in with an Office 365 account with access to the target Team and Channel.
+resource "azurerm_api_connection" "teams-api-connection" {
+  name                = "${var.environment-prefix}-teams-api"
+  resource_group_name = azurerm_resource_group.resource-group.name
+  managed_api_id      = data.azurerm_managed_api.teams-api.id
+  display_name        = "Teams"
+  tags                = local.common-tags
+
+  parameter_values = {}
+
+  lifecycle {
+    # NOTE: since the connectionString is a secure value it's not returned from the API
+    ignore_changes = [parameter_values]
+  }
+}

--- a/support-analytics/terraform/main.tf
+++ b/support-analytics/terraform/main.tf
@@ -16,16 +16,4 @@ resource "azurerm_resource_group" "resource-group" {
   tags     = local.common-tags
 }
 
-resource "azurerm_monitor_action_group" "service-support-action" {
-  name                = "Service support"
-  resource_group_name = azurerm_resource_group.resource-group.name
-  short_name          = "Support"
-  tags                = local.common-tags
-
-  email_receiver {
-    name                    = "send-to-support"
-    email_address           = var.support-alert-email
-    use_common_alert_schema = true
-  }
-}
 

--- a/support-analytics/terraform/terraform.tfvars
+++ b/support-analytics/terraform/terraform.tfvars
@@ -3,3 +3,9 @@ environment         = "__environment__"
 location            = "__location__"
 cip-environment     = "__cipEnvironment__"
 support-alert-email = "__support-alert-email__"
+
+# To obtain the Team ID and (must be URL decoded) Channel ID, find the target Channel in Teams  
+# and select 'Get link to channel' from the context menu. From the URL, obtain the IDs as:
+# https://teams.microsoft.com/l/channel/<Channel ID>/FBIT%20Alerts?groupId=<Team ID>&tenantId=<UNUSED>
+teams-team-id    = "__support-alert-teams-team-id__"
+teams-channel-id = "__support-alert-teams-channel-id__"

--- a/support-analytics/terraform/variables.tf
+++ b/support-analytics/terraform/variables.tf
@@ -3,6 +3,8 @@ variable "cip-environment" {}
 variable "environment-prefix" {}
 variable "location" {}
 variable "support-alert-email" {}
+variable "teams-team-id" {}
+variable "teams-channel-id" {}
 
 variable "configuration" {
   type = map(object({


### PR DESCRIPTION
### Context
[AB#234736](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/234736) [AB#225322](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/225322)

### Change proposed in this pull request
Logic App authored to post an alert schema-ed message to a Teams Channel from an Action Group. Other properties on the source message are also available, so the target message templates may be tweaked as required.

### Guidance to review 
Deployed to and tested in `d12` feature environment. Target Team and Channel may be set in `support` Variable Group. Authorisation between the provisioned API Connection in Azure and Teams in Office 365 does, unfortunately, require interaction via Azure Portal. This is a one-off task per deployment, at least until the respective authorising user expires in Office 365.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

