### PR TITLE
Track custom event for Azure Search requests

### DIFF
--- a/platform/Directory.Packages.props
+++ b/platform/Directory.Packages.props
@@ -1,62 +1,63 @@
 <Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageVersion Include="AspNetCore.HealthChecks.AzureSearch" Version="8.0.1" />
-    <PackageVersion Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.2" />
-    <PackageVersion Include="AutoFixture" Version="4.18.1" />
-    <PackageVersion Include="Azure.Search.Documents" Version="11.6.0" />
-    <PackageVersion Include="AzureExtensions.Swashbuckle" Version="3.3.2" />
-    <PackageVersion Include="CommandLineParser" Version="2.9.1" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageVersion>
-    <PackageVersion Include="Dapper" Version="2.1.35" />
-    <PackageVersion Include="Dapper.Contrib" Version="2.0.78" />
-    <PackageVersion Include="Dapper.SqlBuilder" Version="2.0.78" />
-    <PackageVersion Include="dbup-sqlserver" Version="5.0.40" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.1" />
-    <PackageVersion Include="FluentValidation" Version="11.10.0" />
-    <PackageVersion Include="JsonSubTypes" Version="2.0.1" />
-    <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
-    <PackageVersion Include="Microsoft.Azure.Core.NewtonsoftJson" Version="2.0.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="1.19.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.4.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.1.7" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.OpenApi" Version="1.5.1" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage" Version="6.6.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.OpenApi.Core" Version="1.5.1" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.NET.Sdk.Functions" Version="4.4.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageVersion>
-    <PackageVersion Include="Reqnroll" Version="2.1.1" />
-    <PackageVersion Include="Reqnroll.xUnit" Version="2.1.1" />
-    <PackageVersion Include="Dynamitey" Version="3.0.3" />
-  </ItemGroup>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include="AspNetCore.HealthChecks.AzureSearch" Version="8.0.1"/>
+        <PackageVersion Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.2"/>
+        <PackageVersion Include="AutoFixture" Version="4.18.1"/>
+        <PackageVersion Include="Azure.Search.Documents" Version="11.6.0"/>
+        <PackageVersion Include="AzureExtensions.Swashbuckle" Version="3.3.2"/>
+        <PackageVersion Include="CommandLineParser" Version="2.9.1"/>
+        <PackageVersion Include="coverlet.collector" Version="6.0.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageVersion>
+        <PackageVersion Include="Dapper" Version="2.1.35"/>
+        <PackageVersion Include="Dapper.Contrib" Version="2.0.78"/>
+        <PackageVersion Include="Dapper.SqlBuilder" Version="2.0.78"/>
+        <PackageVersion Include="dbup-sqlserver" Version="5.0.40"/>
+        <PackageVersion Include="FluentAssertions" Version="6.12.1"/>
+        <PackageVersion Include="FluentValidation" Version="11.10.0"/>
+        <PackageVersion Include="JsonSubTypes" Version="2.0.1"/>
+        <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.22.0"/>
+        <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0"/>
+        <PackageVersion Include="Microsoft.Azure.Core.NewtonsoftJson" Version="2.0.0"/>
+        <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="1.23.0"/>
+        <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="1.19.0"/>
+        <PackageVersion Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.4.0"/>
+        <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0"/>
+        <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.1.7"/>
+        <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0"/>
+        <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.OpenApi" Version="1.5.1"/>
+        <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage" Version="6.6.0"/>
+        <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.0"/>
+        <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1"/>
+        <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1"/>
+        <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.OpenApi.Core" Version="1.5.1"/>
+        <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1"/>
+        <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.7"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1"/>
+        <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2"/>
+        <PackageVersion Include="Microsoft.NET.Sdk.Functions" Version="4.4.0"/>
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
+        <PackageVersion Include="Moq" Version="4.20.72"/>
+        <PackageVersion Include="Newtonsoft.Json" Version="13.0.3"/>
+        <PackageVersion Include="System.Linq.Async" Version="6.0.1"/>
+        <PackageVersion Include="System.Text.Json" Version="8.0.4"/>
+        <PackageVersion Include="xunit" Version="2.9.2"/>
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageVersion>
+        <PackageVersion Include="Reqnroll" Version="2.1.1"/>
+        <PackageVersion Include="Reqnroll.xUnit" Version="2.1.1"/>
+        <PackageVersion Include="Dynamitey" Version="3.0.3"/>
+    </ItemGroup>
 </Project>

--- a/platform/src/abstractions/Platform.Search/Platform.Search.csproj
+++ b/platform/src/abstractions/Platform.Search/Platform.Search.csproj
@@ -11,6 +11,7 @@
     <ItemGroup>
         <PackageReference Include="Azure.Search.Documents"/>
         <PackageReference Include="FluentValidation"/>
+        <PackageReference Include="Microsoft.ApplicationInsights"/>
     </ItemGroup>
 
 </Project>

--- a/platform/src/abstractions/Platform.Search/Requests/SuggestRequest.cs
+++ b/platform/src/abstractions/Platform.Search/Requests/SuggestRequest.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
-
-namespace Platform.Search;
+// ReSharper disable PropertyCanBeMadeInitOnly.Global
+namespace Platform.Search.Requests;
 
 [ExcludeFromCodeCoverage]
 public record SuggestRequest

--- a/platform/src/abstractions/Platform.Search/Responses/SuggestResponse.cs
+++ b/platform/src/abstractions/Platform.Search/Responses/SuggestResponse.cs
@@ -1,7 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
 using Azure.Search.Documents.Models;
-
-namespace Platform.Search;
+// ReSharper disable PropertyCanBeMadeInitOnly.Global
+// ReSharper disable MemberCanBePrivate.Global
+namespace Platform.Search.Responses;
 
 [ExcludeFromCodeCoverage]
 public record SuggestResponse<T>
@@ -15,12 +16,9 @@ public record SuggestValue<T>
     public string? Text { get; set; }
     public T? Document { get; set; }
 
-    public static SuggestValue<T> Create(SearchSuggestion<T> suggestion)
+    public static SuggestValue<T> Create(SearchSuggestion<T> suggestion) => new()
     {
-        return new SuggestValue<T>
-        {
-            Text = suggestion.Text,
-            Document = suggestion.Document
-        };
-    }
+        Text = suggestion.Text,
+        Document = suggestion.Document
+    };
 }

--- a/platform/src/abstractions/Platform.Search/SearchConnection.cs
+++ b/platform/src/abstractions/Platform.Search/SearchConnection.cs
@@ -15,10 +15,12 @@ public interface ISearchConnection<T>
     Task<SuggestResponse<T>> SuggestAsync(SuggestRequest request, Func<string?>? filterExpBuilder = null, string[]? selectFields = null);
 }
 
