### PR TITLE
Remove commercial resources for certain categories if red/amber RAG is less than average

### DIFF
--- a/web/src/Web.App/Controllers/SchoolController.cs
+++ b/web/src/Web.App/Controllers/SchoolController.cs
@@ -129,7 +129,6 @@ public class SchoolController(
     [SchoolRequestTelemetry(TrackedRequestFeature.Resources)]
     public async Task<IActionResult> Resources(string urn)
     {
-
         using (logger.BeginScope(new
         {
             urn
@@ -144,7 +143,7 @@ public class SchoolController(
 
                 await Task.WhenAll(school, ratings);
 
-                var viewModel = new SchoolViewModel(school.Result, ratings.Result);
+                var viewModel = new SchoolResourcesViewModel(school.Result, ratings.Result);
                 return View(viewModel);
             }
             catch (Exception e)

--- a/web/src/Web.App/Domain/CostCategories.cs
+++ b/web/src/Web.App/Domain/CostCategories.cs
@@ -116,7 +116,7 @@ public class EducationalIct(RagRating rating) : CostCategory(rating)
     {
         this[urn] = new Category(expenditure.LearningResourcesIctCosts ?? 0);
     }
-    
+
     public override bool CanShowCommercialResources => base.CanShowCommercialResources && Rating.Value >= Rating.Mean;
 }
 
@@ -128,7 +128,7 @@ public class EducationalSupplies(RagRating rating) : CostCategory(rating)
     {
         this[urn] = new Category(expenditure.TotalEducationalSuppliesCosts ?? 0);
     }
-    
+
     public override bool CanShowCommercialResources => base.CanShowCommercialResources && Rating.Value >= Rating.Mean;
 }
 

--- a/web/src/Web.App/Domain/CostCategories.cs
+++ b/web/src/Web.App/Domain/CostCategories.cs
@@ -84,6 +84,8 @@ public abstract class CostCategory(RagRating rating)
 
     public abstract string[] SubCategories { get; }
     public abstract void Add(string urn, SchoolExpenditure expenditure);
+
+    public virtual bool CanShowCommercialResources => Rating.RAG != "green";
 }
 
 public class AdministrativeSupplies(RagRating rating) : CostCategory(rating)
@@ -114,6 +116,8 @@ public class EducationalIct(RagRating rating) : CostCategory(rating)
     {
         this[urn] = new Category(expenditure.LearningResourcesIctCosts ?? 0);
     }
+    
+    public override bool CanShowCommercialResources => base.CanShowCommercialResources && Rating.Value >= Rating.Mean;
 }
 
 public class EducationalSupplies(RagRating rating) : CostCategory(rating)
@@ -124,6 +128,8 @@ public class EducationalSupplies(RagRating rating) : CostCategory(rating)
     {
         this[urn] = new Category(expenditure.TotalEducationalSuppliesCosts ?? 0);
     }
+    
+    public override bool CanShowCommercialResources => base.CanShowCommercialResources && Rating.Value >= Rating.Mean;
 }
 
 public class NonEducationalSupportStaff(RagRating rating) : CostCategory(rating)
@@ -144,6 +150,8 @@ public class TeachingStaff(RagRating rating) : CostCategory(rating)
     {
         this[urn] = new Category(expenditure.TotalTeachingSupportStaffCosts ?? 0);
     }
+
+    public override bool CanShowCommercialResources => base.CanShowCommercialResources && Rating.Value >= Rating.Mean;
 }
 
 public class Other(RagRating rating) : CostCategory(rating)

--- a/web/src/Web.App/Domain/Insight/RagRating.cs
+++ b/web/src/Web.App/Domain/Insight/RagRating.cs
@@ -7,6 +7,8 @@ public record RagRating
     public string? Category { get; set; }
     public string? SubCategory { get; set; }
     public decimal? Value { get; set; }
+    
+    // todo: rename to Median as part of #238518
     public decimal? Mean { get; set; }
     public decimal? DiffMean { get; set; }
     public decimal? PercentDiff { get; set; }

--- a/web/src/Web.App/Domain/Insight/RagRating.cs
+++ b/web/src/Web.App/Domain/Insight/RagRating.cs
@@ -7,7 +7,7 @@ public record RagRating
     public string? Category { get; set; }
     public string? SubCategory { get; set; }
     public decimal? Value { get; set; }
