### PR TITLE
fix: Container App name must be unique

### DIFF
--- a/data-pipeline/terraform/container_app/README.md
+++ b/data-pipeline/terraform/container_app/README.md
@@ -32,6 +32,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_common-tags"></a> [common-tags](#input\_common-tags) | Tags to be applied to all resources. | `map(string)` | n/a | yes |
 | <a name="input_container-app-environment-id"></a> [container-app-environment-id](#input\_container-app-environment-id) | Container App Environment ID | `string` | n/a | yes |
+| <a name="input_container-app-name-suffix"></a> [container-app-name-suffix](#input\_container-app-name-suffix) | Unique suffix for the Container App name. | `string` | n/a | yes |
 | <a name="input_container-app-resource-group-name"></a> [container-app-resource-group-name](#input\_container-app-resource-group-name) | Name of the Azure Resource group in which Container App resources are to be created. | `string` | n/a | yes |
 | <a name="input_core-db-domain-name-secret-name"></a> [core-db-domain-name-secret-name](#input\_core-db-domain-name-secret-name) | Name of the Azure Key Vault Secret for the DB host. | `string` | `"core-sql-domain-name"` | no |
 | <a name="input_core-db-name-secret-name"></a> [core-db-name-secret-name](#input\_core-db-name-secret-name) | Name of the Azure Key Vault Secret for the DB name. | `string` | `"core-sql-db-name"` | no |

--- a/data-pipeline/terraform/container_app/main.tf
+++ b/data-pipeline/terraform/container_app/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_container_app" "data-pipeline" {
-  name                         = "${var.environment-prefix}-ebis-data-pipeline"
+  name                         = "${var.environment-prefix}-ebis-data-pipeline-${var.container-app-name-suffix}"
   container_app_environment_id = var.container-app-environment-id
   resource_group_name          = var.resource-group-name
   revision_mode                = "Single"

--- a/data-pipeline/terraform/container_app/variables.tf
+++ b/data-pipeline/terraform/container_app/variables.tf
@@ -28,6 +28,11 @@ variable "container-app-resource-group-name" {
   type        = string
 }
 
+variable "container-app-name-suffix" {
+  description = "Unique suffix for the Container App name."
+  type        = string
+}
+
 variable "resource-group-name" {
   description = "Name of the Azure Resource group in which various resources are to be created."
   type        = string

--- a/data-pipeline/terraform/container_apps.tf
+++ b/data-pipeline/terraform/container_apps.tf
@@ -17,6 +17,7 @@ resource "azurerm_container_app_environment" "main" {
 module "container_app_default" {
   source = "./container_app"
 
+  container-app-name-suffix         = "default"
   container-app-environment-id      = azurerm_container_app_environment.main.id
   container-app-resource-group-name = azurerm_resource_group.resource-group.name
 
@@ -40,6 +41,7 @@ module "container_app_default" {
 module "container_app_custom" {
   source = "./container_app"
 
+  container-app-name-suffix         = "custom"
   container-app-environment-id      = azurerm_container_app_environment.main.id
   container-app-resource-group-name = azurerm_resource_group.resource-group.name
 


### PR DESCRIPTION
### Context

Container App name must be unique.

[AB#235428](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/235428)

### Change proposed in this pull request

Pass a suffix to be appended to the Container App name.

### Guidance to review 

`terraform plan` actually passes; this failed at the `apply`.

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~You have run all unit/integration tests and they pass~
- [x] Your branch has been rebased onto main
- [ ] ~You have tested by running locally~
- [ ] ~You have reviewed with UX/Design~

