### PR TITLE
fix: limit Container App name to 32 chars.

### DIFF
--- a/data-pipeline/terraform/container_app/locals.tf
+++ b/data-pipeline/terraform/container_app/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  container-app-name = substr("${var.environment-prefix}-ebis-pipeline-${var.container-app-name-suffix}", 0, 32)
+}

--- a/data-pipeline/terraform/container_app/main.tf
+++ b/data-pipeline/terraform/container_app/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_container_app" "data-pipeline" {
-  name                         = "${var.environment-prefix}-ebis-data-pipeline-${var.container-app-name-suffix}"
+  name                         = local.container-app-name
   container_app_environment_id = var.container-app-environment-id
   resource_group_name          = var.resource-group-name
   revision_mode                = "Single"


### PR DESCRIPTION
### Context

`apply` is failing as a _"name must…not be more than 32 characters."_

[AB#235428](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/235428)

### Change proposed in this pull request

- drop the `data` part of `data-pipeline`
- truncate the name to 32 characters in any case to avoid future issues.

### Guidance to review 

Again, no failures in the `plan` just the `apply`.

### Checklist (add/remove as appropriate)

- [ ] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] ~You have run all unit/integration tests and they pass~
- [ ] Your branch has been rebased onto main
- [ ] ~You have tested by running locally~
- [ ] ~You have reviewed with UX/Design~

