### PR TITLE
Replaced Teams Alert basic message with adaptive cards

### DIFF
--- a/support-analytics/README.md
+++ b/support-analytics/README.md
@@ -2,6 +2,11 @@
 
 This is a supplementary project that contains configuration for supporting and monitoring the service.
 
+## Prerequisites
+
+1. Install [Adaptive Card Previewer](https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.vscode-adaptive-cards)
+for VS Code
+
 ## Log Analytics
 
 ### Functions

--- a/support-analytics/terraform/README.md
+++ b/support-analytics/terraform/README.md
@@ -62,8 +62,11 @@ No modules.
 | [azurerm_log_analytics_saved_search.get-users](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_saved_search.get-waf-blocked-requests](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_saved_search.get-waf-logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
-| [azurerm_logic_app_action_custom.condition-post-teams](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
 | [azurerm_logic_app_action_custom.initialise-affected-resource-ids](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
+| [azurerm_logic_app_action_custom.initialise-alert-id](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
+| [azurerm_logic_app_action_custom.initialise-message-content](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
+| [azurerm_logic_app_action_custom.initialise-message-id](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
+| [azurerm_logic_app_action_custom.is-alert-resolved](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
 | [azurerm_logic_app_trigger_http_request.http-trigger](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_trigger_http_request) | resource |
 | [azurerm_logic_app_workflow.alert-teams](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_workflow) | resource |
 | [azurerm_monitor_action_group.service-support-action](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |

--- a/support-analytics/terraform/adaptive-cards/alert-assigned.json
+++ b/support-analytics/terraform/adaptive-cards/alert-assigned.json
@@ -1,0 +1,88 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.5",
+    "type": "AdaptiveCard",
+    "body": [
+        {
+            "type": "TextBlock",
+            "size": "medium",
+            "weight": "bolder",
+            "text": "@{triggerBody()?['data']?['essentials']?['severity']} Azure Monitor Alert @{triggerBody()?['data']?['essentials']?['monitorCondition']} in @{parameters('Environment')}",
+            "style": "heading",
+            "wrap": true
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "size": "extraLarge",
+                            "style": "heading",
+                            "text": "🚨",
+                            "color": "attention"
+                        }
+                    ],
+                    "width": "auto"
+                },
+                {
+                    "type": "Column",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "weight": "bolder",
+                            "text": "@{triggerBody()?['data']?['essentials']?['alertRule']}"
+                        },
+                        {
+                            "type": "TextBlock",
+                            "spacing": "none",
+                            "text": "Fired at @{formatDateTime(triggerBody()?['data']?['essentials']?['firedDateTime'], 'F', 'en-GB')}",
+                            "isSubtle": true,
+                            "wrap": true
+                        }
+                    ],
+                    "width": "stretch"
+                }
+            ]
+        },
+        {
+            "type": "FactSet",
+            "facts": [
+                {
+                    "title": "Affected resource",
+                    "value": "@{variables('AffectedResourceIds')[8]}"
+                },
+                {
+                    "title": "Resource type",
+                    "value": "@{variables('AffectedResourceIds')[6]}/@{variables('AffectedResourceIds')[7]}"
+                },
+                {
+                    "title": "Resource group",
+                    "value": "@{variables('AffectedResourceIds')[4]}"
+                },
+                {
+                    "title": "Description",
+                    "value": "@{triggerBody()?['data']?['essentials']?['description']}"
+                },
+                {
+                    "title": "Monitoring service",
+                    "value": "@{triggerBody()?['data']?['essentials']?['monitoringService']}"
+                },
+                {
+                    "title": "Assigned to",
+                    "value": "@{body('Post_adaptive_card_and_wait_for_a_response')?['responder']?['displayName']}"
+                }
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "type": "Action.OpenUrl",
+            "title": "View the alert in Azure Monitor",
+            "url": "https://portal.azure.com/#blade/Microsoft_Azure_Monitoring_Alerts/AlertDetails.ReactView/alertId/%2fsubscriptions%2f@{variables('AffectedResourceIds')[2]}%2fresourceGroups%2f@{variables('AffectedResourceIds')[4]}%2fproviders%2fMicrosoft.AlertsManagement%2falerts%2f@{substring(triggerBody()?['data']?['essentials']?['alertId'], add(lastIndexOf(triggerBody()?['data']?['essentials']?['alertId'], '/'), 1))}",
+            "style": "positive"
+        }
+    ]
+}

--- a/support-analytics/terraform/adaptive-cards/alert-fired.json
+++ b/support-analytics/terraform/adaptive-cards/alert-fired.json
@@ -1,0 +1,91 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.5",
+    "type": "AdaptiveCard",
+    "body": [
+        {
+            "type": "TextBlock",
+            "size": "medium",
+            "weight": "bolder",
+            "text": "@{triggerBody()?['data']?['essentials']?['severity']} Azure Monitor Alert @{triggerBody()?['data']?['essentials']?['monitorCondition']} in @{parameters('Environment')}",
+            "style": "heading",
+            "wrap": true
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "size": "extraLarge",
+                            "style": "heading",
+                            "text": "🚨",
+                            "color": "attention"
+                        }
+                    ],
+                    "width": "auto"
+                },
+                {
+                    "type": "Column",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "weight": "bolder",
+                            "text": "@{triggerBody()?['data']?['essentials']?['alertRule']}"
+                        },
+                        {
+                            "type": "TextBlock",
+                            "spacing": "none",
+                            "text": "Fired at @{formatDateTime(triggerBody()?['data']?['essentials']?['firedDateTime'], 'F', 'en-GB')}",
+                            "isSubtle": true,
+                            "wrap": true
+                        }
+                    ],
+                    "width": "stretch"
+                }
+            ]
+        },
+        {
+            "type": "FactSet",
+            "facts": [
+                {
+                    "title": "Affected resource",
+                    "value": "@{variables('AffectedResourceIds')[8]}"
+                },
+                {
+                    "title": "Resource type",
+                    "value": "@{variables('AffectedResourceIds')[6]}/@{variables('AffectedResourceIds')[7]}"
+                },
+                {
+                    "title": "Resource group",
+                    "value": "@{variables('AffectedResourceIds')[4]}"
+                },
+                {
+                    "title": "Description",
+                    "value": "@{triggerBody()?['data']?['essentials']?['description']}"
+                },
+                {
+                    "title": "Monitoring service",
+                    "value": "@{triggerBody()?['data']?['essentials']?['monitoringService']}"
+                }
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "type": "Action.OpenUrl",
+            "title": "View the alert in Azure Monitor",
+            "url": "https://portal.azure.com/#blade/Microsoft_Azure_Monitoring_Alerts/AlertDetails.ReactView/alertId/%2fsubscriptions%2f@{variables('AffectedResourceIds')[2]}%2fresourceGroups%2f@{variables('AffectedResourceIds')[4]}%2fproviders%2fMicrosoft.AlertsManagement%2falerts%2f@{substring(triggerBody()?['data']?['essentials']?['alertId'], add(lastIndexOf(triggerBody()?['data']?['essentials']?['alertId'], '/'), 1))}",
+            "style": "positive"
+        },
+        {
+            "type": "Action.Submit",
+            "title": "Assign",
+            "data": {
+                "action": "assigned"
+            }
+        }
+    ]
+}

