### PR TITLE
Support Company Number or LA Code with Phase as well as collection of URNs for Metric RAG Ratings Query endpoint

### DIFF
--- a/core-infrastructure/src/db/Core.Database/Scripts/062-CreateSchoolMetricRAGView.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/062-CreateSchoolMetricRAGView.sql
@@ -1,0 +1,21 @@
+CREATE VIEW [dbo].[SchoolMetricRAG] AS
+SELECT
+   s.URN,
+   s.OverallPhase,
+   s.LACode,
+   s.TrustCompanyNumber,
+   r.RunType,
+   r.RunId,
+   r.Category,
+   r.SubCategory,
+   r.Value,
+   r.Mean,
+   r.DiffMean,
+   r.PercentDiff,
+   r.Percentile,
+   r.Decile,
+   r.RAG
+FROM
+   School s
+   LEFT JOIN MetricRAG r ON r.URN = s.URN
+GO

--- a/platform/src/apis/Platform.Api.Insight/Configuration/Services.cs
+++ b/platform/src/apis/Platform.Api.Insight/Configuration/Services.cs
@@ -46,7 +46,8 @@ internal static class Services
             .AddTransient<IValidator<QueryTrustExpenditureParameters>, QueryTrustExpenditureParametersValidator>()
             .AddTransient<IValidator<IncomeParameters>, IncomeParametersValidator>()
             .AddTransient<IValidator<QuerySchoolIncomeParameters>, QuerySchoolIncomeParametersValidator>()
-            .AddTransient<IValidator<QueryTrustIncomeParameters>, QueryTrustIncomeParametersValidator>();
+            .AddTransient<IValidator<QueryTrustIncomeParameters>, QueryTrustIncomeParametersValidator>()
+            .AddTransient<IValidator<MetricRagRatingsParameters>, MetricRagRatingsParametersValidator>();
 
         //TODO: Add serilog configuration AB#227696
         serviceCollection

--- a/platform/src/apis/Platform.Api.Insight/Domain/CostCategory.cs
+++ b/platform/src/apis/Platform.Api.Insight/Domain/CostCategory.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Linq;
+namespace Platform.Api.Insight.Domain;
+
+public static class CostCategory
+{
+    internal const string TeachingStaff = "Teaching and Teaching support staff";
+    private const string NonEducationalSupportStaff = "Non-educational support staff and services";
+    private const string EducationalSupplies = "Educational supplies";
+    private const string EducationalIct = "Educational ICT";
+    private const string PremisesStaffServices = "Premises staff and services";
+    private const string Utilities = "Utilities";
+    private const string AdministrativeSupplies = "Administrative supplies";
+    private const string CateringStaffServices = "Catering staff and supplies";
+    private const string Other = "Other costs";
+
+    public static readonly string[] All =
+    [
+        TeachingStaff,
+        NonEducationalSupportStaff,
+        EducationalSupplies,
+        EducationalIct,
+        PremisesStaffServices,
+        Utilities,
+        AdministrativeSupplies,
+        CateringStaffServices,
+        Other
+    ];
+
+    public static bool IsValid(string? category) => All.Any(a => a.Equals(category, StringComparison.OrdinalIgnoreCase));
+}

--- a/platform/src/apis/Platform.Api.Insight/Domain/RagRating.cs
+++ b/platform/src/apis/Platform.Api.Insight/Domain/RagRating.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Linq;
+namespace Platform.Api.Insight.Domain;
+
+public static class RagRating
+{
+    internal const string Red = "red";
+    private const string Amber = "amber";
+    private const string Green = "green";
+
+    public static readonly string[] All =
+    [
+        Red,
+        Amber,
+        Green
+    ];
+
+    public static bool IsValid(string? ragRating) => All.Any(a => a.Equals(ragRating, StringComparison.OrdinalIgnoreCase));
+}

--- a/platform/src/apis/Platform.Api.Insight/Income/Income.cs
+++ b/platform/src/apis/Platform.Api.Insight/Income/Income.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-
 namespace Platform.Api.Insight.Income;
 
 public static class IncomeCategories
@@ -9,11 +8,11 @@ public static class IncomeCategories
     public const string DirectRevenueFinancing = nameof(DirectRevenueFinancing);
 
     public static readonly string[] All =
-    {
+    [
         GrantFunding,
         SelfGenerated,
         DirectRevenueFinancing
-    };
+    ];
 
     public static bool IsValid(string? category) => All.Any(a => a == category);
 }
@@ -26,12 +25,12 @@ public static class IncomeDimensions
     public const string PercentExpenditure = nameof(PercentExpenditure);
 
     public static readonly string[] All =
-    {
+    [
         Actuals,
         PerUnit,
         PercentIncome,
         PercentExpenditure
-    };
+    ];
 
     public static bool IsValid(string? dimension) => All.Any(a => a == dimension);
 }

--- a/platform/src/apis/Platform.Api.Insight/MetricRagRatings/MetricRagRatingService.cs
+++ b/platform/src/apis/Platform.Api.Insight/MetricRagRatings/MetricRagRatingService.cs
@@ -54,10 +54,9 @@ public class MetricRagRatingsService(IDatabaseFactory dbFactory) : IMetricRagRat
         }
         else if (!string.IsNullOrWhiteSpace(companyNumber))
         {
-            builder.Where("TrustCompanyNumber = @CompanyNumber AND OverallPhase = @Phase", new
+            builder.Where("TrustCompanyNumber = @CompanyNumber", new
             {
-                CompanyNumber = companyNumber,
-                Phase = phase
+                CompanyNumber = companyNumber
             });
         }
         else if (!string.IsNullOrWhiteSpace(laCode))

--- a/platform/src/apis/Platform.Api.Insight/MetricRagRatings/MetricRagRatingsFunctions.cs
+++ b/platform/src/apis/Platform.Api.Insight/MetricRagRatings/MetricRagRatingsFunctions.cs
@@ -2,16 +2,22 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
+using FluentValidation;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
+using Platform.Api.Insight.OpenApi.Examples;
+using Platform.Functions;
 using Platform.Functions.Extensions;
 using Platform.Functions.OpenApi;
 namespace Platform.Api.Insight.MetricRagRatings;
 
-public class MetricRagRatingsFunctions(IMetricRagRatingsService service, ILogger<MetricRagRatingsFunctions> logger)
+public class MetricRagRatingsFunctions(
+    ILogger<MetricRagRatingsFunctions> logger,
+    IMetricRagRatingsService service,
+    IValidator<MetricRagRatingsParameters> metricRagRatingsParametersValidator)
 {
     [Function(nameof(UserDefinedAsync))]
     [OpenApiOperation(nameof(UserDefinedAsync), "Metric RAG Ratings")]
@@ -55,11 +61,15 @@ public class MetricRagRatingsFunctions(IMetricRagRatingsService service, ILogger
 
     [Function(nameof(QueryDefaultAsync))]
     [OpenApiOperation(nameof(QueryDefaultAsync), "Metric RAG Ratings")]
-    [OpenApiParameter("urns", In = ParameterLocation.Query, Description = "List of school URNs", Type = typeof(string[]), Required = true)]
-    [OpenApiParameter("categories", In = ParameterLocation.Query, Description = "List of cost category", Type = typeof(string[]))]
-    [OpenApiParameter("statuses", In = ParameterLocation.Query, Description = "List of RAG statuses", Type = typeof(string[]))]
+    [OpenApiParameter("urns", In = ParameterLocation.Query, Description = "List of school URNs", Type = typeof(string[]), Required = false)]
+    [OpenApiParameter("phase", In = ParameterLocation.Query, Description = "School overall phase", Type = typeof(string), Example = typeof(ExampleOverallPhase))]
+    [OpenApiParameter("companyNumber", In = ParameterLocation.Query, Description = "Eight digit trust company number", Type = typeof(string))]
+    [OpenApiParameter("laCode", In = ParameterLocation.Query, Description = "Local authority three digit code", Type = typeof(string))]
+    [OpenApiParameter("categories", In = ParameterLocation.Query, Description = "List of cost category", Type = typeof(string[]), Example = typeof(ExampleExpenditureCategory))]
+    [OpenApiParameter("statuses", In = ParameterLocation.Query, Description = "List of RAG statuses", Type = typeof(string[]), Example = typeof(ExampleRagStatuses))]
     [OpenApiSecurityHeader]
     [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(MetricRagRating[]))]
+    [OpenApiResponseWithBody(HttpStatusCode.BadRequest, "application/json", typeof(ValidationError[]))]
     [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
     public async Task<HttpResponseData> QueryDefaultAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "get", Route = "metric-rag/default")] HttpRequestData req)
