### PR TITLE
Added 'other' spending priority categories to BRCs

### DIFF
--- a/web/src/Web.App/ViewModels/SchoolBenchmarkingReportCardsViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolBenchmarkingReportCardsViewModel.cs
@@ -27,6 +27,11 @@ public class SchoolBenchmarkingReportCardsViewModel(
         .OrderBy(x => Lookups.StatusOrderMap[x.Rating.RAG ?? string.Empty])
         .ThenByDescending(x => x.Rating.Decile)
         .ThenByDescending(x => x.Rating.Value);
+    public IEnumerable<CostCategory> CostsOtherPriorities => _categories
+        .Where(x => !_allSchoolsCategories.Contains(x.Rating.Category))
+        .OrderBy(x => Lookups.StatusOrderMap[x.Rating.RAG ?? string.Empty])
+        .ThenByDescending(x => x.Rating.Decile)
+        .ThenByDescending(x => x.Rating.Value);
     public string? OverallPhase => school.OverallPhase;
     public string? OfstedRating => school.OfstedDescription;
     public decimal? InYearBalance => balance?.InYearBalance;

--- a/web/src/Web.App/Views/SchoolBenchmarkingReportCards/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolBenchmarkingReportCards/Index.cshtml
@@ -12,3 +12,7 @@
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
 @await Html.PartialAsync("_PriorityAreasAllSchools", Model)
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+@await Html.PartialAsync("_PriorityAreasOther", Model)

--- a/web/src/Web.App/Views/SchoolBenchmarkingReportCards/_Costs.cshtml
+++ b/web/src/Web.App/Views/SchoolBenchmarkingReportCards/_Costs.cshtml
@@ -11,7 +11,7 @@
         ? "Non-educational support staff"
         : category.Rating.Category;
 
-    var ratingPrefix = $"<strong>{category.Rating.Value.ToCurrency(0)}</strong> {Lookups.CategoryUnitMap[category.Rating.Category ?? string.Empty]};";
+    var ratingPrefix = $"<strong>{category.Rating.Value.ToCurrency(0)}</strong> {Lookups.CategoryUnitMap[category.Rating.Category ?? string.Empty].Replace("square", "sq.")};";
 
     <section id="spending-priorities-@category.Rating.CostCategoryAnchorId">
         <div class="govuk-grid-row govuk-!-margin-top-4 govuk-!-margin-bottom-8"

--- a/web/src/Web.App/Views/SchoolBenchmarkingReportCards/_PriorityAreasOther.cshtml
+++ b/web/src/Web.App/Views/SchoolBenchmarkingReportCards/_PriorityAreasOther.cshtml
@@ -1,0 +1,40 @@
+@using Web.App.ViewModels
+@model Web.App.ViewModels.SchoolBenchmarkingReportCardsViewModel
+
+<h2 class="govuk-heading-l" id="priority-areas-other">Other top spending priorities for your school</h2>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <p class="govuk-body">
+            Your school's top three priority areas in other spend categories, based on the variance of your school's
+            spend against similar schools.
+        </p>
+        <p class="govuk-body">
+            Find out about the schools you are compared with in
+            @Html.ActionLink(Constants.ServiceName, "Index", "SchoolComparison", new
+            {
+                urn = Model.Urn
+            }, new
+            {
+                @class = "govuk-link"
+            }).
+        </p>
+    </div>
+</div>
+
+@await Html.PartialAsync("_Costs", new CostsViewModel
+{
+    Costs = Model.CostsOtherPriorities.Take(3),
+    Id = "costs-other-priorities",
+    Urn = Model.Urn
+})
+
+<p class="govuk-body">
+    View more insights in
+    @Html.ActionLink(Constants.ServiceName, "Index", "SchoolComparison", new
+    {
+        urn = Model.Urn
+    }, new
+    {
+        @class = "govuk-link"
+    }).
+</p>

--- a/web/tests/Web.Tests/ViewModels/GivenASchoolBenchmarkingReportCardsViewModel.cs
+++ b/web/tests/Web.Tests/ViewModels/GivenASchoolBenchmarkingReportCardsViewModel.cs
@@ -18,7 +18,11 @@ public class GivenASchoolBenchmarkingReportCardsViewModel
             .Build<School>()
             .With(s => s.URN, URN)
             .Create();
-        _years = new FinanceYears { Aar = 2020, Cfr = 2024 };
+        _years = new FinanceYears
+        {
+            Aar = 2020,
+            Cfr = 2024
+        };
         _balance = fixture.Create<SchoolBalance>();
     }
 
