### PR TITLE
Display custom `404` page when BRCs not available to school due to its financial position

### DIFF
--- a/web/src/Web.App/Controllers/SchoolBenchmarkingReportCardsController.cs
+++ b/web/src/Web.App/Controllers/SchoolBenchmarkingReportCardsController.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.FeatureManagement.Mvc;
 using Web.App.Attributes.RequestTelemetry;
 using Web.App.Domain;
@@ -37,16 +39,25 @@ public class SchoolBenchmarkingReportCardsController(
             try
             {
                 var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
+                var years = await financeService.GetYears();
                 var isNonLeadFederation = !string.IsNullOrEmpty(school.FederationLeadURN) && school.FederationLeadURN != urn;
                 if (isNonLeadFederation)
                 {
-                    return new NotFoundResult();
+                    return Unavailable(school, years, SchoolBenchmarkingReportCardsUnavailableViewModel.UnavailableReason.NonLeadFederatedSchool);
                 }
 
-                var years = await financeService.GetYears();
                 var balance = await balanceApi
                     .School(urn)
                     .GetResultOrDefault<SchoolBalance>();
+
+                if (balance?.PeriodCoveredByReturn is not 12)
+                {
+                    return Unavailable(
+                        school,
+                        years,
+                        balance?.PeriodCoveredByReturn == null ? SchoolBenchmarkingReportCardsUnavailableViewModel.UnavailableReason.MissingExpenditure : SchoolBenchmarkingReportCardsUnavailableViewModel.UnavailableReason.PartYear);
+                }
+
                 var ratings = await metricRagRatingApi
                     .GetDefaultAsync(new ApiQuery().AddIfNotNull("urns", urn))
                     .GetResultOrDefault<RagRating[]>();
@@ -55,7 +66,7 @@ public class SchoolBenchmarkingReportCardsController(
                 var pupilExpenditure = set is { Pupil.Length: > 0 }
                     ? await expenditureApi.QuerySchools(BuildQuery(set.Pupil)).GetResultOrDefault<SchoolExpenditure[]>()
                     : [];
-                var areaExpenditure = set is { Pupil.Length: > 0 }
+                var areaExpenditure = set is { Building.Length: > 0 }
                     ? await expenditureApi.QuerySchools(BuildQuery(set.Building)).GetResultOrDefault<SchoolExpenditure[]>()
                     : [];
 
@@ -73,6 +84,20 @@ public class SchoolBenchmarkingReportCardsController(
                 return e is StatusCodeException s ? StatusCode((int)s.Status) : StatusCode(500);
             }
         }
+    }
+
+    private ViewResult Unavailable(School school, FinanceYears years, SchoolBenchmarkingReportCardsUnavailableViewModel.UnavailableReason reason)
+    {
+        logger.LogInformation(new EventId((int)reason, reason.ToString()), "Unable to display benchmarking report cards for {urn} ({reason})", school.URN, reason);
+        return new ViewResult
+        {
+            ViewData = new ViewDataDictionary(new EmptyModelMetadataProvider(), new ModelStateDictionary())
+            {
+                Model = new SchoolBenchmarkingReportCardsUnavailableViewModel(school, years, reason)
+            },
+            ViewName = nameof(Unavailable),
+            StatusCode = StatusCodes.Status404NotFound
+        };
     }
 
     private static ApiQuery BuildQuery(IEnumerable<string> urns, string dimension = "PerUnit")

--- a/web/src/Web.App/ViewModels/SchoolBenchmarkingReportCardsUnavailableViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolBenchmarkingReportCardsUnavailableViewModel.cs
@@ -1,0 +1,25 @@
+using Web.App.Domain;
+using Web.App.Extensions;
+namespace Web.App.ViewModels;
+
+public class SchoolBenchmarkingReportCardsUnavailableViewModel(School school, FinanceYears years, SchoolBenchmarkingReportCardsUnavailableViewModel.UnavailableReason? reason)
+{
+    public enum UnavailableReason
+    {
+        NonLeadFederatedSchool,
+        MissingExpenditure,
+        PartYear
+    }
+
+    public string? Commentary => reason switch
+    {
+        UnavailableReason.NonLeadFederatedSchool => "this is a non lead school in a federation",
+        UnavailableReason.MissingExpenditure => "expenditure data is not available for this school",
+        UnavailableReason.PartYear => "this school does not have data for the entire period",
+        _ => null
+    };
+    public string? Name => school.SchoolName;
+    public string? Urn => school.URN;
+    public bool IsPartOfTrust => school.IsPartOfTrust;
+    public string Years => IsPartOfTrust ? years.Aar.ToFinanceYear() : years.Cfr.ToFinanceYear();
+}

--- a/web/src/Web.App/Views/SchoolBenchmarkingReportCards/Unavailable.cshtml
+++ b/web/src/Web.App/Views/SchoolBenchmarkingReportCards/Unavailable.cshtml
@@ -1,0 +1,41 @@
+@model Web.App.ViewModels.SchoolBenchmarkingReportCardsUnavailableViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.SchoolBenchmarkingReportCards;
+    var header = $"{Constants.ServiceName.Replace("Tool", string.Empty)} Summary";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters">
+        <span class="govuk-caption-l">
+            @header
+            @Model.Years:
+        </span>
+        <h1 class="govuk-heading-l">@Model.Name</h1>
+    </div>
+</div>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <div class="app-finance-warn govuk-!-margin-bottom-3">
+            <div class="govuk-warning-text govuk-!-margin-0">
+                <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                <strong class="govuk-warning-text__text">
+                    <span class="govuk-visually-hidden">Warning</span>
+                    The @header cannot be displayed
+                    @(string.IsNullOrWhiteSpace(Model.Commentary) ? string.Empty : $"because {Model.Commentary}.")
+                </strong>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="govuk-!-margin-top-9 govuk-!-text-align-centre govuk-!-display-none-print">
+    @Html.ActionLink($"Visit the {Constants.ServiceName}", "Index", "School", new
+    {
+        urn = Model.Urn
+    }, new
+    {
+        @class = "govuk-button govuk-button--secondary ",
+        dataModule = "govuk-button"
+    })
+</div>

--- a/web/src/Web.App/Views/SchoolBenchmarkingReportCards/_Introduction.cshtml
+++ b/web/src/Web.App/Views/SchoolBenchmarkingReportCards/_Introduction.cshtml
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
         <span class="govuk-caption-l">
-            @Constants.ServiceName Summary
+            @Constants.ServiceName.Replace("Tool", string.Empty) Summary
             @Model.Years:
         </span>
         <h1 class="govuk-heading-l">@Model.Name</h1>

--- a/web/tests/Web.E2ETests/Extensions/PageExtensions.cs
+++ b/web/tests/Web.E2ETests/Extensions/PageExtensions.cs
@@ -8,9 +8,10 @@ public static class PageExtensions
     public static async Task<bool> IsSignedIn(this IPage page) => !await page.SignInLink().IsVisibleAsync() && await page.SignOutLink().IsVisibleAsync();
 
 
-    public static async Task GotoAndWaitForLoadAsync(this IPage page, string url)
+    public static async Task<IResponse?> GotoAndWaitForLoadAsync(this IPage page, string url)
     {
-        await page.GotoAsync(url);
+        var response = await page.GotoAsync(url);
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        return response;
     }
 }