@@ -79,7 +89,13 @@ public class MetricRagRatingsFunctions(IMetricRagRatingsService service, ILogger
         {
             try
             {
-                var result = await service.QueryAsync(queryParams.Schools, queryParams.Categories, queryParams.Statuses);
+                var validationResult = await metricRagRatingsParametersValidator.ValidateAsync(queryParams);
+                if (!validationResult.IsValid)
+                {
+                    return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+                }
+
+                var result = await service.QueryAsync(queryParams.Urns, queryParams.Categories, queryParams.Statuses, queryParams.CompanyNumber, queryParams.LaCode, queryParams.Phase);
                 return await req.CreateJsonResponseAsync(result);
             }
             catch (Exception e)

--- a/platform/src/apis/Platform.Api.Insight/MetricRagRatings/MetricRagRatingsParameters.cs
+++ b/platform/src/apis/Platform.Api.Insight/MetricRagRatings/MetricRagRatingsParameters.cs
@@ -1,21 +1,24 @@
-﻿using System;
-using System.Linq;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Platform.Functions;
 using Platform.Functions.Extensions;
-
 namespace Platform.Api.Insight.MetricRagRatings;
 
 public record MetricRagRatingsParameters : QueryParameters
 {
-    public string[] Categories { get; private set; } = Array.Empty<string>();
-    public string[] Schools { get; private set; } = Array.Empty<string>();
-    public string[] Statuses { get; private set; } = Array.Empty<string>();
+    public string[] Categories { get; internal set; } = [];
+    public string[] Statuses { get; internal set; } = [];
+    public string[] Urns { get; internal set; } = [];
+    public string? Phase { get; internal set; }
+    public string? CompanyNumber { get; internal set; }
+    public string? LaCode { get; internal set; }
 
     public override void SetValues(IQueryCollection query)
     {
         Statuses = query.ToStringArray("statuses");
         Categories = query.ToStringArray("categories");
-        Schools = query.ToStringArray("urns");
+        Urns = query.ToStringArray("urns");
+        CompanyNumber = query["companyNumber"].ToString();
+        Phase = query["phase"].ToString();
+        LaCode = query["laCode"].ToString();
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/OpenApi/Examples/ExpenditureExamples.cs
+++ b/platform/src/apis/Platform.Api.Insight/OpenApi/Examples/ExpenditureExamples.cs
@@ -47,3 +47,18 @@ internal class ExampleOverallPhase : OpenApiExample<string>
         return this;
     }
 }
+
+[ExcludeFromCodeCoverage]
+internal class ExampleRagStatuses : OpenApiExample<string>
+{
+    public override IOpenApiExample<string> Build(NamingStrategy namingStrategy = null!)
+    {
+        foreach (var status in RagRating.All)
+        {
+            Examples.Add(OpenApiExampleResolver.Resolve(status, status, namingStrategy));
+
+        }
+
+        return this;
+    }
+}

--- a/platform/src/apis/Platform.Api.Insight/Validators/IncomeParametersValidator.cs
+++ b/platform/src/apis/Platform.Api.Insight/Validators/IncomeParametersValidator.cs
@@ -1,5 +1,4 @@
 ﻿using FluentValidation;
-using Platform.Api.Insight.Expenditure;
 using Platform.Api.Insight.Income;
 namespace Platform.Api.Insight.Validators;
 
@@ -17,5 +16,5 @@ public class IncomeParametersValidator : AbstractValidator<IncomeParameters>
     }
 
     private static bool BeAnEmptyOrValidCategory(string? category) => string.IsNullOrWhiteSpace(category) || IncomeCategories.IsValid(category);
-    private static bool BeAValidDimension(string? dimension) => ExpenditureDimensions.IsValid(dimension);
+    private static bool BeAValidDimension(string? dimension) => IncomeDimensions.IsValid(dimension);
 }

--- a/platform/src/apis/Platform.Api.Insight/Validators/MetricRagRatingsParametersValidator.cs
+++ b/platform/src/apis/Platform.Api.Insight/Validators/MetricRagRatingsParametersValidator.cs
@@ -1,0 +1,43 @@
+﻿using System.Linq;
+using FluentValidation;
+using Platform.Api.Insight.Domain;
+using Platform.Api.Insight.Expenditure;
+using Platform.Api.Insight.MetricRagRatings;
+namespace Platform.Api.Insight.Validators;
+
+public class MetricRagRatingsParametersValidator : AbstractValidator<MetricRagRatingsParameters>
+{
+    public MetricRagRatingsParametersValidator()
+    {
+        RuleFor(x => x.Categories)
+            .Must(ContainValidCategories)
+            .WithMessage($"{{PropertyName}} must only contain the supported values: {string.Join(", ", ExpenditureCategories.All)}");
+
+        RuleFor(x => x.Statuses)
+            .Must(ContainValidStatuses)
+            .WithMessage($"{{PropertyName}} must only contain the supported values: {string.Join(", ", RagRating.All)}");
+
+        RuleFor(x => x.Urns)
+            .NotEmpty()
+            .When(x => string.IsNullOrWhiteSpace(x.CompanyNumber))
+            .When(x => string.IsNullOrWhiteSpace(x.LaCode))
+            .WithMessage($"Either a collection of URNs or one of {nameof(MetricRagRatingsParameters.CompanyNumber)} or {nameof(MetricRagRatingsParameters.LaCode)} must be specified");
+
+        RuleFor(x => x.LaCode)
+            .Empty()
+            .When(x => x.Urns.Length == 0)
+            .When(x => !string.IsNullOrWhiteSpace(x.CompanyNumber))
+            .WithMessage($"Either {nameof(MetricRagRatingsParameters.CompanyNumber)} or {nameof(MetricRagRatingsParameters.LaCode)} must be specified, not both");
+
+        RuleFor(x => x.Phase)
+            .Must(BeAValidPhase)
+            .When(x => x.Urns.Length == 0)
+            .When(x => !string.IsNullOrWhiteSpace(x.CompanyNumber) || !string.IsNullOrWhiteSpace(x.LaCode))
+            .WithMessage($"{{PropertyName}} must be be specified when {nameof(MetricRagRatingsParameters.CompanyNumber)} or {nameof(MetricRagRatingsParameters.LaCode)} is supplied and be one of the supported values: {string.Join(", ", OverallPhase.All)}");
+
+    }
+
+    private static bool ContainValidCategories(string[] categories) => categories.All(CostCategory.IsValid);
+    private static bool ContainValidStatuses(string[] statuses) => statuses.All(RagRating.IsValid);
+    private static bool BeAValidPhase(string? phase) => OverallPhase.IsValid(phase);
+}

--- a/platform/src/apis/Platform.Api.Insight/Validators/MetricRagRatingsParametersValidator.cs
+++ b/platform/src/apis/Platform.Api.Insight/Validators/MetricRagRatingsParametersValidator.cs
@@ -32,9 +32,8 @@ public class MetricRagRatingsParametersValidator : AbstractValidator<MetricRagRa
         RuleFor(x => x.Phase)
             .Must(BeAValidPhase)
             .When(x => x.Urns.Length == 0)
