### PR TITLE
Bumped `azapi` and `azurerm` Terraform providers in Core

### DIFF
--- a/core-infrastructure/terraform/README.md
+++ b/core-infrastructure/terraform/README.md
@@ -3,18 +3,18 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | 1.15.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.8 |
+| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | ~> 2.0.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.8.0 |
 | <a name="requirement_mssql"></a> [mssql](#requirement\_mssql) | 0.3.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azapi"></a> [azapi](#provider\_azapi) | 1.15.0 |
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.53.1 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.3.0 |
+| <a name="provider_azapi"></a> [azapi](#provider\_azapi) | 2.0.1 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.0.2 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.8.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | 2.5.2 |
 | <a name="provider_mssql"></a> [mssql](#provider\_mssql) | 0.3.1 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
@@ -27,7 +27,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azapi_resource_action.sql-server-auto-tuning](https://registry.terraform.io/providers/azure/azapi/1.15.0/docs/resources/resource_action) | resource |
+| [azapi_resource_action.sql-server-auto-tuning](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource_action) | resource |
 | [azurerm_application_insights.application-insights](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights) | resource |
 | [azurerm_automation_account.automation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_account) | resource |
 | [azurerm_automation_job_schedule.backup-database-runbook-daily-schedule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_job_schedule) | resource |

--- a/core-infrastructure/terraform/databases.tf
+++ b/core-infrastructure/terraform/databases.tf
@@ -256,7 +256,7 @@ resource "azapi_resource_action" "sql-server-auto-tuning" {
   resource_id = "${azurerm_mssql_server.sql-server.id}/automaticTuning/current"
   type        = "Microsoft.Sql/servers/automaticTuning@2021-11-01"
   method      = "PATCH"
-  body = jsonencode({
+  body = {
     properties = {
       desiredState = "Auto"
       options = {
@@ -266,7 +266,7 @@ resource "azapi_resource_action" "sql-server-auto-tuning" {
         dropIndex         = { desiredState = "On" }
       }
     }
-  })
+  }
   depends_on = [azurerm_mssql_database.sql-db]
 }
 

--- a/core-infrastructure/terraform/provider.tf
+++ b/core-infrastructure/terraform/provider.tf
@@ -1,13 +1,13 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.9.8"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.3.0"
+      version = "~> 4.8.0"
     }
     azapi = {
       source  = "azure/azapi"
-      version = "1.15.0"
+      version = "~> 2.0.1"
     }
     mssql = {
       source  = "betr-io/mssql"

--- a/pipelines/common/destroy-terraform.yaml
+++ b/pipelines/common/destroy-terraform.yaml
@@ -35,12 +35,12 @@ steps:
       TerraformDirectory: ${{ parameters.workspaceDir }}
       DisablePreventDestroy: true
 
-  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-installer.TerraformInstaller@0
+  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-installer.TerraformInstaller@1
     displayName: 'Install terraform'
     inputs:
-      terraformVersion: 1.9.0
+      terraformVersion: 1.9.8
 
-  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@1
     displayName: 'Initialise terraform'
     inputs:
       command: init
@@ -54,7 +54,7 @@ steps:
       backendAzureRmKey: education-benchmarking-${{ parameters.module }}.tfstate
       backendAzureRmResourceGroupLocation: ${{ parameters.location }}
 
-  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@1
     displayName: 'Destroy infrastructure'
     inputs:
       command: destroy

--- a/pipelines/common/fmt-validate-terraform.yaml
+++ b/pipelines/common/fmt-validate-terraform.yaml
@@ -2,26 +2,26 @@ parameters:
   TerraformDirectory: ''
 
 steps:
-  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-installer.TerraformInstaller@0
+  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-installer.TerraformInstaller@1
     displayName: 'Install terraform'
     inputs:
-      terraformVersion: 1.9.0
+      terraformVersion: 1.9.8
 
-  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@1
     displayName: 'Run terraform format'
     inputs:
       command: fmt
       commandOptions: '-recursive -check'
       workingDirectory: '${{ parameters.TerraformDirectory }}'
 
-  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@1
     displayName: 'Initialise terraform'
     inputs:
       command: init
       commandOptions: '-backend=false'
       workingDirectory: '${{ parameters.TerraformDirectory }}'
 
-  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@1
     displayName: 'Run terraform validate'
     inputs:
       command: validate

--- a/pipelines/common/run-terraform.yaml
+++ b/pipelines/common/run-terraform.yaml
@@ -51,12 +51,12 @@ steps:
       escape: off
       tokenPattern: doubleunderscores
 
-  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-installer.TerraformInstaller@0
+  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-installer.TerraformInstaller@1
     displayName: 'Install terraform'
     inputs:
-      terraformVersion: 1.9.0
+      terraformVersion: 1.9.8
 
-  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@1
     displayName: 'Initialise terraform'
     inputs:
       command: init
@@ -70,7 +70,7 @@ steps:
       backendAzureRmKey: education-benchmarking-${{ parameters.module }}.tfstate
       backendAzureRmResourceGroupLocation: ${{ parameters.location }}
 
-  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@1
     displayName: 'Run terraform plan'
     inputs:
       command: plan
@@ -86,7 +86,7 @@ steps:
       publishPlanResults: '${{ parameters.environmentPrefix }}-${{ parameters.module }}-plan'
       backendAzureRmResourceGroupLocation: ${{ parameters.location }}
 
-  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@1
     displayName: 'Run terraform apply'
     condition: and(succeeded(), ne('${{ parameters.planOnly }}', 'true'))
     inputs:

--- a/pipelines/common/sync-terraform.yaml
+++ b/pipelines/common/sync-terraform.yaml
@@ -44,13 +44,13 @@ steps:
       escape: off
       tokenPattern: doubleunderscores
 
-  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-installer.TerraformInstaller@0
+  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-installer.TerraformInstaller@1
     condition: and(succeeded(), ne(variables['SkipSync'], 'true'))
     displayName: 'Install terraform'
     inputs:
-      terraformVersion: 1.9.0
+      terraformVersion: 1.9.8
 
-  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@1
     condition: and(succeeded(), ne(variables['SkipSync'], 'true'))
     displayName: 'Initialise terraform'
     inputs:
@@ -65,7 +65,7 @@ steps:
       backendAzureRmKey: education-benchmarking-${{ parameters.module }}.tfstate
       backendAzureRmResourceGroupLocation: ${{ parameters.location }}
 
-  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@1
     condition: and(succeeded(), ne(variables['SkipSync'], 'true'))
     displayName: 'Run terraform plan'
     inputs:
@@ -82,7 +82,7 @@ steps:
       publishPlanResults: '${{ parameters.environmentPrefix }}-${{ parameters.module }}-plan'
       backendAzureRmResourceGroupLocation: ${{ parameters.location }}
 
-  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+  - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@1
     condition: and(succeeded(), ne(variables['SkipSync'], 'true'))
     displayName: 'Run terraform apply'
     inputs:


### PR DESCRIPTION
### Context
[AB#235615](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/235615) [AB#235614](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/235614)

### Change proposed in this pull request
Bumped Terraform providers in Core. `azure/azapi` v2.0 is a major update with some [breaking changes](https://registry.terraform.io/providers/Azure/azapi/latest/docs/guides/2.0-upgrade-guide#breaking-changes).

### Guidance to review 
This requires latest Terraform to be installed to prevent `This configuration does not support Terraform version XXX` error.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [ ] ~~You have tested by running locally~~
- [ ] ~~You have reviewed with UX/Design~~