--- a/web/tests/Web.E2ETests/Features/School/SchoolBenchmarkingReportCards.feature
+++ b/web/tests/Web.E2ETests/Features/School/SchoolBenchmarkingReportCards.feature
@@ -28,6 +28,7 @@ So that I can see how my school is performing from a financial point of view and
           | Pupil-to-teacher metric                | 2.73\n\nPupils per teacher                 | Similar schools range from 0.3 to 8.59 pupils per teacher.                  |
           | Pupil-to-senior leadership role metric | 18.42\n\nPupils per senior leadership role | Similar schools range from 4.26 to 34.33 pupils per senior leadership role. |
         And the print page cta is visible
+        And the response should be OK
 
     Scenario: Print page as PDF
         Given I am on the Benchmarking Report Card page for school with urn '777042'
@@ -48,3 +49,13 @@ So that I can see how my school is performing from a financial point of view and
         Given I am on the Benchmarking Report Card page for school with urn '777042'
         When I click on the financial benchmarking and insight tool link under pupil and workforce metrics
         Then I am directed to school census page for the school with urn '777042'
+
+    Scenario: View BRCs as a non-lead federated school
+        Given I am on the Benchmarking Report Card page for unavailable school with urn '777045'
+        Then the 'this is a non lead school in a federation' warning message should be displayed
+        And the response should be NotFound
+
+    Scenario: View BRCs as a part-year school
+        Given I am on the Benchmarking Report Card page for unavailable school with urn '777043'
+        Then the 'this school does not have data for the entire period' warning message should be displayed
+        And the response should be NotFound

