### PR TITLE
feat: aggregate lead-school data for Federations

### DIFF
--- a/data-pipeline/src/pipeline/pre_processing.py
+++ b/data-pipeline/src/pipeline/pre_processing.py
@@ -253,8 +253,13 @@ def prepare_central_services_data(cs_path, current_year: int):
         dtype=input_schemas.aar_central_services,
     )
 
-    if "BNCH11123-BTI011-A (MAT Central services - Income)" not in central_services_financial.columns:
-        central_services_financial["BNCH11123-BTI011-A (MAT Central services - Income)"] = 0.0
+    if (
+        "BNCH11123-BTI011-A (MAT Central services - Income)"
+        not in central_services_financial.columns
+    ):
+        central_services_financial[
+            "BNCH11123-BTI011-A (MAT Central services - Income)"
+        ] = 0.0
 
     central_services_financial["Income_Direct revenue finance"] = (
         central_services_financial[
@@ -303,7 +308,9 @@ def prepare_central_services_data(cs_path, current_year: int):
     central_services_financial["Income_Pre Post 16"] = (
         central_services_financial["BNCH11110T (EFA Revenue Grants)"]
         + central_services_financial["BNCH11131 (DfE Family Revenue Grants)"]
-        + central_services_financial["BNCH11123-BTI011-A (MAT Central services - Income)"]
+        + central_services_financial[
+            "BNCH11123-BTI011-A (MAT Central services - Income)"
+        ]
     )
 
     central_services_financial["Income_Other Revenue Income"] = (
@@ -1093,6 +1100,9 @@ def build_maintained_school_data(
     maintained_schools_list = pd.read_csv(
         maintained_schools_data_path,
         encoding="unicode-escape",
+        # TODO: explicit schema as per below?
+        # index_col=input_schemas.maintained_schools_master_list_index_col,
+        # dtype=input_schemas.maintained_schools_master_list,
         usecols=input_schemas.maintained_schools_master_list.keys(),
     )
 

--- a/data-pipeline/tests/unit/pre_processing/conftest.py
+++ b/data-pipeline/tests/unit/pre_processing/conftest.py
@@ -689,7 +689,7 @@ def maintained_schools_master_list():
         {
             "URN": [100150, 100152, 100153, 100154],
             "School Name": ["A", "B", "C", "D"],
-            "LAEstab": [20136154, 2026005, 2026006, 2026007],
+            "LAEstab": ["20136154", "2026005", "2026006", "2026007"],
             "Phase": [
                 "Infant and junior",
                 "Infant and junior",
@@ -705,8 +705,8 @@ def maintained_schools_master_list():
             ],
             "Period covered by return (months)": [11, 18, 4, 11],
             "Did Not Supply flag": [0, 0, 1, 0],
-            "Federation": ["No", "Lead School", "No", "Yes"],
-            "Lead school in federation": [20136154, 0, 0, 20136154],
+            "Federation": ["Lead School", "No", "Yes", "No"],
+            "Lead school in federation": ["20136154", "0", "20136154", "0"],
             "Urban  Rural": [
                 "Urban major conurbation",
                 "Urban major conurbation",

--- a/pipelines/common/validate-branch.yaml
+++ b/pipelines/common/validate-branch.yaml
@@ -23,7 +23,7 @@ parameters:
 steps:
   - bash: |
       branchName="${{ parameters.branchName }}"
-      regex="refs\/heads\/main$|refs\/heads\/(feature|bugfix|hotfix|exp|tech-debt|doc|prototype)\/(\d+\/){0,1}[a-z0-9-]+"
+      regex="(refs\/heads\/)?main$|(refs\/heads\/)?(feature|bugfix|hotfix|exp|tech-debt|doc|prototype)\/(\d+\/){0,1}[a-z0-9-]+"
       if echo "$branchName" | sed -En "/$regex/p" | grep -q .; then
         echo "$branchName is a valid branch"
       else

--- a/pipelines/common/vars.yaml
+++ b/pipelines/common/vars.yaml
@@ -31,7 +31,7 @@ variables:
   - name: Version.BuildVersion
     value: $(Version.BuildNumber)
   - name: SourceBranch
-    ${{ if ne(variables['System.PullRequest.SourceBranch'], '') }}:
+    ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
       value: $(System.PullRequest.SourceBranch)
     ${{ else }}:
       value: $(Build.SourceBranch)


### PR DESCRIPTION
### Context

Financial data for lead-schools are submitted as the aggregate of all schools in the Federation. Metrics (e.g. pupil numbers) are not, however. Lead-school metrics should therefore reflect the aggregated values across all Federation members.

[AB#234742](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/234742)

### Change proposed in this pull request

- extend the recently-added Federation logic to aggregate require metrics based on the `Lead school in federation` value.
- update the existing Maintained School data with these aggregate values.

### Guidance to review 

WIP at the moment; needs testing.

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [ ] You have tested by running locally
- [ ] You have reviewed with UX/Design

