### PR TITLE
Display feedback in FBIS when RAG or Census data missing to prevent empty section render

### DIFF
--- a/web/src/Web.App/ViewModels/SchoolFinancialBenchmarkingInsightsSummaryViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolFinancialBenchmarkingInsightsSummaryViewModel.cs
@@ -37,6 +37,8 @@ public class SchoolFinancialBenchmarkingInsightsSummaryViewModel(
         .ThenByDescending(x => x.Rating.Value);
     public SchoolFinancialBenchmarkingInsightsSummaryCensusViewModel PupilsPerTeacher => new("teacher", census, school.URN, c => c.Teachers);
     public SchoolFinancialBenchmarkingInsightsSummaryCensusViewModel PupilsPerSeniorLeadership => new("senior leadership role", census, school.URN, c => c.SeniorLeadership);
+    public bool HasRagData => ratings?.Any() ?? false;
+    public bool HasCensusData => census?.Any(c => c.URN == school.URN && c.TotalPupils.HasValue) ?? false;
     public string? OverallPhase => school.OverallPhase;
     public string? OfstedRating => school.OfstedDescription;
     public decimal? InYearBalance => balance?.InYearBalance;

--- a/web/src/Web.App/Views/SchoolFinancialBenchmarkingInsightsSummary/_PriorityAreasAllSchools.cshtml
+++ b/web/src/Web.App/Views/SchoolFinancialBenchmarkingInsightsSummary/_PriorityAreasAllSchools.cshtml
@@ -3,40 +3,47 @@
 
 <section id="priority-areas-all-schools-section" aria-labelledby="priority-areas-all-schools">
     <h2 class="govuk-heading-l" id="priority-areas-all-schools">Your spend in priority areas for all schools</h2>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <p class="govuk-body">
-                Your school's spend compared against similar schools in the three areas in which schools in England spend
-                the most money.
-            </p>
-            <p class="govuk-body">
-                Find out about the schools you are compared with in
-                @Html.ActionLink(Constants.ServiceName, "Index", "SchoolComparators", new
-                {
-                    urn = Model.Urn
-                }, new
-                {
-                    @class = "govuk-link"
-                }).
-            </p>
-        </div>
-    </div>
-
-    @await Html.PartialAsync("_Costs", new CostsViewModel
+    @if (Model.HasRagData)
     {
-        Costs = Model.CostsAllSchools,
-        Id = "costs-all-schools",
-        Urn = Model.Urn
-    })
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+                <p class="govuk-body">
+                    Your school's spend compared against similar schools in the three areas in which schools in England spend
+                    the most money.
+                </p>
+                <p class="govuk-body">
+                    Find out about the schools you are compared with in
+                    @Html.ActionLink(Constants.ServiceName, "Index", "SchoolComparators", new
+                    {
+                        urn = Model.Urn
+                    }, new
+                    {
+                        @class = "govuk-link"
+                    }).
+                </p>
+            </div>
+        </div>
 
-    <p class="govuk-body govuk-!-display-none-print">
-        View more insights in
-        @Html.ActionLink(Constants.ServiceName, "Index", "SchoolComparison", new
+        @await Html.PartialAsync("_Costs", new CostsViewModel
         {
-            urn = Model.Urn
-        }, new
-        {
-            @class = "govuk-link"
-        }).
-    </p>
+            Costs = Model.CostsAllSchools,
+            Id = "costs-all-schools",
+            Urn = Model.Urn
+        })
+
+        <p class="govuk-body govuk-!-display-none-print">
+            View more insights in
+            @Html.ActionLink(Constants.ServiceName, "Index", "SchoolComparison", new
+            {
+                urn = Model.Urn
+            }, new
+            {
+                @class = "govuk-link"
+            }).
+        </p>
+    }
+    else
+    {
+        <p class="govuk-body">This school does not have comparator data available for this period.</p>
+    }
 </section>

--- a/web/src/Web.App/Views/SchoolFinancialBenchmarkingInsightsSummary/_PriorityAreasOther.cshtml
+++ b/web/src/Web.App/Views/SchoolFinancialBenchmarkingInsightsSummary/_PriorityAreasOther.cshtml
@@ -3,40 +3,47 @@
 
 <section id="priority-areas-other-section" aria-labelledby="priority-areas-other">
     <h2 class="govuk-heading-l" id="priority-areas-other">Other top spending priorities for your school</h2>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <p class="govuk-body">
