### PR TITLE
Trim search suggester input to `100` characters before submitting

### DIFF
--- a/front-end-components/src/components/auto-complete/component.tsx
+++ b/front-end-components/src/components/auto-complete/component.tsx
@@ -9,6 +9,7 @@ export function AutoComplete<T>({
   onSuggest,
   suggestionFormatter,
   valueFormatter,
+  maxLength,
   ...props
 }: AutoCompleteProps<T>) {
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -20,6 +21,13 @@ export function AutoComplete<T>({
     setIsLoading(true);
 
     try {
+      if (query) {
+        query = query.trim();
+        if (maxLength > props.minLength) {
+          query = query.substring(0, maxLength).trim();
+        }
+      }
+
       const results = await onSuggest(query);
       if (results && Array.isArray(results)) {
         populateResults(results);

--- a/front-end-components/src/components/auto-complete/types.tsx
+++ b/front-end-components/src/components/auto-complete/types.tsx
@@ -3,31 +3,40 @@ import { AccessibleAutocompleteProps } from "accessible-autocomplete/react";
 export type AutoCompleteProps<T> = Pick<
   AccessibleAutocompleteProps,
   "defaultValue" | "id" | "name" | "minLength" | "required"
-> & {
-  /**
-   * When the user selects an option.
-   * @param value The option selected by the user
-   */
-  onSelected(value: T): void;
+> &
+  Pick<HTMLInputElement, "maxLength"> & {
+    /**
+     * When the user selects an option.
+     * @param value The option selected by the user
+     */
+    onSelected(value: T): void;
 
-  /**
-   * Executes a suggester using the supplied query
-   * @param query The value entered by the user
-   * @returns The suggested matches based on the query
-   */
-  onSuggest: (query: string) => Promise<T[]>;
+    /**
+     * Executes a suggester using the supplied query
+     * @param query The value entered by the user
+     * @returns The suggested matches based on the query
+     */
+    onSuggest: (query: string) => Promise<T[]>;
 
-  /**
-   * Formatter to use when rendering a suggestion to be displayed
-   * @param value Suggested value
-   * @returns ⚠️ `string` that may contain HTML
-   */
-  suggestionFormatter: (value: T) => string;
+    /**
+     * Formatter to use when rendering a suggestion to be displayed
+     * @param value Suggested value
+     * @returns ⚠️ `string` that may contain HTML
+     */
+    suggestionFormatter: (value: T) => string;
 
-  /**
-   * Formatter to use to generate the value to be inserted into the input field
-   * @param value Selected value
-   * @returns Plain `string` that represents the value
-   */
-  valueFormatter: (value: T) => string;
-};
+    /**
+     * Formatter to use to generate the value to be inserted into the input field
+     * @param value Selected value
+     * @returns Plain `string` that represents the value
+     */
+    valueFormatter: (value: T) => string;
+
+    /**
+     * The minimum number of characters that should be entered before the autocomplete will
+     * attempt to suggest options. When the query length is under this, the aria status region
+     * will also provide helpful text to the user informing them they should type in more.
+     * Default 0.
+     */
+    minLength: number;
+  };

--- a/front-end-components/src/views/find-organisation/partials/la-input.tsx
+++ b/front-end-components/src/views/find-organisation/partials/la-input.tsx
@@ -63,6 +63,7 @@ const LaInput: React.FunctionComponent<LaInputProps> = (props) => {
         id="la-input"
         name="laInput"
         minLength={3}
+        maxLength={100}
         onSelected={handleSelected}
         onSuggest={handleSuggest}
         suggestionFormatter={suggestionFormatter}

--- a/front-end-components/src/views/find-organisation/partials/school-input.tsx
+++ b/front-end-components/src/views/find-organisation/partials/school-input.tsx
@@ -63,6 +63,7 @@ const SchoolInput: React.FunctionComponent<SchoolInputProps> = (props) => {
         id="school-input"
         name="schoolInput"
         minLength={3}
+        maxLength={100}
         onSelected={handleSelected}
         onSuggest={handleSuggest}
         suggestionFormatter={suggestionFormatter}

--- a/front-end-components/src/views/find-organisation/partials/trust-input.tsx
+++ b/front-end-components/src/views/find-organisation/partials/trust-input.tsx
@@ -64,6 +64,7 @@ const TrustInput: React.FunctionComponent<TrustInputProps> = (props) => {
         id="trust-input"
         name="trustInput"
         minLength={3}
+        maxLength={100}
         onSelected={handleSelected}
         onSuggest={handleSuggest}
         suggestionFormatter={suggestionFormatter}

--- a/platform/src/abstractions/Platform.Search/Validators/PostSuggestRequestValidator.cs
+++ b/platform/src/abstractions/Platform.Search/Validators/PostSuggestRequestValidator.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using FluentValidation;
-
-namespace Platform.Search;
+namespace Platform.Search.Validators;
 
 [ExcludeFromCodeCoverage]
 public class PostSuggestRequestValidator : AbstractValidator<SuggestRequest>
@@ -9,7 +8,9 @@ public class PostSuggestRequestValidator : AbstractValidator<SuggestRequest>
     public PostSuggestRequestValidator()
     {
         RuleFor(p => p.SuggesterName).NotNull();
-        RuleFor(p => p.SearchText).NotNull();
+        RuleFor(p => p.SearchText).NotNull()
+            .MinimumLength(3)
+            .MaximumLength(100);
         RuleFor(p => p.Size).GreaterThanOrEqualTo(5);
     }
 }

--- a/platform/src/apis/Platform.Api.Establishment/Configuration/Services.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Configuration/Services.cs
@@ -13,6 +13,7 @@ using Platform.Api.Establishment.Trusts;
 using Platform.Functions.Extensions;
 using Platform.Infrastructure;
 using Platform.Search;
+using Platform.Search.Validators;
 using Platform.Sql;
 namespace Platform.Api.Establishment.Configuration;
 

--- a/platform/src/apis/Platform.Api.Establishment/LocalAuthorities/LocalAuthoritiesFunctions.cs
+++ b/platform/src/apis/Platform.Api.Establishment/LocalAuthorities/LocalAuthoritiesFunctions.cs
@@ -9,6 +9,7 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
+using Platform.Functions;
 using Platform.Functions.Extensions;
 using Platform.Functions.OpenApi;
 using Platform.Search;
@@ -69,7 +70,7 @@ public class LocalAuthoritiesFunctions(
     [OpenApiSecurityHeader]
     [OpenApiRequestBody("application/json", typeof(SuggestRequest), Description = "The suggest object")]
     [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(SuggestResponse<LocalAuthority>))]
-    [OpenApiResponseWithoutBody(HttpStatusCode.BadRequest)]
+    [OpenApiResponseWithBody(HttpStatusCode.BadRequest, "application/json", typeof(ValidationError[]))]
     [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
     public async Task<HttpResponseData> SuggestLocalAuthoritiesAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "post", Route = "local-authorities/suggest")] HttpRequestData req)

--- a/platform/src/apis/Platform.Api.Establishment/Schools/SchoolsFunctions.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Schools/SchoolsFunctions.cs
@@ -9,6 +9,7 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
+using Platform.Functions;
 using Platform.Functions.Extensions;
 using Platform.Functions.OpenApi;
 using Platform.Search;
@@ -109,7 +110,7 @@ public class SchoolsFunctions(ILogger<SchoolsFunctions> logger,
     [OpenApiSecurityHeader]
     [OpenApiRequestBody("application/json", typeof(SuggestRequest), Description = "The suggest object")]
     [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(SuggestResponse<School>))]
-    [OpenApiResponseWithoutBody(HttpStatusCode.BadRequest)]
+    [OpenApiResponseWithBody(HttpStatusCode.BadRequest, "application/json", typeof(ValidationError[]))]
     [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
     public async Task<HttpResponseData> SuggestSchoolsAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "post", Route = "schools/suggest")] HttpRequestData req)

--- a/platform/src/apis/Platform.Api.Establishment/Trusts/TrustsFunctions.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Trusts/TrustsFunctions.cs
@@ -9,6 +9,7 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
+using Platform.Functions;
 using Platform.Functions.Extensions;
 using Platform.Functions.OpenApi;
 using Platform.Search;
@@ -69,7 +70,7 @@ public class TrustsFunctions(
     [OpenApiSecurityHeader]
     [OpenApiRequestBody("application/json", typeof(SuggestRequest), Description = "The suggest object")]
     [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(SuggestResponse<Trust>))]
-    [OpenApiResponseWithoutBody(HttpStatusCode.BadRequest)]
+    [OpenApiResponseWithBody(HttpStatusCode.BadRequest, "application/json", typeof(ValidationError[]))]
     [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
     public async Task<HttpResponseData> SuggestTrustsAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "post", Route = "trusts/suggest")] HttpRequestData req)

--- a/platform/tests/Platform.ApiTests/Features/EstablishmentLocalAuthorities.feature
+++ b/platform/tests/Platform.ApiTests/Features/EstablishmentLocalAuthorities.feature
@@ -42,10 +42,16 @@ Feature: Establishment local authorities endpoints
         Then the local authorities suggest result should be empty
 
     Scenario: Sending an invalid suggest local authorities request returns the validation results
-        Given an invalid local authorities suggest request
+        Given an invalid local authorities suggest request with '<SuggesterName>', '<SearchText>' and '<Size>'
         When I submit the local authorities request
         Then the local authorities suggest result should be bad request and have the following validation errors:
-          | PropertyName  | ErrorMessage                                 |
-          | SuggesterName | 'Suggester Name' must not be empty.          |
-          | SearchText    | 'Search Text' must not be empty.             |
-          | Size          | 'Size' must be greater than or equal to '5'. |
+          | PropertyName  | ErrorMessage                |
+          | SuggesterName | <SuggesterNameErrorMessage> |
+          | SearchText    | <SearchTextErrorMessage>    |
+          | Size          | <SizeErrorMessage>          |
+
+    Examples:
+      | SuggesterName | SearchText                                                                                                    | Size | SuggesterNameErrorMessage           | SearchTextErrorMessage                                                                   | SizeErrorMessage                             |
+      |               |                                                                                                               | 0    | 'Suggester Name' must not be empty. | 'Search Text' must not be empty.                                                         | 'Size' must be greater than or equal to '5'. |
+      | suggester     | te                                                                                                            | 5    |                                     | The length of 'Search Text' must be at least 3 characters. You entered 2 characters.     |                                              |
+      | suggester     | 0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789 | 5    |                                     | The length of 'Search Text' must be 100 characters or fewer. You entered 109 characters. |                                              |

--- a/platform/tests/Platform.ApiTests/Features/EstablishmentSchools.feature
+++ b/platform/tests/Platform.ApiTests/Features/EstablishmentSchools.feature
@@ -39,13 +39,19 @@ Feature: Establishment schools endpoints
         Then the schools suggest result should be empty
 
     Scenario: Sending an invalid suggest schools request returns the validation results
-        Given an invalid schools suggest request
+        Given an invalid schools suggest request with '<SuggesterName>', '<SearchText>' and '<Size>'
         When I submit the schools request
         Then the schools suggest result should be bad request and have the following validation errors:
-          | PropertyName  | ErrorMessage                                 |
-          | SuggesterName | 'Suggester Name' must not be empty.          |
-          | SearchText    | 'Search Text' must not be empty.             |
-          | Size          | 'Size' must be greater than or equal to '5'. |
+          | PropertyName  | ErrorMessage                |
+          | SuggesterName | <SuggesterNameErrorMessage> |
+          | SearchText    | <SearchTextErrorMessage>    |
+          | Size          | <SizeErrorMessage>          |
+
+    Examples:
+      | SuggesterName | SearchText                                                                                                    | Size | SuggesterNameErrorMessage           | SearchTextErrorMessage                                                                   | SizeErrorMessage                             |
+      |               |                                                                                                               | 0    | 'Suggester Name' must not be empty. | 'Search Text' must not be empty.                                                         | 'Size' must be greater than or equal to '5'. |
+      | suggester     | te                                                                                                            | 5    |                                     | The length of 'Search Text' must be at least 3 characters. You entered 2 characters.     |                                              |
+      | suggester     | 0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789 | 5    |                                     | The length of 'Search Text' must be 100 characters or fewer. You entered 109 characters. |                                              |
 
     Scenario: Sending a valid query schools request for laCode
         Given a valid query schools request phase '' laCode '201' and companyNumber ''

--- a/platform/tests/Platform.ApiTests/Features/EstablishmentTrusts.feature
+++ b/platform/tests/Platform.ApiTests/Features/EstablishmentTrusts.feature
@@ -42,10 +42,16 @@ Feature: Establishment trusts endpoints
         Then the trust suggest result should be empty
 
     Scenario: Sending an invalid suggest trust request returns the validation results
-        Given an invalid trust suggest request
+        Given an invalid trust suggest request with '<SuggesterName>', '<SearchText>' and '<Size>'
         When I submit the trust request
         Then the trust suggest result should be bad request and have the following validation errors:
-          | PropertyName  | ErrorMessage                                 |
-          | SuggesterName | 'Suggester Name' must not be empty.          |
-          | SearchText    | 'Search Text' must not be empty.             |
-          | Size          | 'Size' must be greater than or equal to '5'. |
+          | PropertyName  | ErrorMessage                |
+          | SuggesterName | <SuggesterNameErrorMessage> |
+          | SearchText    | <SearchTextErrorMessage>    |
+          | Size          | <SizeErrorMessage>          |
+
+    Examples:
+      | SuggesterName | SearchText                                                                                                    | Size | SuggesterNameErrorMessage           | SearchTextErrorMessage                                                                   | SizeErrorMessage                             |
+      |               |                                                                                                               | 0    | 'Suggester Name' must not be empty. | 'Search Text' must not be empty.                                                         | 'Size' must be greater than or equal to '5'. |
+      | suggester     | te                                                                                                            | 5    |                                     | The length of 'Search Text' must be at least 3 characters. You entered 2 characters.     |                                              |
+      | suggester     | 0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789 | 5    |                                     | The length of 'Search Text' must be 100 characters or fewer. You entered 109 characters. |                                              |

--- a/platform/tests/Platform.ApiTests/Steps/EstablishmentLocalAuthoritiesSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/EstablishmentLocalAuthoritiesSteps.cs
@@ -52,12 +52,14 @@ public class EstablishmentLocalAuthoritiesSteps(EstablishmentApiDriver api)
         });
     }
 