-public class SearchConnection<T>(SearchClient client, ITelemetryService? telemetryService) : ISearchConnection<T>
+public class SearchConnection<T>(SearchClient? client, ITelemetryService? telemetryService) : ISearchConnection<T>
 {
     public async Task<(long? Total, IEnumerable<ScoreResponse<T>> Response)> SearchAsync(string? search, string? filters, int? size = null)
     {
+        ArgumentNullException.ThrowIfNull(client);
+
         var options = new SearchOptions
         {
             Size = size,
@@ -49,12 +51,16 @@ public class SearchConnection<T>(SearchClient client, ITelemetryService? telemet
 
     public async Task<T> LookUpAsync(string? key)
     {
+        ArgumentNullException.ThrowIfNull(client);
+
         var response = await client.GetDocumentAsync<T>(key);
         return response.Value;
     }
 
     public async Task<SearchResponse<T>> SearchAsync(SearchRequest request, Func<FilterCriteria[], string?>? filterExpBuilder = null, string[]? facets = null)
     {
+        ArgumentNullException.ThrowIfNull(client);
+
         var options = new SearchOptions
         {
             Size = request.PageSize,
@@ -93,6 +99,8 @@ public class SearchConnection<T>(SearchClient client, ITelemetryService? telemet
 
     public async Task<SuggestResponse<T>> SuggestAsync(SuggestRequest request, Func<string?>? filterExpBuilder = null, string[]? selectFields = null)
     {
+        ArgumentNullException.ThrowIfNull(client);
+
         var options = new SuggestOptions
         {
             HighlightPreTag = "*",

--- a/platform/src/abstractions/Platform.Search/Telemetry/TelemetryService.cs
+++ b/platform/src/abstractions/Platform.Search/Telemetry/TelemetryService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.ApplicationInsights;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.ApplicationInsights;
 namespace Platform.Search.Telemetry;
 
 public interface ITelemetryService
@@ -7,6 +8,7 @@ public interface ITelemetryService
     void TrackSuggestEvent(SuggestTelemetryProperties properties);
 }
 
+[ExcludeFromCodeCoverage]
 public class TelemetryService(TelemetryClient telemetryClient) : ITelemetryService
 {
     public void TrackSearchEvent(SearchTelemetryProperties properties)

--- a/platform/src/abstractions/Platform.Search/Telemetry/TelemetryService.cs
+++ b/platform/src/abstractions/Platform.Search/Telemetry/TelemetryService.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.ApplicationInsights;
+namespace Platform.Search.Telemetry;
+
+public interface ITelemetryService
+{
+    void TrackSearchEvent(SearchTelemetryProperties properties);
+    void TrackSuggestEvent(SuggestTelemetryProperties properties);
+}
+
+public class TelemetryService(TelemetryClient telemetryClient) : ITelemetryService
+{
+    public void TrackSearchEvent(SearchTelemetryProperties properties)
+    {
+        var propertiesDict = BuildDictionary(properties,
+            (nameof(SearchTelemetryProperties.Facets), string.Join(",", properties.Facets)),
+            (nameof(SearchTelemetryProperties.Filter), properties.Filter)
+        );
+
+        telemetryClient.TrackEvent("Search", propertiesDict);
+        telemetryClient.Flush();
+    }
+
+    public void TrackSuggestEvent(SuggestTelemetryProperties properties)
+    {
+        var propertiesDict = BuildDictionary(properties,
+            (nameof(SuggestTelemetryProperties.SuggesterName), properties.SuggesterName),
+            (nameof(SuggestTelemetryProperties.Fields), string.Join(",", properties.Fields)),
+            (nameof(SuggestTelemetryProperties.Filter), properties.Filter)
+        );
+
+        telemetryClient.TrackEvent("Search", propertiesDict);
+        telemetryClient.Flush();
+    }
+
+    private static Dictionary<string, string?> BuildDictionary(SearchTelemetryCommonProperties properties, params (string Key, string? Value)[] merge)
+    {
+        var merged = new Dictionary<string, string?>
+        {
+            [nameof(SearchTelemetryCommonProperties.SearchId)] = properties.SearchId.ToString(),
+            [nameof(SearchTelemetryCommonProperties.SearchServiceName)] = properties.SearchServiceName,
+            [nameof(SearchTelemetryCommonProperties.IndexName)] = properties.IndexName,
+            [nameof(SearchTelemetryCommonProperties.SearchText)] = properties.SearchText,
+            [nameof(SearchTelemetryCommonProperties.ResultCount)] = properties.ResultCount.ToString()
+        };
+
+        foreach (var kvp in merge)
+        {
+            merged[kvp.Key] = kvp.Value;
+        }
+
+        return merged;
+    }
+}
+
+public abstract record SearchTelemetryCommonProperties(Guid SearchId, string SearchServiceName, string IndexName, string? SearchText, long? ResultCount);
+
+public record SearchTelemetryProperties(Guid SearchId, string SearchServiceName, string IndexName, IList<string> Facets, string? Filter, string? SearchText, long? ResultCount)
+    : SearchTelemetryCommonProperties(SearchId, SearchServiceName, IndexName, SearchText, ResultCount);
+
+public record SuggestTelemetryProperties(Guid SearchId, string SearchServiceName, string IndexName, string? SuggesterName, IList<string> Fields, string? Filter, string? SearchText, long? ResultCount)
+    : SearchTelemetryCommonProperties(SearchId, SearchServiceName, IndexName, SearchText, ResultCount);

--- a/platform/src/abstractions/Platform.Search/Validators/PostSuggestRequestValidator.cs
+++ b/platform/src/abstractions/Platform.Search/Validators/PostSuggestRequestValidator.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using FluentValidation;
+using Platform.Search.Requests;
 namespace Platform.Search.Validators;
 
 [ExcludeFromCodeCoverage]

--- a/platform/src/abstractions/Platform.Search/packages.lock.json
+++ b/platform/src/abstractions/Platform.Search/packages.lock.json
@@ -19,6 +19,15 @@
         "resolved": "11.10.0",
         "contentHash": "qsJGSJDdZ8qiG+lVJ70PZfJHcEdq8UQZ/tZDXoj78/iHKG6lVKtMJsD11zyyv/IPc7rwqGqnFoFLTNzpo3IPYg=="
       },
+      "Microsoft.ApplicationInsights": {
+        "type": "Direct",
+        "requested": "[2.22.0, )",
+        "resolved": "2.22.0",
+        "contentHash": "3AOM9bZtku7RQwHyMEY3tQMrHIgjcfRDa6YQpd/QG2LDGvMydSlL9Di+8LLMt7J2RDdfJ7/2jdYv6yHcMJAnNw==",
+        "dependencies": {
+          "System.Diagnostics.DiagnosticSource": "5.0.0"
+        }
+      },
       "Azure.Core": {
         "type": "Transitive",
         "resolved": "1.41.0",

--- a/platform/src/apis/Platform.Api.Benchmark/packages.lock.json
+++ b/platform/src/apis/Platform.Api.Benchmark/packages.lock.json
@@ -218,14 +218,6 @@
           "Grpc.Core.Api": "2.60.0"
         }
       },
-      "Microsoft.ApplicationInsights": {
-        "type": "Transitive",
-        "resolved": "2.22.0",
-        "contentHash": "3AOM9bZtku7RQwHyMEY3tQMrHIgjcfRDa6YQpd/QG2LDGvMydSlL9Di+8LLMt7J2RDdfJ7/2jdYv6yHcMJAnNw==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "5.0.0"
-        }
-      },
       "Microsoft.ApplicationInsights.DependencyCollector": {
         "type": "Transitive",
         "resolved": "2.22.0",
@@ -2033,6 +2025,15 @@
         "contentHash": "1Po+Ypf0SjCeEKx5+C89Nb5OgTcqNvfS3uTI46MUM+KEp6Rq/M0h+vVsTUt/6DFRwZMTpsAJM4yJrZmEObVANA==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "CentralTransitive",
+        "requested": "[2.22.0, )",
+        "resolved": "2.22.0",
+        "contentHash": "3AOM9bZtku7RQwHyMEY3tQMrHIgjcfRDa6YQpd/QG2LDGvMydSlL9Di+8LLMt7J2RDdfJ7/2jdYv6yHcMJAnNw==",
+        "dependencies": {
+          "System.Diagnostics.DiagnosticSource": "5.0.0"
         }
       },
       "Microsoft.Azure.Core.NewtonsoftJson": {

--- a/platform/src/apis/Platform.Api.Establishment/Configuration/Services.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Configuration/Services.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Azure;
+using Azure.Search.Documents;
 using FluentValidation;
 using HealthChecks.AzureSearch.DependencyInjection;
 using Microsoft.Azure.Functions.Worker;
@@ -51,16 +52,21 @@ internal static class Services
 
         serviceCollection
             .AddSingleton<IDatabaseFactory>(new DatabaseFactory(sqlConnString))
-            .AddSingleton<ISearchConnection<LocalAuthority>>(x =>
-                new SearchConnection<LocalAuthority>(searchEndpoint, searchCredential, ResourceNames.Search.Indexes.LocalAuthority, x.GetService<ITelemetryService>()))
-            .AddSingleton<ISearchConnection<School>>(x =>
-                new SearchConnection<School>(searchEndpoint, searchCredential, ResourceNames.Search.Indexes.School, x.GetService<ITelemetryService>()))
-            .AddSingleton<ISearchConnection<Trust>>(x =>
-                new SearchConnection<Trust>(searchEndpoint, searchCredential, ResourceNames.Search.Indexes.Trust, x.GetService<ITelemetryService>()))
-            .AddSingleton<ISearchConnection<ComparatorSchool>>(x =>
-                new SearchConnection<ComparatorSchool>(searchEndpoint, searchCredential, ResourceNames.Search.Indexes.SchoolComparators, x.GetService<ITelemetryService>()))
-            .AddSingleton<ISearchConnection<ComparatorTrust>>(x =>
-                new SearchConnection<ComparatorTrust>(searchEndpoint, searchCredential, ResourceNames.Search.Indexes.TrustComparators, x.GetService<ITelemetryService>()))
+            .AddSingleton<ISearchConnection<LocalAuthority>>(x => new SearchConnection<LocalAuthority>(
+                new SearchClient(searchEndpoint, ResourceNames.Search.Indexes.LocalAuthority, searchCredential),
+                x.GetService<ITelemetryService>()))
+            .AddSingleton<ISearchConnection<School>>(x => new SearchConnection<School>(
+                new SearchClient(searchEndpoint, ResourceNames.Search.Indexes.School, searchCredential),
+                x.GetService<ITelemetryService>()))
+            .AddSingleton<ISearchConnection<Trust>>(x => new SearchConnection<Trust>(
+                new SearchClient(searchEndpoint, ResourceNames.Search.Indexes.Trust, searchCredential),
+                x.GetService<ITelemetryService>()))
+            .AddSingleton<ISearchConnection<ComparatorSchool>>(x => new SearchConnection<ComparatorSchool>(
+                new SearchClient(searchEndpoint, ResourceNames.Search.Indexes.SchoolComparators, searchCredential),
+                x.GetService<ITelemetryService>()))
+            .AddSingleton<ISearchConnection<ComparatorTrust>>(x => new SearchConnection<ComparatorTrust>(
+                new SearchClient(searchEndpoint, ResourceNames.Search.Indexes.TrustComparators, searchCredential),
+                x.GetService<ITelemetryService>()))
             .AddSingleton<ISchoolsService, SchoolsService>()
             .AddSingleton<ITrustsService, TrustsService>()
             .AddSingleton<ILocalAuthoritiesService, LocalAuthoritiesService>()

--- a/platform/src/apis/Platform.Api.Establishment/Configuration/Services.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Configuration/Services.cs
@@ -13,6 +13,8 @@ using Platform.Api.Establishment.Trusts;
 using Platform.Functions.Extensions;
 using Platform.Infrastructure;
 using Platform.Search;
+using Platform.Search.Requests;
+using Platform.Search.Telemetry;
 using Platform.Search.Validators;
 using Platform.Sql;
 namespace Platform.Api.Establishment.Configuration;
@@ -49,16 +51,22 @@ internal static class Services
 
         serviceCollection
             .AddSingleton<IDatabaseFactory>(new DatabaseFactory(sqlConnString))
-            .AddSingleton<ISearchConnection<LocalAuthority>>(new SearchConnection<LocalAuthority>(searchEndpoint, searchCredential, ResourceNames.Search.Indexes.LocalAuthority))
-            .AddSingleton<ISearchConnection<School>>(new SearchConnection<School>(searchEndpoint, searchCredential, ResourceNames.Search.Indexes.School))
-            .AddSingleton<ISearchConnection<Trust>>(new SearchConnection<Trust>(searchEndpoint, searchCredential, ResourceNames.Search.Indexes.Trust))
-            .AddSingleton<ISearchConnection<ComparatorSchool>>(new SearchConnection<ComparatorSchool>(searchEndpoint, searchCredential, ResourceNames.Search.Indexes.SchoolComparators))
-            .AddSingleton<ISearchConnection<ComparatorTrust>>(new SearchConnection<ComparatorTrust>(searchEndpoint, searchCredential, ResourceNames.Search.Indexes.TrustComparators))
+            .AddSingleton<ISearchConnection<LocalAuthority>>(x =>
+                new SearchConnection<LocalAuthority>(searchEndpoint, searchCredential, ResourceNames.Search.Indexes.LocalAuthority, x.GetService<ITelemetryService>()))
+            .AddSingleton<ISearchConnection<School>>(x =>
+                new SearchConnection<School>(searchEndpoint, searchCredential, ResourceNames.Search.Indexes.School, x.GetService<ITelemetryService>()))
+            .AddSingleton<ISearchConnection<Trust>>(x =>
+                new SearchConnection<Trust>(searchEndpoint, searchCredential, ResourceNames.Search.Indexes.Trust, x.GetService<ITelemetryService>()))
+            .AddSingleton<ISearchConnection<ComparatorSchool>>(x =>
+                new SearchConnection<ComparatorSchool>(searchEndpoint, searchCredential, ResourceNames.Search.Indexes.SchoolComparators, x.GetService<ITelemetryService>()))
+            .AddSingleton<ISearchConnection<ComparatorTrust>>(x =>
+                new SearchConnection<ComparatorTrust>(searchEndpoint, searchCredential, ResourceNames.Search.Indexes.TrustComparators, x.GetService<ITelemetryService>()))
             .AddSingleton<ISchoolsService, SchoolsService>()
             .AddSingleton<ITrustsService, TrustsService>()
             .AddSingleton<ILocalAuthoritiesService, LocalAuthoritiesService>()
             .AddSingleton<IComparatorSchoolsService, ComparatorSchoolsService>()
-            .AddSingleton<IComparatorTrustsService, ComparatorTrustsService>();
+            .AddSingleton<IComparatorTrustsService, ComparatorTrustsService>()
+            .AddSingleton<ITelemetryService, TelemetryService>();
 
         serviceCollection
             .AddTransient<IValidator<SuggestRequest>, PostSuggestRequestValidator>();

--- a/platform/src/apis/Platform.Api.Establishment/LocalAuthorities/LocalAuthoritiesFunctions.cs
+++ b/platform/src/apis/Platform.Api.Establishment/LocalAuthorities/LocalAuthoritiesFunctions.cs
@@ -12,8 +12,8 @@ using Microsoft.OpenApi.Models;
 using Platform.Functions;
 using Platform.Functions.Extensions;
 using Platform.Functions.OpenApi;
-using Platform.Search;
 using Platform.Search.Requests;
+using Platform.Search.Responses;
 namespace Platform.Api.Establishment.LocalAuthorities;
 
 public class LocalAuthoritiesFunctions(
@@ -87,7 +87,6 @@ public class LocalAuthoritiesFunctions(
                        "CorrelationID", correlationId
                    }
                }))
-        //using (HttpPipeline.CreateClientRequestIdScope(correlationId.ToString()))
         {
             try
             {

--- a/platform/src/apis/Platform.Api.Establishment/LocalAuthorities/LocalAuthoritiesFunctions.cs
+++ b/platform/src/apis/Platform.Api.Establishment/LocalAuthorities/LocalAuthoritiesFunctions.cs
@@ -13,6 +13,7 @@ using Platform.Functions;
 using Platform.Functions.Extensions;
 using Platform.Functions.OpenApi;
 using Platform.Search;
+using Platform.Search.Requests;
 namespace Platform.Api.Establishment.LocalAuthorities;
 
 public class LocalAuthoritiesFunctions(
@@ -86,6 +87,7 @@ public class LocalAuthoritiesFunctions(
                        "CorrelationID", correlationId
                    }
                }))
+        //using (HttpPipeline.CreateClientRequestIdScope(correlationId.ToString()))
         {
             try
             {

--- a/platform/src/apis/Platform.Api.Establishment/LocalAuthorities/LocalAuthoritiesService.cs
+++ b/platform/src/apis/Platform.Api.Establishment/LocalAuthorities/LocalAuthoritiesService.cs
@@ -3,8 +3,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Platform.Search;
+using Platform.Search.Requests;
 using Platform.Sql;
-
 namespace Platform.Api.Establishment.LocalAuthorities;
 
 public interface ILocalAuthoritiesService

--- a/platform/src/apis/Platform.Api.Establishment/LocalAuthorities/LocalAuthoritiesService.cs
+++ b/platform/src/apis/Platform.Api.Establishment/LocalAuthorities/LocalAuthoritiesService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Platform.Search;
 using Platform.Search.Requests;
+using Platform.Search.Responses;
 using Platform.Sql;
 namespace Platform.Api.Establishment.LocalAuthorities;
 

--- a/platform/src/apis/Platform.Api.Establishment/Schools/SchoolsFunctions.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Schools/SchoolsFunctions.cs
@@ -12,8 +12,8 @@ using Microsoft.OpenApi.Models;
 using Platform.Functions;
 using Platform.Functions.Extensions;
 using Platform.Functions.OpenApi;
-using Platform.Search;
 using Platform.Search.Requests;
+using Platform.Search.Responses;
 namespace Platform.Api.Establishment.Schools;
 
 public class SchoolsFunctions(ILogger<SchoolsFunctions> logger,
@@ -127,7 +127,6 @@ public class SchoolsFunctions(ILogger<SchoolsFunctions> logger,
                        "CorrelationID", correlationId
                    }
                }))
-        //using (HttpPipeline.CreateClientRequestIdScope(correlationId.ToString()))
         {
             try
             {

--- a/platform/src/apis/Platform.Api.Establishment/Schools/SchoolsFunctions.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Schools/SchoolsFunctions.cs
@@ -13,6 +13,7 @@ using Platform.Functions;
 using Platform.Functions.Extensions;
 using Platform.Functions.OpenApi;
 using Platform.Search;
+using Platform.Search.Requests;
 namespace Platform.Api.Establishment.Schools;
 
 public class SchoolsFunctions(ILogger<SchoolsFunctions> logger,
@@ -126,6 +127,7 @@ public class SchoolsFunctions(ILogger<SchoolsFunctions> logger,
                        "CorrelationID", correlationId
                    }
                }))
+        //using (HttpPipeline.CreateClientRequestIdScope(correlationId.ToString()))
         {
             try
             {

--- a/platform/src/apis/Platform.Api.Establishment/Schools/SchoolsService.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Schools/SchoolsService.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Dapper;
 using Platform.Search;
 using Platform.Search.Requests;
+using Platform.Search.Responses;
 using Platform.Sql;
 namespace Platform.Api.Establishment.Schools;
 

--- a/platform/src/apis/Platform.Api.Establishment/Schools/SchoolsService.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Schools/SchoolsService.cs
@@ -4,8 +4,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using Dapper;
 using Platform.Search;
+using Platform.Search.Requests;
 using Platform.Sql;
-
 namespace Platform.Api.Establishment.Schools;
 
 public interface ISchoolsService
@@ -24,11 +24,17 @@ public class SchoolsService(ISearchConnection<School> searchConnection, IDatabas
         const string childSchoolsSql = "SELECT * FROM School WHERE FederationLeadURN = @URN";
 
         using var conn = await dbFactory.GetConnection();
-        var school = await conn.QueryFirstOrDefaultAsync<School>(schoolSql, new { URN = urn });
+        var school = await conn.QueryFirstOrDefaultAsync<School>(schoolSql, new
+        {
+            URN = urn
+        });
 
         if (school != null && !string.IsNullOrEmpty(school.FederationLeadURN))
         {
-            school.FederationSchools = await conn.QueryAsync<School>(childSchoolsSql, new { URN = urn });
+            school.FederationSchools = await conn.QueryAsync<School>(childSchoolsSql, new
+            {
+                URN = urn
+            });
         }
 
         return school;
@@ -42,17 +48,26 @@ public class SchoolsService(ISearchConnection<School> searchConnection, IDatabas
 
         if (!string.IsNullOrEmpty(companyNumber))
         {
-            builder.Where("TrustCompanyNumber = @CompanyNumber AND FinanceType = 'Academy'", new { companyNumber });
+            builder.Where("TrustCompanyNumber = @CompanyNumber AND FinanceType = 'Academy'", new
+            {
+                companyNumber
+            });
         }
 
         if (!string.IsNullOrEmpty(laCode))
         {
-            builder.Where("LaCode = @LaCode AND FinanceType = 'Maintained'", new { laCode });
+            builder.Where("LaCode = @LaCode AND FinanceType = 'Maintained'", new
+            {
+                laCode
+            });
         }
 
         if (!string.IsNullOrEmpty(phase))
         {
-            builder.Where("OverallPhase = @phase", new { phase });
+            builder.Where("OverallPhase = @phase", new
+            {
+                phase
+            });
         }
 
         using var conn = await dbFactory.GetConnection();
@@ -73,7 +88,7 @@ public class SchoolsService(ISearchConnection<School> searchConnection, IDatabas
             nameof(School.AddressPostcode)
         };
 
-        return searchConnection.SuggestAsync(request, CreateFilterExpression, selectFields: fields);
+        return searchConnection.SuggestAsync(request, CreateFilterExpression, fields);
 
         string? CreateFilterExpression()
         {

--- a/platform/src/apis/Platform.Api.Establishment/Trusts/TrustsFunctions.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Trusts/TrustsFunctions.cs
@@ -12,8 +12,8 @@ using Microsoft.OpenApi.Models;
 using Platform.Functions;
 using Platform.Functions.Extensions;
 using Platform.Functions.OpenApi;
-using Platform.Search;
 using Platform.Search.Requests;
+using Platform.Search.Responses;
 namespace Platform.Api.Establishment.Trusts;
 
 public class TrustsFunctions(
@@ -87,7 +87,6 @@ public class TrustsFunctions(
                        "CorrelationID", correlationId
                    }
                }))
-        //using (HttpPipeline.CreateClientRequestIdScope(correlationId.ToString()))
         {
             try
             {

--- a/platform/src/apis/Platform.Api.Establishment/Trusts/TrustsFunctions.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Trusts/TrustsFunctions.cs
@@ -13,6 +13,7 @@ using Platform.Functions;
 using Platform.Functions.Extensions;
 using Platform.Functions.OpenApi;
 using Platform.Search;
+using Platform.Search.Requests;
 namespace Platform.Api.Establishment.Trusts;
 
 public class TrustsFunctions(
@@ -86,6 +87,7 @@ public class TrustsFunctions(
                        "CorrelationID", correlationId
                    }
                }))
+        //using (HttpPipeline.CreateClientRequestIdScope(correlationId.ToString()))
         {
             try
             {

--- a/platform/src/apis/Platform.Api.Establishment/Trusts/TrustsService.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Trusts/TrustsService.cs
@@ -3,8 +3,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Platform.Search;
+using Platform.Search.Requests;
 using Platform.Sql;
-
 namespace Platform.Api.Establishment.Trusts;
 
 public interface ITrustsService

--- a/platform/src/apis/Platform.Api.Establishment/Trusts/TrustsService.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Trusts/TrustsService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Platform.Search;
 using Platform.Search.Requests;
+using Platform.Search.Responses;
 using Platform.Sql;
 namespace Platform.Api.Establishment.Trusts;
 

--- a/platform/src/apis/Platform.Api.Establishment/packages.lock.json
+++ b/platform/src/apis/Platform.Api.Establishment/packages.lock.json
@@ -217,14 +217,6 @@
           "Grpc.Core.Api": "2.60.0"
         }
       },
-      "Microsoft.ApplicationInsights": {
-        "type": "Transitive",
-        "resolved": "2.22.0",
-        "contentHash": "3AOM9bZtku7RQwHyMEY3tQMrHIgjcfRDa6YQpd/QG2LDGvMydSlL9Di+8LLMt7J2RDdfJ7/2jdYv6yHcMJAnNw==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "5.0.0"
-        }
-      },
       "Microsoft.ApplicationInsights.DependencyCollector": {
         "type": "Transitive",
         "resolved": "2.22.0",
@@ -2015,7 +2007,8 @@
         "type": "Project",
         "dependencies": {
           "Azure.Search.Documents": "[11.6.0, )",
-          "FluentValidation": "[11.10.0, )"
+          "FluentValidation": "[11.10.0, )",
+          "Microsoft.ApplicationInsights": "[2.22.0, )"
         }
       },
       "platform.sql": {
@@ -2055,6 +2048,15 @@
         "contentHash": "1Po+Ypf0SjCeEKx5+C89Nb5OgTcqNvfS3uTI46MUM+KEp6Rq/M0h+vVsTUt/6DFRwZMTpsAJM4yJrZmEObVANA==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "CentralTransitive",
+        "requested": "[2.22.0, )",
+        "resolved": "2.22.0",
+        "contentHash": "3AOM9bZtku7RQwHyMEY3tQMrHIgjcfRDa6YQpd/QG2LDGvMydSlL9Di+8LLMt7J2RDdfJ7/2jdYv6yHcMJAnNw==",
+        "dependencies": {
+          "System.Diagnostics.DiagnosticSource": "5.0.0"
         }
       },
       "Microsoft.Azure.Core.NewtonsoftJson": {

--- a/platform/src/apis/Platform.Api.Insight/packages.lock.json
+++ b/platform/src/apis/Platform.Api.Insight/packages.lock.json
@@ -198,14 +198,6 @@
           "Grpc.Core.Api": "2.60.0"
         }
       },
-      "Microsoft.ApplicationInsights": {
-        "type": "Transitive",
-        "resolved": "2.22.0",
-        "contentHash": "3AOM9bZtku7RQwHyMEY3tQMrHIgjcfRDa6YQpd/QG2LDGvMydSlL9Di+8LLMt7J2RDdfJ7/2jdYv6yHcMJAnNw==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "5.0.0"
-        }
-      },
       "Microsoft.ApplicationInsights.DependencyCollector": {
         "type": "Transitive",
         "resolved": "2.22.0",
@@ -2010,6 +2002,15 @@
         "contentHash": "1Po+Ypf0SjCeEKx5+C89Nb5OgTcqNvfS3uTI46MUM+KEp6Rq/M0h+vVsTUt/6DFRwZMTpsAJM4yJrZmEObVANA==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "CentralTransitive",
+        "requested": "[2.22.0, )",
+        "resolved": "2.22.0",
+        "contentHash": "3AOM9bZtku7RQwHyMEY3tQMrHIgjcfRDa6YQpd/QG2LDGvMydSlL9Di+8LLMt7J2RDdfJ7/2jdYv6yHcMJAnNw==",
+        "dependencies": {
+          "System.Diagnostics.DiagnosticSource": "5.0.0"
         }
       },
       "Microsoft.Azure.Core.NewtonsoftJson": {

--- a/platform/src/apis/Platform.Orchestrator/packages.lock.json
+++ b/platform/src/apis/Platform.Orchestrator/packages.lock.json
@@ -208,14 +208,6 @@
           "Grpc.Core.Api": "2.60.0"
         }
       },
-      "Microsoft.ApplicationInsights": {
-        "type": "Transitive",
-        "resolved": "2.22.0",
-        "contentHash": "3AOM9bZtku7RQwHyMEY3tQMrHIgjcfRDa6YQpd/QG2LDGvMydSlL9Di+8LLMt7J2RDdfJ7/2jdYv6yHcMJAnNw==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "5.0.0"
-        }
-      },
       "Microsoft.ApplicationInsights.DependencyCollector": {
         "type": "Transitive",
         "resolved": "2.22.0",
@@ -2125,6 +2117,15 @@
         "contentHash": "1Po+Ypf0SjCeEKx5+C89Nb5OgTcqNvfS3uTI46MUM+KEp6Rq/M0h+vVsTUt/6DFRwZMTpsAJM4yJrZmEObVANA==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "CentralTransitive",
+        "requested": "[2.22.0, )",
+        "resolved": "2.22.0",
+        "contentHash": "3AOM9bZtku7RQwHyMEY3tQMrHIgjcfRDa6YQpd/QG2LDGvMydSlL9Di+8LLMt7J2RDdfJ7/2jdYv6yHcMJAnNw==",
+        "dependencies": {
+          "System.Diagnostics.DiagnosticSource": "5.0.0"
         }
       },
       "Microsoft.Azure.Functions.Worker.Core": {

--- a/platform/src/apis/Platform.UserDataCleanUp/packages.lock.json
+++ b/platform/src/apis/Platform.UserDataCleanUp/packages.lock.json
@@ -137,14 +137,6 @@
           "Grpc.Core.Api": "2.60.0"
         }
       },
-      "Microsoft.ApplicationInsights": {
-        "type": "Transitive",
-        "resolved": "2.22.0",
-        "contentHash": "3AOM9bZtku7RQwHyMEY3tQMrHIgjcfRDa6YQpd/QG2LDGvMydSlL9Di+8LLMt7J2RDdfJ7/2jdYv6yHcMJAnNw==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "5.0.0"
-        }
-      },
       "Microsoft.ApplicationInsights.DependencyCollector": {
         "type": "Transitive",
         "resolved": "2.22.0",
@@ -1896,6 +1888,15 @@
         "contentHash": "1Po+Ypf0SjCeEKx5+C89Nb5OgTcqNvfS3uTI46MUM+KEp6Rq/M0h+vVsTUt/6DFRwZMTpsAJM4yJrZmEObVANA==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "CentralTransitive",
+        "requested": "[2.22.0, )",
+        "resolved": "2.22.0",
+        "contentHash": "3AOM9bZtku7RQwHyMEY3tQMrHIgjcfRDa6YQpd/QG2LDGvMydSlL9Di+8LLMt7J2RDdfJ7/2jdYv6yHcMJAnNw==",
+        "dependencies": {
+          "System.Diagnostics.DiagnosticSource": "5.0.0"
         }
       },
       "Microsoft.Azure.Core.NewtonsoftJson": {

--- a/platform/tests/Platform.ApiTests/Steps/EstablishmentLocalAuthoritiesSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/EstablishmentLocalAuthoritiesSteps.cs
@@ -5,7 +5,7 @@ using Platform.Api.Establishment.LocalAuthorities;
 using Platform.ApiTests.Drivers;
 using Platform.Functions;
 using Platform.Functions.Extensions;
-using Platform.Search;
+using Platform.Search.Responses;
 namespace Platform.ApiTests.Steps;
 
 [Binding]

--- a/platform/tests/Platform.ApiTests/Steps/EstablishmentSchoolsSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/EstablishmentSchoolsSteps.cs
@@ -5,7 +5,7 @@ using Platform.Api.Establishment.Schools;
 using Platform.ApiTests.Drivers;
 using Platform.Functions;
 using Platform.Functions.Extensions;
-using Platform.Search;
+using Platform.Search.Responses;
 namespace Platform.ApiTests.Steps;
 
 [Binding]

--- a/platform/tests/Platform.ApiTests/Steps/EstablishmentTrustsSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/EstablishmentTrustsSteps.cs
@@ -5,7 +5,7 @@ using Platform.Api.Establishment.Trusts;
 using Platform.ApiTests.Drivers;
 using Platform.Functions;
 using Platform.Functions.Extensions;
-using Platform.Search;
+using Platform.Search.Responses;
 namespace Platform.ApiTests.Steps;
 
 [Binding]

--- a/platform/tests/Platform.ApiTests/packages.lock.json
+++ b/platform/tests/Platform.ApiTests/packages.lock.json
@@ -194,14 +194,6 @@
           "Grpc.Core.Api": "2.60.0"
         }
       },
