### PR TITLE
bugfix: remove grey colour from suffix due a11y contrast issue

### DIFF
--- a/front-end-components/src/index.css
+++ b/front-end-components/src/index.css
@@ -230,7 +230,6 @@
   .chart-stat-wrapper
   .chart-stat-value
   .chart-stat-value-suffix {
-  color: var(--label-colour);
   margin-left: 5px;
   font-size: 0.38em;
 }


### PR DESCRIPTION
### Context
[AB#233972](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/233972), [AB#236858](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/236858)

### Change proposed in this pull request
Removes grey colour from suffix due to a11y contrast issues

### Guidance to review 
a11y tests pass locally

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