-    [Given("an invalid local authorities suggest request")]
-    private void GivenAnInvalidLocalAuthoritiesSuggestRequest()
+    [Given("an invalid local authorities suggest request with '(.*)', '(.*)' and '(.*)'")]
+    private void GivenAnInvalidLocalAuthoritiesSuggestRequestWithAnd(string suggesterName, string searchText, int size)
     {
         var content = new
         {
-            Size = 0
+            SuggesterName = string.IsNullOrWhiteSpace(suggesterName) ? null : suggesterName,
+            SearchText = string.IsNullOrWhiteSpace(searchText) ? null : searchText,
+            Size = size
         };
 
         api.CreateRequest(SuggestRequestKey, new HttpRequestMessage
@@ -185,6 +187,12 @@ public class EstablishmentLocalAuthoritiesSteps(EstablishmentApiDriver api)
         var content = await response.Content.ReadAsByteArrayAsync();
         var results = content.FromJson<ValidationError[]>();
 
-        table.CompareToSet(results);
+        var filteredTable = new DataTable(table.Header.ToArray());
+        foreach (var row in table.Rows.Where(r => !string.IsNullOrWhiteSpace(r["ErrorMessage"])))
+        {
+            filteredTable.AddRow(row);
+        }
+
+        filteredTable.CompareToSet(results);
     }
 }

