### PR TITLE
Modify Teams Alert logic app to ensure correct message ID is updated for `resolved` monitor state message

### DIFF
--- a/support-analytics/terraform/README.md
+++ b/support-analytics/terraform/README.md
@@ -64,7 +64,7 @@ No modules.
 | [azurerm_log_analytics_saved_search.get-waf-logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_logic_app_action_custom.initialise-affected-resource-ids](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
 | [azurerm_logic_app_action_custom.initialise-alert-id](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
-| [azurerm_logic_app_action_custom.initialise-message-content](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
+| [azurerm_logic_app_action_custom.initialise-fired-timestamp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
 | [azurerm_logic_app_action_custom.initialise-message-id](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
 | [azurerm_logic_app_action_custom.is-alert-resolved](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
 | [azurerm_logic_app_trigger_http_request.http-trigger](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_trigger_http_request) | resource |

--- a/support-analytics/terraform/adaptive-cards/alert-assigned-minimal.json
+++ b/support-analytics/terraform/adaptive-cards/alert-assigned-minimal.json
@@ -51,18 +51,6 @@
             "type": "FactSet",
             "facts": [
                 {
-                    "title": "Affected resource",
-                    "value": "@{variables('AffectedResourceIds')[8]}"
-                },
-                {
-                    "title": "Resource type",
-                    "value": "@{variables('AffectedResourceIds')[6]}/@{variables('AffectedResourceIds')[7]}"
-                },
-                {
-                    "title": "Resource group",
-                    "value": "@{variables('AffectedResourceIds')[4]}"
-                },
-                {
                     "title": "Description",
                     "value": "@{triggerBody()?['data']?['essentials']?['description']}"
                 },
@@ -72,7 +60,7 @@
                 },
                 {
                     "title": "Assigned to",
-                    "value": "@{body('Post_adaptive_card_and_wait_for_a_response')?['responder']?['displayName']} 👀"
+                    "value": "@{body('Post_minimal_adaptive_card_and_wait_for_a_response')?['responder']?['displayName']} 👀"
                 }
             ]
         },
@@ -85,14 +73,6 @@
                     "value": "@{triggerBody()?['data']?['essentials']?['firedDateTime']}"
                 }
             ]
-        }
-    ],
-    "actions": [
-        {
-            "type": "Action.OpenUrl",
-            "title": "View the alert in Azure Monitor",
-            "url": "https://portal.azure.com/#blade/Microsoft_Azure_Monitoring_Alerts/AlertDetails.ReactView/alertId/%2fsubscriptions%2f@{variables('AffectedResourceIds')[2]}%2fresourceGroups%2f@{variables('AffectedResourceIds')[4]}%2fproviders%2fMicrosoft.AlertsManagement%2falerts%2f@{substring(triggerBody()?['data']?['essentials']?['alertId'], add(lastIndexOf(triggerBody()?['data']?['essentials']?['alertId'], '/'), 1))}",
-            "style": "positive"
         }
     ]
 }

--- a/support-analytics/terraform/adaptive-cards/alert-fired-minimal.json
+++ b/support-analytics/terraform/adaptive-cards/alert-fired-minimal.json
@@ -51,28 +51,12 @@
             "type": "FactSet",
             "facts": [
                 {
-                    "title": "Affected resource",
-                    "value": "@{variables('AffectedResourceIds')[8]}"
-                },
-                {
-                    "title": "Resource type",
-                    "value": "@{variables('AffectedResourceIds')[6]}/@{variables('AffectedResourceIds')[7]}"
-                },
-                {
-                    "title": "Resource group",
-                    "value": "@{variables('AffectedResourceIds')[4]}"
-                },
-                {
                     "title": "Description",
                     "value": "@{triggerBody()?['data']?['essentials']?['description']}"
                 },
                 {
                     "title": "Monitoring service",
                     "value": "@{triggerBody()?['data']?['essentials']?['monitoringService']}"
-                },
-                {
-                    "title": "Assigned to",
-                    "value": "@{body('Post_adaptive_card_and_wait_for_a_response')?['responder']?['displayName']} 👀"
                 }
             ]
         },
@@ -89,10 +73,11 @@
     ],
     "actions": [
         {
-            "type": "Action.OpenUrl",
-            "title": "View the alert in Azure Monitor",
-            "url": "https://portal.azure.com/#blade/Microsoft_Azure_Monitoring_Alerts/AlertDetails.ReactView/alertId/%2fsubscriptions%2f@{variables('AffectedResourceIds')[2]}%2fresourceGroups%2f@{variables('AffectedResourceIds')[4]}%2fproviders%2fMicrosoft.AlertsManagement%2falerts%2f@{substring(triggerBody()?['data']?['essentials']?['alertId'], add(lastIndexOf(triggerBody()?['data']?['essentials']?['alertId'], '/'), 1))}",
-            "style": "positive"
+            "type": "Action.Submit",
+            "title": "Assign",
+            "data": {
+                "action": "assigned"
+            }
         }
     ]
 }

