### PR TITLE
Added pupil workforce metrics to BRCs

### DIFF
--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -313,3 +313,38 @@ form.characteristics {
   padding: 0;
   border: none;
 }
+
+.census-metrics {
+  > div {
+    &:first-of-type {
+      margin-bottom: 1rem;
+    }
+  }
+
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 140px;
+
+    > div {
+      display: flex;
+      flex: 1;
+      flex-flow: column;
+      position: relative;
+
+      &:first-of-type {
+        margin-bottom: 0;
+
+        &::after {
+          content: '';
+          position: absolute;
+          right: -70px;
+          top: 1px;
+          width: 1px;
+          height: 100%;
+          background-color: $govuk-border-colour;
+        }
+      }
+    }
+  }
+}

--- a/web/src/Web.App/ViewModels/SchoolBenchmarkingReportCardCensusViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolBenchmarkingReportCardCensusViewModel.cs
@@ -1,0 +1,31 @@
+using Web.App.Domain;
+namespace Web.App.ViewModels;
+
+public class SchoolBenchmarkingReportCardCensusViewModel(string name)
+{
+    public SchoolBenchmarkingReportCardCensusViewModel(string name, IEnumerable<Census>? census, string? urn, Func<Census, decimal?> selector) : this(name)
+    {
+        if (census == null)
+        {
+            return;
+        }
+
+        var enumerated = census.ToArray();
+
+        if (!string.IsNullOrWhiteSpace(urn))
+        {
+            SchoolValue = enumerated
+                .Where(c => c.URN == urn)
+                .Select(selector)
+                .FirstOrDefault();
+        }
+
+        MinValue = enumerated.Select(selector).Min();
+        MaxValue = enumerated.Select(selector).Max();
+    }
+
+    public string Name => name;
+    public decimal? SchoolValue { get; set; }
+    public decimal? MinValue { get; set; }
+    public decimal? MaxValue { get; set; }
+}