-                Your school's top three priority areas in other spend categories, based on the variance of your school's
-                spend against similar schools.
-            </p>
-            <p class="govuk-body">
-                Find out about the schools you are compared with in
-                @Html.ActionLink(Constants.ServiceName, "Index", "SchoolComparators", new
-                {
-                    urn = Model.Urn
-                }, new
-                {
-                    @class = "govuk-link"
-                }).
-            </p>
-        </div>
-    </div>
-
-    @await Html.PartialAsync("_Costs", new CostsViewModel
+    @if (Model.HasRagData)
     {
-        Costs = Model.CostsOtherPriorities.Take(3),
-        Id = "costs-other-priorities",
-        Urn = Model.Urn
-    })
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+                <p class="govuk-body">
+                    Your school's top three priority areas in other spend categories, based on the variance of your school's
+                    spend against similar schools.
+                </p>
+                <p class="govuk-body">
+                    Find out about the schools you are compared with in
+                    @Html.ActionLink(Constants.ServiceName, "Index", "SchoolComparators", new
+                    {
+                        urn = Model.Urn
+                    }, new
+                    {
+                        @class = "govuk-link"
+                    }).
+                </p>
+            </div>
+        </div>
 
-    <p class="govuk-body govuk-!-display-none-print">
-        View more insights in
-        @Html.ActionLink(Constants.ServiceName, "Index", "SchoolComparison", new
+        @await Html.PartialAsync("_Costs", new CostsViewModel
         {
-            urn = Model.Urn
-        }, new
-        {
-            @class = "govuk-link"
-        }).
-    </p>
+            Costs = Model.CostsOtherPriorities.Take(3),
+            Id = "costs-other-priorities",
+            Urn = Model.Urn
+        })
+
+        <p class="govuk-body govuk-!-display-none-print">
+            View more insights in
+            @Html.ActionLink(Constants.ServiceName, "Index", "SchoolComparison", new
+            {
+                urn = Model.Urn
+            }, new
+            {
+                @class = "govuk-link"
+            }).
+        </p>
+    }
+    else
+    {
+        <p class="govuk-body">This school does not have comparator data available for this period.</p>
+    }
 </section>

--- a/web/src/Web.App/Views/SchoolFinancialBenchmarkingInsightsSummary/_PupilWorkforceMetrics.cshtml
+++ b/web/src/Web.App/Views/SchoolFinancialBenchmarkingInsightsSummary/_PupilWorkforceMetrics.cshtml
@@ -2,23 +2,30 @@
 
 <section id="pupil-workforce-metrics-section" aria-labelledby="pupil-workforce-metrics">
     <h2 class="govuk-heading-l" id="pupil-workforce-metrics">Pupil and workforce metrics</h2>
-    <div class="two-halves-with-divider govuk-!-margin-bottom-6">
-        <div>
-            @await Html.PartialAsync("_Metric", Model.PupilsPerTeacher)
+    @if (Model.HasCensusData)
+    {
+        <div class="two-halves-with-divider govuk-!-margin-bottom-6">
+            <div>
+                @await Html.PartialAsync("_Metric", Model.PupilsPerTeacher)
+            </div>
+            <div>
+                @await Html.PartialAsync("_Metric", Model.PupilsPerSeniorLeadership)
+            </div>
         </div>
-        <div>
-            @await Html.PartialAsync("_Metric", Model.PupilsPerSeniorLeadership)
-        </div>
-    </div>
 
-    <p class="govuk-body govuk-!-display-none-print">
-        View more insights in
-        @Html.ActionLink(Constants.ServiceName, "Index", "SchoolCensus", new
-        {
-            urn = Model.Urn
-        }, new
-        {
-            @class = "govuk-link"
-        }).
-    </p>
+        <p class="govuk-body govuk-!-display-none-print">
+            View more insights in
+            @Html.ActionLink(Constants.ServiceName, "Index", "SchoolCensus", new
+            {
+                urn = Model.Urn
+            }, new
+            {
+                @class = "govuk-link"
+            }).
+        </p>
+    }
+    else
+    {
+        <p class="govuk-body">This school does not have workforce data available for this period.</p>
+    }
 </section>

