### PR TITLE
fix: remove "Direct revenue financing"

### DIFF
--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -192,7 +192,6 @@ def pre_process_academies_data(run_type, year, data_ref) -> pd.DataFrame:
     schools, census, sen, cdc, aar, ks2, ks4, cfo, central_services = data_ref
 
     academies = build_academy_data(
-        year,
         schools,
         census,
         sen,

--- a/data-pipeline/src/pipeline/pre_processing.py
+++ b/data-pipeline/src/pipeline/pre_processing.py
@@ -365,9 +365,6 @@ def prepare_central_services_data(cs_path, current_year: int):
         + central_services_financial["BNCH21703 (Auditor costs)"]
         + central_services_financial["BNCH21801 (Interest charges for Loan and bank)"]
         + central_services_financial["BNCH21802 (PFI Charges)"]
-        - central_services_financial[
-            "BNCH21707 (Direct revenue financing (Revenue contributions to capital))"
-        ]
     )
 
     central_services_financial["Total Income"] = (

--- a/data-pipeline/src/pipeline/pre_processing.py
+++ b/data-pipeline/src/pipeline/pre_processing.py
@@ -510,7 +510,6 @@ def prepare_aar_data(aar_path, current_year: int):
         + aar["BNCH21703 (Auditor costs)"]
         + aar["BNCH21801 (Interest charges for Loan and bank)"]
         + aar["BNCH21802 (PFI Charges)"]
-        - aar["BNCH21707 (Direct revenue financing (Revenue contributions to capital))"]
     )
 
     aar["Total Income"] = (
@@ -750,7 +749,6 @@ def _trust_revenue_reserve(
 
 
 def build_academy_data(
-    year,
     schools,
     census,
     sen,

--- a/data-pipeline/tests/unit/pre_processing/test_aar.py
+++ b/data-pipeline/tests/unit/pre_processing/test_aar.py
@@ -86,7 +86,7 @@ def test_aar_data_has_correct_output_columns(prepared_aar_data: pd.DataFrame):
 
 
 def test_aar_balance_aggregated_at_trust_level(prepared_aar_data: pd.DataFrame):
-    assert prepared_aar_data["Trust Balance"].loc[100150] == -45075.0
+    assert prepared_aar_data["Trust Balance"].loc[100150] == -48080.0
 
 
 def test_aar_academy_financial_position(prepared_aar_data: pd.DataFrame):
@@ -94,7 +94,7 @@ def test_aar_academy_financial_position(prepared_aar_data: pd.DataFrame):
 
 
 def test_aar_academy_financial_in_year_balance(prepared_aar_data: pd.DataFrame):
-    assert prepared_aar_data["In year balance"].loc[100153] == -15030.0
+    assert prepared_aar_data["In year balance"].loc[100153] == -16032.0
 
 
 def test_aar_academy_financial_position_deficit(prepared_aar_data: pd.DataFrame):


### PR DESCRIPTION
### Context

See ticket for details: `Direct revenue financing (Revenue contributions to capital)` shouldn't be part of the `Total Expenditure` calculation for Academies (inc. Central Services).

[AB#235396](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/235396)

### Change proposed in this pull request

deduction of `Direct revenue financing (Revenue contributions to capital)` removed from `Total Expenditure` from both AAR and Central Services data.

### Guidance to review

N/A

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] You have reviewed with UX/Design

