### PR TITLE
Added explicit App Insights telemetry tracking for referrals to BRCs page

### DIFF
--- a/support-analytics/README.md
+++ b/support-analytics/README.md
@@ -1,0 +1,52 @@
+# Support & Analytics
+
+This is a supplementary project that contains configuration for supporting and monitoring the service.
+
+## Log Analytics
+
+### Functions
+
+The functions in `./queries/functions` are published to a query pack within the resource group for use either directly against
+Application Insights or Log Analytics Workspace, or via Queries defined below. They are maintained in the repository as `.kql`
+files which may be executed in Azure for validation purposes. Some intentionally contain tokenised values that are populated via
+the Terraform scripts during a pipeline run. These are denoted by `${TOKEN_NAME}`, where `templatefile()` contains `TOKEN_NAME`
+with an appropriate value in the `vars` dynamic block.
+
+### Queries
+
+The queries in `./queries` are published to a query pack within the resource group for use either directly against Application
+Insights or Log Analytics Workspace, or via the Dashboards befined below. They may have dependencies on the Functions defined
+above.
+
+### Request logs
+
+Requests from the Web App Service log custom properties along with the base
+[Request telemetry](https://github.com/DFE-Digital/education-benchmarking-and-insights/tree/main/web/src/Web.App/Attributes/RequestTelemetry).
+Some of these are consumed by Functions or Queries defined above, and include:
+
+| Name            | Purpose               | Example       | Enum |
+|-----------------|-----------------------|---------------|------|
+| `Code`          | Local Authority code  | `123`         |      |
+| `CompanyNumber` | Trust company number  | `012354678`   |      |
+| `Establishment` | Type of establishment | `school`      | [TrackedRequestEstablishmentType](https://github.com/DFE-Digital/education-benchmarking-and-insights/blob/main/web/src/Web.App/Constants/TrackedRequestType.cs) |
+| `Feature`       | Feature name          | `home`        | [TrackedRequestFeature](https://github.com/DFE-Digital/education-benchmarking-and-insights/blob/main/web/src/Web.App/Constants/TrackedRequestType.cs)     |
+| `Referrer`      | Referrer name         | `school-home` |      |
+| `Urn`           | School URN            | `123546`      |      |
+
+## Dashboards
+
+Shared Dashboards in `./dashboards` are maintained as `.tpl` JSON files in the repository. When making changes to the Dashboards
+it is far easier to do this live in Azure Portal and then export and merge the source JSON with the appropriate `.tpl` file here.
+Hard-coded environmental values will need to be tokenised and populated in the existing `templatefile()` Terraform function.
+
+### Management Information
+
+Usage and user analytics, such as page views, session length and establishment feature breakdowns.
+
+### Operational Information
+
+Platform metrics for consumption by operational support staff, such as availability, performance, failure rates and infrastructure map.
+
+## Alerts
+
+<!-- TODO -->

--- a/support-analytics/terraform/README.md
+++ b/support-analytics/terraform/README.md
@@ -3,8 +3,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.8 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.8.0 |
 
 ## Providers
 
@@ -51,6 +51,7 @@ No modules.
 | [azurerm_log_analytics_saved_search.get-feature-requests](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_saved_search.get-new-users](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_saved_search.get-queue-put-messages](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
+| [azurerm_log_analytics_saved_search.get-school-benchmarking-report-cards-requests](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_saved_search.get-session-length](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_saved_search.get-sessions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_saved_search.get-tracked-links](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |

--- a/support-analytics/terraform/provider.tf
+++ b/support-analytics/terraform/provider.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.9.8"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.3.0"
+      version = "~> 4.8.0"
     }
   }
   backend "azurerm" {}

--- a/support-analytics/terraform/queries.tf
+++ b/support-analytics/terraform/queries.tf
@@ -467,3 +467,14 @@ resource "azurerm_log_analytics_query_pack_query" "function-app-role-instance-co
 
   body = file("${path.module}/queries/function-app-role-instance-count.kql")
 }
+
+resource "azurerm_log_analytics_saved_search" "get-school-benchmarking-report-cards-requests" {
+  name                       = "GetSchoolBenchmarkingReportCardsRequests"
+  log_analytics_workspace_id = data.azurerm_log_analytics_workspace.application-insights-workspace.id
+  category                   = "Function"
+  display_name               = "GetSchoolBenchmarkingReportCardsRequests"
+  function_alias             = "GetSchoolBenchmarkingReportCardsRequests"
+  tags                       = local.query-tags
+
+  query = file("${path.module}/queries/functions/get-school-benchmarking-report-cards-requests.kql")
+}

--- a/support-analytics/terraform/queries/functions/get-school-benchmarking-report-cards-requests.kql
+++ b/support-analytics/terraform/queries/functions/get-school-benchmarking-report-cards-requests.kql
@@ -1,0 +1,24 @@
+AppRequests
+| extend
+    Urn = tostring(Properties["Urn"]),
+    Establishment = tostring(Properties["Establishment"]),
+    Feature = tostring(Properties["Feature"]),
+    Referrer = tostring(Properties["Referrer"])
+| where 
+    Establishment == "school"
+| where
+    Feature == "benchmarking-report-cards"
+| where 
+    isempty(SyntheticSource)
+| project
+    TimeGenerated,
+    Name,
+    ResultCode,
+    OperationId,
+    UserId,
+    Establishment,
+    Feature,
+    Identifier = Urn,
+    Referrer
+| order by
+    TimeGenerated asc

--- a/web/src/Web.App/Attributes/RequestTelemetry/RequestTelemetryAttribute.cs
+++ b/web/src/Web.App/Attributes/RequestTelemetry/RequestTelemetryAttribute.cs
@@ -18,42 +18,53 @@ public abstract class RequestTelemetryAttribute : TypeFilterAttribute
         Arguments =
         [
             Properties,
-            RoutePropertyNames
+            RoutePropertyNames,
+            ContextProperties
         ];
     }
 
     internal Dictionary<string, object?> Properties { get; }
     internal string[] RoutePropertyNames { get; }
+    internal Dictionary<string, Func<HttpContext, object?>> ContextProperties { get; } = new();
 }
 
 internal class RequestTelemetryFilter(
     ILogger<RequestTelemetryFilter> logger,
     Dictionary<string, object?> properties,
-    string[] routePropertyNames) : ActionFilterAttribute
+    string[] routePropertyNames,
+    Dictionary<string, Func<HttpContext, object?>> contextProperties) : ActionFilterAttribute
 {
     public override void OnActionExecuted(ActionExecutedContext context)
     {
         base.OnActionExecuted(context);
 
         var telemetry = context.HttpContext.Features.Get<Microsoft.ApplicationInsights.DataContracts.RequestTelemetry>();
-        if (telemetry != null)
+        if (telemetry == null)
         {
-            foreach (var property in properties.Keys)
-            {
-                var value = properties[property];
-                telemetry.Properties[property.Capitalise()] = value?.ToString();
-            }
-
-            foreach (var property in routePropertyNames)
-            {
-                var value = context.RouteData.Values[property];
-                telemetry.Properties[property.Capitalise()] = value?.ToString();
-            }
-
-            logger.LogDebug("Updated telemetry properties to {Properties} for {Method} {URL}",
-                telemetry.Properties,
-                context.HttpContext.Request.Method,
-                context.HttpContext.Request.GetDisplayUrl());
+            return;
         }
+
+        foreach (var property in properties.Keys)
+        {
+            var value = properties[property];
+            telemetry.Properties[property.Capitalise()] = value?.ToString();
+        }
+
+        foreach (var property in routePropertyNames)
+        {
+            var value = context.RouteData.Values[property];
+            telemetry.Properties[property.Capitalise()] = value?.ToString();
+        }
+
+        foreach (var property in contextProperties)
+        {
+            var value = property.Value(context.HttpContext);
+            telemetry.Properties[property.Key.Capitalise()] = value?.ToString();
+        }
+
+        logger.LogDebug("Updated telemetry properties to {Properties} for {Method} {URL}",
+            telemetry.Properties,
+            context.HttpContext.Request.Method,
+            context.HttpContext.Request.GetDisplayUrl());
     }
 }