-            .When(x => !string.IsNullOrWhiteSpace(x.CompanyNumber) || !string.IsNullOrWhiteSpace(x.LaCode))
-            .WithMessage($"{{PropertyName}} must be be specified when {nameof(MetricRagRatingsParameters.CompanyNumber)} or {nameof(MetricRagRatingsParameters.LaCode)} is supplied and be one of the supported values: {string.Join(", ", OverallPhase.All)}");
-
+            .When(x => !string.IsNullOrWhiteSpace(x.LaCode))
+            .WithMessage($"{{PropertyName}} must be be specified when {nameof(MetricRagRatingsParameters.LaCode)} is supplied and be one of the supported values: {string.Join(", ", OverallPhase.All)}");
     }
 
     private static bool ContainValidCategories(string[] categories) => categories.All(CostCategory.IsValid);

--- a/platform/tests/Platform.ApiTests/Features/InsightMetricRagRatings.feature
+++ b/platform/tests/Platform.ApiTests/Features/InsightMetricRagRatings.feature
@@ -25,7 +25,7 @@
           | 777042 | Utilities                                  | Total       | 9.08    | 10.45   | -1.37    | -15.12      | 39.00      | 3.00   | amber |
 
     Scenario: Sending a valid default metric rag rating with company number and phase and default options
-        Given a valid default metric rag rating with categories '' and statuses '' with company number '8104190' and phase 'Secondary'
+        Given a valid default metric rag rating with categories '' and statuses '' with company number '8104190'
         When I submit the metric rag rating request
         Then the metric rag rating result should be ok and contain:
           | URN    | Category                                   | SubCategory | Value    | Mean    | DiffMean | PercentDiff | Percentile | Decile | RAG   |
@@ -38,6 +38,15 @@
           | 777051 | Premises staff and services                | Total       | 138.42   | 57.88   | 80.54    | 139.13      | 100.00     | 10.00  | red   |
           | 777051 | Teaching and Teaching support staff        | Total       | 11199.60 | 8855.38 | 2344.22  | 26.47       | 76.67      | 7.00   | amber |
           | 777051 | Utilities                                  | Total       | 0.00     | 12.26   | -12.26   | -100.00     | 3.33       | 0.00   | green |
+          | 777049 | Administrative supplies                    | Total       | 365.43   | 51.61   | 313.82   | 608.08      | 100.00     | 10.00  | red   |
+          | 777049 | Catering staff and supplies                | Total       | 373.66   | 261.96  | 111.71   | 42.64       | 86.67      | 8.00   | red   |
+          | 777049 | Educational ICT                            | Total       | 1.05     | 65.67   | -64.62   | -98.39      | 10.00      | 1.00   | amber |
+          | 777049 | Educational supplies                       | Total       | 344.54   | 211.04  | 133.50   | 63.26       | 96.67      | 9.00   | red   |
+          | 777049 | Non-educational support staff and services | Total       | 823.25   | 506.43  | 316.81   | 62.56       | 96.67      | 9.00   | red   |
+          | 777049 | Other costs                                | Total       | 358.80   | 256.77  | 102.03   | 39.74       | 83.33      | 8.00   | red   |
+          | 777049 | Premises staff and services                | Total       | 62.80    | 43.12   | 19.68    | 45.62       | 83.33      | 8.00   | red   |
+          | 777049 | Teaching and Teaching support staff        | Total       | 6465.78  | 4075.20 | 2390.58  | 58.66       | 100.00     | 10.00  | red   |
+          | 777049 | Utilities                                  | Total       | 14.17    | 12.17   | 2.00     | 16.43       | 73.33      | 7.00   | amber |
 
     Scenario: Sending a valid default metric rag rating with LA code and phase and default options
         Given a valid default metric rag rating with categories '' and statuses '' with LA code '205' and phase 'Primary'

--- a/platform/tests/Platform.ApiTests/Features/InsightMetricRagRatings.feature
+++ b/platform/tests/Platform.ApiTests/Features/InsightMetricRagRatings.feature
@@ -6,7 +6,7 @@
         Then the metric rag rating result should be ok and contain:
           | URN | Category | SubCategory | Value | Mean | DiffMean | PercentDiff | Percentile | Decile | RAG |
 
-    Scenario: Sending a valid default metric rag rating request with default options
+    Scenario: Sending a valid default metric rag rating request with URNs and default options
         Given a valid default metric rag rating with categories '' and statuses '' for urns:
           | Urn    |
           | 777042 |
@@ -23,6 +23,37 @@
           | 777042 | Premises staff and services                | Total       | 92.75   | 42.42   | 50.33    | 54.26       | 99.00      | 9.00   | red   |
           | 777042 | Teaching and Teaching support staff        | Total       | 6314.59 | 3540.90 | 2773.68  | 43.93       | 99.00      | 9.00   | red   |
           | 777042 | Utilities                                  | Total       | 9.08    | 10.45   | -1.37    | -15.12      | 39.00      | 3.00   | amber |
+
+    Scenario: Sending a valid default metric rag rating with company number and phase and default options
+        Given a valid default metric rag rating with categories '' and statuses '' with company number '8104190' and phase 'Secondary'
+        When I submit the metric rag rating request
+        Then the metric rag rating result should be ok and contain:
+          | URN    | Category                                   | SubCategory | Value    | Mean    | DiffMean | PercentDiff | Percentile | Decile | RAG   |
+          | 777051 | Administrative supplies                    | Total       | 60.15    | 116.30  | -56.16   | -48.28      | 26.67      | 2.00   | green |
+          | 777051 | Catering staff and supplies                | Total       | 1080.40  | 426.62  | 653.78   | 153.24      | 96.67      | 9.00   | red   |
+          | 777051 | Educational ICT                            | Total       | 0.00     | 45.74   | -45.74   | -100.00     | 10.00      | 1.00   | amber |
+          | 777051 | Educational supplies                       | Total       | 73.65    | 118.68  | -45.03   | -37.94      | 30.00      | 3.00   | green |
+          | 777051 | Non-educational support staff and services | Total       | 1594.56  | 1585.13 | 9.43     | 0.59        | 53.33      | 5.00   | amber |
+          | 777051 | Other costs                                | Total       | 784.94   | 437.39  | 347.55   | 79.46       | 86.67      | 8.00   | red   |
+          | 777051 | Premises staff and services                | Total       | 138.42   | 57.88   | 80.54    | 139.13      | 100.00     | 10.00  | red   |
+          | 777051 | Teaching and Teaching support staff        | Total       | 11199.60 | 8855.38 | 2344.22  | 26.47       | 76.67      | 7.00   | amber |
+          | 777051 | Utilities                                  | Total       | 0.00     | 12.26   | -12.26   | -100.00     | 3.33       | 0.00   | green |
+
+    Scenario: Sending a valid default metric rag rating with LA code and phase and default options
+        Given a valid default metric rag rating with categories '' and statuses '' with LA code '205' and phase 'Primary'
+        When I submit the metric rag rating request
+        Then the metric rag rating result should be ok and contain:
+          | URN    | Category                                   | SubCategory | Value   | Mean    | DiffMean | PercentDiff | Percentile | Decile | RAG   |
+          | 777042 | Administrative supplies                    | Total       | 429.07  | 47.78   | 381.28   | 88.86       | 99.00      | 9.00   | red   |
+          | 777042 | Catering staff and supplies                | Total       | 362.59  | 173.19  | 189.40   | 52.23       | 92.33      | 9.00   | red   |
+          | 777042 | Educational ICT                            | Total       | 37.59   | 67.38   | -29.79   | -79.26      | 22.33      | 2.00   | amber |
+          | 777042 | Educational supplies                       | Total       | 407.06  | 124.94  | 282.12   | 69.31       | 99.00      | 9.00   | red   |
+          | 777042 | Non-educational support staff and services | Total       | 844.54  | 493.42  | 351.12   | 41.58       | 95.67      | 9.00   | red   |
+          | 777042 | Other costs                                | Total       | 374.24  | 225.45  | 148.78   | 39.76       | 89.00      | 8.00   | red   |
+          | 777042 | Premises staff and services                | Total       | 92.75   | 42.42   | 50.33    | 54.26       | 99.00      | 9.00   | red   |
+          | 777042 | Teaching and Teaching support staff        | Total       | 6314.59 | 3540.90 | 2773.68  | 43.93       | 99.00      | 9.00   | red   |
+          | 777042 | Utilities                                  | Total       | 9.08    | 10.45   | -1.37    | -15.12      | 39.00      | 3.00   | amber |
+          | 990183 | Catering staff and supplies                | Total       | 480.00  | 260.00  | 219.00   | 46.00       | 96.00      | 9.00   | red   |
 
     Scenario: Sending a valid default metric rag rating request with categories
         Given a valid default metric rag rating with categories 'Administrative supplies,Catering staff and supplies' and statuses '' for urns:
