### PR TITLE
Resolved invalid pattern match when resolving expenditure for building comparator set

### DIFF
--- a/web/src/Web.App/Controllers/SchoolSpendingController.cs
+++ b/web/src/Web.App/Controllers/SchoolSpendingController.cs
@@ -10,7 +10,6 @@ using Web.App.Infrastructure.Apis.Insight;
 using Web.App.Infrastructure.Extensions;
 using Web.App.Services;
 using Web.App.ViewModels;
-
 namespace Web.App.Controllers;
 
 [Controller]
@@ -51,10 +50,9 @@ public class SchoolSpendingController(
                     pupilExpenditure = set is { Pupil.Length: > 0 }
                         ? await expenditureApi.QuerySchools(BuildQuery(set.Pupil)).GetResultOrThrow<SchoolExpenditure[]>()
                         : [];
-                    areaExpenditure = set is { Pupil.Length: > 0 }
+                    areaExpenditure = set is { Building.Length: > 0 }
                         ? await expenditureApi.QuerySchools(BuildQuery(set.Building)).GetResultOrThrow<SchoolExpenditure[]>()
                         : [];
-
                 }
                 else
                 {


### PR DESCRIPTION
### Context
[AB#237809](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/237809) [AB#237597](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/237597)

### Guidance to review 
Fix may be validated with any of the URNs currently failing in prod and then viewing the Spending Priorities page:
- `146949`
- `148595`
- `148060`
- `147574`
- `149075`
- `146822`
- `147183`
- `148561`

Viewing the 'two sets of comparator schools' for the above should also show `0` for the building comparators.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