--- a/web/tests/Web.E2ETests/Features/School/SchoolHome.feature
+++ b/web/tests/Web.E2ETests/Features/School/SchoolHome.feature
@@ -61,10 +61,3 @@
     Scenario: RAG guidance is displayed
         Given I am on school homepage for school with urn '777042'
         Then the RAG guidance is visible
-        
-    # To be confirmed as an outcome of #236251    
-    @ignore
-    Scenario: Error message for part-year data schools
-        Given I am on part year school homepage for school with urn '777044'
-        When I click on benchmarking report cards
-        Then I should see a 404 error page indicating the BRC is not available for this school

--- a/web/tests/Web.E2ETests/Pages/School/SchoolBenchmarkingReportCardsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/SchoolBenchmarkingReportCardsPage.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.Playwright;
+﻿using System.Net;
+using Microsoft.Playwright;
 using Xunit;
 namespace Web.E2ETests.Pages.School;
 
-public class SchoolBenchmarkingReportCardsPage(IPage page)
+public class SchoolBenchmarkingReportCardsPage(IPage page, IResponse? response = null)
 {
     private ILocator PageH1Heading => page.Locator(Selectors.H1);
     private ILocator IntroductionSection => page.Locator(Selectors.BrcIntroduction);
@@ -23,10 +24,18 @@ public class SchoolBenchmarkingReportCardsPage(IPage page)
     private ILocator PupilToTeacherMetric => page.Locator("h3:has-text('Pupil-to-teacher metric')");
     private ILocator PupilToSeniorLeadershipRoles => page.Locator("h3:has-text('Pupil-to-senior leadership role metric')");
     private ILocator PupilWorkforceContent => page.Locator(Selectors.PupilWorkforceContent);
+    private ILocator WarningMessage => page.Locator(Selectors.GovWarning);
 
-    public async Task IsDisplayed()
+    public async Task IsDisplayed(bool unavailable = false)
     {
         await PageH1Heading.ShouldBeVisible();
+        await VisitFbitButton.ShouldBeVisible();
+
+        if (unavailable)
+        {
+            return;
+        }
+
         await KeyInformationShouldBeVisible();
         await SpendPrioritySectionShouldBeVisible();
         await AssertSpendPriorityItems();
@@ -41,14 +50,17 @@ public class SchoolBenchmarkingReportCardsPage(IPage page)
         await PupilWorkforceMetricsSectionShouldBeVisible();
         await AssertPupilWorkforceMetrics();
         await PrintPageCtaShouldBeVisible();
-        await VisitFbitButton.ShouldBeVisible();
         await NextStepsSection.ShouldBeVisible();
     }
 
-    public async Task IsNotDisplayed()
+    public void IsOk()
     {
-        await PageH1Heading.ShouldBeVisible();
-        await PageH1Heading.ShouldHaveText("Page not found");
+        Assert.Equal((int)HttpStatusCode.OK, response?.Status);
+    }
+
+    public void IsNotFound()
+    {
+        Assert.Equal((int)HttpStatusCode.NotFound, response?.Status);
     }
 
     public async Task KeyInformationShouldBeVisible()
@@ -157,5 +169,10 @@ public class SchoolBenchmarkingReportCardsPage(IPage page)
     {
         await PupilWorkforceMetricsSection.Locator("a").ClickAsync();
         return new BenchmarkCensusPage(page);
+    }
+
+    public async Task AssertWarningMessage(string commentary)
+    {
+        await WarningMessage.ShouldContainText(commentary);
     }
 }