@@ -45,3 +76,8 @@
           | URN    | Category        | SubCategory | Value | Mean  | DiffMean | PercentDiff | Percentile | Decile | RAG   |
           | 777042 | Educational ICT | Total       | 37.59 | 67.38 | -29.79   | -79.26      | 22.33      | 2.00   | amber |
           | 777042 | Utilities       | Total       | 9.08  | 10.45 | -1.37    | -15.12      | 39.00      | 3.00   | amber |
+
+    Scenario: Sending an invalid default metric rag rating request
+        Given a valid default metric rag rating with categories '' and statuses '' with LA code '205' and phase 'Invalid'
+        When I submit the metric rag rating request
+        Then the metric rag rating result should be bad request

--- a/platform/tests/Platform.ApiTests/Steps/InsightMetricRagRatingSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/InsightMetricRagRatingSteps.cs
@@ -31,12 +31,12 @@ public class MetricRagRatingsBalanceSteps(InsightApiDriver api)
         });
     }
 
-    [Given("a valid default metric rag rating with categories '(.*)' and statuses '(.*)' with company number '(.*)' and phase '(.*)'")]
-    public void GivenAValidDefaultMetricRagRatingWithCategoriesAndStatusesWithCompanyNumberAndPhase(string categories, string statuses, string companyNumber, string phase)
+    [Given("a valid default metric rag rating with categories '(.*)' and statuses '(.*)' with company number '(.*)'")]
+    public void GivenAValidDefaultMetricRagRatingWithCategoriesAndStatusesWithCompanyNumber(string categories, string statuses, string companyNumber)
     {
         api.CreateRequest(MetricRagRatingsKey, new HttpRequestMessage
         {
-            RequestUri = new Uri($"/api/metric-rag/default/?companyNumber={companyNumber}&phase={phase}&categories={string.Join("&categories=", categories.Split(","))}&statuses={string.Join("&statuses=", statuses.Split(","))}", UriKind.Relative),
+            RequestUri = new Uri($"/api/metric-rag/default/?companyNumber={companyNumber}&categories={string.Join("&categories=", categories.Split(","))}&statuses={string.Join("&statuses=", statuses.Split(","))}", UriKind.Relative),
             Method = HttpMethod.Get
         });
     }

--- a/platform/tests/Platform.ApiTests/Steps/InsightMetricRagRatingSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/InsightMetricRagRatingSteps.cs
@@ -31,6 +31,26 @@ public class MetricRagRatingsBalanceSteps(InsightApiDriver api)
         });
     }
 
+    [Given("a valid default metric rag rating with categories '(.*)' and statuses '(.*)' with company number '(.*)' and phase '(.*)'")]
+    public void GivenAValidDefaultMetricRagRatingWithCategoriesAndStatusesWithCompanyNumberAndPhase(string categories, string statuses, string companyNumber, string phase)
+    {
+        api.CreateRequest(MetricRagRatingsKey, new HttpRequestMessage
+        {
+            RequestUri = new Uri($"/api/metric-rag/default/?companyNumber={companyNumber}&phase={phase}&categories={string.Join("&categories=", categories.Split(","))}&statuses={string.Join("&statuses=", statuses.Split(","))}", UriKind.Relative),
+            Method = HttpMethod.Get
+        });
+    }
+
+    [Given("a valid default metric rag rating with categories '(.*)' and statuses '(.*)' with LA code '(.*)' and phase '(.*)'")]
+    public void GivenAValidDefaultMetricRagRatingWithCategoriesAndStatusesWithLaCodeAndPhase(string categories, string statuses, string laCode, string phase)
+    {
+        api.CreateRequest(MetricRagRatingsKey, new HttpRequestMessage
+        {
+            RequestUri = new Uri($"/api/metric-rag/default/?laCode={laCode}&phase={phase}&categories={string.Join("&categories=", categories.Split(","))}&statuses={string.Join("&statuses=", statuses.Split(","))}", UriKind.Relative),
+            Method = HttpMethod.Get
+        });
+    }
+
     [When("I submit the metric rag rating request")]
     public async Task WhenISubmitTheMetricRagRatingRequest()
     {
@@ -48,6 +68,15 @@ public class MetricRagRatingsBalanceSteps(InsightApiDriver api)
         var content = await response.Content.ReadAsByteArrayAsync();
         var result = content.FromJson<MetricRagRating[]>();
         table.CompareToSet(result);
+    }
+
+    [Then("the metric rag rating result should be bad request")]
+    public void ThenTheMetricRagRatingResultShouldBeBadRequest()
+    {
+        var response = api[MetricRagRatingsKey].Response;
+
+        response.Should().NotBeNull();
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     private static IEnumerable<string> GetFirstColumnsFromTableRowsAsString(DataTable table)

--- a/platform/tests/Platform.Tests/Insight/MetricRagRatings/WhenBudgetForecastServiceQueriesAsync.cs
+++ b/platform/tests/Platform.Tests/Insight/MetricRagRatings/WhenBudgetForecastServiceQueriesAsync.cs
@@ -53,7 +53,7 @@ public class WhenMetricRagRatingsServiceQueriesAsync
     {
         "1,2,3"
     }, new string[0], new string[0], null, null, null, "runType", true, "SELECT * from SchoolMetricRAG WHERE RunType = @RunType AND RunId = @RunId AND URN IN @URNS")]