--- a/platform/tests/Platform.ApiTests/Steps/EstablishmentSchoolsSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/EstablishmentSchoolsSteps.cs
@@ -26,7 +26,7 @@ public class EstablishmentSchoolsSteps(EstablishmentApiDriver api)
     }
 
     [Given("an invalid school request with id '(.*)'")]
-    private void GivenAnInvalidValidSchoolRequestWithId(string id)
+    private void GivenAnInvalidSchoolRequestWithId(string id)
     {
         api.CreateRequest(RequestKey, new HttpRequestMessage
         {
@@ -36,7 +36,7 @@ public class EstablishmentSchoolsSteps(EstablishmentApiDriver api)
     }
 
     [Given("a valid schools suggest request with searchText '(.*)")]
-    private void GivenAValidSchoolsSuggestRequest(string searchText)
+    private void GivenAValidSchoolsSuggestRequestWithSearchText(string searchText)
     {
         var content = new
         {
@@ -53,12 +53,14 @@ public class EstablishmentSchoolsSteps(EstablishmentApiDriver api)
         });
     }
 
-    [Given("an invalid schools suggest request")]
-    private void GivenAnInvalidSchoolsSuggestRequest()
+    [Given("an invalid schools suggest request with '(.*)', '(.*)' and '(.*)'")]
+    private void GivenAnInvalidSchoolsSuggestRequestWithAnd(string suggesterName, string searchText, int size)
     {
         var content = new
         {
-            Size = 0
+            SuggesterName = string.IsNullOrWhiteSpace(suggesterName) ? null : suggesterName,
+            SearchText = string.IsNullOrWhiteSpace(searchText) ? null : searchText,
+            Size = size
         };
 
         api.CreateRequest(SuggestRequestKey, new HttpRequestMessage
@@ -70,7 +72,7 @@ public class EstablishmentSchoolsSteps(EstablishmentApiDriver api)
     }
 
     [Given("a valid query schools request phase '(.*)' laCode '(.*)' and companyNumber '(.*)'")]
-    private void GivenAValidSchoolsQueryRequest(string phase, string laCode, string companyNumber)
+    private void GivenAValidQuerySchoolsRequestPhaseLaCodeAndCompanyNumber(string phase, string laCode, string companyNumber)
     {
         const string baseApiUrl = "/api/schools";
         var queryString = new StringBuilder();
@@ -114,7 +116,7 @@ public class EstablishmentSchoolsSteps(EstablishmentApiDriver api)
     }
 
     [Then("the school result should be ok and have the following values:")]
-    private async Task ThenTheSchoolResultShouldHaveValues(DataTable table)
+    private async Task ThenTheSchoolResultShouldBeOkAndHaveTheFollowingValues(DataTable table)
     {
         var response = api[RequestKey].Response;
 
@@ -137,7 +139,7 @@ public class EstablishmentSchoolsSteps(EstablishmentApiDriver api)
     }
 
     [Then("the school suggest result should be ok and have the following values:")]
-    private async Task ThenTheSchoolsSuggestResultShouldShouldHaveValues(DataTable table)
+    private async Task ThenTheSchoolSuggestResultShouldBeOkAndHaveTheFollowingValues(DataTable table)
     {
         var response = api[SuggestRequestKey].Response;
 
@@ -160,7 +162,7 @@ public class EstablishmentSchoolsSteps(EstablishmentApiDriver api)
     }
 
     [Then("the schools suggest result should be ok and have the following multiple values:")]
-    private async Task ThenTheSchoolsSuggestResultShouldShouldHaveMultipleValues(DataTable table)
+    private async Task ThenTheSchoolsSuggestResultShouldBeOkAndHaveTheFollowingMultipleValues(DataTable table)
     {
         var response = api[SuggestRequestKey].Response;
 
@@ -195,7 +197,7 @@ public class EstablishmentSchoolsSteps(EstablishmentApiDriver api)
     }
 
     [Then("the schools suggest result should be bad request and have the following validation errors:")]
-    private async Task ThenTheSchoolsSuggestResultShouldHaveTheFollowingValidationErrors(DataTable table)
+    private async Task ThenTheSchoolsSuggestResultShouldBeBadRequestAndHaveTheFollowingValidationErrors(DataTable table)
     {
         var response = api[SuggestRequestKey].Response;
 
@@ -204,11 +206,17 @@ public class EstablishmentSchoolsSteps(EstablishmentApiDriver api)
         var content = await response.Content.ReadAsByteArrayAsync();
         var results = content.FromJson<ValidationError[]>();
 
-        table.CompareToSet(results);
+        var filteredTable = new DataTable(table.Header.ToArray());
+        foreach (var row in table.Rows.Where(r => !string.IsNullOrWhiteSpace(r["ErrorMessage"])))
+        {
+            filteredTable.AddRow(row);
+        }
+
+        filteredTable.CompareToSet(results);
     }
 
     [Then("the schools query result should be ok and have the following values:")]
-    private async Task ThenTheSchoolsQueryResultShouldHaveValues(DataTable table)
+    private async Task ThenTheSchoolsQueryResultShouldBeOkAndHaveTheFollowingValues(DataTable table)
     {
         var response = api[QueryRequestKey].Response;
 

--- a/platform/tests/Platform.ApiTests/Steps/EstablishmentTrustsSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/EstablishmentTrustsSteps.cs
@@ -52,12 +52,14 @@ public class EstablishmentTrustsSteps(EstablishmentApiDriver api)
         });
     }
 