--- a/web/tests/Web.E2ETests/Features/School/SchoolFinancialBenchmarkingInsightsSummary.feature
+++ b/web/tests/Web.E2ETests/Features/School/SchoolFinancialBenchmarkingInsightsSummary.feature
@@ -6,7 +6,6 @@ So that I can see how my school is performing from a financial point of view and
 
     Scenario: View Financial Benchmarking Insights Summary
         Given I am on the Financial Benchmarking Insights Summary page for school with urn '777042'
-        When I click on the 'Print Page' button
         Then I should see the following boxes displayed under Key Information about school
           | Name            | Value    |
           | In year balance | £27,196  |
@@ -27,6 +26,20 @@ So that I can see how my school is performing from a financial point of view and
           | Name                                   | Value                                      | Comparison                                                                  |
           | Pupil-to-teacher metric                | 2.73\n\nPupils per teacher                 | Similar schools range from 0.3 to 8.59 pupils per teacher.                  |
           | Pupil-to-senior leadership role metric | 18.42\n\nPupils per senior leadership role | Similar schools range from 4.26 to 34.33 pupils per senior leadership role. |
+        And the print page cta is visible
+        And the response should be OK
+
+    Scenario: View Financial Benchmarking Insights Summary for school with missing data
+        Given I am on the Financial Benchmarking Insights Summary page for school with urn '990754' with missing RAG and census data
+        Then I should see the following boxes displayed under Key Information about school
+          | Name            | Value     |
+          | In year balance | £95,414   |
+          | Revenue reserve | £212,906  |
+          | Ofsted rating   | Good      |
+          | School phase    | Secondary |
+        And I should see the warning message under Spend in priority areas
+        And I should see the warning message under Other top spending priorities
+        And I should see the warning message under Pupil and workforce metrics
         And the print page cta is visible
         And the response should be OK
 