--- a/support-analytics/terraform/adaptive-cards/alert-fired.json
+++ b/support-analytics/terraform/adaptive-cards/alert-fired.json
@@ -71,6 +71,16 @@
                     "value": "@{triggerBody()?['data']?['essentials']?['monitoringService']}"
                 }
             ]
+        },
+        {
+            "type": "FactSet",
+            "isVisible": false,
+            "facts": [
+                {
+                    "title": "firedDateTime",
+                    "value": "@{triggerBody()?['data']?['essentials']?['firedDateTime']}"
+                }
+            ]
         }
     ],
     "actions": [

--- a/support-analytics/terraform/adaptive-cards/alert-resolved-minimal.json
+++ b/support-analytics/terraform/adaptive-cards/alert-resolved-minimal.json
@@ -21,7 +21,7 @@
                             "type": "TextBlock",
                             "size": "extraLarge",
                             "style": "heading",
-                            "text": "🚨",
+                            "text": "✅",
                             "color": "attention"
                         }
                     ],
@@ -51,18 +51,6 @@
             "type": "FactSet",
             "facts": [
                 {
-                    "title": "Affected resource",
-                    "value": "@{variables('AffectedResourceIds')[8]}"
-                },
-                {
-                    "title": "Resource type",
-                    "value": "@{variables('AffectedResourceIds')[6]}/@{variables('AffectedResourceIds')[7]}"
-                },
-                {
-                    "title": "Resource group",
-                    "value": "@{variables('AffectedResourceIds')[4]}"
-                },
-                {
                     "title": "Description",
                     "value": "@{triggerBody()?['data']?['essentials']?['description']}"
                 },
@@ -71,8 +59,8 @@
                     "value": "@{triggerBody()?['data']?['essentials']?['monitoringService']}"
                 },
                 {
-                    "title": "Assigned to",
-                    "value": "@{body('Post_adaptive_card_and_wait_for_a_response')?['responder']?['displayName']} 👀"
+                    "title": "Resolved at",
+                    "value": "@{formatDateTime(triggerBody()?['data']?['essentials']?['resolvedDateTime'], 'F', 'en-GB')}"
                 }
             ]
         },
@@ -83,16 +71,12 @@
                 {
                     "title": "firedDateTime",
                     "value": "@{triggerBody()?['data']?['essentials']?['firedDateTime']}"
+                },
+                {
+                    "title": "resolvedDateTime",
+                    "value": "@{triggerBody()?['data']?['essentials']?['resolvedDateTime']}"
                 }
             ]
-        }
-    ],
-    "actions": [
-        {
-            "type": "Action.OpenUrl",
-            "title": "View the alert in Azure Monitor",
-            "url": "https://portal.azure.com/#blade/Microsoft_Azure_Monitoring_Alerts/AlertDetails.ReactView/alertId/%2fsubscriptions%2f@{variables('AffectedResourceIds')[2]}%2fresourceGroups%2f@{variables('AffectedResourceIds')[4]}%2fproviders%2fMicrosoft.AlertsManagement%2falerts%2f@{substring(triggerBody()?['data']?['essentials']?['alertId'], add(lastIndexOf(triggerBody()?['data']?['essentials']?['alertId'], '/'), 1))}",
-            "style": "positive"
         }
     ]
 }

--- a/support-analytics/terraform/adaptive-cards/alert-resolved.json
+++ b/support-analytics/terraform/adaptive-cards/alert-resolved.json
@@ -75,6 +75,20 @@
                     "value": "@{formatDateTime(triggerBody()?['data']?['essentials']?['resolvedDateTime'], 'F', 'en-GB')}"
                 }
             ]
+        },
+        {
+            "type": "FactSet",
+            "isVisible": false,
+            "facts": [
+                {
+                    "title": "firedDateTime",
+                    "value": "@{triggerBody()?['data']?['essentials']?['firedDateTime']}"
+                },
+                {
+                    "title": "resolvedDateTime",
+                    "value": "@{triggerBody()?['data']?['essentials']?['resolvedDateTime']}"
+                }
+            ]
         }
     ],
     "actions": [


### PR DESCRIPTION
### Context
[AB#240650](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/240650) [AB#236780](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/236780)

### Change proposed in this pull request
1. Ensured message correlation done by original fired date time rather than alert ID when updating based on a new HTTP trigger (the mixed en-US date format is intentional and is caused by some inconsistent date formatting within Logic Apps)
2. Support 'minimal' data alert types from Azure Monitor that previously caused Logic App to fail

### Guidance to review 
May be tested in `d17` by firing and then resolving a test to the action group. To resolve the test message, obtain the `body` from the original test trigger, change the monitor condition to `Resolved` and add a `resolvedDateTime`. Then choose Run > Payload from the Logic App designer.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~~Your code builds clean without any errors or warnings~~
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