-      "Microsoft.ApplicationInsights": {
-        "type": "Transitive",
-        "resolved": "2.22.0",
-        "contentHash": "3AOM9bZtku7RQwHyMEY3tQMrHIgjcfRDa6YQpd/QG2LDGvMydSlL9Di+8LLMt7J2RDdfJ7/2jdYv6yHcMJAnNw==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "5.0.0"
-        }
-      },
       "Microsoft.ApplicationInsights.DependencyCollector": {
         "type": "Transitive",
         "resolved": "2.22.0",
@@ -2119,7 +2111,8 @@
         "type": "Project",
         "dependencies": {
           "Azure.Search.Documents": "[11.6.0, )",
-          "FluentValidation": "[11.10.0, )"
+          "FluentValidation": "[11.10.0, )",
+          "Microsoft.ApplicationInsights": "[2.22.0, )"
         }
       },
       "platform.sql": {
@@ -2197,6 +2190,15 @@
         "contentHash": "1Po+Ypf0SjCeEKx5+C89Nb5OgTcqNvfS3uTI46MUM+KEp6Rq/M0h+vVsTUt/6DFRwZMTpsAJM4yJrZmEObVANA==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "CentralTransitive",
+        "requested": "[2.22.0, )",
+        "resolved": "2.22.0",
+        "contentHash": "3AOM9bZtku7RQwHyMEY3tQMrHIgjcfRDa6YQpd/QG2LDGvMydSlL9Di+8LLMt7J2RDdfJ7/2jdYv6yHcMJAnNw==",
+        "dependencies": {
+          "System.Diagnostics.DiagnosticSource": "5.0.0"
         }
       },
       "Microsoft.ApplicationInsights.WorkerService": {

--- a/platform/tests/Platform.Tests/Establishment/LocalAuthoritiesFunctionsTestBase.cs
+++ b/platform/tests/Platform.Tests/Establishment/LocalAuthoritiesFunctionsTestBase.cs
@@ -2,7 +2,7 @@ using FluentValidation;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Platform.Api.Establishment.LocalAuthorities;
-using Platform.Search;
+using Platform.Search.Requests;
 namespace Platform.Tests.Establishment;
 
 public class LocalAuthoritiesFunctionsTestBase : FunctionsTestBase

--- a/platform/tests/Platform.Tests/Establishment/SchoolsFunctionsTestBase.cs
+++ b/platform/tests/Platform.Tests/Establishment/SchoolsFunctionsTestBase.cs
@@ -2,8 +2,7 @@ using FluentValidation;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Platform.Api.Establishment.Schools;
-using Platform.Search;
-
+using Platform.Search.Requests;
 namespace Platform.Tests.Establishment;
 
 public class SchoolsFunctionsTestBase : FunctionsTestBase

--- a/platform/tests/Platform.Tests/Establishment/TrustsFunctionsTestBase.cs
+++ b/platform/tests/Platform.Tests/Establishment/TrustsFunctionsTestBase.cs
@@ -2,7 +2,7 @@ using FluentValidation;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Platform.Api.Establishment.Trusts;
-using Platform.Search;
+using Platform.Search.Requests;
 namespace Platform.Tests.Establishment;
 
 public class TrustsFunctionsTestBase : FunctionsTestBase

--- a/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesSuggestLocalAuthoritiesRequest.cs
+++ b/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesSuggestLocalAuthoritiesRequest.cs
@@ -3,8 +3,8 @@ using FluentValidation.Results;
 using Moq;
 using Platform.Api.Establishment.LocalAuthorities;
 using Platform.Functions;
-using Platform.Search;
 using Platform.Search.Requests;
+using Platform.Search.Responses;
 using Xunit;
 namespace Platform.Tests.Establishment;
 

--- a/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesSuggestLocalAuthoritiesRequest.cs
+++ b/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesSuggestLocalAuthoritiesRequest.cs
@@ -4,6 +4,7 @@ using Moq;
 using Platform.Api.Establishment.LocalAuthorities;
 using Platform.Functions;
 using Platform.Search;
+using Platform.Search.Requests;
 using Xunit;
 namespace Platform.Tests.Establishment;
 

--- a/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesSuggestSchoolsRequest.cs
+++ b/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesSuggestSchoolsRequest.cs
@@ -4,7 +4,7 @@ using Moq;
 using Platform.Api.Establishment.Schools;
 using Platform.Functions;
 using Platform.Search;
-using Platform.Tests.Extensions;
+using Platform.Search.Requests;
 using Xunit;
 namespace Platform.Tests.Establishment;
 

--- a/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesSuggestSchoolsRequest.cs
+++ b/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesSuggestSchoolsRequest.cs
@@ -3,8 +3,8 @@ using FluentValidation.Results;
 using Moq;
 using Platform.Api.Establishment.Schools;
 using Platform.Functions;
-using Platform.Search;
 using Platform.Search.Requests;
+using Platform.Search.Responses;
 using Xunit;
 namespace Platform.Tests.Establishment;
 

--- a/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesSuggestTrustsRequest.cs
+++ b/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesSuggestTrustsRequest.cs
@@ -4,6 +4,7 @@ using Moq;
 using Platform.Api.Establishment.Trusts;
 using Platform.Functions;
 using Platform.Search;
+using Platform.Search.Requests;
 using Xunit;
 namespace Platform.Tests.Establishment;
 

--- a/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesSuggestTrustsRequest.cs
+++ b/platform/tests/Platform.Tests/Establishment/WhenFunctionReceivesSuggestTrustsRequest.cs
@@ -3,8 +3,8 @@ using FluentValidation.Results;
 using Moq;
 using Platform.Api.Establishment.Trusts;
 using Platform.Functions;
-using Platform.Search;
 using Platform.Search.Requests;
+using Platform.Search.Responses;
 using Xunit;
 namespace Platform.Tests.Establishment;
 

--- a/platform/tests/Platform.Tests/Search/Validators/PostSuggestRequestValidatorValidates.cs
+++ b/platform/tests/Platform.Tests/Search/Validators/PostSuggestRequestValidatorValidates.cs
@@ -1,4 +1,4 @@
-﻿using Platform.Search;
+﻿using Platform.Search.Requests;
 using Platform.Search.Validators;
 using Xunit;
 namespace Platform.Tests.Search.Validators;

--- a/platform/tests/Platform.Tests/Search/WhenSearchConnectionLooksUp.cs
+++ b/platform/tests/Platform.Tests/Search/WhenSearchConnectionLooksUp.cs
@@ -1,0 +1,45 @@
+﻿using Azure;
+using Azure.Search.Documents;
+using Moq;
+using Platform.Search;
+using Platform.Search.Telemetry;
+using Xunit;
+namespace Platform.Tests.Search;
+
+public class WhenSearchConnectionLooksUp
+{
+    private readonly Mock<SearchClient> _searchClient = new();
+    private readonly SearchConnection<TestType> _service;
+    private readonly Mock<ITelemetryService> _telemetryService = new();
+    private string _indexName = nameof(_indexName);
+    private string _serviceName = nameof(_serviceName);
+
+    public WhenSearchConnectionLooksUp()
+    {
+        _searchClient.SetupGet(c => c.ServiceName).Returns(_serviceName);
+        _searchClient.SetupGet(c => c.IndexName).Returns(_indexName);
+
+        _service = new SearchConnection<TestType>(_searchClient.Object, _telemetryService.Object);
+    }
+
+    [Fact]
+    public async Task ShouldReturnExpectedResult()
+    {
+        // arrange
+        const string key = nameof(key);
+
+        var result = new TestType();
+
+        _searchClient
+            .Setup(c => c.GetDocumentAsync<TestType>(key, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(result, Mock.Of<Response>()));
+
+        // act
+        var results = await _service.LookUpAsync(key);
+
+        // assert
+        Assert.Equal(result, results);
+    }
+
+    private record TestType;
+}

--- a/platform/tests/Platform.Tests/Search/WhenSearchConnectionReceivesSearchBySearchRequest.cs
+++ b/platform/tests/Platform.Tests/Search/WhenSearchConnectionReceivesSearchBySearchRequest.cs
@@ -1,0 +1,228 @@
+﻿using Azure;
+using Azure.Search.Documents;
+using Azure.Search.Documents.Models;
+using Moq;
+using Platform.Search;
+using Platform.Search.Telemetry;
+using Xunit;
+namespace Platform.Tests.Search;
+
+public class WhenSearchConnectionReceivesSearchBySearchRequest
+{
+    private readonly Mock<SearchClient> _searchClient = new();
+    private readonly SearchConnection<TestType> _service;
+    private readonly Mock<ITelemetryService> _telemetryService = new();
+    private string _indexName = nameof(_indexName);
+    private string _serviceName = nameof(_serviceName);
+
+    public WhenSearchConnectionReceivesSearchBySearchRequest()
+    {
+        _searchClient.SetupGet(c => c.ServiceName).Returns(_serviceName);
+        _searchClient.SetupGet(c => c.IndexName).Returns(_indexName);
+
+        _service = new SearchConnection<TestType>(_searchClient.Object, _telemetryService.Object);
+    }
+
+    [Fact]
+    public async Task ShouldReturnExpectedResultsWithoutFacets()
+    {
+        // arrange
+        const string search = nameof(search);
+        FilterCriteria[] filters =
+        [
+            new()
+            {
+                Field = nameof(FilterCriteria.Field),
+                Value = nameof(FilterCriteria.Value)
+            }
+        ];
+        const int size = 10;
+        const int page = 1;
+        const long totalCount = 5;
+        const double resultScore = 1.0;
+
+        var request = new SearchRequest
+        {
+            Filters = filters,
+            PageSize = size,
+            Page = page,
+            SearchText = search
+        };
+
+        Func<FilterCriteria[], string?> filterBuilder = _ => nameof(filterBuilder);
+
+        var result = new TestType();
+        var searchResults = SearchModelFactory.SearchResults(
+            [
+                SearchModelFactory.SearchResult(result, resultScore, new Dictionary<string, IList<string>>())
+            ],
+            totalCount,
+            new Dictionary<string, IList<FacetResult>>(),
+            null,
+            Mock.Of<Response>());
+
+        _searchClient
+            .Setup(c => c.SearchAsync<TestType>(
+                search,
+                It.Is<SearchOptions>(o =>
+                    o.Size == size
+                    && o.Skip == 0
+                    && o.IncludeTotalCount == true
+                    && o.Filter == nameof(filterBuilder)
+                    && o.QueryType == SearchQueryType.Simple), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(searchResults, Mock.Of<Response>()));
+
+        // act
+        var results = await _service.SearchAsync(request, filterBuilder);
+
+        // assert
+        Assert.Equal(totalCount, results.TotalResults);
+        Assert.Equal([result], results.Results);
+    }
+
+    [Fact]
+    public async Task ShouldReturnExpectedResultsWithFacets()
+    {
+        // arrange
+        const string search = nameof(search);
+        FilterCriteria[] filters =
+        [
+            new()
+            {
+                Field = nameof(FilterCriteria.Field),
+                Value = nameof(FilterCriteria.Value)
+            }
+        ];
+        const int size = 10;
+        const int page = 1;
+        const long totalCount = 5;
+        const double resultScore = 1.0;
+        string[] facets = [nameof(facets)];
+
+        var request = new SearchRequest
+        {
+            Filters = filters,
+            PageSize = size,
+            Page = page,
+            SearchText = search
+        };
+
+        Func<FilterCriteria[], string?> filterBuilder = _ => nameof(filterBuilder);
+
+        const int facetCount = 3;
+        const string facetResultKey = nameof(facetResultKey);
+        const string facetValue = nameof(facetValue);
+        var facetResult = SearchModelFactory.FacetResult(facetCount, new Dictionary<string, object>
+        {
+            {
+                "value", facetValue
+            }
+        });
+        var resultFacets = new Dictionary<string, IList<FacetResult>>
+        {
+            {
+                facetResultKey, new List<FacetResult>
+                {
+                    facetResult
+                }
+            }
+        };
+
+        var result = new TestType();
+        var searchResults = SearchModelFactory.SearchResults(
+            [
+                SearchModelFactory.SearchResult(result, resultScore, new Dictionary<string, IList<string>>())
+            ],
+            totalCount,
+            resultFacets,
+            null,
+            Mock.Of<Response>());
+
+        _searchClient
+            .Setup(c => c.SearchAsync<TestType>(
+                search,
+                It.Is<SearchOptions>(o =>
+                    o.Size == size
+                    && o.Skip == 0
+                    && o.IncludeTotalCount == true
+                    && o.Filter == nameof(filterBuilder)
+                    && o.QueryType == SearchQueryType.Simple
+                    && o.Facets[0] == facets[0]), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(searchResults, Mock.Of<Response>()));
+
+        var expectedFacets = new Dictionary<string, IList<FacetValueResponseModel>>
+        {
+            {
+                facetResultKey, new List<FacetValueResponseModel>
+                {
+                    new()
+                    {
+                        Value = facetValue,
+                        Count = facetCount
+                    }
+                }
+            }
+        };
+
+        // act
+        var results = await _service.SearchAsync(request, filterBuilder, facets);
+
+        // assert
+        Assert.Equal(totalCount, results.TotalResults);
+        Assert.Equal([result], results.Results);
+        Assert.Equal(expectedFacets, results.Facets);
+    }
+
+    [Fact]
+    public async Task ShouldTrackSearchEvent()
+    {
+        // arrange
+        const string search = nameof(search);
+        FilterCriteria[] filters =
+        [
+            new()
+            {
+                Field = nameof(FilterCriteria.Field),
+                Value = nameof(FilterCriteria.Value)
+            }
+        ];
+        const int size = 10;
+        const int page = 1;
+        const long totalCount = 5;
+
+        var request = new SearchRequest
+        {
+            Filters = filters,
+            PageSize = size,
+            Page = page,
+            SearchText = search
+        };
+
+        Func<FilterCriteria[], string?> filterBuilder = _ => nameof(filterBuilder);
+
+        var searchResults = SearchModelFactory.SearchResults(
+            Array.Empty<SearchResult<TestType>>(),
+            totalCount,
+            new Dictionary<string, IList<FacetResult>>(),
+            null,
+            Mock.Of<Response>());
+
+        _searchClient
+            .Setup(c => c.SearchAsync<TestType>(It.IsAny<string>(), It.IsAny<SearchOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(searchResults, Mock.Of<Response>()));
+
+        // act
+        await _service.SearchAsync(request, filterBuilder);
+
+        // assert
+        _telemetryService.Verify(t => t.TrackSearchEvent(It.Is<SearchTelemetryProperties>(p =>
+            p.SearchId != Guid.Empty
+            && p.SearchServiceName == _serviceName
+            && p.IndexName == _indexName
+            && p.Filter == nameof(filterBuilder)
+            && p.SearchText == search
+            && p.ResultCount == totalCount)));
+    }
+
+    private record TestType;
+}

--- a/platform/tests/Platform.Tests/Search/WhenSearchConnectionReceivesSearchRequestByString.cs
+++ b/platform/tests/Platform.Tests/Search/WhenSearchConnectionReceivesSearchRequestByString.cs
@@ -1,0 +1,100 @@
+﻿using Azure;
+using Azure.Search.Documents;
+using Azure.Search.Documents.Models;
+using Moq;
+using Platform.Search;
+using Platform.Search.Telemetry;
+using Xunit;
+namespace Platform.Tests.Search;
+
+public class WhenSearchConnectionReceivesSearchByString
+{
+    private readonly Mock<SearchClient> _searchClient = new();
+    private readonly SearchConnection<TestType> _service;
+    private readonly Mock<ITelemetryService> _telemetryService = new();
+    private string _indexName = nameof(_indexName);
+    private string _serviceName = nameof(_serviceName);
+
+    public WhenSearchConnectionReceivesSearchByString()
+    {
+        _searchClient.SetupGet(c => c.ServiceName).Returns(_serviceName);
+        _searchClient.SetupGet(c => c.IndexName).Returns(_indexName);
+
+        _service = new SearchConnection<TestType>(_searchClient.Object, _telemetryService.Object);
+    }
+
+    [Fact]
+    public async Task ShouldReturnExpectedResults()
+    {
+        // arrange
+        const string search = nameof(search);
+        const string filters = nameof(filters);
+        const int size = 10;
+        const long totalCount = 5;
+        const double resultScore = 1.0;
+
+        var result = new TestType();
+        var searchResults = SearchModelFactory.SearchResults(
+            [
+                SearchModelFactory.SearchResult(result, resultScore, new Dictionary<string, IList<string>>())
+            ],
+            totalCount,
+            new Dictionary<string, IList<FacetResult>>(),
+            null,
+            Mock.Of<Response>());
+
+        _searchClient
+            .Setup(c => c.SearchAsync<TestType>(
+                search,
+                It.Is<SearchOptions>(o =>
+                    o.Size == size
+                    && o.IncludeTotalCount == true
+                    && o.Filter == filters
+                    && o.QueryType == SearchQueryType.Full), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(searchResults, Mock.Of<Response>()));
+
+        // act
+        var (total, results) = await _service.SearchAsync(search, filters, size);
+
+        // assert
+        Assert.Equal(total, totalCount);
+        var scoreResponses = results as ScoreResponse<TestType>[] ?? results.ToArray();
+        Assert.Equal([result], scoreResponses.Select(r => r.Document));
+        Assert.Equal([resultScore], scoreResponses.Select(r => r.Score));
+    }
+
+    [Fact]
+    public async Task ShouldTrackSearchEvent()
+    {
+        // arrange
+        const string search = nameof(search);
+        const string filters = nameof(filters);
+        const int size = 10;
+        const long totalCount = 5;
+
+        var searchResults = SearchModelFactory.SearchResults(
+            Array.Empty<SearchResult<TestType>>(),
+            totalCount,
+            new Dictionary<string, IList<FacetResult>>(),
+            null,
+            Mock.Of<Response>());
+
+        _searchClient
+            .Setup(c => c.SearchAsync<TestType>(It.IsAny<string>(), It.IsAny<SearchOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(searchResults, Mock.Of<Response>()));
+
+        // act
+        await _service.SearchAsync(search, filters, size);
+
+        // assert
+        _telemetryService.Verify(t => t.TrackSearchEvent(It.Is<SearchTelemetryProperties>(p =>
+            p.SearchId != Guid.Empty
+            && p.SearchServiceName == _serviceName
+            && p.IndexName == _indexName
+            && p.Filter == filters
+            && p.SearchText == search
+            && p.ResultCount == totalCount)));
+    }
+
+    private record TestType;
+}

--- a/platform/tests/Platform.Tests/Search/WhenSearchConnectionReceivesSuggestRequest.cs
+++ b/platform/tests/Platform.Tests/Search/WhenSearchConnectionReceivesSuggestRequest.cs
@@ -1,0 +1,112 @@
+﻿using Azure;
+using Azure.Search.Documents;
+using Azure.Search.Documents.Models;
+using Moq;
+using Platform.Search;
+using Platform.Search.Requests;
+using Platform.Search.Telemetry;
+using Xunit;
+namespace Platform.Tests.Search;
+
+public class WhenSearchConnectionReceivesSuggestRequest
+{
+    private readonly Mock<SearchClient> _searchClient = new();
+    private readonly SearchConnection<TestType> _service;
+    private readonly Mock<ITelemetryService> _telemetryService = new();
+    private string _indexName = nameof(_indexName);
+    private string _serviceName = nameof(_serviceName);
+
+    public WhenSearchConnectionReceivesSuggestRequest()
+    {
+        _searchClient.SetupGet(c => c.ServiceName).Returns(_serviceName);
+        _searchClient.SetupGet(c => c.IndexName).Returns(_indexName);
+
+        _service = new SearchConnection<TestType>(_searchClient.Object, _telemetryService.Object);
+    }
+
+    [Fact]
+    public async Task ShouldReturnExpectedResultsWithoutFacets()
+    {
+        // arrange
+        const string search = nameof(search);
+        const string suggesterName = nameof(suggesterName);
+        const int size = 10;
+        const double coverage = 1.0;
+
+        var request = new SuggestRequest
+        {
+            SuggesterName = suggesterName,
+            Size = size,
+            SearchText = search
+        };
+
+        Func<string?> filterBuilder = () => nameof(filterBuilder);
+        string[] selectFields = [nameof(selectFields)];
+
+        var result = new TestType();
+        var suggestion = SearchModelFactory.SearchSuggestion(result, search);
+        var suggestResults = SearchModelFactory.SuggestResults<TestType>([suggestion], coverage);
+
+        _searchClient
+            .Setup(c => c.SuggestAsync<TestType>(
+                search,
+                suggesterName,
+                It.Is<SuggestOptions>(o =>
+                    o.HighlightPreTag == "*"
+                    && o.HighlightPostTag == "*"
+                    && o.Filter == nameof(filterBuilder)
+                    && o.Size == size
+                    && o.UseFuzzyMatching == false
+                    && o.Select[0] == selectFields[0]), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(suggestResults, Mock.Of<Response>()));
+
+        // act
+        var results = await _service.SuggestAsync(request, filterBuilder, selectFields);
+
+        // assert
+        Assert.Equal([result], results.Results.Select(r => r.Document));
+    }
+
+    [Fact]
+    public async Task ShouldTrackSuggestEvent()
+    {
+        // arrange
+        const string search = nameof(search);
+        const string suggesterName = nameof(suggesterName);
+        const int size = 10;
+        const int totalCount = 5;
+        const double coverage = 1.0;
+
+        var request = new SuggestRequest
+        {
+            SuggesterName = suggesterName,
+            Size = size,
+            SearchText = search
+        };
+
+        Func<string?> filterBuilder = () => nameof(filterBuilder);
+        string[] selectFields = [nameof(selectFields)];
+
+        var suggestResults = SearchModelFactory.SuggestResults(new SearchSuggestion<TestType>[totalCount], coverage);
+
+        _searchClient
+            .Setup(c => c.SuggestAsync<TestType>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SuggestOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(suggestResults, Mock.Of<Response>()));
+
+        // act
+        await _service.SuggestAsync(request, filterBuilder, selectFields);
+
+        // assert
+        _telemetryService.Verify(t => t.TrackSuggestEvent(It.Is<SuggestTelemetryProperties>(p =>
+            p.SearchId != Guid.Empty
+            && p.SearchServiceName == _serviceName
+            && p.IndexName == _indexName
+            && p.SuggesterName == suggesterName
+            && p.Fields[0] == nameof(selectFields)
+            && p.Filter == nameof(filterBuilder)
+            && p.SearchText == search
+            && p.ResultCount == totalCount)));
+    }
+
+    private record TestType;
+}

--- a/platform/tests/Platform.Tests/packages.lock.json
+++ b/platform/tests/Platform.Tests/packages.lock.json
@@ -163,14 +163,6 @@
           "Grpc.Core.Api": "2.60.0"
         }
       },
-      "Microsoft.ApplicationInsights": {
-        "type": "Transitive",
-        "resolved": "2.22.0",
-        "contentHash": "3AOM9bZtku7RQwHyMEY3tQMrHIgjcfRDa6YQpd/QG2LDGvMydSlL9Di+8LLMt7J2RDdfJ7/2jdYv6yHcMJAnNw==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "5.0.0"
-        }
-      },
       "Microsoft.ApplicationInsights.DependencyCollector": {
         "type": "Transitive",
         "resolved": "2.22.0",
@@ -2246,7 +2238,8 @@
         "type": "Project",
         "dependencies": {
           "Azure.Search.Documents": "[11.6.0, )",
-          "FluentValidation": "[11.10.0, )"
+          "FluentValidation": "[11.10.0, )",
+          "Microsoft.ApplicationInsights": "[2.22.0, )"
         }
       },
       "platform.sql": {
@@ -2324,6 +2317,15 @@
         "contentHash": "1Po+Ypf0SjCeEKx5+C89Nb5OgTcqNvfS3uTI46MUM+KEp6Rq/M0h+vVsTUt/6DFRwZMTpsAJM4yJrZmEObVANA==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "CentralTransitive",
+        "requested": "[2.22.0, )",
+        "resolved": "2.22.0",
+        "contentHash": "3AOM9bZtku7RQwHyMEY3tQMrHIgjcfRDa6YQpd/QG2LDGvMydSlL9Di+8LLMt7J2RDdfJ7/2jdYv6yHcMJAnNw==",
+        "dependencies": {
+          "System.Diagnostics.DiagnosticSource": "5.0.0"
         }
       },
       "Microsoft.ApplicationInsights.WorkerService": {


### PR DESCRIPTION
### Context
[AB#239253](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/239253) [AB#229670](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/229670)

### Change proposed in this pull request
Includes test coverage for `SearchConnection`

### Guidance to review 
Using the search suggester to locate a school, trust or LA should log the 'suggest' search criteria. Creating a custom comparator set for a school or trust should log the 'search' search criteria. These should both be visible in the Transaction (not timeline) view in App Insights as Custom Events linked to the parent Azure Search dependency and source API request, e.g.:

![image](https://github.com/user-attachments/assets/58549170-8afd-4ae2-b6b2-78e265c3c691)

![image](https://github.com/user-attachments/assets/506c55d8-36e6-46ff-8b53-9ef0626a9100)

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running ~~locally~~ in `d17` feature environment
- [ ] ~~You have reviewed with UX/Design~~

