### PR TITLE
Split default/custom Container Apps.

### DIFF
--- a/core-infrastructure/terraform/storage.tf
+++ b/core-infrastructure/terraform/storage.tf
@@ -57,6 +57,16 @@ resource "azurerm_storage_queue" "pipeline-message-start-queue" {
   storage_account_name = azurerm_storage_account.data.name
 }
 
+resource "azurerm_storage_queue" "pipeline-message-default-start-queue" {
+  name                 = "data-pipeline-job-default-start"
+  storage_account_name = azurerm_storage_account.data.name
+}
+
+resource "azurerm_storage_queue" "pipeline-message-custom-start-queue" {
+  name                 = "data-pipeline-job-custom-start"
+  storage_account_name = azurerm_storage_account.data.name
+}
+
 resource "azurerm_storage_queue" "pipeline-message-finished-queue" {
   name                 = "data-pipeline-job-finished"
   storage_account_name = azurerm_storage_account.data.name

--- a/data-pipeline/terraform/container_app/data.tf
+++ b/data-pipeline/terraform/container_app/data.tf
@@ -1,0 +1,29 @@
+data "azurerm_container_registry" "acr" {
+  name                = var.registry-name
+  resource_group_name = var.resource-group-name
+}
+
+data "azurerm_key_vault" "key-vault" {
+  name                = var.key-vault-name
+  resource_group_name = var.resource-group-name
+}
+
+data "azurerm_key_vault_secret" "core-db-domain-name" {
+  name         = var.core-db-domain-name-secret-name
+  key_vault_id = data.azurerm_key_vault.key-vault.id
+}
+
+data "azurerm_key_vault_secret" "core-db-name" {
+  name         = var.core-db-name-secret-name
+  key_vault_id = data.azurerm_key_vault.key-vault.id
+}
+
+data "azurerm_key_vault_secret" "core-db-user-name" {
+  name         = var.core-db-user-name-secret-name
+  key_vault_id = data.azurerm_key_vault.key-vault.id
+}
+
+data "azurerm_key_vault_secret" "core-db-password" {
+  name         = var.core-db-password-secret-name
+  key_vault_id = data.azurerm_key_vault.key-vault.id
+}

--- a/data-pipeline/terraform/container_app/data.tf
+++ b/data-pipeline/terraform/container_app/data.tf
@@ -3,6 +3,11 @@ data "azurerm_container_registry" "acr" {
   resource_group_name = var.resource-group-name
 }
 
+data "azurerm_storage_account" "main" {
+  name                = var.storage-account-name
+  resource_group_name = var.resource-group-name
+}
+
 data "azurerm_key_vault" "key-vault" {
   name                = var.key-vault-name
   resource_group_name = var.resource-group-name

--- a/data-pipeline/terraform/container_app/main.tf
+++ b/data-pipeline/terraform/container_app/main.tf
@@ -32,7 +32,7 @@ resource "azurerm_container_app" "data-pipeline" {
 
   template {
     min_replicas    = 0
-    max_replicas    = var.environment == "development" ? 1 : 10
+    max_replicas    = var.max-replicas
     revision_suffix = replace(split(":", var.image-name)[1], ".", "-")
     container {
       name   = "edis-data-pipeline"

--- a/data-pipeline/terraform/container_app/main.tf
+++ b/data-pipeline/terraform/container_app/main.tf
@@ -11,7 +11,7 @@ resource "azurerm_container_app" "data-pipeline" {
 
   secret {
     name  = "queue-connection-string"
-    value = var.queue-connection-string
+    value = data.azurerm_storage_account.main.primary_connection_string
   }
 
   secret {

--- a/data-pipeline/terraform/container_app/main.tf
+++ b/data-pipeline/terraform/container_app/main.tf
@@ -1,0 +1,116 @@
+resource "azurerm_container_app" "data-pipeline" {
+  name                         = "${var.environment-prefix}-ebis-data-pipeline"
+  container_app_environment_id = var.container-app-environment-id
+  resource_group_name          = var.resource-group-name
+  revision_mode                = "Single"
+  workload_profile_name        = "Pipeline"
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  secret {
+    name  = "queue-connection-string"
+    value = var.queue-connection-string
+  }
+
+  secret {
+    name  = "db-password"
+    value = data.azurerm_key_vault_secret.core-db-password.value
+  }
+
+  secret {
+    name  = "registry-password"
+    value = data.azurerm_container_registry.acr.admin_password
+  }
+
+  registry {
+    server               = data.azurerm_container_registry.acr.login_server
+    username             = data.azurerm_container_registry.acr.admin_username
+    password_secret_name = "registry-password"
+  }
+
+  template {
+    min_replicas    = 0
+    max_replicas    = var.environment == "development" ? 1 : 10
+    revision_suffix = replace(split(":", var.image-name)[1], ".", "-")
+    container {
+      name   = "edis-data-pipeline"
+      image  = var.image-name
+      cpu    = 4
+      memory = "16Gi"
+
+      env {
+        name  = "WORKER_QUEUE_NAME"
+        value = var.worker-queue-name
+      }
+
+      env {
+        name  = "COMPLETE_QUEUE_NAME"
+        value = "data-pipeline-job-finished"
+      }
+
+      env {
+        name  = "DEAD_LETTER_QUEUE_NAME"
+        value = "data-pipeline-job-dlq"
+      }
+
+      env {
+        name  = "DEAD_LETTER_QUEUE_DEQUEUE_MAX"
+        value = "5"
+      }
+
+      env {
+        name  = "RAW_DATA_CONTAINER"
+        value = "raw"
+      }
+
+      env {
+        name        = "STORAGE_CONNECTION_STRING"
+        secret_name = "queue-connection-string"
+      }
+
+      env {
+        name        = "DB_PWD"
+        secret_name = "db-password"
+      }
+
+      env {
+        name  = "DB_HOST"
+        value = data.azurerm_key_vault_secret.core-db-domain-name.value
+      }
+
+      env {
+        name  = "DB_NAME"
+        value = data.azurerm_key_vault_secret.core-db-name.value
+      }
+
+      env {
+        name  = "DB_PORT"
+        value = "1433"
+      }
+
+      env {
+        name  = "DB_USER"
+        value = data.azurerm_key_vault_secret.core-db-user-name.value
+      }
+
+      env {
+        name  = "DB_ARGS"
+        value = "Encrypt=no;TrustServerCertificate=no;Connection Timeout=30"
+      }
+    }
+
+    azure_queue_scale_rule {
+      name         = "${var.environment-prefix}-data-pipeline-scaler"
+      queue_name   = var.worker-queue-name
+      queue_length = 1
+      authentication {
+        secret_name       = "queue-connection-string"
+        trigger_parameter = "connection"
+      }
+    }
+  }
+
+  tags = var.common-tags
+}

--- a/data-pipeline/terraform/container_app/variables.tf
+++ b/data-pipeline/terraform/container_app/variables.tf
@@ -1,0 +1,72 @@
+variable "common-tags" {
+  description = "Tags to be applied to all resources."
+  type        = map(string)
+}
+
+variable "image-name" {
+  description = "Container image to be used for each worker."
+  type        = string
+}
+
+variable "environment" {
+  description = "Descriptor for the current environment (e.g. 'development')."
+  type        = string
+}
+
+variable "environment-prefix" {
+  description = "Prefix to be used for resources in the current environment."
+  type        = string
+}
+
+variable "worker-queue-name" {
+  description = "Name of the queue which will trigger the worker."
+  type        = string
+}
+
+variable "container-app-environment-id" {
+  description = "Container App Environment ID"
+  type        = string
+}
+
+variable "resource-group-name" {
+  description = "Name of the Azure Resource group in which resources are to be created."
+  type        = string
+}
+
+variable "queue-connection-string" {
+  description = "Connection string for the Azure Storage Account."
+  type        = string
+}
+
+variable "registry-name" {
+  description = "Azure Container Registry name."
+  type        = string
+}
+
+variable "key-vault-name" {
+  description = "Azure Key Vault name."
+  type        = string
+}
+
+variable "core-db-domain-name-secret-name" {
+  description = "Name of the Azure Key Vault Secret for the DB host."
+  type        = string
+  default     = "core-sql-domain-name"
+}
+variable "core-db-name-secret-name" {
+  description = "Name of the Azure Key Vault Secret for the DB name."
+  type        = string
+  default     = "core-sql-db-name"
+}
+
+variable "core-db-user-name-secret-name" {
+  description = "Name of the Azure Key Vault Secret for the DB username."
+  type        = string
+  default     = "core-sql-user-name"
+}
+
+variable "core-db-password-secret-name" {
+  description = "Name of the Azure Key Vault Secret for the DB password."
+  type        = string
+  default     = "core-sql-password"
+}

--- a/data-pipeline/terraform/container_app/variables.tf
+++ b/data-pipeline/terraform/container_app/variables.tf
@@ -8,11 +8,6 @@ variable "image-name" {
   type        = string
 }
 
-variable "environment" {
-  description = "Descriptor for the current environment (e.g. 'development')."
-  type        = string
-}
-
 variable "environment-prefix" {
   description = "Prefix to be used for resources in the current environment."
   type        = string
@@ -69,4 +64,9 @@ variable "core-db-password-secret-name" {
   description = "Name of the Azure Key Vault Secret for the DB password."
   type        = string
   default     = "core-sql-password"
+}
+
+variable "max-replicas" {
+  description = "The max. number of Container App replicas to launch."
+  type        = number
 }

--- a/data-pipeline/terraform/container_app/variables.tf
+++ b/data-pipeline/terraform/container_app/variables.tf
@@ -28,13 +28,13 @@ variable "resource-group-name" {
   type        = string
 }
 
-variable "queue-connection-string" {
-  description = "Connection string for the Azure Storage Account."
+variable "registry-name" {
+  description = "Azure Container Registry name."
   type        = string
 }
 
-variable "registry-name" {
-  description = "Azure Container Registry name."
+variable "storage-account-name" {
+  description = "Azure Storage Account name."
   type        = string
 }
 

--- a/data-pipeline/terraform/container_apps.tf
+++ b/data-pipeline/terraform/container_apps.tf
@@ -14,21 +14,6 @@ resource "azurerm_container_app_environment" "main" {
   tags = local.common-tags
 }
 
-# resource "azurerm_user_assigned_identity" "container-app" {
-#   location            = azurerm_resource_group.resource-group.location
-#   name                = "${var.environment-prefix}containerappmi"
-#   resource_group_name = azurerm_resource_group.resource-group.name
-# }
-#
-# resource "azurerm_role_assignment" "container-app" {
-#   scope                = data.azurerm_container_registry.acr.id
-#   role_definition_name = "acrpull"
-#   principal_id         = azurerm_user_assigned_identity.container-app.principal_id
-#   depends_on = [
-#     azurerm_user_assigned_identity.container-app
-#   ]
-# }
-
 resource "azurerm_container_app" "data-pipeline" {
   name                         = "${var.environment-prefix}-ebis-data-pipeline"
   container_app_environment_id = azurerm_container_app_environment.main.id
@@ -38,7 +23,6 @@ resource "azurerm_container_app" "data-pipeline" {
 
   identity {
     type = "SystemAssigned"
-    #     identity_ids = [azurerm_user_assigned_identity.container-app.id]
   }
 
   secret {
@@ -60,7 +44,6 @@ resource "azurerm_container_app" "data-pipeline" {
     server               = data.azurerm_container_registry.acr.login_server
     username             = data.azurerm_container_registry.acr.admin_username
     password_secret_name = "registry-password"
-    #     identity = azurerm_user_assigned_identity.container-app.id
   }
 
   template {

--- a/data-pipeline/terraform/container_apps.tf
+++ b/data-pipeline/terraform/container_apps.tf
@@ -23,13 +23,13 @@ module "container_app_default" {
   registry-name = "${var.environment-prefix}acr"
   image-name    = var.image-name
 
-  environment        = var.environment
   environment-prefix = var.environment-prefix
 
   key-vault-name = "${var.environment-prefix}-ebis-keyvault"
 
   queue-connection-string = data.azurerm_storage_account.main.primary_connection_string
   worker-queue-name       = "data-pipeline-job-default-start"
+  max-replicas            = 1
 
   common-tags = local.common-tags
 }
@@ -43,13 +43,13 @@ module "container_app_custom" {
   registry-name = "${var.environment-prefix}acr"
   image-name    = var.image-name
 
-  environment        = var.environment
   environment-prefix = var.environment-prefix
 
   key-vault-name = "${var.environment-prefix}-ebis-keyvault"
 
   queue-connection-string = data.azurerm_storage_account.main.primary_connection_string
   worker-queue-name       = "data-pipeline-job-custom-start"
+  max-replicas            = var.environment == "development" ? 1 : 10
 
   common-tags = local.common-tags
 }

--- a/data-pipeline/terraform/container_apps.tf
+++ b/data-pipeline/terraform/container_apps.tf
@@ -23,13 +23,14 @@ module "container_app_default" {
   registry-name = "${var.environment-prefix}acr"
   image-name    = var.image-name
 
+  storage-account-name = "${var.environment-prefix}-ebis-core"
+
   environment-prefix = var.environment-prefix
 
   key-vault-name = "${var.environment-prefix}-ebis-keyvault"
 
-  queue-connection-string = data.azurerm_storage_account.main.primary_connection_string
-  worker-queue-name       = "data-pipeline-job-default-start"
-  max-replicas            = 1
+  worker-queue-name = "data-pipeline-job-default-start"
+  max-replicas      = 1
 
   common-tags = local.common-tags
 }
@@ -43,13 +44,14 @@ module "container_app_custom" {
   registry-name = "${var.environment-prefix}acr"
   image-name    = var.image-name
 
+  storage-account-name = "${var.environment-prefix}-ebis-core"
+
   environment-prefix = var.environment-prefix
 
   key-vault-name = "${var.environment-prefix}-ebis-keyvault"
 
-  queue-connection-string = data.azurerm_storage_account.main.primary_connection_string
-  worker-queue-name       = "data-pipeline-job-custom-start"
-  max-replicas            = var.environment == "development" ? 1 : 10
+  worker-queue-name = "data-pipeline-job-custom-start"
+  max-replicas      = var.environment == "development" ? 1 : 10
 
   common-tags = local.common-tags
 }

--- a/data-pipeline/terraform/data.tf
+++ b/data-pipeline/terraform/data.tf
@@ -1,8 +1,3 @@
-data "azurerm_key_vault" "key-vault" {
-  name                = "${var.environment-prefix}-ebis-keyvault"
-  resource_group_name = "${var.environment-prefix}-ebis-core"
-}
-
 data "azurerm_application_insights" "application-insights" {
   name                = "${var.environment-prefix}-ebis-ai"
   resource_group_name = "${var.environment-prefix}-ebis-core"
@@ -13,32 +8,7 @@ data "azurerm_log_analytics_workspace" "application-insights-workspace" {
   resource_group_name = "${var.environment-prefix}-ebis-core"
 }
 
-data "azurerm_container_registry" "acr" {
-  name                = "${var.environment-prefix}acr"
-  resource_group_name = "${var.environment-prefix}-ebis-core"
-}
-
 data "azurerm_storage_account" "main" {
   name                = "${var.environment-prefix}data"
   resource_group_name = "${var.environment-prefix}-ebis-core"
-}
-
-data "azurerm_key_vault_secret" "core-db-domain-name" {
-  name         = "core-sql-domain-name"
-  key_vault_id = data.azurerm_key_vault.key-vault.id
-}
-
-data "azurerm_key_vault_secret" "core-db-name" {
-  name         = "core-sql-db-name"
-  key_vault_id = data.azurerm_key_vault.key-vault.id
-}
-
-data "azurerm_key_vault_secret" "core-db-user-name" {
-  name         = "core-sql-user-name"
-  key_vault_id = data.azurerm_key_vault.key-vault.id
-}
-
-data "azurerm_key_vault_secret" "core-db-password" {
-  name         = "core-sql-password"
-  key_vault_id = data.azurerm_key_vault.key-vault.id
 }

--- a/data-pipeline/terraform/data.tf
+++ b/data-pipeline/terraform/data.tf
@@ -7,8 +7,3 @@ data "azurerm_log_analytics_workspace" "application-insights-workspace" {
   name                = "${var.environment-prefix}-ebis-aiw"
   resource_group_name = "${var.environment-prefix}-ebis-core"
 }
-
-data "azurerm_storage_account" "main" {
-  name                = "${var.environment-prefix}data"
-  resource_group_name = "${var.environment-prefix}-ebis-core"
-}

--- a/platform/terraform/functions.tf
+++ b/platform/terraform/functions.tf
@@ -124,7 +124,7 @@ module "orchestrator-fa" {
   app-settings = merge(local.default_app_settings, {
     "PipelineMessageHub__ConnectionString" = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.pipeline-message-hub-storage-connection-string.versionless_id})"
     "PipelineMessageHub__JobFinishedQueue" = "data-pipeline-job-finished"
-    "PipelineMessageHub__JobStartQueue"    = "data-pipeline-job-start"
+    "PipelineMessageHub__JobStartQueue"    = "data-pipeline-job-custom-start"
     "PipelineMessageHub__JobPendingQueue"  = "data-pipeline-job-pending"
     "Sql__ConnectionString"                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.core-sql-connection-string.versionless_id})"
   })


### PR DESCRIPTION
### Context

The current `data-pipeline-job-start` queue will instead be split into `data-pipeline-job-custom-start` and `data-pipeline-job-default-start` queues, each serviced by a distinct Container App.

[AB#235428](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/235428)

### Change proposed in this pull request

- add the new queues
- refactor the existing `container_apps.tf` into a Terraform module
  - call this module twice, once for `default` and once for `custom` apps.

### Guidance to review 

WIP

### Checklist (add/remove as appropriate)

- [ ] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally
- [ ] You have reviewed with UX/Design

