### PR TITLE
fix: correct resource groups

### DIFF
--- a/data-pipeline/terraform/README.md
+++ b/data-pipeline/terraform/README.md
@@ -10,28 +10,23 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.3.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.3.0 |
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_container_app_custom"></a> [container\_app\_custom](#module\_container\_app\_custom) | ./container_app | n/a |
+| <a name="module_container_app_default"></a> [container\_app\_default](#module\_container\_app\_default) | ./container_app | n/a |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [azurerm_container_app.data-pipeline](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_app) | resource |
 | [azurerm_container_app_environment.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_app_environment) | resource |
 | [azurerm_resource_group.resource-group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_application_insights.application-insights](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/application_insights) | data source |
-| [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/container_registry) | data source |
-| [azurerm_key_vault.key-vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
-| [azurerm_key_vault_secret.core-db-domain-name](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
-| [azurerm_key_vault_secret.core-db-name](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
-| [azurerm_key_vault_secret.core-db-password](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
-| [azurerm_key_vault_secret.core-db-user-name](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_log_analytics_workspace.application-insights-workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |
-| [azurerm_storage_account.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 
 ## Inputs
 

--- a/data-pipeline/terraform/container_app/README.md
+++ b/data-pipeline/terraform/container_app/README.md
@@ -1,0 +1,52 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.7.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_container_app.data-pipeline](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_app) | resource |
+| [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/container_registry) | data source |
+| [azurerm_key_vault.key-vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
+| [azurerm_key_vault_secret.core-db-domain-name](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_key_vault_secret.core-db-name](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_key_vault_secret.core-db-password](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_key_vault_secret.core-db-user-name](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_storage_account.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_common-tags"></a> [common-tags](#input\_common-tags) | Tags to be applied to all resources. | `map(string)` | n/a | yes |
+| <a name="input_container-app-environment-id"></a> [container-app-environment-id](#input\_container-app-environment-id) | Container App Environment ID | `string` | n/a | yes |
+| <a name="input_container-app-resource-group-name"></a> [container-app-resource-group-name](#input\_container-app-resource-group-name) | Name of the Azure Resource group in which Container App resources are to be created. | `string` | n/a | yes |
+| <a name="input_core-db-domain-name-secret-name"></a> [core-db-domain-name-secret-name](#input\_core-db-domain-name-secret-name) | Name of the Azure Key Vault Secret for the DB host. | `string` | `"core-sql-domain-name"` | no |
+| <a name="input_core-db-name-secret-name"></a> [core-db-name-secret-name](#input\_core-db-name-secret-name) | Name of the Azure Key Vault Secret for the DB name. | `string` | `"core-sql-db-name"` | no |
+| <a name="input_core-db-password-secret-name"></a> [core-db-password-secret-name](#input\_core-db-password-secret-name) | Name of the Azure Key Vault Secret for the DB password. | `string` | `"core-sql-password"` | no |
+| <a name="input_core-db-user-name-secret-name"></a> [core-db-user-name-secret-name](#input\_core-db-user-name-secret-name) | Name of the Azure Key Vault Secret for the DB username. | `string` | `"core-sql-user-name"` | no |
+| <a name="input_environment-prefix"></a> [environment-prefix](#input\_environment-prefix) | Prefix to be used for resources in the current environment. | `string` | n/a | yes |
+| <a name="input_image-name"></a> [image-name](#input\_image-name) | Container image to be used for each worker. | `string` | n/a | yes |
+| <a name="input_key-vault-name"></a> [key-vault-name](#input\_key-vault-name) | Azure Key Vault name. | `string` | n/a | yes |
+| <a name="input_max-replicas"></a> [max-replicas](#input\_max-replicas) | The max. number of Container App replicas to launch. | `number` | n/a | yes |
+| <a name="input_registry-name"></a> [registry-name](#input\_registry-name) | Azure Container Registry name. | `string` | n/a | yes |
+| <a name="input_resource-group-name"></a> [resource-group-name](#input\_resource-group-name) | Name of the Azure Resource group in which various resources are to be created. | `string` | n/a | yes |
+| <a name="input_storage-account-name"></a> [storage-account-name](#input\_storage-account-name) | Azure Storage Account name. | `string` | n/a | yes |
+| <a name="input_worker-queue-name"></a> [worker-queue-name](#input\_worker-queue-name) | Name of the queue which will trigger the worker. | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/data-pipeline/terraform/container_app/variables.tf
+++ b/data-pipeline/terraform/container_app/variables.tf
@@ -23,8 +23,13 @@ variable "container-app-environment-id" {
   type        = string
 }
 
+variable "container-app-resource-group-name" {
+  description = "Name of the Azure Resource group in which Container App resources are to be created."
+  type        = string
+}
+
 variable "resource-group-name" {
-  description = "Name of the Azure Resource group in which resources are to be created."
+  description = "Name of the Azure Resource group in which various resources are to be created."
   type        = string
 }
 

--- a/data-pipeline/terraform/container_apps.tf
+++ b/data-pipeline/terraform/container_apps.tf
@@ -17,13 +17,15 @@ resource "azurerm_container_app_environment" "main" {
 module "container_app_default" {
   source = "./container_app"
 
-  container-app-environment-id = azurerm_container_app_environment.main.id
-  resource-group-name          = azurerm_resource_group.resource-group.name
+  container-app-environment-id      = azurerm_container_app_environment.main.id
+  container-app-resource-group-name = azurerm_resource_group.resource-group.name
+
+  resource-group-name = "${var.environment-prefix}-ebis-core"
 
   registry-name = "${var.environment-prefix}acr"
   image-name    = var.image-name
 
-  storage-account-name = "${var.environment-prefix}-ebis-core"
+  storage-account-name = "${var.environment-prefix}data"
 
   environment-prefix = var.environment-prefix
 
@@ -38,13 +40,15 @@ module "container_app_default" {
 module "container_app_custom" {
   source = "./container_app"
 
-  container-app-environment-id = azurerm_container_app_environment.main.id
-  resource-group-name          = azurerm_resource_group.resource-group.name
+  container-app-environment-id      = azurerm_container_app_environment.main.id
+  container-app-resource-group-name = azurerm_resource_group.resource-group.name
+
+  resource-group-name = "${var.environment-prefix}-ebis-core"
 
   registry-name = "${var.environment-prefix}acr"
   image-name    = var.image-name
 
-  storage-account-name = "${var.environment-prefix}-ebis-core"
+  storage-account-name = "${var.environment-prefix}data"
 
   environment-prefix = var.environment-prefix
 


### PR DESCRIPTION
### Context

Incorrect Resource Group passed to Storage Account/Registry.

Also updated the existing README and added one for the new module.

[AB#235428](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/235428)

### Change proposed in this pull request

Pass a distinct Resource Group name for the Container Apps (as multiple resource types use the `*-ebis-core` name).

### Guidance to review 

Definitely needs sanity-checking; I've reviewed the changes and values from the existing infra. but definitely needs another pair of eyes (or a `terraform plan`, if folks have the means).

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~You have run all unit/integration tests and they pass~
- [x] Your branch has been rebased onto main
- [ ] ~You have tested by running locally~
- [ ] ~You have reviewed with UX/Design~

