### PR TITLE
chore: re-enable a11y tests in pipeline

### DIFF
--- a/pipelines/web/build.yaml
+++ b/pipelines/web/build.yaml
@@ -147,15 +147,15 @@ stages:
             parameters:
               workspaceDir: '$(Pipeline.Workspace)'
 
-#      - job: RunA11YTests
-#        dependsOn: [ WebDeployment ]
-#        displayName: 'Run automated a11y tests'
-#        steps:
-#          - template: steps\run-a11y-tests.yaml
-#            parameters:
-#              workspaceDir: '$(Pipeline.Workspace)'
-#              subscription: 's198d.azdo-deployment'
-#              environmentPrefix: 's198d02'
+      - job: RunA11YTests
+        dependsOn: [ WebDeployment ]
+        displayName: 'Run automated a11y tests'
+        steps:
+          - template: steps\run-a11y-tests.yaml
+            parameters:
+              workspaceDir: '$(Pipeline.Workspace)'
+              subscription: 's198d.azdo-deployment'
+              environmentPrefix: 's198d02'
 
   - stage: DeployTest
     dependsOn: [ DeployAutomatedTest ]

--- a/pipelines/web/steps/run-a11y-tests.yaml
+++ b/pipelines/web/steps/run-a11y-tests.yaml
@@ -28,7 +28,8 @@ steps:
 
   - task: DotNetCoreCLI@2
     displayName: 'Run a11y tests'
-    continueOnError: true #temp allow pipeline to continue whilst func test env is seeded with data
+    continueOnError: true
+    retryCountOnTaskFailure: 3
     inputs:
       command: test
       projects: '${{ parameters.workspaceDir }}/a11y-tests-files/Web.A11yTests/Web.A11yTests.dll'


### PR DESCRIPTION
### Context
[AB#235250](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/235250), [AB#236368](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/236368)

### Change proposed in this pull request
Re-enables a11y tests in pipeline.

### Guidance to review 
N/A

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your branch has been rebased onto main