--- a/support-analytics/terraform/adaptive-cards/alert-resolved.json
+++ b/support-analytics/terraform/adaptive-cards/alert-resolved.json
@@ -1,0 +1,88 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.5",
+    "type": "AdaptiveCard",
+    "body": [
+        {
+            "type": "TextBlock",
+            "size": "medium",
+            "weight": "bolder",
+            "text": "@{triggerBody()?['data']?['essentials']?['severity']} Azure Monitor Alert @{triggerBody()?['data']?['essentials']?['monitorCondition']} in @{parameters('Environment')}",
+            "style": "heading",
+            "wrap": true
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "size": "extraLarge",
+                            "style": "heading",
+                            "text": "✅",
+                            "color": "attention"
+                        }
+                    ],
+                    "width": "auto"
+                },
+                {
+                    "type": "Column",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "weight": "bolder",
+                            "text": "@{triggerBody()?['data']?['essentials']?['alertRule']}"
+                        },
+                        {
+                            "type": "TextBlock",
+                            "spacing": "none",
+                            "text": "Fired at @{formatDateTime(triggerBody()?['data']?['essentials']?['firedDateTime'], 'F', 'en-GB')}",
+                            "isSubtle": true,
+                            "wrap": true
+                        }
+                    ],
+                    "width": "stretch"
+                }
+            ]
+        },
+        {
+            "type": "FactSet",
+            "facts": [
+                {
+                    "title": "Affected resource",
+                    "value": "@{variables('AffectedResourceIds')[8]}"
+                },
+                {
+                    "title": "Resource type",
+                    "value": "@{variables('AffectedResourceIds')[6]}/@{variables('AffectedResourceIds')[7]}"
+                },
+                {
+                    "title": "Resource group",
+                    "value": "@{variables('AffectedResourceIds')[4]}"
+                },
+                {
+                    "title": "Description",
+                    "value": "@{triggerBody()?['data']?['essentials']?['description']}"
+                },
+                {
+                    "title": "Monitoring service",
+                    "value": "@{triggerBody()?['data']?['essentials']?['monitoringService']}"
+                },
+                {
+                    "title": "Resolved at",
+                    "value": "@{formatDateTime(triggerBody()?['data']?['essentials']?['resolvedDateTime'], 'F', 'en-GB')}"
+                }
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "type": "Action.OpenUrl",
+            "title": "View the alert in Azure Monitor",
+            "url": "https://portal.azure.com/#blade/Microsoft_Azure_Monitoring_Alerts/AlertDetails.ReactView/alertId/%2fsubscriptions%2f@{variables('AffectedResourceIds')[2]}%2fresourceGroups%2f@{variables('AffectedResourceIds')[4]}%2fproviders%2fMicrosoft.AlertsManagement%2falerts%2f@{substring(triggerBody()?['data']?['essentials']?['alertId'], add(lastIndexOf(triggerBody()?['data']?['essentials']?['alertId'], '/'), 1))}",
+            "style": "positive"
+        }
+    ]
+}


### PR DESCRIPTION
### Context
[AB#240303](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/240303) [AB#236780](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/236780)

### Change proposed in this pull request
Logic app code changes for more joined up alert reporting.

### Guidance to review 
Deployed to `d17` feature environment which has been manually configured to point to the `FBIT Alerts - Development` channel in Teams for testing purposes. Upon a new alert firing, the 'fired' adaptive card is posted, which can then be self-assigned and updated to the 'assigned' card. Later, once resolved, the 'resolved' card is updated into the original message (based on the matching `alertId` from the last ~10 messages in the channel). See story or use VS Code plugin to view adaptive card designs.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running ~~locally~~ in `d17`
- [ ] You have reviewed with UX/Design

