### PR TITLE
fix: correct Federation-aggregation logic

### DIFF
--- a/data-pipeline/src/pipeline/maintained_schools.py
+++ b/data-pipeline/src/pipeline/maintained_schools.py
@@ -219,13 +219,11 @@ def _federation_lead_school_agg(df: pd.DataFrame) -> pd.DataFrame:
         lead_schools_agg["_Number of pupils SEN"] / lead_schools_agg["Number of pupils"]
     ) * 100.0
 
-    return (
-        lead_schools_agg.drop(
-            columns=[
-                "_Number of pupils FSM",
-                "_Number of pupils SEN",
-            ]
-        )
+    return lead_schools_agg.drop(
+        columns=[
+            "_Number of pupils FSM",
+            "_Number of pupils SEN",
+        ]
     )
 
 
@@ -262,7 +260,7 @@ def join_federations(df: pd.DataFrame) -> pd.DataFrame:
     lead_schools_agg = _federation_lead_school_agg(df)
 
     return (
-        lead_schools_agg.combine_first(df.set_index("Federation LAEstab"))
+        lead_schools_agg.combine_first(df.set_index("LAEstab"))
         .sort_values("URN")
         .reset_index()
     )


### PR DESCRIPTION
### Context

incorrectly joining on `Federation LAEstab`, leading to aggregation for Federation members as well as leads.

[AB#234742](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/234742)

### Change proposed in this pull request

- join the aggregated data on `LAEstab`, not `Federation LEAstab`
- add a test to validate that non-lead-schools are unaffected

### Guidance to review 

Needs validating in a local run of the pipeline (and I'm having issues with Storage Explorer).

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [ ] You have tested by running locally
- [ ] You have reviewed with UX/Design