-    
+
     // todo: rename to Median as part of #238518
     public decimal? Mean { get; set; }
     public decimal? DiffMean { get; set; }

--- a/web/src/Web.App/ViewModels/SchoolResourcesViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolResourcesViewModel.cs
@@ -1,0 +1,17 @@
+using Web.App.Domain;
+namespace Web.App.ViewModels;
+
+public class SchoolResourcesViewModel(School school, IEnumerable<RagRating> ratings)
+{
+    private readonly CostCategory[] _categories = CategoryBuilder.Build(ratings, Array.Empty<SchoolExpenditure>(), Array.Empty<SchoolExpenditure>()).ToArray();
+
+    public string? Name => school.SchoolName;
+    public string? Urn => school.URN;
+    public bool HasMetricRag => ratings.Any();
+
+    public IEnumerable<CostCategory> CostCategories => _categories
+        .Where(x => x.Rating.RAG is "red" or "amber" && x.Rating.Category is not Category.Other)
+        .OrderBy(x => Lookups.StatusOrderMap[x.Rating.RAG ?? string.Empty])
+        .ThenByDescending(x => x.Rating.Decile)
+        .ThenByDescending(x => x.Rating.Value);
+}

--- a/web/src/Web.App/ViewModels/SchoolResourcesViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolResourcesViewModel.cs
@@ -11,6 +11,7 @@ public class SchoolResourcesViewModel(School school, IEnumerable<RagRating> rati
 
     public IEnumerable<CostCategory> CostCategories => _categories
         .Where(x => x.Rating.RAG is "red" or "amber" && x.Rating.Category is not Category.Other)
+        .Where(x => x.CanShowCommercialResources)
         .OrderBy(x => Lookups.StatusOrderMap[x.Rating.RAG ?? string.Empty])
         .ThenByDescending(x => x.Rating.Decile)
         .ThenByDescending(x => x.Rating.Value);

--- a/web/src/Web.App/ViewModels/SchoolViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolViewModel.cs
@@ -34,21 +34,6 @@ public class SchoolViewModel(School school) : ISchoolKeyInformationViewModel
 
     public SchoolViewModel(
         School school,
-        IEnumerable<RagRating> ratings)
-        : this(school)
-    {
-        var ratingsArray = ratings.ToArray();
-
-        HasMetricRag = ratingsArray.Length != 0;
-        Ratings = ratingsArray
-            .Where(x => x.RAG is "red" or "amber" && x.Category is not Category.Other)
-            .OrderBy(x => Lookups.StatusOrderMap[x.RAG ?? string.Empty])
-            .ThenByDescending(x => x.Decile)
-            .ThenByDescending(x => x.Value);
-    }
-
-    public SchoolViewModel(
-        School school,
         bool? customDataGenerated = false)
         : this(school)
     {
@@ -65,8 +50,6 @@ public class SchoolViewModel(School school) : ISchoolKeyInformationViewModel
 
     public string? Name => school.SchoolName;
     public string? Urn => school.URN;
-    public string? OverallPhase => school.OverallPhase;
-    public string? OfstedRating => school.OfstedDescription;
     public bool IsPartOfTrust => school.IsPartOfTrust;
     public string? Address => school.Address;
     public string? Telephone => school.Telephone;
@@ -99,11 +82,13 @@ public class SchoolViewModel(School school) : ISchoolKeyInformationViewModel
 
     public string? UserDefinedSetId { get; }
     public string? CustomDataId { get; }
-    public decimal? InYearBalance { get; }
-    public decimal? RevenueReserve { get; }
     public bool HasMetricRag { get; }
     public IEnumerable<RagRating> Ratings { get; } = [];
     public bool? ComparatorGenerated { get; }
     public bool? ComparatorReverted { get; }
     public bool? CustomDataGenerated { get; }
+    public string? OverallPhase => school.OverallPhase;
+    public string? OfstedRating => school.OfstedDescription;
+    public decimal? InYearBalance { get; }
+    public decimal? RevenueReserve { get; }
 }

--- a/web/src/Web.App/Views/School/Resources.cshtml
+++ b/web/src/Web.App/Views/School/Resources.cshtml
@@ -1,10 +1,16 @@
 ﻿@using Web.App.TagHelpers
-@model Web.App.ViewModels.SchoolViewModel
+@model Web.App.ViewModels.SchoolResourcesViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.Resources;
 }
 