--- a/web/tests/Web.E2ETests/Pages/School/SchoolFinancialBenchmarkingInsightsSummaryPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/SchoolFinancialBenchmarkingInsightsSummaryPage.cs
@@ -26,7 +26,7 @@ public class SchoolFinancialBenchmarkingInsightsSummaryPage(IPage page, IRespons
     private ILocator PupilWorkforceContent => page.Locator(Selectors.PupilWorkforceContent);
     private ILocator WarningMessage => page.Locator(Selectors.GovWarning);
 
-    public async Task IsDisplayed(bool unavailable = false)
+    public async Task IsDisplayed(bool unavailable = false, bool hasRagData = true, bool hasCensusData = true)
     {
         await PageH1Heading.ShouldBeVisible();
         await VisitFbitButton.ShouldBeVisible();
@@ -37,18 +37,26 @@ public class SchoolFinancialBenchmarkingInsightsSummaryPage(IPage page, IRespons
         }
 
         await KeyInformationShouldBeVisible();
-        await SpendPrioritySectionShouldBeVisible();
-        await AssertSpendPriorityItems();
-        await OtherSpendingPrioritiesSectionShouldBeVisible();
-        await AssertOtherTopSpendingPriorities();
-        Assert.Equal(3, await Top3SpendingPriorities.Count());
-        foreach (var priority in await Top3SpendingPriorities.AllAsync())
+
+        if (hasRagData)
         {
-            await priority.ShouldBeVisible();
+            await SpendPrioritySectionShouldBeVisible();
+            await AssertSpendPriorityItems();
+            await OtherSpendingPrioritiesSectionShouldBeVisible();
+            await AssertOtherTopSpendingPriorities();
+            Assert.Equal(3, await Top3SpendingPriorities.Count());
+            foreach (var priority in await Top3SpendingPriorities.AllAsync())
+            {
+                await priority.ShouldBeVisible();
+            }
         }
 
-        await PupilWorkforceMetricsSectionShouldBeVisible();
-        await AssertPupilWorkforceMetrics();
+        if (hasCensusData)
+        {
+            await PupilWorkforceMetricsSectionShouldBeVisible();
+            await AssertPupilWorkforceMetrics();
+        }
+
         await PrintPageCtaShouldBeVisible();
         await NextStepsSection.ShouldBeVisible();
     }
@@ -85,6 +93,11 @@ public class SchoolFinancialBenchmarkingInsightsSummaryPage(IPage page, IRespons
         await SpendPrioritySection.ShouldBeVisible();
     }
 
+    public async Task SpendPrioritySectionShouldContainWarning()
+    {
+        await SpendPrioritySection.Locator("p").ShouldHaveText("This school does not have comparator data available for this period.");
+    }
+
     public async Task SpendPrioritySectionShouldContain(string name, string tag, string value)
     {
         var nameElement = SpendPrioritySection.Locator($"h3:has-text('{name}')");
@@ -104,6 +117,11 @@ public class SchoolFinancialBenchmarkingInsightsSummaryPage(IPage page, IRespons
         await OtherSpendingPrioritiesSection.ShouldBeVisible();
     }
 
+    public async Task OtherSpendingPrioritiesSectionShouldContainWarning()
+    {
+        await OtherSpendingPrioritiesSection.Locator("p").ShouldHaveText("This school does not have comparator data available for this period.");
+    }
+
     private async Task AssertOtherTopSpendingPriorities()
     {
         var topSpendingItems = await Top3SpendingPriorities.AllAsync();
@@ -120,6 +138,11 @@ public class SchoolFinancialBenchmarkingInsightsSummaryPage(IPage page, IRespons
     public async Task PupilWorkforceMetricsSectionShouldBeVisible()
     {
         await PupilWorkforceMetricsSection.ShouldBeVisible();
+    }
+
+    public async Task PupilWorkforceMetricsSectionShouldContainWarning()
+    {
+        await PupilWorkforceMetricsSection.Locator("p").ShouldHaveText("This school does not have workforce data available for this period.");
     }
 
     private async Task AssertPupilWorkforceMetrics()

--- a/web/tests/Web.E2ETests/Steps/School/SchoolFinancialBenchmarkingInsightsSummarySteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/SchoolFinancialBenchmarkingInsightsSummarySteps.cs
@@ -27,6 +27,13 @@ public class SchoolFinancialBenchmarkingInsightsSummarySteps(PageDriver driver)
         await _fbisPage.IsDisplayed(true);
     }
 
+    [Given("I am on the Financial Benchmarking Insights Summary page for school with urn '(.*)' with missing RAG and census data")]
+    public async Task GivenIAmOnTheFinancialBenchmarkingInsightsSummaryPageForSchoolWithUrnWithMissingRagAndCensusData(string urn)
+    {
+        _fbisPage = await LoadFinancialBenchmarkingInsightsSummaryPageForSchoolWithUrn(urn);
+        await _fbisPage.IsDisplayed(false, false, false);
+    }
+
     [Then("I should see the following boxes displayed under Key Information about school")]
     public async Task ThenIShouldSeeTheFollowingBoxesDisplayedUnderKeyInformationAboutSchool(DataTable table)
     {
@@ -73,6 +80,30 @@ public class SchoolFinancialBenchmarkingInsightsSummarySteps(PageDriver driver)
         {
             await _fbisPage.PupilWorkforceMetricsSectionShouldContain(row["Name"], row["Value"], row["Comparison"]);
         }
+    }
+
+    [Then("I should see the warning message under Spend in priority areas")]
+    public async Task ThenIShouldSeeTheWarningMessageUnderSpendInPriorityAreas()
+    {
+        Assert.NotNull(_fbisPage);
+        await _fbisPage.SpendPrioritySectionShouldBeVisible();
+        await _fbisPage.SpendPrioritySectionShouldContainWarning();
+    }
+
+    [Then("I should see the warning message under Other top spending priorities")]
+    public async Task ThenIShouldSeeTheWarningMessageUnderOtherTopSpendingPriorities()
+    {
+        Assert.NotNull(_fbisPage);
+        await _fbisPage.OtherSpendingPrioritiesSectionShouldBeVisible();
+        await _fbisPage.OtherSpendingPrioritiesSectionShouldContainWarning();
+    }
+
+    [Then("I should see the warning message under Pupil and workforce metrics")]
+    public async Task ThenIShouldSeeTheWarningMessageUnderPupilAndWorkforceMetrics()
+    {
+        Assert.NotNull(_fbisPage);
+        await _fbisPage.PupilWorkforceMetricsSectionShouldBeVisible();
+        await _fbisPage.PupilWorkforceMetricsSectionShouldContainWarning();
     }
 
     [Then("the print page cta is visible")]

--- a/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingFinancialBenchmarkingInsightsSummary.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingFinancialBenchmarkingInsightsSummary.cs
@@ -278,8 +278,8 @@ public class WhenViewingFinancialBenchmarkingInsightsSummary(SchoolBenchmarkingW
             .QuerySelectorAll(".app-headline-figures")
             .Select(e => string.Join(" ", e.ChildNodes.Select(n => n.TextContent.Trim())).Trim());
         Assert.Equal([
-            $"{census.Teachers}  Pupils per teacher",
-            $"{census.SeniorLeadership}  Pupils per senior leadership role"
+            $"{census.Teachers}  Pupil{(census.Teachers == 1 ? string.Empty : "s")} per teacher",
+            $"{census.SeniorLeadership}  Pupil{(census.SeniorLeadership == 1 ? string.Empty : "s")} per senior leadership role"
         ], headlineFiguresTexts);
 
         var link = pupilWorkforceMetricsSection.ChildNodes.QuerySelector("a");

--- a/web/tests/Web.Tests/ViewModels/GivenASchoolFinancialBenchmarkingInsightsSummaryViewModel.cs
+++ b/web/tests/Web.Tests/ViewModels/GivenASchoolFinancialBenchmarkingInsightsSummaryViewModel.cs
@@ -31,7 +31,8 @@ public class GivenASchoolFinancialBenchmarkingInsightsSummaryViewModel
         IEnumerable<SchoolExpenditure>,
         IEnumerable<SchoolExpenditure>,
         IEnumerable<CostCategory>,
-        IEnumerable<CostCategory>
+        IEnumerable<CostCategory>,
+        bool
     > WhenRagRatingsAreData
     {
         get
@@ -77,7 +78,8 @@ public class GivenASchoolFinancialBenchmarkingInsightsSummaryViewModel
                 IEnumerable<SchoolExpenditure>,
                 IEnumerable<SchoolExpenditure>,
                 IEnumerable<CostCategory>,
-                IEnumerable<CostCategory>
+                IEnumerable<CostCategory>,
+                bool
             >
             {
                 {
@@ -93,7 +95,22 @@ public class GivenASchoolFinancialBenchmarkingInsightsSummaryViewModel
                             URN = URN
                         }
                     ],
-                    [new AdministrativeSupplies(administrativeSuppliesRagRating), new TeachingStaff(teachingStaffRagRating), new NonEducationalSupportStaff(nonEducationalSupportStaffRagRating)], [new Utilities(utilitiesRagRating)]
+                    [new AdministrativeSupplies(administrativeSuppliesRagRating), new TeachingStaff(teachingStaffRagRating), new NonEducationalSupportStaff(nonEducationalSupportStaffRagRating)], [new Utilities(utilitiesRagRating)], true
+                },
+                {
+                    [], [
+                        new SchoolExpenditure
+                        {
+                            URN = URN
+                        }
+                    ],
+                    [
+                        new SchoolExpenditure
+                        {
+                            URN = URN
+                        }
+                    ],
+                    [], [], false
                 }
             };
         }
@@ -102,7 +119,8 @@ public class GivenASchoolFinancialBenchmarkingInsightsSummaryViewModel
     public static TheoryData<
         IEnumerable<Census>,
         SchoolFinancialBenchmarkingInsightsSummaryCensusViewModel,
-        SchoolFinancialBenchmarkingInsightsSummaryCensusViewModel
+        SchoolFinancialBenchmarkingInsightsSummaryCensusViewModel,
+        bool
     > WhenCensusesAreData
     {
         get
@@ -111,37 +129,48 @@ public class GivenASchoolFinancialBenchmarkingInsightsSummaryViewModel
             {
                 URN = URN,
                 Teachers = 100,
-                SeniorLeadership = 10
+                SeniorLeadership = 10,
+                TotalPupils = 110
+            };
+
+            var schoolCensusInvalid = new Census
+            {
+                URN = URN
             };
 
             var minTeachersCensus = new Census
             {
                 Teachers = 90,
-                SeniorLeadership = 11
+                SeniorLeadership = 11,
+                TotalPupils = 101
             };
 
             var minSeniorLeadershipCensus = new Census
             {
                 Teachers = 101,
-                SeniorLeadership = 1
+                SeniorLeadership = 1,
+                TotalPupils = 102
             };
 
             var maxTeachersCensus = new Census
             {
                 Teachers = 200,
-                SeniorLeadership = 11
+                SeniorLeadership = 11,
+                TotalPupils = 211
             };
 
             var maxSeniorLeadershipCensus = new Census
             {
                 Teachers = 101,
-                SeniorLeadership = 20
+                SeniorLeadership = 20,
+                TotalPupils = 121
             };
 
             return new TheoryData<
                 IEnumerable<Census>,
                 SchoolFinancialBenchmarkingInsightsSummaryCensusViewModel,
-                SchoolFinancialBenchmarkingInsightsSummaryCensusViewModel
+                SchoolFinancialBenchmarkingInsightsSummaryCensusViewModel,
+                bool
             >
             {
                 {
@@ -156,7 +185,23 @@ public class GivenASchoolFinancialBenchmarkingInsightsSummaryViewModel
                         SchoolValue = schoolCensus.SeniorLeadership,
                         MinValue = minSeniorLeadershipCensus.SeniorLeadership,
                         MaxValue = maxSeniorLeadershipCensus.SeniorLeadership
-                    }
+                    },
+                    true
+                },
+                {
+                    [minTeachersCensus, maxTeachersCensus, schoolCensusInvalid, minSeniorLeadershipCensus, maxSeniorLeadershipCensus], new SchoolFinancialBenchmarkingInsightsSummaryCensusViewModel("teacher")
+                    {
+                        SchoolValue = schoolCensusInvalid.Teachers,
+                        MinValue = minTeachersCensus.Teachers,
+                        MaxValue = maxTeachersCensus.Teachers
+                    },
+                    new SchoolFinancialBenchmarkingInsightsSummaryCensusViewModel("senior leadership role")
+                    {
+                        SchoolValue = schoolCensusInvalid.SeniorLeadership,
+                        MinValue = minSeniorLeadershipCensus.SeniorLeadership,
+                        MaxValue = maxSeniorLeadershipCensus.SeniorLeadership
+                    },
+                    false
                 }
             };
         }