--- a/web/src/Web.App/Attributes/RequestTelemetry/SchoolBenchmarkingReportCardsTelemetry.cs
+++ b/web/src/Web.App/Attributes/RequestTelemetry/SchoolBenchmarkingReportCardsTelemetry.cs
@@ -1,0 +1,18 @@
+﻿using Web.App.Extensions;
+namespace Web.App.Attributes.RequestTelemetry;
+
+public class SchoolBenchmarkingReportCardsTelemetry : SchoolRequestTelemetryAttribute
+{
+    public SchoolBenchmarkingReportCardsTelemetry(TrackedRequestQueryParameters referrerKey) : base(TrackedRequestFeature.BenchmarkingReportCards)
+    {
+        ContextProperties.Add(TrackedRequestType.Referrer.GetStringValue(), c =>
+        {
+            if (c.Request.Query.TryGetValue(referrerKey.GetStringValue(), out var referrer))
+            {
+                return referrer;
+            }
+
+            return null;
+        });
+    }
+}

--- a/web/src/Web.App/Constants/TrackedRequestType.cs
+++ b/web/src/Web.App/Constants/TrackedRequestType.cs
@@ -3,10 +3,12 @@ namespace Web.App;
 
 public enum TrackedRequestType
 {
-    [StringValue("Establishment")]
+    [StringValue(nameof(Establishment))]
     Establishment,
-    [StringValue("Feature")]
-    Feature
+    [StringValue(nameof(Feature))]
+    Feature,
+    [StringValue(nameof(Referrer))]
+    Referrer
 }
 
 public enum TrackedRequestEstablishmentType
