### PR TITLE
Skip 'pre-populate' stage of CFP if school has insufficient data to use

### DIFF
--- a/web/src/Web.App/Controllers/SchoolPlanningCreatePlanController.cs
+++ b/web/src/Web.App/Controllers/SchoolPlanningCreatePlanController.cs
@@ -140,7 +140,7 @@ public class SchoolPlanningCreateController(
             var workforce = await censusApi.Get(urn).GetResultOrThrow<Census>();
 
             // AB#235762: prevent DivideByZeroException later on if missing figures pre-populated
-            if (income.TotalIncome == null || expenditure.TotalExpenditure == null || workforce.Teachers == null)
+            if (SkipPrePopulateData(income, expenditure, workforce))
             {
                 return await PrePopulateData(urn, year, new PrePopulateDataStage
                 {
@@ -1493,4 +1493,8 @@ public class SchoolPlanningCreateController(
         urn,
         year
     }));
+
+    private static bool SkipPrePopulateData(SchoolIncome income, SchoolExpenditure expenditure, Census workforce) =>
+        income.TotalIncome == null || expenditure.TotalExpenditure == null || expenditure.TeachingStaffCosts == null
+        || expenditure.EducationSupportStaffCosts == null || workforce.Teachers == null;
 }

--- a/web/src/Web.App/Views/SchoolPlanningCreate/Start.cshtml
+++ b/web/src/Web.App/Views/SchoolPlanningCreate/Start.cshtml
@@ -26,8 +26,7 @@
             A full list of the data you will be asked to input
             <a href="@Url.Action("Help", "SchoolPlanningCreate", new { urn = Model.School.URN })"
                class="govuk-link govuk-link--no-visited-state">
-                can be found here
-            </a>.
+                can be found here</a>.
         </p>
         <a href="@Url.Action("SelectYear", "SchoolPlanningCreate", new { urn = Model.School.URN })"
            role="button"

--- a/web/tests/Web.Integration.Tests/Pages/Schools/FinancialPlanning/WhenViewingPlanningSelectYear.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/FinancialPlanning/WhenViewingPlanningSelectYear.cs
@@ -126,13 +126,27 @@ public class WhenViewingPlanningSelectYear(SchoolBenchmarkingWebAppClient client
     }
 
     [Theory]
-    [InlineData(null, null, null)]
-    [InlineData(1_234_567, 987_654, null)]
-    [InlineData(1_234_567, null, null)]
-    [InlineData(null, null, 123)]
-    public async Task CanSubmitAndContinueToTotalIncome(int? totalIncome, int? totalExpenditure, int? teachers)
+    [InlineData(null, null, null, null, null)]
+    [InlineData(1_234_567, 987_654, null, null, null)]
+    [InlineData(1_234_567, null, null, null, null)]
+    [InlineData(null, null, null, null, 123)]
+    [InlineData(1_234_567, 987_654, 98_765, null, 123)]
+    [InlineData(1_234_567, 987_654, null, 9_876, 123)]
+    public async Task CanSubmitAndContinueToTotalIncome(
+        int? totalIncome,
+        int? totalExpenditure,
+        int? teachingStaffCosts,
+        int? educationSupportStaffCosts,
+        int? teachers)
     {
-        var (page, school) = await SetupNavigateInitPage(EstablishmentTypes.Academies, true, totalIncome, totalExpenditure, teachers);
+        var (page, school) = await SetupNavigateInitPage(
+            EstablishmentTypes.Academies,
+            true,
+            totalIncome,
+            totalExpenditure,
+            teachingStaffCosts,
+            educationSupportStaffCosts,
+            teachers);
         AssertPageLayout(page, school);
 
         var action = page.QuerySelector("main .govuk-button");
@@ -157,6 +171,8 @@ public class WhenViewingPlanningSelectYear(SchoolBenchmarkingWebAppClient client
         bool seedPlan = true,
         decimal? totalIncome = 1_234_567,
         decimal? totalExpenditure = 987_654,
+        decimal? teachingStaffCosts = 98_765,
+        decimal? educationSupportStaffCosts = 9_876,
         decimal? teachers = 123)
     {
         var school = Fixture.Build<School>()
@@ -177,6 +193,8 @@ public class WhenViewingPlanningSelectYear(SchoolBenchmarkingWebAppClient client
 
         var expenditure = Fixture.Build<SchoolExpenditure>()
             .With(i => i.TotalExpenditure, totalExpenditure)
+            .With(i => i.TeachingStaffCosts, teachingStaffCosts)
+            .With(i => i.EducationSupportStaffCosts, educationSupportStaffCosts)
             .Create();
 
         var census = Fixture.Build<Census>()


### PR DESCRIPTION
### Context
[AB#238828](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/238828) [AB#235762](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/235762)

### Change proposed in this pull request
Integration tests added to cover in/valid pre-populate states.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] You have reviewed with UX/Design