-    [Given("an invalid trust suggest request")]
-    private void GivenAnInvalidTrustSuggestRequest()
+    [Given("an invalid trust suggest request with '(.*)', '(.*)' and '(.*)'")]
+    private void GivenAnInvalidTrustSuggestRequestWithAnd(string suggesterName, string searchText, int size)
     {
         var content = new
         {
-            Size = 0
+            SuggesterName = string.IsNullOrWhiteSpace(suggesterName) ? null : suggesterName,
+            SearchText = string.IsNullOrWhiteSpace(searchText) ? null : searchText,
+            Size = size
         };
 
         api.CreateRequest(SuggestRequestKey, new HttpRequestMessage
@@ -185,6 +187,12 @@ public class EstablishmentTrustsSteps(EstablishmentApiDriver api)
         var content = await response.Content.ReadAsByteArrayAsync();
         var results = content.FromJson<ValidationError[]>();
 
-        table.CompareToSet(results);
+        var filteredTable = new DataTable(table.Header.ToArray());
+        foreach (var row in table.Rows.Where(r => !string.IsNullOrWhiteSpace(r["ErrorMessage"])))
+        {
+            filteredTable.AddRow(row);
+        }
+
+        filteredTable.CompareToSet(results);
     }
 }

--- a/platform/tests/Platform.Tests/Search/Validators/PostSuggestRequestValidatorValidates.cs
+++ b/platform/tests/Platform.Tests/Search/Validators/PostSuggestRequestValidatorValidates.cs
@@ -1,0 +1,44 @@
+﻿using Platform.Search;
+using Platform.Search.Validators;
+using Xunit;
+namespace Platform.Tests.Search.Validators;
+
+public class PostSuggestRequestValidatorValidates
+{
+    private readonly PostSuggestRequestValidator _validator = new();
+
+    [Theory]
+    [InlineData("name", "text", 10)]
+    public async Task ShouldValidateAndEvaluateGoodRequestAsValid(string? suggesterName, string? searchText, int size)
+    {
+        var request = new SuggestRequest
+        {
+            SuggesterName = suggesterName,
+            SearchText = searchText,
+            Size = size
+        };
+
+        var actual = await _validator.ValidateAsync(request);
+        Assert.True(actual.IsValid);
+        Assert.Empty(actual.Errors);
+    }
+
+    [Theory]
+    [InlineData("name", "text", 1)]
+    [InlineData("name", "te", 10)]
+    [InlineData("name", "0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789", 10)]
+    [InlineData(null, null, 10)]
+    public async Task ShouldValidateAndEvaluateBadRequestAsInvalid(string? suggesterName, string? searchText, int size)
+    {
+        var request = new SuggestRequest
+        {
+            SuggesterName = suggesterName,
+            SearchText = searchText,
+            Size = size
+        };
+
+        var actual = await _validator.ValidateAsync(request);
+        Assert.False(actual.IsValid);
+        Assert.NotEmpty(actual.Errors);
+    }
+}


### PR DESCRIPTION
### Context
[AB#238713](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/238713) [AB#235691](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/235691)

### Change proposed in this pull request
- Trim input on front end
- Additional validation on search text in API

### Guidance to review 
`front-end-component` will need building and pushing to `Web` to validate the component change locally. If this is not done, and >100 characters are entered into the suggester then the API will reject with a `400` instead of Azure Search.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