@@ -169,11 +214,13 @@ public class GivenASchoolFinancialBenchmarkingInsightsSummaryViewModel
         IEnumerable<SchoolExpenditure> pupilExpenditure,
         IEnumerable<SchoolExpenditure> areaExpenditure,
         IEnumerable<CostCategory> expectedCostsAllSchools,
-        IEnumerable<CostCategory> expectedCostsOtherPriorities)
+        IEnumerable<CostCategory> expectedCostsOtherPriorities,
+        bool hasRagData)
     {
         var actual = new SchoolFinancialBenchmarkingInsightsSummaryViewModel(_school, _years, _balance, ratings, pupilExpenditure, areaExpenditure, Array.Empty<Census>());
         Assert.Equal(expectedCostsAllSchools.Select(c => c.Rating), actual.CostsAllSchools.Select(c => c.Rating));
         Assert.Equal(expectedCostsOtherPriorities.Select(c => c.Rating), actual.CostsOtherPriorities.Select(c => c.Rating));
+        Assert.Equal(hasRagData, actual.HasRagData);
     }
 
     [Theory]
@@ -191,10 +238,12 @@ public class GivenASchoolFinancialBenchmarkingInsightsSummaryViewModel
     public void WhenCensusesAre(
         IEnumerable<Census> census,
         SchoolFinancialBenchmarkingInsightsSummaryCensusViewModel expectedPupilsPerTeacher,
-        SchoolFinancialBenchmarkingInsightsSummaryCensusViewModel expectedPupilsPerSeniorLeadership)
+        SchoolFinancialBenchmarkingInsightsSummaryCensusViewModel expectedPupilsPerSeniorLeadership,
+        bool hasCensusData)
     {
         var actual = new SchoolFinancialBenchmarkingInsightsSummaryViewModel(_school, _years, _balance, Array.Empty<RagRating>(), Array.Empty<SchoolExpenditure>(), Array.Empty<SchoolExpenditure>(), census);
         Assert.Equivalent(expectedPupilsPerTeacher, actual.PupilsPerTeacher);
         Assert.Equivalent(expectedPupilsPerSeniorLeadership, actual.PupilsPerSeniorLeadership);
+        Assert.Equal(hasCensusData, actual.HasCensusData);
     }
 }


### PR DESCRIPTION
### Context
[AB#240076](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/240076) [AB#222988](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/222988)

### Change proposed in this pull request
Updated model to perform RAG and Census presence check and render message instead of summary content if not available.

### Guidance to review 
May be validated in `d02` using URN `990754`, or URN `100060` in `d01`.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

