### PR TITLE
feat: adds additional dsi claims to la users for their schools and academies for their parent trust

### DIFF
--- a/web/src/Web.App/Constants/OrganisationCategories.cs
+++ b/web/src/Web.App/Constants/OrganisationCategories.cs
@@ -1,0 +1,8 @@
+﻿namespace Web.App;
+
+public static class OrganisationCategories
+{
+    public const string SingleAcademyTrust = "013";
+    public const string MultiAcademyTrust = "010";
+    public const string LocalAuthority = "002";
+}

--- a/web/src/Web.App/Program.cs
+++ b/web/src/Web.App/Program.cs
@@ -42,7 +42,8 @@ builder.Services
     .AddScoped<ISuggestService, SuggestService>()
     .AddScoped<IFinancialPlanStageValidator, FinancialPlanStageValidator>()
     .AddScoped<ICustomDataService, CustomDataService>()
-    .AddScoped<IUserDataService, UserDataService>();
+    .AddScoped<IUserDataService, UserDataService>()
+    .AddScoped<IClaimsIdentifierService, ClaimsIdentifierService>();
 
 builder.Services.AddHealthChecks()
     .AddCheck<ApiHealthCheck>("API Health Check");

--- a/web/src/Web.App/Services/ClaimsIdentifierService.cs
+++ b/web/src/Web.App/Services/ClaimsIdentifierService.cs
@@ -1,0 +1,88 @@
+﻿using Web.App.Domain;
+using Web.App.Identity.Models;
+using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Apis.Establishment;
+using Web.App.Infrastructure.Extensions;
+
+namespace Web.App.Services;
+
+public interface IClaimsIdentifierService
+{
+    Task<(string[] schools, string[] trusts)> IdentifyValidClaims(Organisation? organisation);
+}
+
+public class ClaimsIdentifierService(IEstablishmentApi api) : IClaimsIdentifierService
+{
+    public async Task<(string[] schools, string[] trusts)> IdentifyValidClaims(Organisation? organisation)
+    {
+        var schools = Array.Empty<string>();
+        var trusts = Array.Empty<string>();
+
+        if (organisation is { Category.Id: { } orgCategoryId })
+        {
+            switch (orgCategoryId)
+            {
+                case OrganisationCategories.SingleAcademyTrust:
+                case OrganisationCategories.MultiAcademyTrust:
+                    (schools, trusts) = await HandleTrustSchoolsAsync(organisation);
+                    break;
+                case OrganisationCategories.LocalAuthority:
+                    schools = await HandleLocalAuthoritySchoolsAsync(organisation);
+                    break;
+                default:
+                    var urn = organisation.UrnValue.ToString();
+                    schools = [urn];
+                    trusts = await HandleAcademyTrustAsync(urn);
+                    break;
+            }
+        }
+
+        return (schools, trusts);
+    }
+
+    private async Task<(string[] schools, string[] trusts)> HandleTrustSchoolsAsync(Organisation organisation)
+    {
+        var schools = Array.Empty<string>();
+        var trusts = Array.Empty<string>();
+
+        var companyNumber = organisation.CompanyRegistrationNumber?.ToString("00000000");
+        if (companyNumber != null)
+        {
+            var query = new ApiQuery().AddIfNotNull("companyNumber", companyNumber);
+            var trustSchools = await api.QuerySchools(query).GetResultOrDefault<School[]>() ?? [];
+            trusts = [companyNumber];
+            schools = trustSchools.Select(x => x.URN).OfType<string>().ToArray();
+        }
+
+        return (schools, trusts);
+    }
+
+    private async Task<string[]> HandleLocalAuthoritySchoolsAsync(Organisation organisation)
+    {
+        var schools = Array.Empty<string>();
+
+        var laCode = organisation.EstablishmentNumber?.ToString("000");
+        if (laCode != null)
+        {
+            var query = new ApiQuery().AddIfNotNull("laCode", laCode);
+            var laSchools = await api.QuerySchools(query).GetResultOrDefault<School[]>() ?? [];
+            schools = laSchools.Select(x => x.URN).OfType<string>().ToArray();
+        }
+
+        return schools;
+    }
+
+    private async Task<string[]> HandleAcademyTrustAsync(string urn)
+    {
+        var trusts = Array.Empty<string>();
+        var school = await api.GetSchool(urn).GetResultOrDefault<School>();
+        var companyNumber = school?.TrustCompanyNumber;
+
+        if (companyNumber != null)
+        {
+            trusts = [companyNumber];
+        }
+
+        return trusts;
+    }
+}

--- a/web/src/Web.App/Services/ClaimsIdentifierService.cs
+++ b/web/src/Web.App/Services/ClaimsIdentifierService.cs
@@ -30,7 +30,7 @@ public class ClaimsIdentifierService(IEstablishmentApi api) : IClaimsIdentifierS
                     schools = await HandleLocalAuthoritySchoolsAsync(organisation);
                     break;
                 default:
-                    (schools, trusts) = await HandleAcademyTrustAsync(organisation);
+                    (schools, trusts) = await HandleSchoolAsync(organisation);
                     break;
             }
         }
@@ -70,7 +70,7 @@ public class ClaimsIdentifierService(IEstablishmentApi api) : IClaimsIdentifierS
         return schools;
     }
 
-    private async Task<(string[] schools, string[] trusts)> HandleAcademyTrustAsync(Organisation organisation)
+    private async Task<(string[] schools, string[] trusts)> HandleSchoolAsync(Organisation organisation)
     {
         var urn = organisation.UrnValue.ToString();
         var schools = new[] { urn };

--- a/web/src/Web.App/Services/ClaimsIdentifierService.cs
+++ b/web/src/Web.App/Services/ClaimsIdentifierService.cs
@@ -30,9 +30,7 @@ public class ClaimsIdentifierService(IEstablishmentApi api) : IClaimsIdentifierS
                     schools = await HandleLocalAuthoritySchoolsAsync(organisation);
                     break;
                 default:
-                    var urn = organisation.UrnValue.ToString();
-                    schools = [urn];
-                    trusts = await HandleAcademyTrustAsync(urn);
+                    (schools, trusts) = await HandleAcademyTrustAsync(organisation);
                     break;
             }
         }
@@ -72,8 +70,10 @@ public class ClaimsIdentifierService(IEstablishmentApi api) : IClaimsIdentifierS
         return schools;
     }
 
-    private async Task<string[]> HandleAcademyTrustAsync(string urn)
+    private async Task<(string[] schools, string[] trusts)> HandleAcademyTrustAsync(Organisation organisation)
     {
+        var urn = organisation.UrnValue.ToString();
+        var schools = new[] { urn };
         var trusts = Array.Empty<string>();
         var school = await api.GetSchool(urn).GetResultOrDefault<School>();
         var companyNumber = school?.TrustCompanyNumber;
@@ -83,6 +83,6 @@ public class ClaimsIdentifierService(IEstablishmentApi api) : IClaimsIdentifierS
             trusts = [companyNumber];
         }
 
-        return trusts;
+        return (schools, trusts);
     }
 }

