### PR TITLE
bugfix: adds a11y tests for spending priorities page

### DIFF
--- a/web/tests/Web.A11yTests/Pages/Schools/WhenViewingSpendingPriorities.cs
+++ b/web/tests/Web.A11yTests/Pages/Schools/WhenViewingSpendingPriorities.cs
@@ -1,0 +1,20 @@
+using Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Web.A11yTests.Pages.Schools;
+
+public class WhenViewingSpendingPriorities(
+    ITestOutputHelper testOutputHelper,
+    WebDriver webDriver)
+    : PageBase(testOutputHelper, webDriver)
+{
+    protected override string PageUrl => $"/school/{TestConfiguration.School}/spending-and-costs";
+
+    [Fact]
+    public async Task ThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await EvaluatePage();
+    }
+}


### PR DESCRIPTION
### Context
[AB#233972](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/233972), [AB#236856](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/236856)

### Change proposed in this pull request
Adds a11y tests for spending priorities page. This should fail pending bug fix,

### Guidance to review 
As expected the page fails the Axe assertions

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

