### PR TITLE
fix: add Container App to correct Resource Group

### DIFF
--- a/data-pipeline/terraform/container_app/README.md
+++ b/data-pipeline/terraform/container_app/README.md
@@ -38,12 +38,12 @@ No modules.
 | <a name="input_core-db-name-secret-name"></a> [core-db-name-secret-name](#input\_core-db-name-secret-name) | Name of the Azure Key Vault Secret for the DB name. | `string` | `"core-sql-db-name"` | no |
 | <a name="input_core-db-password-secret-name"></a> [core-db-password-secret-name](#input\_core-db-password-secret-name) | Name of the Azure Key Vault Secret for the DB password. | `string` | `"core-sql-password"` | no |
 | <a name="input_core-db-user-name-secret-name"></a> [core-db-user-name-secret-name](#input\_core-db-user-name-secret-name) | Name of the Azure Key Vault Secret for the DB username. | `string` | `"core-sql-user-name"` | no |
+| <a name="input_core-resource-group-name"></a> [core-resource-group-name](#input\_core-resource-group-name) | Name of the core Azure Resource group from which various data sources are referenced. | `string` | n/a | yes |
 | <a name="input_environment-prefix"></a> [environment-prefix](#input\_environment-prefix) | Prefix to be used for resources in the current environment. | `string` | n/a | yes |
 | <a name="input_image-name"></a> [image-name](#input\_image-name) | Container image to be used for each worker. | `string` | n/a | yes |
 | <a name="input_key-vault-name"></a> [key-vault-name](#input\_key-vault-name) | Azure Key Vault name. | `string` | n/a | yes |
 | <a name="input_max-replicas"></a> [max-replicas](#input\_max-replicas) | The max. number of Container App replicas to launch. | `number` | n/a | yes |
 | <a name="input_registry-name"></a> [registry-name](#input\_registry-name) | Azure Container Registry name. | `string` | n/a | yes |
-| <a name="input_resource-group-name"></a> [resource-group-name](#input\_resource-group-name) | Name of the Azure Resource group in which various resources are to be created. | `string` | n/a | yes |
 | <a name="input_storage-account-name"></a> [storage-account-name](#input\_storage-account-name) | Azure Storage Account name. | `string` | n/a | yes |
 | <a name="input_worker-queue-name"></a> [worker-queue-name](#input\_worker-queue-name) | Name of the queue which will trigger the worker. | `string` | n/a | yes |
 

--- a/data-pipeline/terraform/container_app/data.tf
+++ b/data-pipeline/terraform/container_app/data.tf
@@ -1,16 +1,16 @@
 data "azurerm_container_registry" "acr" {
   name                = var.registry-name
-  resource_group_name = var.resource-group-name
+  resource_group_name = var.core-resource-group-name
 }
 
 data "azurerm_storage_account" "main" {
   name                = var.storage-account-name
-  resource_group_name = var.resource-group-name
+  resource_group_name = var.core-resource-group-name
 }
 
 data "azurerm_key_vault" "key-vault" {
   name                = var.key-vault-name
-  resource_group_name = var.resource-group-name
+  resource_group_name = var.core-resource-group-name
 }
 
 data "azurerm_key_vault_secret" "core-db-domain-name" {

--- a/data-pipeline/terraform/container_app/main.tf
+++ b/data-pipeline/terraform/container_app/main.tf
@@ -1,7 +1,7 @@
 resource "azurerm_container_app" "data-pipeline" {
   name                         = local.container-app-name
   container_app_environment_id = var.container-app-environment-id
-  resource_group_name          = var.resource-group-name
+  resource_group_name          = var.container-app-resource-group-name
   revision_mode                = "Single"
   workload_profile_name        = "Pipeline"
 

--- a/data-pipeline/terraform/container_app/variables.tf
+++ b/data-pipeline/terraform/container_app/variables.tf
@@ -33,8 +33,8 @@ variable "container-app-name-suffix" {
   type        = string
 }
 
-variable "resource-group-name" {
-  description = "Name of the Azure Resource group in which various resources are to be created."
+variable "core-resource-group-name" {
+  description = "Name of the core Azure Resource group from which various data sources are referenced."
   type        = string
 }
 

--- a/data-pipeline/terraform/container_apps.tf
+++ b/data-pipeline/terraform/container_apps.tf
@@ -21,7 +21,7 @@ module "container_app_default" {
   container-app-environment-id      = azurerm_container_app_environment.main.id
   container-app-resource-group-name = azurerm_resource_group.resource-group.name
 
-  resource-group-name = "${var.environment-prefix}-ebis-core"
+  core-resource-group-name = "${var.environment-prefix}-ebis-core"
 
   registry-name = "${var.environment-prefix}acr"
   image-name    = var.image-name
@@ -45,7 +45,7 @@ module "container_app_custom" {
   container-app-environment-id      = azurerm_container_app_environment.main.id
   container-app-resource-group-name = azurerm_resource_group.resource-group.name
 
-  resource-group-name = "${var.environment-prefix}-ebis-core"
+  core-resource-group-name = "${var.environment-prefix}-ebis-core"
 
   registry-name = "${var.environment-prefix}acr"
   image-name    = var.image-name


### PR DESCRIPTION
### Context

`container-app-resource-group-name` was added/passed but unused.

[AB#235428](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/235428)

### Change proposed in this pull request

- correctly reference `container-app-resource-group-name` for the Container App resources.
- make the "core" Resource Group variable name clearer.

### Guidance to review 

…

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~You have run all unit/integration tests and they pass~
- [x] Your branch has been rebased onto main
- [ ] ~You have tested by running locally~
- [ ] ~You have reviewed with UX/Design~