--- a/web/tests/Web.Tests/Services/WhenClaimsIdentifierServiceIsCalled.cs
+++ b/web/tests/Web.Tests/Services/WhenClaimsIdentifierServiceIsCalled.cs
@@ -1,0 +1,186 @@
+﻿using Moq;
+using Xunit;
+using Web.App.Services;
+using Web.App.Infrastructure.Apis.Establishment;
+using Web.App.Domain;
+using Web.App.Identity.Models;
+using Web.App.Infrastructure.Apis;
+
+namespace Web.Tests.Services;
+
+public class WhenClaimsIdentifierServiceIsCalled
+{
+    private readonly Mock<IEstablishmentApi> _mockApi = new();
+
+    [Fact]
+    public async Task ShouldReturnSchoolsAndTrustCorrectlyWhenSingleAcademyTrust()
+    {
+        var organisationItem = new OrganisationItem
+        {
+            Id = "013"
+        };
+        var organisation = new Organisation
+        {
+            Category = organisationItem,
+            CompanyRegistrationNumber = 12345678,
+        };
+        var response = new[] {
+            new School { URN = "123456", TrustCompanyNumber = "12345678" },
+        };
+        ApiQuery? query = null;
+        _mockApi.Setup(api => api.QuerySchools(It.IsAny<ApiQuery>()))
+            .Callback<ApiQuery>(x =>
+            {
+                query = x;
+            })
+            .ReturnsAsync(ApiResult.Ok(response));
+        var service = new ClaimsIdentifierService(_mockApi.Object);
+
+        var (schools, trusts) = await service.IdentifyValidClaims(organisation);
+
+        Assert.Single(schools);
+        Assert.Contains("123456", schools);
+        Assert.Single(trusts);
+        Assert.Contains("12345678", trusts);
+        Assert.Equal("?companyNumber=12345678", query?.ToQueryString());
+    }
+
+    [Fact]
+    public async Task ShouldReturnTrustSchoolsCorrectlyWhenMultiAcademyTrust()
+    {
+        var organisationItem = new OrganisationItem
+        {
+            Id = "010"
+        };
+        var organisation = new Organisation
+        {
+            Category = organisationItem,
+            CompanyRegistrationNumber = 12345678,
+        };
+        var response = new[] {
+            new School { URN = "123456", TrustCompanyNumber = "12345678" },
+            new School { URN = "987654", TrustCompanyNumber = "12345678" }
+        };
+        ApiQuery? query = null;
+        _mockApi.Setup(api => api.QuerySchools(It.IsAny<ApiQuery>()))
+            .Callback<ApiQuery>(x =>
+            {
+                query = x;
+            })
+            .ReturnsAsync(ApiResult.Ok(response));
+        var service = new ClaimsIdentifierService(_mockApi.Object);
+
+        var (schools, trusts) = await service.IdentifyValidClaims(organisation);
+
+        Assert.Equal(2, schools.Length);
+        Assert.Contains("123456", schools);
+        Assert.Contains("987654", schools);
+        Assert.Single(trusts);
+        Assert.Contains("12345678", trusts);
+        Assert.Equal("?companyNumber=12345678", query?.ToQueryString());
+    }
+
+    [Fact]
+    public async Task ShouldReturnLaSchoolsCorrectlyWhenLocalAuthority()
+    {
+        var organisationItem = new OrganisationItem
+        {
+            Id = "002"
+        };
+        var organisation = new Organisation
+        {
+            Category = organisationItem,
+            EstablishmentNumber = 123,
+        };
+        var response = new[] {
+            new School { URN = "123456", LACode = "123" },
+            new School { URN = "987654", LACode = "123" }
+        };
+        ApiQuery? query = null;
+        _mockApi.Setup(api => api.QuerySchools(It.IsAny<ApiQuery>()))
+            .Callback<ApiQuery>(x =>
+            {
+                query = x;
+            })
+            .ReturnsAsync(ApiResult.Ok(response));
+        var service = new ClaimsIdentifierService(_mockApi.Object);
+
+        var (schools, trusts) = await service.IdentifyValidClaims(organisation);
+
+        Assert.Equal(2, schools.Length);
+        Assert.Contains("123456", schools);
+        Assert.Contains("987654", schools);
+        Assert.Empty(trusts);
+        Assert.Equal("?laCode=123", query?.ToQueryString());
+    }
+
+    [Fact]
+    public async Task ShouldReturnCorrectlyWhenAcademy()
+    {
+        var organisationItem = new OrganisationItem()
+        {
+            Id = "001"
+        };
+        var organisation = new Organisation
+        {
+            Category = organisationItem,
+            URN = 123456
+        };
+
+        var response = new School { URN = "123456", TrustCompanyNumber = "12345678" };
+        _mockApi.Setup(api => api.GetSchool(organisation.URN.ToString()))
+            .ReturnsAsync(ApiResult.Ok(response));
+        var service = new ClaimsIdentifierService(_mockApi.Object);
+
+        var (schools, trusts) = await service.IdentifyValidClaims(organisation);
+
+        Assert.Single(schools);
+        Assert.Contains("123456", schools);
+        Assert.Single(trusts);
+        Assert.Contains("12345678", trusts);
+    }
+
+    [Fact]
+    public async Task ShouldReturnCorrectlyWhenNotAcademy()
+    {
+        var organisationItem = new OrganisationItem()
+        {
+            Id = "001"
+        };
+        var organisation = new Organisation
+        {
+            Category = organisationItem,
+            URN = 123456
+        };
+        var response = new School { URN = "123456" };
+
+        _mockApi.Setup(api => api.GetSchool(organisation.URN.ToString()))
+            .ReturnsAsync(ApiResult.Ok(response));
+        var service = new ClaimsIdentifierService(_mockApi.Object);
+
+        var (schools, trusts) = await service.IdentifyValidClaims(organisation);
+
+        Assert.Single(schools);
+        Assert.Contains("123456", schools);
+        Assert.Empty(trusts);
+    }
+
+    [Fact]
+    public async Task ShouldReturnCorrectlyWhenOrganisationIsNull()
+    {
+        Organisation? organisation = null;
+        _mockApi.Setup(api => api.GetSchool(It.IsAny<string>()))
+            .ReturnsAsync(ApiResult.Ok());
+
+        _mockApi.Setup(api => api.QuerySchools(It.IsAny<ApiQuery>()))
+            .ReturnsAsync(ApiResult.Ok());
+        var service = new ClaimsIdentifierService(_mockApi.Object);
+
+        var (schools, trusts) = await service.IdentifyValidClaims(organisation);
+
+        Assert.Empty(schools);
+        Assert.Empty(trusts);
+        _mockApi.Verify(api => api.GetSchool(It.IsAny<string>()), Times.Never);
+        _mockApi.Verify(api => api.QuerySchools(It.IsAny<ApiQuery>()), Times.Never);
+    }
+}


### PR DESCRIPTION
### Context
[AB#236854](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/236854) 
[AB#236921](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/236921)

Closes [AB#237759](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/237759)
Closes [AB#238501](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/238501)

### Change proposed in this pull request
- Similar to the approach for Trusts look up for all maintained schools in the local authority performed and claims for those schools added for the user when they log in with an `organisation.category.id` of `002`
- When `TrustCompanyNumber` is present in FBIT for a user logging in with a school adds the claim for the parent Trust
- Refactor into a service as suggested in this review for easier unit testing.
- Adds unit tests 
- Adds constants for these organisation categories.

### Guidance to review 
Unable to fully test this locally. Would be good to test against a variety of organisations set up in DSI pre prod

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main