@@ -26,6 +30,7 @@ public class GivenASchoolBenchmarkingReportCardsViewModel
         IEnumerable<RagRating>,
         IEnumerable<SchoolExpenditure>,
         IEnumerable<SchoolExpenditure>,
+        IEnumerable<CostCategory>,
         IEnumerable<CostCategory>
     > WhenRagRatingsAreData
     {
@@ -61,15 +66,22 @@ public class GivenASchoolBenchmarkingReportCardsViewModel
                 RAG = "green"
             };
 
+            var utilitiesRagRating = new RagRating
+            {
+                Category = Category.Utilities,
+                RAG = "red"
+            };
+
             return new TheoryData<
                 IEnumerable<RagRating>,
                 IEnumerable<SchoolExpenditure>,
                 IEnumerable<SchoolExpenditure>,
+                IEnumerable<CostCategory>,
                 IEnumerable<CostCategory>
             >
             {
                 {
-                    [administrativeSuppliesRagRating, teachingStaffRagRating, nonEducationalSupportStaffRagRating, educationalIctRagRating, otherRagRating], [
+                    [administrativeSuppliesRagRating, teachingStaffRagRating, nonEducationalSupportStaffRagRating, educationalIctRagRating, otherRagRating, utilitiesRagRating], [
                         new SchoolExpenditure
                         {
                             URN = URN
@@ -81,7 +93,7 @@ public class GivenASchoolBenchmarkingReportCardsViewModel
                             URN = URN
                         }
                     ],
-                    [new AdministrativeSupplies(administrativeSuppliesRagRating), new TeachingStaff(teachingStaffRagRating), new NonEducationalSupportStaff(nonEducationalSupportStaffRagRating)]
+                    [new AdministrativeSupplies(administrativeSuppliesRagRating), new TeachingStaff(teachingStaffRagRating), new NonEducationalSupportStaff(nonEducationalSupportStaffRagRating)], [new Utilities(utilitiesRagRating), new Other(otherRagRating), new EducationalIct(educationalIctRagRating)]
                 }
             };
         }
@@ -93,10 +105,12 @@ public class GivenASchoolBenchmarkingReportCardsViewModel
         IEnumerable<RagRating> ratings,
         IEnumerable<SchoolExpenditure> pupilExpenditure,
         IEnumerable<SchoolExpenditure> areaExpenditure,
-        IEnumerable<CostCategory> expectedCostsAllSchools)
+        IEnumerable<CostCategory> expectedCostsAllSchools,
+        IEnumerable<CostCategory> expectedCostsOtherPriorities)
     {
         var actual = new SchoolBenchmarkingReportCardsViewModel(_school, _years, _balance, ratings, pupilExpenditure, areaExpenditure);
         Assert.Equal(expectedCostsAllSchools.Select(c => c.Rating), actual.CostsAllSchools.Select(c => c.Rating));
+        Assert.Equal(expectedCostsOtherPriorities.Select(c => c.Rating), actual.CostsOtherPriorities.Select(c => c.Rating));
     }
 
     [Theory]


### PR DESCRIPTION
### Context
[AB#235831](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/235831) [AB#222988](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/222988) #1556

### Change proposed in this pull request
Additional spending priorities in the same vein as the dependent #1556. Space issue meant that the only sensible way to prevent text wrapping for building area-specific cost categories was to shorten `per square metre` to `per sq. metre`. If this is not sufficient it could be revisited by playing with the CSS again (with care over responsiveness).

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