-    [InlineData(new string[0], new string[0], new string[0], "companyNumber", null, "phase", "runType", true, "SELECT * from SchoolMetricRAG WHERE RunType = @RunType AND RunId = @RunId AND TrustCompanyNumber = @CompanyNumber AND OverallPhase = @Phase")]
+    [InlineData(new string[0], new string[0], new string[0], "companyNumber", null, null, "runType", true, "SELECT * from SchoolMetricRAG WHERE RunType = @RunType AND RunId = @RunId AND TrustCompanyNumber = @CompanyNumber")]
     [InlineData(new string[0], new string[0], new string[0], null, "laCode", "phase", "runType", true, "SELECT * from SchoolMetricRAG WHERE RunType = @RunType AND RunId = @RunId AND LaCode = @LaCode AND OverallPhase = @Phase")]
     public async Task ShouldQueryAsyncWhenQueryAsync(
         string[] urns,

--- a/platform/tests/Platform.Tests/Insight/MetricRagRatings/WhenMetricRagRatingsParametersSetsValues.cs
+++ b/platform/tests/Platform.Tests/Insight/MetricRagRatings/WhenMetricRagRatingsParametersSetsValues.cs
@@ -7,9 +7,21 @@ namespace Platform.Tests.Insight.MetricRagRatings;
 public class WhenMetricRagRatingsParametersSetsValues
 {
     [Theory]
-    [InlineData("1,2,3", "4,5,6", "7,8,9", "1|2|3", "4|5|6", "7|8|9")]
-    [InlineData(null, null, null, "", "", "")]
-    public void ShouldSetValuesFromIQueryCollection(string? statuses, string? categories, string? urns, string expectedStatuses, string expectedCategories, string expectedSchools)
+    [InlineData("1,2,3", "4,5,6", "7,8,9", "companyNumber", "phase", "laCode", "1|2|3", "4|5|6", "7|8|9", "companyNumber", "phase", "laCode")]
+    [InlineData(null, null, null, null, null, null, "", "", "", "", "", "")]
+    public void ShouldSetValuesFromIQueryCollection(
+        string? statuses,
+        string? categories,
+        string? urns,
+        string? companyNumber,
+        string? phase,
+        string? laCode,
+        string expectedStatuses,
+        string expectedCategories,
+        string expectedUrns,
+        string expectedCompanyNumber,
+        string expectedPhase,
+        string expectedLaCode)
     {
         var parameters = new MetricRagRatingsParameters();
         var query = new QueryCollection(new Dictionary<string, StringValues>
@@ -22,6 +34,15 @@ public class WhenMetricRagRatingsParametersSetsValues
             },
             {
                 "urns", urns
+            },
+            {
+                "companyNumber", companyNumber
+            },
+            {
+                "phase", phase
+            },
+            {
+                "laCode", laCode
             }
         });
 
@@ -29,6 +50,9 @@ public class WhenMetricRagRatingsParametersSetsValues
 
         Assert.Equal(expectedStatuses, string.Join("|", parameters.Statuses));
         Assert.Equal(expectedCategories, string.Join("|", parameters.Categories));
-        Assert.Equal(expectedSchools, string.Join("|", parameters.Schools));
+        Assert.Equal(expectedUrns, string.Join("|", parameters.Urns));
+        Assert.Equal(expectedCompanyNumber, parameters.CompanyNumber);
+        Assert.Equal(expectedPhase, parameters.Phase);
+        Assert.Equal(expectedLaCode, parameters.LaCode);
     }
 }

--- a/platform/tests/Platform.Tests/Insight/Validators/WhenMetricRagRatingsParametersValidatorValidates.cs
+++ b/platform/tests/Platform.Tests/Insight/Validators/WhenMetricRagRatingsParametersValidatorValidates.cs
@@ -36,14 +36,7 @@ public class WhenMetricRagRatingsParametersValidatorValidates
     }, new[]
     {
         RagRating.Red
-    }, "12345678", null, OverallPhase.Primary)]
-    [InlineData(new string[0], new[]
-    {
-        CostCategory.TeachingStaff
-    }, new[]
-    {
-        RagRating.Red
-    }, null, "123", OverallPhase.Primary)]
+    }, "12345678", null, null)]
     [InlineData(new string[0], new[]
     {
         CostCategory.TeachingStaff
@@ -51,6 +44,13 @@ public class WhenMetricRagRatingsParametersValidatorValidates
     {
         RagRating.Red
     }, null, "123", "Pupil referral unit")]
+    [InlineData(new string[0], new[]
+    {
+        CostCategory.TeachingStaff
+    }, new[]
+    {
+        RagRating.Red
+    }, null, "123", OverallPhase.Primary)]
     public async Task ShouldValidateAndEvaluateGoodParametersAsValid(string[] urns, string[] categories, string[] statuses, string? companyNumber, string? laCode, string? phase)
     {
         var parameters = new MetricRagRatingsParameters
@@ -96,20 +96,6 @@ public class WhenMetricRagRatingsParametersValidatorValidates
     {
         RagRating.Red
     }, null, null, null)]