--- a/web/src/Web.App/ViewModels/SchoolBenchmarkingReportCardsViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolBenchmarkingReportCardsViewModel.cs
@@ -8,7 +8,8 @@ public class SchoolBenchmarkingReportCardsViewModel(
     SchoolBalance? balance,
     IEnumerable<RagRating>? ratings,
     IEnumerable<SchoolExpenditure>? pupilExpenditure,
-    IEnumerable<SchoolExpenditure>? areaExpenditure) : ISchoolKeyInformationViewModel
+    IEnumerable<SchoolExpenditure>? areaExpenditure,
+    IEnumerable<Census>? census) : ISchoolKeyInformationViewModel
 {
     private readonly string[] _allSchoolsCategories = [Category.TeachingStaff, Category.NonEducationalSupportStaff, Category.AdministrativeSupplies];
     private readonly CostCategory[] _categories = CategoryBuilder
@@ -32,6 +33,8 @@ public class SchoolBenchmarkingReportCardsViewModel(
         .OrderBy(x => Lookups.StatusOrderMap[x.Rating.RAG ?? string.Empty])
         .ThenByDescending(x => x.Rating.Decile)
         .ThenByDescending(x => x.Rating.Value);
+    public SchoolBenchmarkingReportCardCensusViewModel PupilsPerTeacher => new("teacher", census, school.URN, c => c.Teachers);
+    public SchoolBenchmarkingReportCardCensusViewModel PupilsPerSeniorLeadership => new("senior leadership role", census, school.URN, c => c.SeniorLeadership);
     public string? OverallPhase => school.OverallPhase;
     public string? OfstedRating => school.OfstedDescription;
     public decimal? InYearBalance => balance?.InYearBalance;

--- a/web/src/Web.App/Views/SchoolBenchmarkingReportCards/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolBenchmarkingReportCards/Index.cshtml
@@ -16,3 +16,7 @@
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
 @await Html.PartialAsync("_PriorityAreasOther", Model)
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+@await Html.PartialAsync("_PupilWorkforceMetrics", Model)

--- a/web/src/Web.App/Views/SchoolBenchmarkingReportCards/_Metric.cshtml
+++ b/web/src/Web.App/Views/SchoolBenchmarkingReportCards/_Metric.cshtml
@@ -1,0 +1,21 @@
+@using Web.App.Extensions
+@model Web.App.ViewModels.SchoolBenchmarkingReportCardCensusViewModel
+
+<div>
+    <h3 class="govuk-heading-m">Pupil-to-@Model.Name metric</h3>
+    <div class="app-headline-figures govuk-!-padding-top-7 govuk-!-padding-bottom-7 govuk-!-padding-left-3 govuk-!-padding-right-3 govuk-!-text-align-centre">
+        <p class="govuk-heading-l govuk-!-font-weight-bold govuk-!-margin-bottom-1">
+            @Model.SchoolValue.ToSimpleDisplay()
+        </p>
+        <p class="govuk-body-l govuk-!-margin-0">
+            <strong>
+                Pupil@(Model.SchoolValue == 1 ? string.Empty : "s") per @Model.Name
+            </strong>
+        </p>
+    </div>
+    <p class="govuk-body-s govuk-!-margin-top-3 govuk-!-margin-bottom-1">
+        Similar schools range from
+        <strong>@Model.MinValue.ToSimpleDisplay()</strong> to <strong>@Model.MaxValue.ToSimpleDisplay()</strong>
+        pupil@(Model.MaxValue == 1 ? string.Empty : "s") per @Model.Name.
+    </p>
+</div>

--- a/web/src/Web.App/Views/SchoolBenchmarkingReportCards/_PupilWorkforceMetrics.cshtml
+++ b/web/src/Web.App/Views/SchoolBenchmarkingReportCards/_PupilWorkforceMetrics.cshtml
@@ -1,0 +1,22 @@
+@model Web.App.ViewModels.SchoolBenchmarkingReportCardsViewModel
+
+<h2 class="govuk-heading-l" id="pupil-workforce-metrics">Pupil and workforce metrics</h2>
+<div class="census-metrics govuk-!-margin-bottom-6">
+    <div>
+        @await Html.PartialAsync("_Metric", Model.PupilsPerTeacher)
+    </div>
+    <div>
+        @await Html.PartialAsync("_Metric", Model.PupilsPerSeniorLeadership)
+    </div>
+</div>
+
+<p class="govuk-body">
+    View more insights in
+    @Html.ActionLink(Constants.ServiceName, "Index", "SchoolCensus", new
+    {
+        urn = Model.Urn
+    }, new
+    {
+        @class = "govuk-link"
+    }).
+</p>

--- a/web/tests/Web.Tests/ViewModels/GivenASchoolBenchmarkingReportCardsViewModel.cs
+++ b/web/tests/Web.Tests/ViewModels/GivenASchoolBenchmarkingReportCardsViewModel.cs
@@ -99,6 +99,69 @@ public class GivenASchoolBenchmarkingReportCardsViewModel
         }
     }
 
