### PR TITLE
Maintain state of 'focused' tick tooltip(s) and prevent rechart tooltip from rendering at the same time

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -92,14 +92,14 @@
       ></div>
       <button type="submit">Submit</button>
     </form>-->
-    <div id="compare-your-trust" data-id="09617166"></div>
+    <!--<div id="compare-your-trust" data-id="09617166"></div>-->
     <!--<div
       id="compare-your-costs"
       data-type="trust"
       data-id="02387916"
       data-phases='["Secondary","Primary","Post-16"]'
     ></div>-->
-    <!--<div id="compare-your-costs" data-type="school" data-id="143996"></div>-->
+   <div id="compare-your-costs" data-type="school" data-id="143996"></div>
     <!--<div id="historic-data" data-type="school" data-id="990095"></div>-->
     <!--<div
       id="compare-your-costs"

--- a/front-end-components/src/components/charts/establishment-tick/component.tsx
+++ b/front-end-components/src/components/charts/establishment-tick/component.tsx
@@ -4,6 +4,7 @@ import { EstablishmentTickProps } from "src/components/charts/establishment-tick
 import { ChartLink } from "../chart-link";
 import {
   createElement,
+  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -17,6 +18,7 @@ export function EstablishmentTick(props: EstablishmentTickProps) {
     highlightedItemKey,
     href,
     linkToEstablishment,
+    onFocused,
     payload: { value },
     specialItemFlags,
     tickFormatter,
@@ -26,7 +28,7 @@ export function EstablishmentTick(props: EstablishmentTickProps) {
     ...rest
   } = props;
   const textRef = useRef<SVGTextElement>(null);
-  const [focused, setFocused] = useState<boolean>();
+  const [focused, setFocused] = useState<boolean>(false);
   const key = useMemo(() => {
     return (
       linkToEstablishment &&
@@ -49,6 +51,12 @@ export function EstablishmentTick(props: EstablishmentTickProps) {
     const bbox = textRef.current?.getBBox();
     setTextBoundingBox({ x: bbox?.x, y: bbox?.y });
   }, []);
+
+  useEffect(() => {
+    if (key && onFocused) {
+      onFocused(key, focused);
+    }
+  }, [key, onFocused, focused]);
 
   if (!key) {
     return <Text>{value}</Text>;

--- a/front-end-components/src/components/charts/establishment-tick/types.tsx
+++ b/front-end-components/src/components/charts/establishment-tick/types.tsx
@@ -14,6 +14,7 @@ export interface EstablishmentTickProps
   highlightedItemKey?: string;
   href: (key: string) => string;
   linkToEstablishment?: boolean;
+  onFocused?: (key: string, focused: boolean) => void;
   payload: CartesianTickItem;
   specialItemFlags?: (key: string) => SpecialItemFlag[];
   tooltip?: FunctionComponent<TooltipProps<ValueType, NameType>>;

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -43,6 +43,7 @@ export function HorizontalBarChartWrapper<
   const selectedEstabishment = useContext(SelectedEstablishmentContext);
   const chartRef = useRef<ChartHandler>(null);
   const [imageLoading, setImageLoading] = useState<boolean>();
+  const [tickFocused, setTickFocused] = useState<Record<string, boolean>>({});
   const keyField = (trust ? "companyNumber" : "urn") as keyof TData;
   const seriesLabelField = (trust ? "trustName" : "schoolName") as keyof TData;
   const seriesConfig: { [key: string]: ChartSeriesConfigItem } = {
@@ -149,6 +150,10 @@ export function HorizontalBarChartWrapper<
     return flags;
   };
 
+  const handleTickFocused = (key: string, focused: boolean) => {
+    setTickFocused(Object.assign(tickFocused, { [key]: focused }));
+  };
+
   return (
     <>
       <div className="govuk-grid-row">
@@ -204,10 +209,15 @@ export function HorizontalBarChartWrapper<
                           establishmentKeyResolver={getEstablishmentKey}
                           tooltip={(p) => renderTooltip(p, t)}
                           specialItemFlags={getSpecialItemFlags}
+                          onFocused={handleTickFocused}
                         />
                       );
                     }}
-                    tooltip={(p) => renderTooltip(p)}
+                    tooltip={(p) =>
+                      Object.values(tickFocused).some((t) => t)
+                        ? null
+                        : renderTooltip(p)
+                    }
                     valueFormatter={shortValueFormatter}
                     valueLabel={dimension.label}
                     valueUnit={valueUnit ?? dimension.unit}


### PR DESCRIPTION
### Context
[AB#240111](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/240111) [AB#226832](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/226832)

### Change proposed in this pull request
`<HorizontalBarChartWrapper>` and `<EstablishmentTick>` front end component updates.

### Guidance to review 
Build `front-end-components` and copy to `web`, or run vite server to validate.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

