### PR TITLE
Create and insert Mean as well as Median (with diffs) into `MetricRAG` table

### DIFF
--- a/core-infrastructure/src/db/Core.Database/Scripts/064-AddMedianToMetricRAG.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/064-AddMedianToMetricRAG.sql
@@ -1,0 +1,24 @@
+IF EXISTS (
+SELECT *
+FROM INFORMATION_SCHEMA.TABLES
+WHERE table_name = 'MetricRAG'
+) 
+BEGIN
+    IF NOT EXISTS (
+    SELECT 1
+    FROM sys.columns
+    WHERE Name = N'Median' AND Object_ID = Object_ID(N'dbo.MetricRAG')
+    ) 
+    BEGIN
+        ALTER TABLE MetricRAG ADD Median decimal(16, 2) NULL;
+    END
+
+    IF NOT EXISTS(
+    SELECT 1
+    FROM sys.columns
+    WHERE Name = N'DiffMedian' AND Object_ID = Object_ID(N'dbo.MetricRAG')
+    ) 
+    BEGIN
+        ALTER TABLE MetricRAG ADD DiffMedian decimal(16, 2) NULL;
+    END
+END

--- a/data-pipeline/.gitignore
+++ b/data-pipeline/.gitignore
@@ -27,3 +27,5 @@ workbooks/output
 tests/output/
 
 !/tests/e2e/.env
+
+__azurite*.json

--- a/data-pipeline/README.md
+++ b/data-pipeline/README.md
@@ -178,7 +178,7 @@ To run the pipeline locally, follow these steps:
     Set the following program arguments to target this instance:
 
     ```
-    -c "Server=localhost,1433;Database=data;User Id=SA;Password=mystrong!Pa55word;Encrypt=False;
+    -c "Server=localhost,1433;Database=data;User Id=SA;Password=mystrong!Pa55word;Encrypt=False;"
     ```
 
 4. Create an `.env` file:

--- a/data-pipeline/src/pipeline/database.py
+++ b/data-pipeline/src/pipeline/database.py
@@ -105,6 +105,8 @@ def insert_metric_rag(run_type: str, run_id: str, df: pd.DataFrame):
             "Value",
             "Mean",
             "DiffMean",
+            "Median",
+            "DiffMedian",
             "PercentDiff",
             "Percentile",
             "Decile",

--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -22,15 +22,15 @@ from src.pipeline.database import (
     insert_metric_rag,
     insert_non_financial_data,
     insert_schools_and_local_authorities,
-    insert_trusts,
     insert_trust_financial_data,
+    insert_trusts,
 )
 from src.pipeline.log import setup_logger
 from src.pipeline.message import MessageType, get_message_type
 from src.pipeline.pre_processing import (
     build_academy_data,
-    build_bfr_historical_data,
     build_bfr_data,
+    build_bfr_historical_data,
     build_cfo_data,
     build_maintained_school_data,
     build_trust_data,
@@ -712,6 +712,8 @@ def compute_rag_for(
                 "Value",
                 "Mean",
                 "DiffMean",
+                "Median",
+                "DiffMedian",
                 "Key",
                 "PercentDiff",
                 "Percentile",

--- a/data-pipeline/src/pipeline/rag.py
+++ b/data-pipeline/src/pipeline/rag.py
@@ -121,11 +121,13 @@ def category_stats(urn, category_name, data, ofsted_rating, rag_mapping, close_c
 
     percentile = find_percentile(series, value)
     decile = int(percentile / 10)
-    mean = np.median(series)
-    diff = value - mean
+    mean = np.mean(series)
+    diff_mean = value - mean
+    median = np.median(series)
+    diff_median = value - median
     diff_percent = (
-        (diff / mean) * 100
-        if mean != 0 and mean != np.inf and mean != np.nan and not pd.isna(mean)
+        (diff_median / median) * 100
+        if median != 0 and median != np.inf and median != np.nan and not pd.isna(median)
         else 0
     )
     cats = category_name.split("_")
@@ -135,8 +137,11 @@ def category_stats(urn, category_name, data, ofsted_rating, rag_mapping, close_c
         "SubCategory": cats[1],
         "Value": value,
         "Mean": mean,
-        "DiffMean": diff,
+        "DiffMean": diff_mean,
+        "Median": median,
+        "DiffMedian": diff_median,
         "Key": key,
+        # note: `PercentDiff` is not consumed in api or web
         "PercentDiff": diff_percent,
         "Percentile": percentile,
         "Decile": decile,

--- a/data-pipeline/tests/unit/rag/test_rag.py
+++ b/data-pipeline/tests/unit/rag/test_rag.py
@@ -114,11 +114,12 @@ def test_find_percentile():
 
 
 @pytest.mark.parametrize(
-    "value,data,diff_mean,percent_diff,percentile,decile,expected_rag",
+    "value,data,diff_mean,diff_median,percent_diff,percentile,decile,expected_rag",
     [
         (
             20,
             [20, 5, 6, 15, 16, 19, 22, 25, 76, 150],
+            -15.399999999999999,
             0.5,
             2.564102564102564,
             60.0,
@@ -128,6 +129,7 @@ def test_find_percentile():
         (
             150,
             [150, 5, 6, 15, 16, 19, 22, 25, 76, 20],
+            114.6,
             130.5,
             669.2307692307693,
             100.0,
@@ -137,6 +139,7 @@ def test_find_percentile():
         (
             15,
             [15, 5, 6, 150, 16, 19, 22, 25, 76, 20],
+            -20.4,
             -4.5,
             -23.076923076923077,
             30.0,
@@ -146,7 +149,7 @@ def test_find_percentile():
     ],
 )
 def test_category_stats(
-    value, data, diff_mean, percent_diff, percentile, decile, expected_rag
+    value, data, diff_mean, diff_median, percent_diff, percentile, decile, expected_rag
 ):
     category = "Teaching and Teaching support staff_Sub Cat"
     data = {
@@ -160,8 +163,10 @@ def test_category_stats(
         "Category": "Teaching and Teaching support staff",
         "SubCategory": "Sub Cat",
         "Value": value,
-        "Mean": 19.5,
+        "Mean": 35.4,
         "DiffMean": diff_mean,
+        "Median": 19.5,
+        "DiffMedian": diff_median,
         "Key": "outstanding",
         "PercentDiff": percent_diff,
         "Percentile": percentile,


### PR DESCRIPTION
### Context
[AB#238511](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/238511) [AB#238512](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/238512) [AB#236925](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/236925)

### Change proposed in this pull request
- Added new columns to `MetricRAG` table
- During pipeline run, insert mean and median to correct `MetricRAG` columns

### Guidance to review 
A future piece of work will deprecate the `Mean` columns. For now, both averages will exist so as to not break the service. This can be validated by running the `data-pipeline` locally, after having first run the database migrations.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

