### PR TITLE
fix: include registry prefix for image

### DIFF
--- a/data-pipeline/terraform/container_app/main.tf
+++ b/data-pipeline/terraform/container_app/main.tf
@@ -36,7 +36,7 @@ resource "azurerm_container_app" "data-pipeline" {
     revision_suffix = replace(split(":", var.image-name)[1], ".", "-")
     container {
       name   = "edis-data-pipeline"
-      image  = var.image-name
+      image  = "${data.azurerm_container_registry.acr.login_server}/${var.image-name}"
       cpu    = 4
       memory = "16Gi"
 


### PR DESCRIPTION
### Context

Image lacks the registry prefix:

```sh
'Invalid value: \"fbit-data-pipeline:1.1.7\": ET https:: UNAUTHORIZED:
```

[AB#235428](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/235428)

### Change proposed in this pull request

Include prefix as per previous config.

### Guidance to review 

…

### Checklist (add/remove as appropriate)

- [ ] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] ~You have run all unit/integration tests and they pass~
- [ ] Your branch has been rebased onto main
- [ ] ~You have tested by running locally~
- [ ] ~You have reviewed with UX/Design~