-    [InlineData(new string[0], new[]
-    {
-        CostCategory.TeachingStaff
-    }, new[]
-    {
-        RagRating.Red
-    }, "companyNumber", null, null)]
-    [InlineData(new string[0], new[]
-    {
-        CostCategory.TeachingStaff
-    }, new[]
-    {
-        RagRating.Red
-    }, "companyNumber", null, "Invalid")]
     [InlineData(new string[0], new[]
     {
         CostCategory.TeachingStaff

--- a/platform/tests/Platform.Tests/Insight/Validators/WhenMetricRagRatingsParametersValidatorValidates.cs
+++ b/platform/tests/Platform.Tests/Insight/Validators/WhenMetricRagRatingsParametersValidatorValidates.cs
@@ -1,0 +1,143 @@
+﻿using Platform.Api.Insight.Domain;
+using Platform.Api.Insight.MetricRagRatings;
+using Platform.Api.Insight.Validators;
+using Xunit;
+namespace Platform.Tests.Insight.Validators;
+
+public class WhenMetricRagRatingsParametersValidatorValidates
+{
+    private readonly MetricRagRatingsParametersValidator _validator = new();
+
+    [Theory]
+    [InlineData(new[]
+    {
+        "urn"
+    }, new[]
+    {
+        CostCategory.TeachingStaff
+    }, new[]
+    {
+        RagRating.Red
+    }, null, null, null)]
+    [InlineData(new[]
+    {
+        "urn"
+    }, new[]
+    {
+        CostCategory.TeachingStaff
+    }, new string[0], null, null, null)]
+    [InlineData(new[]
+    {
+        "urn"
+    }, new string[0], new string[0], null, null, null)]
+    [InlineData(new string[0], new[]
+    {
+        CostCategory.TeachingStaff
+    }, new[]
+    {
+        RagRating.Red
+    }, "12345678", null, OverallPhase.Primary)]
+    [InlineData(new string[0], new[]
+    {
+        CostCategory.TeachingStaff
+    }, new[]
+    {
+        RagRating.Red
+    }, null, "123", OverallPhase.Primary)]
+    [InlineData(new string[0], new[]
+    {
+        CostCategory.TeachingStaff
+    }, new[]
+    {
+        RagRating.Red
+    }, null, "123", "Pupil referral unit")]
+    public async Task ShouldValidateAndEvaluateGoodParametersAsValid(string[] urns, string[] categories, string[] statuses, string? companyNumber, string? laCode, string? phase)
+    {
+        var parameters = new MetricRagRatingsParameters
+        {
+            Urns = urns,
+            Categories = categories,
+            Statuses = statuses,
+            CompanyNumber = companyNumber,
+            LaCode = laCode,
+            Phase = phase
+        };
+
+        var actual = await _validator.ValidateAsync(parameters);
+        Assert.True(actual.IsValid);
+        Assert.Empty(actual.Errors);
+    }
+
+    [Theory]
+    [InlineData(new[]
+    {
+        "urn"
+    }, new[]
+    {
+        CostCategory.TeachingStaff
+    }, new[]
+    {
+        "Invalid"
+    }, null, null, null)]
+    [InlineData(new[]
+    {
+        "urn"
+    }, new[]
+    {
+        "Invalid"
+    }, new[]
+    {
+        RagRating.Red
+    }, null, null, null)]
+    [InlineData(new string[0], new[]
+    {
+        CostCategory.TeachingStaff
+    }, new[]
+    {
+        RagRating.Red
+    }, null, null, null)]
+    [InlineData(new string[0], new[]
+    {
+        CostCategory.TeachingStaff
+    }, new[]
+    {
+        RagRating.Red
+    }, "companyNumber", null, null)]
+    [InlineData(new string[0], new[]
+    {
+        CostCategory.TeachingStaff
+    }, new[]
+    {
+        RagRating.Red
+    }, "companyNumber", null, "Invalid")]
+    [InlineData(new string[0], new[]
+    {
+        CostCategory.TeachingStaff
+    }, new[]
+    {
+        RagRating.Red
+    }, null, "laCode", null)]
+    [InlineData(new string[0], new[]
+    {
+        CostCategory.TeachingStaff
+    }, new[]
+    {
+        RagRating.Red
+    }, null, "laCode", "Invalid")]
+    public async Task ShouldValidateAndEvaluateBadParametersAsInvalid(string[] urns, string[] categories, string[] statuses, string? companyNumber, string? laCode, string? phase)
+    {
+        var parameters = new MetricRagRatingsParameters
+        {
+            Urns = urns,
+            Categories = categories,
+            Statuses = statuses,
+            CompanyNumber = companyNumber,
+            LaCode = laCode,
+            Phase = phase
+        };
+
+        var actual = await _validator.ValidateAsync(parameters);
+        Assert.False(actual.IsValid);
+        Assert.NotEmpty(actual.Errors);
+    }
+}

--- a/web/src/Web.App/Controllers/TrustController.cs
+++ b/web/src/Web.App/Controllers/TrustController.cs
@@ -37,12 +37,7 @@ public class TrustController(
 
                 var trust = await Trust(companyNumber);
                 var balance = await TrustBalance(companyNumber);
-                var phases = trust.Schools.Select(s => s.OverallPhase).OfType<string>().Distinct().ToArray();
-                IEnumerable<RagRating> ratings = [];
-                await foreach (var ragRatings in RagRatings(companyNumber, phases))
-                {
-                    ratings = ratings.UnionBy(ragRatings, r => r.URN + r.Category);
-                }
+                var ratings = await RagRatings(companyNumber);
 
                 var viewModel = new TrustViewModel(trust, balance, ratings, comparatorReverted);
                 return View(viewModel);
@@ -135,23 +130,16 @@ public class TrustController(
         }
     }
 
-    private static ApiQuery BuildQuery(string companyNumber, string phase)
+    private static ApiQuery BuildQuery(string companyNumber)
     {
         var query = new ApiQuery();
         query.AddIfNotNull("companyNumber", companyNumber);
-        query.AddIfNotNull("phase", phase);
         return query;
     }
 
-    private async IAsyncEnumerable<RagRating[]> RagRatings(string companyNumber, string[] phases)
-    {
-        foreach (var phase in phases)
-        {
-            yield return await metricRagRatingApi
-                .GetDefaultAsync(BuildQuery(companyNumber, phase))
-                .GetResultOrThrow<RagRating[]>();
-        }
-    }
+    private async Task<RagRating[]> RagRatings(string companyNumber) => await metricRagRatingApi
+        .GetDefaultAsync(BuildQuery(companyNumber))
+        .GetResultOrThrow<RagRating[]>();
 
     private async Task<TrustBalance> TrustBalance(string companyNumber) => await balanceApi
         .Trust(companyNumber)

--- a/web/src/Web.App/Controllers/TrustSpendingController.cs
+++ b/web/src/Web.App/Controllers/TrustSpendingController.cs
@@ -40,10 +40,7 @@ public class TrustSpendingController(ILogger<TrustController> logger, IEstablish
 
                 var trust = await establishmentApi.GetTrust(companyNumber).GetResultOrThrow<Trust>();
                 var schoolsQuery = new ApiQuery();
-                foreach (var school in trust.Schools)
-                {
-                    schoolsQuery.AddIfNotNull("urns", school.URN);
-                }
+                schoolsQuery.AddIfNotNull("companyNumber", companyNumber);
 
                 if (categories != null)
                 {

--- a/web/src/Web.App/Views/TrustSpending/Index.cshtml
+++ b/web/src/Web.App/Views/TrustSpending/Index.cshtml
@@ -70,21 +70,22 @@
             {
                 <div>
                     <h2 class="govuk-heading-m" id="@rating.CostCategory?.ToSlug()">@rating.CostCategory</h2>
-
-                    @foreach (var status in rating.Statuses)
-                    {
-                        <h3 class="govuk-heading-s">@status.PriorityTag?.DisplayText</h3>
-                        @await Html.PartialAsync("_PriorityStatus", new TrustSpendingPriorityStatusViewModel(status.PriorityTag, status.Schools.Count(), Model.NumberSchools))
-                        @await Html.PartialAsync("_PriorityTable", status.Schools, new ViewDataDictionary(ViewData)
+                    <section id="@rating.CostCategory?.ToSlug()-section">
+                        @foreach (var status in rating.Statuses)
                         {
+                            <h3 class="govuk-heading-s">@status.PriorityTag?.DisplayText</h3>
+                            @await Html.PartialAsync("_PriorityStatus", new TrustSpendingPriorityStatusViewModel(status.PriorityTag, status.Schools.Count(), Model.NumberSchools))
+                            @await Html.PartialAsync("_PriorityTable", status.Schools, new ViewDataDictionary(ViewData)
                             {
-                                "Category", rating.CostCategory
-                            },
-                            {
-                                "Status", status.Status
-                            }
-                        })
-                    }
+                                {
+                                    "Category", rating.CostCategory
+                                },
+                                {
+                                    "Status", status.Status
+                                }
+                            })
+                        }
+                    </section>
                 </div>
             }
         }
@@ -93,23 +94,24 @@
             @foreach (var rating in Model.RatingsByPriority)
             {
                 <h2 class="govuk-heading-m" id="@rating.PriorityTag?.DisplayText.ToSlug()">@rating.PriorityTag?.DisplayText</h2>
-
-                @foreach (var category in rating.Categories)
-                {
-                    <div>
-                        <h3 class="govuk-heading-s">@category.Category</h3>
-                        @await Html.PartialAsync("_PriorityStatus", new TrustSpendingPriorityStatusViewModel(rating.PriorityTag, category.Schools.Count(), Model.NumberSchools))
-                        @await Html.PartialAsync("_PriorityTable", category.Schools, new ViewDataDictionary(ViewData)
-                        {
+                <section id="@rating.PriorityTag?.DisplayText.ToSlug()-section">
+                    @foreach (var category in rating.Categories)
+                    {
+                        <div>
+                            <h3 class="govuk-heading-s">@category.Category</h3>
+                            @await Html.PartialAsync("_PriorityStatus", new TrustSpendingPriorityStatusViewModel(rating.PriorityTag, category.Schools.Count(), Model.NumberSchools))
+                            @await Html.PartialAsync("_PriorityTable", category.Schools, new ViewDataDictionary(ViewData)
                             {
-                                "Category", category.Category
-                            },
-                            {
-                                "Status", rating.Status
-                            }
-                        })
-                    </div>
-                }
+                                {
+                                    "Category", category.Category
+                                },
+                                {
+                                    "Status", rating.Status
+                                }
+                            })
+                        </div>
+                    }
+                </section>
             }
         }
     </div>

--- a/web/tests/Web.E2ETests/Features/Trust/SpendingCosts.feature
+++ b/web/tests/Web.E2ETests/Features/Trust/SpendingCosts.feature
@@ -1,0 +1,20 @@
+Feature: Trust spending and costs
+
+    Scenario: Cost categories are in the correct priority
+        Given I am on spending and costs for trust with company number '8104190'
+        Then the priority categories are:
+          | Priority        | Category                                   | Commentary                                      |
+          | High priority   | Catering staff and supplies                | 2 out of 7 schools in the high priority range   |
+          | High priority   | Other costs                                | 2 out of 7 schools in the high priority range   |
+          | High priority   | Premises staff and services                | 2 out of 7 schools in the high priority range   |
+          | High priority   | Administrative supplies                    | 1 out of 7 schools in the high priority range   |
+          | High priority   | Educational supplies                       | 1 out of 7 schools in the high priority range   |
+          | High priority   | Non-educational support staff and services | 1 out of 7 schools in the high priority range   |
+          | High priority   | Teaching and Teaching support staff        | 1 out of 7 schools in the high priority range   |
+          | Medium priority | Educational ICT                            | 2 out of 7 schools in the medium priority range |
+          | Medium priority | Utilities                                  | 1 out of 7 schools in the medium priority range |
+          | Medium priority | Non-educational support staff and services | 1 out of 7 schools in the medium priority range |
+          | Medium priority | Teaching and Teaching support staff        | 1 out of 7 schools in the medium priority range |
+          | Low priority    | Administrative supplies                    | 1 out of 7 schools in the low priority range    |
+          | Low priority    | Educational supplies                       | 1 out of 7 schools in the low priority range    |
+          | Low priority    | Utilities                                  | 1 out of 7 schools in the low priority range    |