+    public static TheoryData<
+        IEnumerable<Census>,
+        SchoolBenchmarkingReportCardCensusViewModel,
+        SchoolBenchmarkingReportCardCensusViewModel
+    > WhenCensusesAreData
+    {
+        get
+        {
+            var schoolCensus = new Census
+            {
+                URN = URN,
+                Teachers = 100,
+                SeniorLeadership = 10
+            };
+
+            var minTeachersCensus = new Census
+            {
+                Teachers = 90,
+                SeniorLeadership = 11
+            };
+
+            var minSeniorLeadershipCensus = new Census
+            {
+                Teachers = 101,
+                SeniorLeadership = 1
+            };
+
+            var maxTeachersCensus = new Census
+            {
+                Teachers = 200,
+                SeniorLeadership = 11
+            };
+
+            var maxSeniorLeadershipCensus = new Census
+            {
+                Teachers = 101,
+                SeniorLeadership = 20
+            };
+
+            return new TheoryData<
+                IEnumerable<Census>,
+                SchoolBenchmarkingReportCardCensusViewModel,
+                SchoolBenchmarkingReportCardCensusViewModel
+            >
+            {
+                {
+                    [minTeachersCensus, maxTeachersCensus, schoolCensus, minSeniorLeadershipCensus, maxSeniorLeadershipCensus], new SchoolBenchmarkingReportCardCensusViewModel("teacher")
+                    {
+                        SchoolValue = schoolCensus.Teachers,
+                        MinValue = minTeachersCensus.Teachers,
+                        MaxValue = maxTeachersCensus.Teachers
+                    },
+                    new SchoolBenchmarkingReportCardCensusViewModel("senior leadership role")
+                    {
+                        SchoolValue = schoolCensus.SeniorLeadership,
+                        MinValue = minSeniorLeadershipCensus.SeniorLeadership,
+                        MaxValue = maxSeniorLeadershipCensus.SeniorLeadership
+                    }
+                }
+            };
+        }
+    }
+
     [Theory]
     [MemberData(nameof(WhenRagRatingsAreData))]
     public void WhenRagRatingsAre(
@@ -108,7 +171,7 @@ public class GivenASchoolBenchmarkingReportCardsViewModel
         IEnumerable<CostCategory> expectedCostsAllSchools,
         IEnumerable<CostCategory> expectedCostsOtherPriorities)
     {
-        var actual = new SchoolBenchmarkingReportCardsViewModel(_school, _years, _balance, ratings, pupilExpenditure, areaExpenditure);
+        var actual = new SchoolBenchmarkingReportCardsViewModel(_school, _years, _balance, ratings, pupilExpenditure, areaExpenditure, Array.Empty<Census>());
         Assert.Equal(expectedCostsAllSchools.Select(c => c.Rating), actual.CostsAllSchools.Select(c => c.Rating));
         Assert.Equal(expectedCostsOtherPriorities.Select(c => c.Rating), actual.CostsOtherPriorities.Select(c => c.Rating));
     }
@@ -119,7 +182,19 @@ public class GivenASchoolBenchmarkingReportCardsViewModel
     public void WhenIsPartOfTrust(bool isPartOfTrust, string expected)
     {
         _school.TrustCompanyNumber = isPartOfTrust ? nameof(isPartOfTrust) : string.Empty;
-        var actual = new SchoolBenchmarkingReportCardsViewModel(_school, _years, _balance, Array.Empty<RagRating>(), Array.Empty<SchoolExpenditure>(), Array.Empty<SchoolExpenditure>());
+        var actual = new SchoolBenchmarkingReportCardsViewModel(_school, _years, _balance, Array.Empty<RagRating>(), Array.Empty<SchoolExpenditure>(), Array.Empty<SchoolExpenditure>(), Array.Empty<Census>());
         Assert.Equal(expected, actual.Years);
+    }
+
+    [Theory]
+    [MemberData(nameof(WhenCensusesAreData))]
+    public void WhenCensusesAre(
+        IEnumerable<Census> census,
+        SchoolBenchmarkingReportCardCensusViewModel expectedPupilsPerTeacher,
+        SchoolBenchmarkingReportCardCensusViewModel expectedPupilsPerSeniorLeadership)
+    {
+        var actual = new SchoolBenchmarkingReportCardsViewModel(_school, _years, _balance, Array.Empty<RagRating>(), Array.Empty<SchoolExpenditure>(), Array.Empty<SchoolExpenditure>(), census);
+        Assert.Equivalent(expectedPupilsPerTeacher, actual.PupilsPerTeacher);
+        Assert.Equivalent(expectedPupilsPerSeniorLeadership, actual.PupilsPerSeniorLeadership);
     }
 }


### PR DESCRIPTION
### Context
[AB#235833](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/235833) [AB#222988](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/222988) #1557

### Change proposed in this pull request
Metrics added to BRCs page. GDS 'half column' layout not used due to design requirements for gap and vertical line, so flexbox used instead on `$tablet` breakpoint and greater.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