--- a/web/tests/Web.E2ETests/Steps/School/HomeSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/HomeSteps.cs
@@ -177,11 +177,4 @@ public class HomeSteps(PageDriver driver)
         Assert.NotNull(_schoolHomePage);
         await _schoolHomePage.AssertRagGuidance();
     }
-
-    [Then("I should see a 404 error page indicating the BRC is not available for this school")]
-    public async Task ThenIShouldSeeAErrorPageIndicatingTheBrcIsNotAvailableForThisSchool()
-    {
-        Assert.NotNull(_benchmarkingReportCardsPage);
-        await _benchmarkingReportCardsPage.IsNotDisplayed();
-    }
 }

--- a/web/tests/Web.E2ETests/Steps/School/SchoolBenchmarkingReportCardsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/SchoolBenchmarkingReportCardsSteps.cs
@@ -20,6 +20,13 @@ public class SchoolBenchmarkingReportCardsSteps(PageDriver driver)
         await _brcPage.IsDisplayed();
     }
 
+    [Given("I am on the Benchmarking Report Card page for unavailable school with urn '(.*)'")]
+    public async Task GivenIAmOnTheBenchmarkingReportCardPageForUnavailableSchoolWithUrn(string urn)
+    {
+        _brcPage = await LoadBenchmarkingReportCardsPageForSchoolWithUrn(urn);
+        await _brcPage.IsDisplayed(true);
+    }
+
     [Then("I should see the following boxes displayed under Key Information about school")]
     public async Task ThenIShouldSeeTheFollowingBoxesDisplayedUnderKeyInformationAboutSchool(DataTable table)
     {
@@ -132,15 +139,36 @@ public class SchoolBenchmarkingReportCardsSteps(PageDriver driver)
         await _censusPage.IsDisplayed();
     }
 
+    [Then("the '(.*)' warning message should be displayed")]
+    public async Task ThenTheWarningMessageShouldBeDisplayed(string commentary)
+    {
+        Assert.NotNull(_brcPage);
+        await _brcPage.AssertWarningMessage(commentary);
+    }
+
+    [Then("the response should be OK")]
+    public void ThenTheResponseShouldBeOk()
+    {
+        Assert.NotNull(_brcPage);
+        _brcPage.IsOk();
+    }
+
+    [Then("the response should be NotFound")]
+    public void ThenTheResponseShouldBeNotFound()
+    {
+        Assert.NotNull(_brcPage);
+        _brcPage.IsNotFound();
+    }
+
     private async Task<SchoolBenchmarkingReportCardsPage> LoadBenchmarkingReportCardsPageForSchoolWithUrn(string urn)
     {
         var url = SchoolBenchmarkingReportCardsUrl(urn);
         var page = await driver.Current;
-        await page.GotoAndWaitForLoadAsync(url);
+        var response = await page.GotoAndWaitForLoadAsync(url);
 
         await driver.WaitForPendingRequests(500);
 
-        return new SchoolBenchmarkingReportCardsPage(page);
+        return new SchoolBenchmarkingReportCardsPage(page, response);
     }
 
     private static string SchoolBenchmarkingReportCardsUrl(string urn) => $"{TestConfiguration.ServiceUrl}/school/{urn}/benchmarking-report-cards";


### PR DESCRIPTION
### Context
[AB#236251](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/236251) [AB#222988](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/222988)

### Change proposed in this pull request
Non-lead Federated schools, part year schools, or those with missing financials should not be able to view their BRCs. Instead they are presented with a `404` with a warning message and a button to take them back to the School homepage.

### Guidance to review 
Schools with sufficient data should not be affected. Schools in one of the exception states should see the warning banner, e.g. (in `d02`):

![image](https://github.com/user-attachments/assets/07ed40ca-81f1-42b3-a374-06192481fc42)

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