-@await Component.InvokeAsync("EstablishmentHeading", new { title = ViewData[ViewDataKeys.Title], name = Model.Name, id = Model.Urn, kind = OrganisationTypes.School })
+@await Component.InvokeAsync("EstablishmentHeading", new
+{
+    title = ViewData[ViewDataKeys.Title],
+    name = Model.Name,
+    id = Model.Urn,
+    kind = OrganisationTypes.School
+})
 @if (Model.HasMetricRag)
 {
     <div class="govuk-grid-row">

--- a/web/src/Web.App/Views/School/_RecommendedResources.cshtml
+++ b/web/src/Web.App/Views/School/_RecommendedResources.cshtml
@@ -1,25 +1,28 @@
 ﻿@using Web.App.ViewModels
-@model Web.App.ViewModels.SchoolViewModel
+@model Web.App.ViewModels.SchoolResourcesViewModel
 
 
 <p class="govuk-body">
     Based on how spending and costs compare to similar schools.
 </p>
 
-@foreach (var rating in Model.Ratings)
+@foreach (var category in Model.CostCategories.Where(c => c.CanShowCommercialResources))
 {
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <h2 class="govuk-heading-s">
-                @rating.Category
+                @category.Rating.Category
             </h2>
         </div>
         <div class="govuk-grid-column-one-third">
-            @await Component.InvokeAsync("Tag", new { rating = new RatingViewModel(rating.PriorityTag?.Colour, rating.PriorityTag?.DisplayText) })
+            @await Component.InvokeAsync("Tag", new
+            {
+                rating = new RatingViewModel(category.Rating.PriorityTag?.Colour, category.Rating.PriorityTag?.DisplayText)
+            })
         </div>
     </div>
-    
-    @await Html.PartialAsync(rating.ResourcePartial, new ResourceViewModel(false))
+
+    @await Html.PartialAsync(category.Rating.ResourcePartial, new ResourceViewModel(false))
 }

--- a/web/src/Web.App/Views/School/_RecommendedResources.cshtml
+++ b/web/src/Web.App/Views/School/_RecommendedResources.cshtml
@@ -6,7 +6,7 @@
     Based on how spending and costs compare to similar schools.
 </p>
 
-@foreach (var category in Model.CostCategories.Where(c => c.CanShowCommercialResources))
+@foreach (var category in Model.CostCategories)
 {
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 

--- a/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
@@ -76,7 +76,7 @@
                     </p>
                 </div>
                 <div class="govuk-grid-column-one-third">
-                    @if (category.Rating.RAG != "green")
+                    @if (category.CanShowCommercialResources)
                     {
                         <div class="govuk-!-margin-top-6">
                             <h4 class="govuk-heading-s">

--- a/web/tests/Web.E2ETests/Features/School/CommercialResources.feature
+++ b/web/tests/Web.E2ETests/Features/School/CommercialResources.feature
@@ -11,7 +11,6 @@
           | Catering staff and supplies                | High priority   |
           | Premises staff and services                | High priority   |
           | Utilities                                  | Medium priority |
-          | Educational ICT                            | Medium priority |
         When I click on all resources
         Then all resources tab is displayed
 

--- a/web/tests/Web.E2ETests/Features/School/SpendingCosts.feature
+++ b/web/tests/Web.E2ETests/Features/School/SpendingCosts.feature
@@ -77,16 +77,6 @@
           | Utilities                           | Supply of energy 2                                                                                        |
           | Utilities                           | Water, wastewater and ancillary services                                                                  |
           | Utilities                           | Water, wastewater and ancillary services                                                                  |
-          | Educational ICT                     | Digital marketplace (G-Cloud 13)                                                                          |
-          | Educational ICT                     | Everything ICT                                                                                            |
-          | Educational ICT                     | IT hardware                                                                                               |
-          | Educational ICT                     | Multi-functional devices and digital solutions                                                            |
-          | Educational ICT                     | Multifunctional devices and digital transformation solutions                                              |
-          | Educational ICT                     | Multifunctional devices, print and digital workflow software services and managed print service provision |
-          | Educational ICT                     | Outsourced ICT                                                                                            |
-          | Educational ICT                     | Print marketplace                                                                                         |
-          | Educational ICT                     | Software licences and associated services for academies and schools                                       |
-          | Educational ICT                     | Technology products & associated services 2                                                               |
 
     Scenario: Categories have the correct category commentary
         Given I am on spending and costs page for school with URN '777042'

--- a/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingResources.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingResources.cs
@@ -1,15 +1,25 @@
 using System.Net;
-using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
-using AngleSharp.XPath;
 using AutoFixture;
 using Web.App.Domain;
 using Xunit;
-
 namespace Web.Integration.Tests.Pages.Schools;
 
 public class WhenViewingResources(SchoolBenchmarkingWebAppClient client) : PageBase<SchoolBenchmarkingWebAppClient>(client)
 {
+    private static readonly List<string> AllCostCategories =
+    [
+        Category.TeachingStaff,
+        Category.NonEducationalSupportStaff,
+        Category.EducationalSupplies,
+        Category.EducationalIct,
+        Category.PremisesStaffServices,
+        Category.Utilities,
+        Category.AdministrativeSupplies,
+        Category.CateringStaffServices,
+        Category.Other
+    ];
+
     [Fact]
     public async Task CanDisplay()
     {
@@ -71,7 +81,10 @@ public class WhenViewingResources(SchoolBenchmarkingWebAppClient client) : PageB
 
         var categorySections = recommended.QuerySelectorAll(".govuk-grid-column-two-thirds h2.govuk-heading-s");
 
-        var expectedCount = rating.Count(x => x.RAG is "red" or "amber" && x.Category is not Category.Other);
+        var expectedCount = rating
+            .Where(x => x.RAG is "red" or "amber")
+            .Where(x => x.Category is not Category.Other)
+            .Count(x => x.Category is not Category.TeachingStaff && x.Category is not Category.EducationalSupplies && x.Category is not Category.EducationalIct || x.Value >= x.Mean);
 
         Assert.Equal(expectedCount, categorySections.Length);
 
@@ -111,18 +124,4 @@ public class WhenViewingResources(SchoolBenchmarkingWebAppClient client) : PageB
 
         return ratings.ToArray();
     }
-
-    private static readonly List<string> AllCostCategories =
-    [
-        Category.TeachingStaff,
-        Category.NonEducationalSupportStaff,
-        Category.EducationalSupplies,
-        Category.EducationalIct,
-        Category.PremisesStaffServices,
-        Category.Utilities,
-        Category.AdministrativeSupplies,
-        Category.CateringStaffServices,
-        Category.Other
-    ];
 }
-

--- a/web/tests/Web.Tests/Domain/GivenACostCategory.cs
+++ b/web/tests/Web.Tests/Domain/GivenACostCategory.cs
@@ -1,0 +1,176 @@
+using Web.App.Domain;
+using Xunit;
+namespace Web.Tests.Domain;
+
+public class GivenAnAdministrativeSuppliesCostCategory
+{
+    [Theory]
+    [InlineData("red", true)]
+    [InlineData("amber", true)]
+    [InlineData("green", false)]
+    public void WhenRagRatingIs(string rag, bool expectedCanShowCommercialResources)
+    {
+        var ragRating = new RagRating
+        {
+            RAG = rag
+        };
+        var category = new AdministrativeSupplies(ragRating);
+
+        Assert.Equal(expectedCanShowCommercialResources, category.CanShowCommercialResources);
+    }
+}
+
+public class GivenACateringStaffServicesCostCategory
+{
+    [Theory]
+    [InlineData("red", true)]
+    [InlineData("amber", true)]
+    [InlineData("green", false)]
+    public void WhenRagRatingIs(string rag, bool expectedCanShowCommercialResources)
+    {
+        var ragRating = new RagRating
+        {
+            RAG = rag
+        };
+        var category = new CateringStaffServices(ragRating);
+
+        Assert.Equal(expectedCanShowCommercialResources, category.CanShowCommercialResources);
+    }
+}
+
+public class GivenAnEducationalIctCategory
+{
+    [Theory]
+    [InlineData("red", 0, 1, false)]
+    [InlineData("amber", 1, 0, true)]
+    [InlineData("amber", 1, 1, true)]
+    [InlineData("green", null, null, false)]
+    public void WhenRagRatingIs(string rag, int? value, int? mean, bool expectedCanShowCommercialResources)
+    {
+        var ragRating = new RagRating
+        {
+            RAG = rag,
+            Value = value,
+            Mean = mean
+        };
+        var category = new EducationalIct(ragRating);
+
+        Assert.Equal(expectedCanShowCommercialResources, category.CanShowCommercialResources);
+    }
+}
+
+public class GivenAnEducationalSuppliesCategory
+{
+    [Theory]
+    [InlineData("red", 0, 1, false)]
+    [InlineData("amber", 1, 0, true)]
+    [InlineData("amber", 1, 1, true)]
+    [InlineData("green", null, null, false)]
+    public void WhenRagRatingIs(string rag, int? value, int? mean, bool expectedCanShowCommercialResources)
+    {
+        var ragRating = new RagRating
+        {
+            RAG = rag,
+            Value = value,
+            Mean = mean
+        };
+        var category = new EducationalSupplies(ragRating);
+
+        Assert.Equal(expectedCanShowCommercialResources, category.CanShowCommercialResources);
+    }
+}
+
+public class GivenNonEducationalSupportStaffCategory
+{
+    [Theory]
+    [InlineData("red", true)]
+    [InlineData("amber", true)]
+    [InlineData("green", false)]
+    public void WhenRagRatingIs(string rag, bool expectedCanShowCommercialResources)
+    {
+        var ragRating = new RagRating
+        {
+            RAG = rag
+        };
+        var category = new NonEducationalSupportStaff(ragRating);
+
+        Assert.Equal(expectedCanShowCommercialResources, category.CanShowCommercialResources);
+    }
+}
+
+public class GivenTeachingStaffCategory
+{
+    [Theory]
+    [InlineData("red", 0, 1, false)]
+    [InlineData("amber", 1, 0, true)]
+    [InlineData("amber", 1, 1, true)]
+    [InlineData("green", null, null, false)]
+    public void WhenRagRatingIs(string rag, int? value, int? mean, bool expectedCanShowCommercialResources)
+    {
+        var ragRating = new RagRating
+        {
+            RAG = rag,
+            Value = value,
+            Mean = mean
+        };
+        var category = new TeachingStaff(ragRating);
+
+        Assert.Equal(expectedCanShowCommercialResources, category.CanShowCommercialResources);
+    }
+}
+
+public class GivenOtherCategory
+{
+    [Theory]
+    [InlineData("red", true)]
+    [InlineData("amber", true)]
+    [InlineData("green", false)]
+    public void WhenRagRatingIs(string rag, bool expectedCanShowCommercialResources)
+    {
+        var ragRating = new RagRating
+        {
+            RAG = rag
+        };
+        var category = new Other(ragRating);
+
+        Assert.Equal(expectedCanShowCommercialResources, category.CanShowCommercialResources);
+    }
+}
+
+
+public class GivenPremisesStaffServicesCategory
+{
+    [Theory]
+    [InlineData("red", true)]
+    [InlineData("amber", true)]
+    [InlineData("green", false)]
+    public void WhenRagRatingIs(string rag, bool expectedCanShowCommercialResources)
+    {
+        var ragRating = new RagRating
+        {
+            RAG = rag
+        };
+        var category = new PremisesStaffServices(ragRating);
+
+        Assert.Equal(expectedCanShowCommercialResources, category.CanShowCommercialResources);
+    }
+}
+
+
+public class GivenUtilitiesCategory
+{
+    [Theory]
+    [InlineData("red", true)]
+    [InlineData("amber", true)]
+    [InlineData("green", false)]
+    public void WhenRagRatingIs(string rag, bool expectedCanShowCommercialResources)
+    {
+        var ragRating = new RagRating
+        {
+            RAG = rag
+        };
+        var category = new Utilities(ragRating);
+
+        Assert.Equal(expectedCanShowCommercialResources, category.CanShowCommercialResources);
+    }
+}

--- a/web/tests/Web.Tests/ViewModels/GivenASchoolResourcesViewModel.cs
+++ b/web/tests/Web.Tests/ViewModels/GivenASchoolResourcesViewModel.cs
@@ -1,0 +1,60 @@
+using AutoFixture;
+using Web.App.Domain;
+using Web.App.ViewModels;
+using Xunit;
+namespace Web.Tests.ViewModels;
+
+public class GivenASchoolResourcesViewModel
+{
+    private const string URN = nameof(URN);
+    private readonly School _school = new Fixture()
+        .Build<School>()
+        .With(s => s.URN, URN)
+        .Create();
+
+    public static TheoryData<IEnumerable<RagRating>, IEnumerable<CostCategory>> WhenRagRatingsAreData
+    {
+        get
+        {
+            var administrativeSuppliesRagRating = new RagRating
+            {
+                Category = Category.AdministrativeSupplies,
+                RAG = "red"
+            };
+
+            var teachingStaffRagRating = new RagRating
+            {
+                Category = Category.TeachingStaff,
+                RAG = "amber"
+            };
+
+            var educationalIctRagRating = new RagRating
+            {
+                Category = Category.EducationalIct,
+                RAG = "green"
+            };
+
+            var otherRagRating = new RagRating
+            {
+                Category = Category.Other,
+                RAG = "red"
+            };
+
+            return new TheoryData<IEnumerable<RagRating>, IEnumerable<CostCategory>>
+            {
+                {
+                    [administrativeSuppliesRagRating, teachingStaffRagRating, educationalIctRagRating, otherRagRating], [new AdministrativeSupplies(administrativeSuppliesRagRating), new TeachingStaff(teachingStaffRagRating)]
+                }
+            };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(WhenRagRatingsAreData))]
+    public void WhenRagRatingsAre(
+        IEnumerable<RagRating> ratings, IEnumerable<CostCategory> expectedCostCategories)
+    {
+        var actual = new SchoolResourcesViewModel(_school, ratings);
+        Assert.Equal(expectedCostCategories.Select(c => c.Rating), actual.CostCategories.Select(c => c.Rating));
+    }
+}

--- a/web/tests/Web.Tests/ViewModels/GivenASchoolResourcesViewModel.cs
+++ b/web/tests/Web.Tests/ViewModels/GivenASchoolResourcesViewModel.cs
@@ -25,13 +25,23 @@ public class GivenASchoolResourcesViewModel
             var teachingStaffRagRating = new RagRating
             {
                 Category = Category.TeachingStaff,
-                RAG = "amber"
+                RAG = "amber",
+                Mean = 0,
+                Value = 1
             };
 
             var educationalIctRagRating = new RagRating
             {
                 Category = Category.EducationalIct,
                 RAG = "green"
+            };
+
+            var educationalSuppliesRagRating = new RagRating
+            {
+                Category = Category.EducationalSupplies,
+                RAG = "red",
+                Mean = 1,
+                Value = 0
             };
 
             var otherRagRating = new RagRating
@@ -43,7 +53,7 @@ public class GivenASchoolResourcesViewModel
             return new TheoryData<IEnumerable<RagRating>, IEnumerable<CostCategory>>
             {
                 {
-                    [administrativeSuppliesRagRating, teachingStaffRagRating, educationalIctRagRating, otherRagRating], [new AdministrativeSupplies(administrativeSuppliesRagRating), new TeachingStaff(teachingStaffRagRating)]
+                    [administrativeSuppliesRagRating, teachingStaffRagRating, educationalIctRagRating, educationalSuppliesRagRating, otherRagRating], [new AdministrativeSupplies(administrativeSuppliesRagRating), new TeachingStaff(teachingStaffRagRating)]
                 }
             };
         }


### PR DESCRIPTION
### Context
[AB#238511](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/238511) [AB#236925](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/236925)

### Change proposed in this pull request
For the cost categories `EducationalIct`, `EducationalSupplies`, `TeachingStaff`:
- Remove commercial resources from Spending Priorities if red/amber RAG is less than average
- Remove commercial resources from Find Ways to Spend Less if red/amber RAG is less than average
- E2E, integration and unit test coverage

### Guidance to review 
Identify schools with RAGs in the state(s) above to validate that the commercial resources are/not present as per the requirement. 

> **NOTE:** This PR intentionally does not make any changes to `RagRating.Mean` to reflect the actual calculation average, which is median. This will be covered by other tickets.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

