### PR TITLE
E2E fix post merge of 536984ada6cea7aa6d5c8d095dad85d7845832d3

### DIFF
--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/BenchmarkCensusPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/BenchmarkCensusPage.cs
@@ -101,7 +101,7 @@ public class BenchmarkCensusPage(IPage page)
     public async Task AreTablesDisplayed()
     {
         var tables = await Tables.AllAsync();
-        Assert.Equal(7, tables.Count);
+        Assert.Equal(8, tables.Count);
         await tables.ShouldBeVisible();
     }
 
@@ -128,7 +128,7 @@ public class BenchmarkCensusPage(IPage page)
     public async Task AreChartsDisplayed()
     {
         var charts = await Charts.AllAsync();
-        Assert.Equal(7, charts.Count);
+        Assert.Equal(8, charts.Count);
         await charts.ShouldBeVisible();
     }
 

--- a/web/tests/Web.E2ETests/Pages/Trust/BenchmarkCensusPage.cs
+++ b/web/tests/Web.E2ETests/Pages/Trust/BenchmarkCensusPage.cs
@@ -101,7 +101,7 @@ public class BenchmarkCensusPage(IPage page)
     public async Task AreTablesDisplayed()
     {
         var tables = await Tables.AllAsync();
-        Assert.Equal(7, tables.Count);
+        Assert.Equal(8, tables.Count);
         await tables.ShouldBeVisible();
     }
 
@@ -128,7 +128,7 @@ public class BenchmarkCensusPage(IPage page)
     public async Task AreChartsDisplayed()
     {
         var charts = await Charts.AllAsync();
-        Assert.Equal(7, charts.Count);
+        Assert.Equal(8, charts.Count);
         await charts.ShouldBeVisible();
     }
 


### PR DESCRIPTION
### Context
[AB#236607](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/236607) [AB#235684](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/235684)

### Change proposed in this pull request
E2E tests currently failing against `d02` due to the merge of #1585 fixing a missing Census chart.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