--- a/web/tests/Web.E2ETests/Features/Trust/TrustHome.feature
+++ b/web/tests/Web.E2ETests/Features/Trust/TrustHome.feature
@@ -5,6 +5,11 @@
         When I click on compare your costs
         Then the compare your costs page is displayed
 
+    Scenario: Go to spending and costs page
+        Given I am on trust homepage for trust with company number '8104190'
+        When I click on view all spending priorities for this trust
+        Then the spending and costs page is displayed
+
     Scenario: View RAG ratings for cost categories in trust
         Given I am on trust homepage for trust with company number '8104190'
         Then I can see the following RAG ratings for cost categories in the trust:

--- a/web/tests/Web.E2ETests/Features/Trust/TrustHome.feature
+++ b/web/tests/Web.E2ETests/Features/Trust/TrustHome.feature
@@ -4,3 +4,28 @@
         Given I am on trust homepage for trust with company number '10074054'
         When I click on compare your costs
         Then the compare your costs page is displayed
+
+    Scenario: View RAG ratings for cost categories in trust
+        Given I am on trust homepage for trust with company number '8104190'
+        Then I can see the following RAG ratings for cost categories in the trust:
+          | Name                                       | Status                                                                               |
+          | Catering staff and supplies                | 2 high, 0 medium and 0 low priorities for Catering staff and supplies                |
+          | Premises staff and services                | 2 high, 0 medium and 0 low priorities for Premises staff and services                |
+          | Non-educational support staff and services | 1 high, 1 medium and 0 low priorities for Non-educational support staff and services |
+          | Teaching and Teaching support staff        | 1 high, 1 medium and 0 low priorities for Teaching and Teaching support staff        |
+          | Administrative supplies                    | 1 high, 0 medium and 1 low priorities for Administrative supplies                    |
+          | Educational supplies                       | 1 high, 0 medium and 1 low priorities for Educational supplies                       |
+          | Educational ICT                            | 0 high, 2 medium and 0 low priorities for Educational ICT                            |
+          | Utilities                                  | 0 high, 1 medium and 1 low priorities for Utilities                                  |
+
+    Scenario: View RAG ratings for schools in trust
+        Given I am on trust homepage for trust with company number '8104190'
+        Then I can see the following RAG ratings for schools in the trust:
+          | Name                    | Status                                                            |
+          | Test academy school 319 | 6 high, 2 medium and 0 low priorities for Test academy school 319 |
+          | Test academy school 87  | 2 high, 3 medium and 3 low priorities for Test academy school 87  |
+          | Test academy school 90  | Status unavailable                                                |
+          | Test academy school 91  | Status unavailable                                                |
+          | Test academy school 92  | Status unavailable                                                |
+          | Test academy school 93  | Status unavailable                                                |
+          | Test academy school 94  | Status unavailable                                                |

--- a/web/tests/Web.E2ETests/Pages/Trust/HomePage.cs
+++ b/web/tests/Web.E2ETests/Pages/Trust/HomePage.cs
@@ -9,6 +9,10 @@ public class HomePage(IPage page)
     {
         HasText = "View school spending"
     });
+    private ILocator SpendingPrioritiesLink => page.Locator(Selectors.GovLink, new PageLocatorOptions
+    {
+        HasText = "View all spending priorities for this trust"
+    });
     private ILocator CookieBanner => page.Locator(Selectors.CookieBanner);
 
     public async Task IsDisplayed()
@@ -21,6 +25,12 @@ public class HomePage(IPage page)
     {
         await CompareYourCostsLink.Click();
         return new CompareYourCostsPage(page);
+    }
+
+    public async Task<SpendingCostsPage> ClickSpendingPriorities()
+    {
+        await SpendingPrioritiesLink.Click();
+        return new SpendingCostsPage(page);
     }
 
     public async Task CookieBannerIsDisplayed()

--- a/web/tests/Web.E2ETests/Pages/Trust/HomePage.cs
+++ b/web/tests/Web.E2ETests/Pages/Trust/HomePage.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Playwright;
+using Xunit;
 namespace Web.E2ETests.Pages.Trust;
 
 public class HomePage(IPage page)
@@ -25,5 +26,21 @@ public class HomePage(IPage page)
     public async Task CookieBannerIsDisplayed()
     {
         await CookieBanner.ShouldBeVisible();
+    }
+
+    public async Task AssertCategoryRags(string name, string status)
+    {
+        var cell = page.Locator($".table-cost-category-rag tbody > tr > td:has-text('{name}'):first-of-type");
+        await cell.ShouldBeVisible();
+        var content = await cell.Locator("~ td").TextContentAsync();
+        Assert.Equal(status, content?.Trim());
+    }
+
+    public async Task AssertSchoolRags(string name, string status)
+    {
+        var cell = page.Locator($".table-school-rag tbody > tr > td:has-text('{name}'):first-of-type");
+        await cell.ShouldBeVisible();
+        var content = await cell.Locator("~ td").TextContentAsync();
+        Assert.Equal(status, content?.Trim());
     }
 }

--- a/web/tests/Web.E2ETests/Pages/Trust/SpendingCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/Trust/SpendingCostsPage.cs
@@ -1,0 +1,38 @@
+using Microsoft.Playwright;
+using Xunit;
+namespace Web.E2ETests.Pages.Trust;
+
+public class SpendingCostsPage(IPage page)
+{
+    private ILocator PageH1Heading => page.Locator(Selectors.H1);
+    private ILocator HighPriorityHeading => PriorityHeading("High priority");
+    private ILocator MediumPriorityHeading => PriorityHeading("Medium priority");
+    private ILocator LowPriorityHeading => PriorityHeading("Low priority");
+    private ILocator Filters => page.Locator(Selectors.Aside);
+    private ILocator PriorityHeading(string priority) => page.Locator(Selectors.H2, new PageLocatorOptions
+    {
+        HasText = priority
+    });
+
+    public async Task IsDisplayed()
+    {
+        await PageH1Heading.ShouldBeVisible();
+        await HighPriorityHeading.ShouldBeVisible();
+        await MediumPriorityHeading.ShouldBeVisible();
+        await LowPriorityHeading.ShouldBeVisible();
+        await Filters.ShouldBeVisible();
+    }
+
+    public async Task AssertCategoryPriority(string priority, string category, string commentary)
+    {
+        var section = page.Locator($"#{priority.ToLower().Replace(" ", "-")}-section");
+        await section.ShouldBeVisible();
+        var heading = section.Locator("> div > h3", new LocatorLocatorOptions
+        {
+            HasText = category
+        });
+        await heading.ShouldBeVisible();
+        var text = await heading.Locator("~ .top-categories").InnerTextAsync();
+        Assert.Equal($"{priority} {commentary}", text);
+    }
+}

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -54,6 +54,7 @@ public static class Selectors
     public const string Charts = ".recharts-surface";
     public const string Table = "table";
     public const string Button = "button";
+    public const string Aside = "aside";
 
     public const string ComparisonChartsAndTables = "#compare-your-costs";
     public const string ComparisonTables = "#compare-your-costs table.govuk-table";