@@ -55,4 +57,10 @@ public enum TrackedRequestRouteParameters
     CompanyNumber,
     [StringValue("urn")]
     Urn
+}
+
+public enum TrackedRequestQueryParameters
+{
+    [StringValue("referrer")]
+    Referrer
 }

--- a/web/src/Web.App/Controllers/SchoolBenchmarkingReportCardsController.cs
+++ b/web/src/Web.App/Controllers/SchoolBenchmarkingReportCardsController.cs
@@ -14,7 +14,7 @@ namespace Web.App.Controllers;
 [Controller]
 [FeatureGate(FeatureFlags.BenchmarkingReportCards)]
 [Route("school/{urn}/benchmarking-report-cards")]
-[SchoolRequestTelemetry(TrackedRequestFeature.BenchmarkingReportCards)]
+[SchoolBenchmarkingReportCardsTelemetry(TrackedRequestQueryParameters.Referrer)]
 public class SchoolBenchmarkingReportCardsController(
     IEstablishmentApi establishmentApi,
     IFinanceService financeService,

--- a/web/src/Web.App/Views/Shared/Components/SchoolFinanceTools/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/SchoolFinanceTools/Default.cshtml
@@ -53,11 +53,11 @@
                     case FinanceTools.BenchmarkingReportCards:
                         <feature name="@FeatureFlags.BenchmarkingReportCards">
                             <li>
-                                <a href="@Url.Action("Index", "SchoolBenchmarkingReportCards", new { urn = Model.Identifier })">
+                                <a href="@Url.Action("Index", "SchoolBenchmarkingReportCards", new { urn = Model.Identifier, referrer = "school-home" })">
                                 <img src="/assets/images/benchmarking-report-cards.png" alt="" class="app-view-component">
                             </a>
                                 <h3 class="govuk-heading-s">
-                                    <a href="@Url.Action("Index", "SchoolBenchmarkingReportCards", new { urn = Model.Identifier })" class="govuk-link govuk-link--no-visited-state">Benchmarking report cards</a>
+                                    <a href="@Url.Action("Index", "SchoolBenchmarkingReportCards", new { urn = Model.Identifier, referrer = "school-home" })" class="govuk-link govuk-link--no-visited-state">Benchmarking report cards</a>
                                 </h3>
                                 <p class="govuk-body">
                                     TODO

--- a/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingHome.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingHome.cs
@@ -81,7 +81,7 @@ public class WhenViewingHome(SchoolBenchmarkingWebAppClient client) : PageBase<S
 
         var newPage = await Client.Follow(anchor);
 
-        DocumentAssert.AssertPageUrl(newPage, Paths.SchoolBenchmarkingReportCards(school.URN).ToAbsolute());
+        DocumentAssert.AssertPageUrl(newPage, Paths.SchoolBenchmarkingReportCards(school.URN, "school-home").ToAbsolute());
     }
 
     [Fact]
@@ -187,6 +187,6 @@ public class WhenViewingHome(SchoolBenchmarkingWebAppClient client) : PageBase<S
         DocumentAssert.Link(toolsLinks[0], "Benchmark spending", Paths.SchoolComparison(school.URN).ToAbsolute());
         DocumentAssert.Link(toolsLinks[1], "Curriculum and financial planning", Paths.SchoolFinancialPlanning(school.URN).ToAbsolute());
         DocumentAssert.Link(toolsLinks[2], "Benchmark pupil and workforce data", Paths.SchoolCensus(school.URN).ToAbsolute());
-        DocumentAssert.Link(toolsLinks[3], "Benchmarking report cards", Paths.SchoolBenchmarkingReportCards(school.URN).ToAbsolute());
+        DocumentAssert.Link(toolsLinks[3], "Benchmarking report cards", Paths.SchoolBenchmarkingReportCards(school.URN, "school-home").ToAbsolute());
     }
 }

