### PR TITLE
bugfix: ensures all phases returns an order for an LA

### DIFF
--- a/web/src/Web.App/ViewModels/LocalAuthorityViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityViewModel.cs
@@ -8,29 +8,23 @@ public class LocalAuthorityViewModel(LocalAuthority localAuthority)
     public IEnumerable<IGrouping<string?, LocalAuthoritySchool>> GroupedSchools { get; } = localAuthority.Schools
         .OrderBy(x => x.SchoolName)
         .GroupBy(x => x.OverallPhase)
-        .OrderBy(x => LaPhaseOrderMap[x.Key ?? string.Empty]);
+        .OrderBy(x => GetLaPhaseOrder(x.Key));
 
-    private static Dictionary<string, int> LaPhaseOrderMap => new()
+
+    private static int GetLaPhaseOrder(string? phase)
     {
+        return phase switch
         {
-            OverallPhaseTypes.Primary, 1
-        },
-        {
-            OverallPhaseTypes.Secondary, 2
-        },
-        {
-            OverallPhaseTypes.Special, 3
-        },
-        {
-            OverallPhaseTypes.PupilReferralUnit, 4
-        },
-        {
-            OverallPhaseTypes.Nursery, 5
-        },
-        {
-            OverallPhaseTypes.AllThrough, 6
-        }
-    };
+            OverallPhaseTypes.Primary => 1,
+            OverallPhaseTypes.Secondary => 2,
+            OverallPhaseTypes.Special => 3,
+            OverallPhaseTypes.PupilReferralUnit => 4,
+            OverallPhaseTypes.Nursery => 5,
+            OverallPhaseTypes.AllThrough => 6,
+            OverallPhaseTypes.PostSixteen => 7,
+            _ => 99
+        };
+    }
 }
 
 public class LocalAuthoritySchoolsSectionViewModel


### PR DESCRIPTION
### Context
[AB#235679](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/235679), closes [AB#236366](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/236366)

### Change proposed in this pull request
Adds post-16 to phase order mapping and adds default order for any phase not explicitly set.

### Guidance to review 
N/A

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