--- a/web/tests/Web.E2ETests/Steps/Trust/HomeSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/Trust/HomeSteps.cs
@@ -8,6 +8,7 @@ namespace Web.E2ETests.Steps.Trust;
 public class HomeSteps(PageDriver driver)
 {
     private CompareYourCostsPage? _compareYourCostsPage;
+    private SpendingCostsPage? _spendingCostsPage;
     private HomePage? _trustHomePage;
 
     [Given("I am on trust homepage for trust with company number '(.*)'")]
@@ -35,8 +36,22 @@ public class HomeSteps(PageDriver driver)
         await _compareYourCostsPage.IsDisplayed();
     }
 
+    [When("I click on view all spending priorities for this trust")]
+    public async Task WhenIClickOnViewAllSpendingPrioritiesForThisTrust()
+    {
+        Assert.NotNull(_trustHomePage);
+        _spendingCostsPage = await _trustHomePage.ClickSpendingPriorities();
+    }
+
+    [Then("the spending and costs page is displayed")]
+    public async Task ThenTheSpendingAndCostsPageIsDisplayed()
+    {
+        Assert.NotNull(_spendingCostsPage);
+        await _spendingCostsPage.IsDisplayed();
+    }
+
     [Then("I can see the following RAG ratings for cost categories in the trust:")]
-    public async Task ThenICanSeeTheFollowingRagRatingsForSchsoolsInTheTrust(DataTable table)
+    public async Task ThenICanSeeTheFollowingRagRatingsForCostCategoriesInTheTrust(DataTable table)
     {
         Assert.NotNull(_trustHomePage);
 

--- a/web/tests/Web.E2ETests/Steps/Trust/HomeSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/Trust/HomeSteps.cs
@@ -1,5 +1,4 @@
-﻿using Reqnroll;
-using Web.E2ETests.Drivers;
+﻿using Web.E2ETests.Drivers;
 using Web.E2ETests.Pages.Trust;
 using Xunit;
 namespace Web.E2ETests.Steps.Trust;
@@ -34,6 +33,30 @@ public class HomeSteps(PageDriver driver)
     {
         Assert.NotNull(_compareYourCostsPage);
         await _compareYourCostsPage.IsDisplayed();
+    }
+
+    [Then("I can see the following RAG ratings for cost categories in the trust:")]
+    public async Task ThenICanSeeTheFollowingRagRatingsForSchsoolsInTheTrust(DataTable table)
+    {
+        Assert.NotNull(_trustHomePage);
+
+        var rags = table.Rows.ToDictionary(row => row["Name"], row => row["Status"]);
+        foreach (var row in rags)
+        {
+            await _trustHomePage.AssertCategoryRags(row.Key, row.Value);
+        }
+    }
+
+    [Then("I can see the following RAG ratings for schools in the trust:")]
+    public async Task ThenICanSeeTheFollowingRagRatingsForSchoolsInTheTrust(DataTable table)
+    {
+        Assert.NotNull(_trustHomePage);
+
+        var rags = table.Rows.ToDictionary(row => row["Name"], row => row["Status"]);
+        foreach (var row in rags)
+        {
+            await _trustHomePage.AssertSchoolRags(row.Key, row.Value);
+        }
     }
 
     private static string TrustHomeUrl(string companyNumber) => $"{TestConfiguration.ServiceUrl}/trust/{companyNumber}";

--- a/web/tests/Web.E2ETests/Steps/Trust/SpendingCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/Trust/SpendingCostsSteps.cs
@@ -1,0 +1,35 @@
+using Web.E2ETests.Drivers;
+using Web.E2ETests.Pages.Trust;
+using Xunit;
+namespace Web.E2ETests.Steps.Trust;
+
+[Binding]
+[Scope(Feature = "Trust spending and costs")]
+public class SpendingCostsSteps(PageDriver driver)
+{
+    private SpendingCostsPage? _spendingCostsPage;
+
+    [Given("I am on spending and costs for trust with company number '(.*)'")]
+    public async Task GivenIAmOnSpendingAndCostsForTrustWithCompanyNumber(string companyNumber)
+    {
+        var url = SpendingCostsUrl(companyNumber);
+        var page = await driver.Current;
+        await page.GotoAndWaitForLoadAsync(url);
+
+        _spendingCostsPage = new SpendingCostsPage(page);
+        await _spendingCostsPage.IsDisplayed();
+    }
+
+    [Then("the priority categories are:")]
+    public async Task ThenThePriorityCategoriesAre(DataTable table)
+    {
+        Assert.NotNull(_spendingCostsPage);
+
+        foreach (var row in table.Rows)
+        {
+            await _spendingCostsPage.AssertCategoryPriority(row["Priority"], row["Category"], row["Commentary"]);
+        }
+    }
+
+    private static string SpendingCostsUrl(string urn) => $"{TestConfiguration.ServiceUrl}/trust/{urn}/spending-and-costs";
+}

--- a/web/tests/Web.E2ETests/Web.E2ETests.csproj
+++ b/web/tests/Web.E2ETests/Web.E2ETests.csproj
@@ -29,42 +29,4 @@
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
     </ItemGroup>
-    <ItemGroup>
-        <Compile Update="Features\Trust\TrustHome.feature.cs">
-            <DependentUpon>SchoolHome.feature</DependentUpon>
-            <AutoGen>true</AutoGen>
-            <DesignTime>true</DesignTime>
-            <Visible>true</Visible>
-        </Compile>
-        <Compile Update="Features\LocalAuthority\CompareYourCosts.feature.cs">
-            <DependentUpon>CompareYourCosts.feature</DependentUpon>
-            <AutoGen>true</AutoGen>
-            <DesignTime>true</DesignTime>
-            <Visible>true</Visible>
-        </Compile>
-        <Compile Update="Features\LocalAuthority\LocalAuthorityHome.feature.cs">
-            <DependentUpon>LocalAuthorityHome.feature</DependentUpon>
-            <AutoGen>true</AutoGen>
-            <DesignTime>true</DesignTime>
-            <Visible>true</Visible>
-        </Compile>
-        <Compile Update="Features\LocalAuthority\BenchmarkCensus.feature.cs">
-            <DependentUpon>BenchmarkCensus.feature</DependentUpon>
-            <AutoGen>true</AutoGen>
-            <DesignTime>true</DesignTime>
-            <Visible>true</Visible>
-        </Compile>
-        <Compile Update="Features\LocalAuthority\CompareYourCosts.feature.cs">
-            <DependentUpon>CompareYourCosts.feature</DependentUpon>
-            <AutoGen>true</AutoGen>
-            <DesignTime>true</DesignTime>
-            <Visible>true</Visible>
-        </Compile>
-        <Compile Update="Features\LocalAuthority\LocalAuthorityHome.feature.cs">
-            <DependentUpon>TrustHome.feature</DependentUpon>
-            <AutoGen>true</AutoGen>
-            <DesignTime>true</DesignTime>
-            <Visible>true</Visible>
-        </Compile>
-    </ItemGroup>
 </Project>


### PR DESCRIPTION
### Context
[AB#236605](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/236605) [AB#235684](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/235684)

### Change proposed in this pull request
- `[dbo].[SchoolMetricRAG]` view created to include `OverallPhase` and `LaCode` as well as contents of `[dbo].[MetricRAG]`
- Insight API updates to support additional query parameters `companyNumber`, `laCode` and `phase`
- Validation added to RAG-related parameters
- Consume modified endpoint from Web
- Additional and modified tests to complete coverage of the above

### Guidance to review 
View addition already pushed to `d02` to aid validation. Modify config as appropriate and start the Platform APIs. All API tests should pass. Start Web, pointing to the local API. All E2E tests should pass. View a Trust and RAG data should load as expected, utilising the modified API endpoint.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