--- a/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingHomeAsFederation.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingHomeAsFederation.cs
@@ -73,7 +73,7 @@ public class WhenViewingHomeAsFederation(SchoolBenchmarkingWebAppClient client) 
 
         var newPage = await Client.Follow(anchor);
 
-        DocumentAssert.AssertPageUrl(newPage, Paths.SchoolBenchmarkingReportCards(school.URN).ToAbsolute());
+        DocumentAssert.AssertPageUrl(newPage, Paths.SchoolBenchmarkingReportCards(school.URN, "school-home").ToAbsolute());
     }
 
     [Fact]
@@ -199,7 +199,7 @@ public class WhenViewingHomeAsFederation(SchoolBenchmarkingWebAppClient client) 
             DocumentAssert.Link(toolsLinks[0], "Benchmark spending", Paths.SchoolComparison(school.URN).ToAbsolute());
             DocumentAssert.Link(toolsLinks[1], "Curriculum and financial planning", Paths.SchoolFinancialPlanning(school.URN).ToAbsolute());
             DocumentAssert.Link(toolsLinks[2], "Benchmark pupil and workforce data", Paths.SchoolCensus(school.URN).ToAbsolute());
-            DocumentAssert.Link(toolsLinks[3], "Benchmarking report cards", Paths.SchoolBenchmarkingReportCards(school.URN).ToAbsolute());
+            DocumentAssert.Link(toolsLinks[3], "Benchmarking report cards", Paths.SchoolBenchmarkingReportCards(school.URN, "school-home").ToAbsolute());
         }
     }
 }

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -32,7 +32,7 @@ public static class Paths
     public static string SchoolComparison(string? urn) => $"/school/{urn}/comparison";
     public static string SchoolComparisonCustomData(string? urn) => $"/school/{urn}/comparison/custom-data";
     public static string SchoolCensus(string? urn) => $"/school/{urn}/census";
-    public static string SchoolBenchmarkingReportCards(string? urn) => $"/school/{urn}/benchmarking-report-cards";
+    public static string SchoolBenchmarkingReportCards(string? urn, string? referrer = null) => $"/school/{urn}/benchmarking-report-cards{(referrer == null ? string.Empty : $"?referrer={referrer}")}";
     public static string SchoolCensusCustomData(string? urn) => $"/school/{urn}/census/custom-data";
     public static string SchoolSpending(string? urn) => $"/school/{urn}/spending-and-costs";
     public static string SchoolSpendingCustomData(string? urn) => $"/school/{urn}/spending-and-costs/custom-data";

--- a/web/tests/Web.Tests/Attributes/GivenASchoolRequestTelemetryAttribute.cs
+++ b/web/tests/Web.Tests/Attributes/GivenASchoolRequestTelemetryAttribute.cs
@@ -72,7 +72,8 @@ public class GivenASchoolRequestTelemetryAttribute
         var filter = new RequestTelemetryFilter(
             provider.GetService<ILogger<RequestTelemetryFilter>>()!,
             attribute.Properties,
-            attribute.RoutePropertyNames);
+            attribute.RoutePropertyNames,
+            attribute.ContextProperties);
         filter.OnActionExecuted(actionExecutedContext);
 
         await (actionExecutedContext.Result?.ExecuteResultAsync(actionContext) ?? Task.CompletedTask);

--- a/web/tests/Web.Tests/Attributes/GivenATrustRequestTelemetryAttribute.cs
+++ b/web/tests/Web.Tests/Attributes/GivenATrustRequestTelemetryAttribute.cs
@@ -72,7 +72,8 @@ public class GivenATrustRequestTelemetryAttribute
         var filter = new RequestTelemetryFilter(
             provider.GetService<ILogger<RequestTelemetryFilter>>()!,
             attribute.Properties,
-            attribute.RoutePropertyNames);
+            attribute.RoutePropertyNames,
+            attribute.ContextProperties);
         filter.OnActionExecuted(actionExecutedContext);
 
         await (actionExecutedContext.Result?.ExecuteResultAsync(actionContext) ?? Task.CompletedTask);


### PR DESCRIPTION
### Context
[AB#236266](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/236266) [AB#222988](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/222988)

### Change proposed in this pull request
Updated telemetry tracking to include `referrer` from query string for BRCs page only. Added `GetSchoolBenchmarkingReportCardsRequests` function to Log Analytics workspace. Documented custom properties logged with majority of requests to Web service.

### Guidance to review 
Browsing to the BRC page from the School homepage should append `?referrer=school-home` to the URL and log the new telemetry property to App Insights. Browsing directly to that page without the `?referrer=` should not have any adverse impact. The `.kql` file in this PR may be executed directly against Log Analytics to show the `Referrer` value as set in the custom properties.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

