### PR TITLE
Remove all 'Ofsted' references from Razor views

### DIFF
--- a/web/src/Web.App/Infrastructure/Apis/ApiRequests/PostSchoolComparatorsRequest.cs
+++ b/web/src/Web.App/Infrastructure/Apis/ApiRequests/PostSchoolComparatorsRequest.cs
@@ -68,10 +68,6 @@ public class PostSchoolComparatorsRequest(string? laName, UserDefinedSchoolChara
         ? new CharacteristicList(viewModel.LondonWeightings)
         : null;
 
-    public CharacteristicList? OfstedDescription => IsSelected(viewModel.OfstedRating)
-        ? new CharacteristicList(viewModel.OfstedRatings)
-        : null;
-
     public CharacteristicRange? TotalPupils => IsSelected(viewModel.TotalPupils)
         ? new CharacteristicRange(viewModel.TotalPupilsFrom, viewModel.TotalPupilsTo)
         : null;

--- a/web/src/Web.App/ViewModels/ISchoolKeyInformationViewModel.cs
+++ b/web/src/Web.App/ViewModels/ISchoolKeyInformationViewModel.cs
@@ -4,6 +4,5 @@ public interface ISchoolKeyInformationViewModel
 {
     public decimal? InYearBalance { get; }
     public decimal? RevenueReserve { get; }
-    public string? OfstedRating { get; }
     public string? OverallPhase { get; }
 }

--- a/web/src/Web.App/ViewModels/SchoolComparatorsPreviewViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolComparatorsPreviewViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using Web.App.Domain;
-
 namespace Web.App.ViewModels;
 
 public class SchoolComparatorsPreviewViewModel(
@@ -46,7 +45,6 @@ public class SchoolComparatorsPreviewViewModel(
     public bool LondonWeightingSelected => IsSelected(userDefinedCharacteristics?.LondonWeighting);
     public bool AverageBuildingAgeSelected => IsSelected(userDefinedCharacteristics?.AverageBuildingAge);
     public bool InternalFloorAreaSelected => IsSelected(userDefinedCharacteristics?.InternalFloorArea);
-    public bool OfstedRatingSelected => IsSelected(userDefinedCharacteristics?.OfstedRating);
     public bool SchoolsInTrustSelected => IsSelected(userDefinedCharacteristics?.SchoolsInTrust);
     public bool DeficitSelected => IsSelected(userDefinedCharacteristics?.Deficit);
     public bool PrivateFinanceInitiativeSelected => IsSelected(userDefinedCharacteristics?.PrivateFinanceInitiative);
@@ -71,7 +69,6 @@ public class SchoolComparatorsPreviewViewModel(
                                                  || LondonWeightingSelected
                                                  || AverageBuildingAgeSelected
                                                  || InternalFloorAreaSelected
-                                                 || OfstedRatingSelected
                                                  || SchoolsInTrustSelected
                                                  || DeficitSelected
                                                  || PrivateFinanceInitiativeSelected

--- a/web/src/Web.App/ViewModels/SchoolFinancialBenchmarkingInsightsSummaryViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolFinancialBenchmarkingInsightsSummaryViewModel.cs
@@ -40,7 +40,6 @@ public class SchoolFinancialBenchmarkingInsightsSummaryViewModel(
     public bool HasRagData => ratings?.Any() ?? false;
     public bool HasCensusData => census?.Any(c => c.URN == school.URN && c.TotalPupils.HasValue) ?? false;
     public string? OverallPhase => school.OverallPhase;
-    public string? OfstedRating => school.OfstedDescription;
     public decimal? InYearBalance => balance?.InYearBalance;
     public decimal? RevenueReserve => balance?.RevenueReserve;
 }

--- a/web/src/Web.App/ViewModels/SchoolViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolViewModel.cs
@@ -88,7 +88,6 @@ public class SchoolViewModel(School school) : ISchoolKeyInformationViewModel
     public bool? ComparatorReverted { get; }
     public bool? CustomDataGenerated { get; }
     public string? OverallPhase => school.OverallPhase;
-    public string? OfstedRating => school.OfstedDescription;
     public decimal? InYearBalance { get; }
     public decimal? RevenueReserve { get; }
 }

--- a/web/src/Web.App/ViewModels/UserDefinedSchoolCharacteristicViewModel.cs
+++ b/web/src/Web.App/ViewModels/UserDefinedSchoolCharacteristicViewModel.cs
@@ -119,12 +119,6 @@ public record UserDefinedSchoolCharacteristicViewModel() : IValidatableObject
     [CompareIntValue(nameof(InternalFloorAreaFrom), Operator.GreaterThanOrEqualTo, "The From value for gross internal floor area must be less than the To value")]
     public int? InternalFloorAreaTo { get; init; }
 
-    // ofsted
-    public string? OfstedRating { get; init; }
-
-    [RequiredDepends(nameof(OfstedRating), "true", ErrorMessage = "Select at least one Oftsed rating")]
-    public string[] OfstedRatings { get; init; } = [];
-
     // number of schools
     public string? SchoolsInTrust { get; init; }
 

--- a/web/src/Web.App/Views/School/NonLeadFederation.cshtml
+++ b/web/src/Web.App/Views/School/NonLeadFederation.cshtml
@@ -105,14 +105,6 @@
             </div>
             <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">
-                    Ofsted rating
-                </dt>
-                <dd class="govuk-summary-list__value">
-                    @Model.OfstedRating
-                </dd>
-            </div>
-            <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">
                     Has sixth form
                 </dt>
                 <dd class="govuk-summary-list__value">

--- a/web/src/Web.App/Views/SchoolComparatorsCreateBy/Characteristic.cshtml
+++ b/web/src/Web.App/Views/SchoolComparatorsCreateBy/Characteristic.cshtml
@@ -147,20 +147,6 @@
                                 inputsSuffix: "square metres"))
 
                         @await Html.PartialAsync(
-                            "Characteristics/_AdditionalCharacteristicsSelect",
-                            new AdditionalCharacteristicsSelectViewModel(
-                                ViewData,
-                                "Ofsted rating",
-                                nameof(Model.Data.OfstedRating),
-                                Model.Data.OfstedRating,
-                                nameof(Model.Data.OfstedRatings),
-                                string.Join(",", Model.Data.OfstedRatings),
-                                Model.Name,
-                                Model.Characteristic?.OfstedDescription,
-                                ["Outstanding", "Good", "Requires improvement", "Inadequate", "Not rated"],
-                                prefix: "is rated"))
-
-                        @await Html.PartialAsync(
                             "Characteristics/_AdditionalCharacteristicsRange",
                             new AdditionalCharacteristicsRangeViewModel(
                                 ViewData,

--- a/web/src/Web.App/Views/SchoolComparatorsCreateBy/Preview.cshtml
+++ b/web/src/Web.App/Views/SchoolComparatorsCreateBy/Preview.cshtml
@@ -153,10 +153,6 @@
                                 {
                                     <p class="govuk-body">Gross internal floor area:</p>
                                 }
-                                @if (Model.OfstedRatingSelected)
-                                {
-                                    <p class="govuk-body">Ofsted rating:</p>
-                                }
                                 @if (Model.SchoolsInTrustSelected)
                                 {
                                     <p class="govuk-body">Number of schools within trust:</p>
@@ -263,10 +259,6 @@
                                 @if (Model.InternalFloorAreaSelected)
                                 {
                                     <p class="govuk-body">@characteristic.TotalInternalFloorArea.GetValueOrDefault().ToNumberSeparator()</p>
-                                }
-                                @if (Model.OfstedRatingSelected)
-                                {
-                                    <p class="govuk-body">@characteristic.OfstedDescription</p>
                                 }
                                 @if (Model.SchoolsInTrustSelected)
                                 {

--- a/web/src/Web.App/Views/Shared/_SchoolKeyInformation.cshtml
+++ b/web/src/Web.App/Views/Shared/_SchoolKeyInformation.cshtml
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row govuk-!-margin-bottom-5">
     <div class="govuk-grid-column-full">
-        <ul class="app-headline app-headline-4 govuk-!-text-align-centre govuk-!-margin-0">
+        <ul class="app-headline app-headline-3 govuk-!-text-align-centre govuk-!-margin-0">
             <li class="app-headline-figures">
                 <p class="govuk-body-l govuk-!-font-weight-bold govuk-!-margin-bottom-4">In year balance</p>
                 <p class="govuk-body-l govuk-!-margin-bottom-2">@Model.InYearBalance.ToCurrency(0)</p>
@@ -11,10 +11,6 @@
             <li class="app-headline-figures">
                 <p class="govuk-body-l govuk-!-font-weight-bold govuk-!-margin-bottom-4">Revenue reserve</p>
                 <p class="govuk-body-l govuk-!-margin-bottom-2">@Model.RevenueReserve.ToCurrency(0)</p>
-            </li>
-            <li class="app-headline-figures">
-                <p class="govuk-body-l govuk-!-font-weight-bold govuk-!-margin-bottom-4">Ofsted rating</p>
-                <p class="govuk-body-l govuk-!-margin-bottom-2">@Model.OfstedRating</p>
             </li>
             <li class="app-headline-figures">
                 <p class="govuk-body-l govuk-!-font-weight-bold govuk-!-margin-bottom-4">School phase</p>

--- a/web/tests/Web.E2ETests/Features/School/SchoolFinancialBenchmarkingInsightsSummary.feature
+++ b/web/tests/Web.E2ETests/Features/School/SchoolFinancialBenchmarkingInsightsSummary.feature
@@ -10,7 +10,6 @@ So that I can see how my school is performing from a financial point of view and
           | Name            | Value    |
           | In year balance | £27,196  |
           | Revenue reserve | £162,440 |
-          | Ofsted rating   | Good     |
           | School phase    | Primary  |
         And I should see the following boxes displayed under Spend in priority areas
           | Name                                | Tag           | Value                                                  |
@@ -35,7 +34,6 @@ So that I can see how my school is performing from a financial point of view and
           | Name            | Value     |
           | In year balance | £95,414   |
           | Revenue reserve | £212,906  |
-          | Ofsted rating   | Good      |
           | School phase    | Secondary |
         And I should see the warning message under Spend in priority areas
         And I should see the warning message under Other top spending priorities

--- a/web/tests/Web.E2ETests/Pages/School/SchoolFinancialBenchmarkingInsightsSummaryPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/SchoolFinancialBenchmarkingInsightsSummaryPage.cs
@@ -74,7 +74,7 @@ public class SchoolFinancialBenchmarkingInsightsSummaryPage(IPage page, IRespons
     public async Task KeyInformationShouldBeVisible()
     {
         await KeyInformationSection.ShouldBeVisible();
-        Assert.Equal(4, await KeyInformationContent.Count());
+        Assert.Equal(3, await KeyInformationContent.Count());
         foreach (var item in await KeyInformationContent.AllAsync())
         {
             await item.ShouldBeVisible();

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -156,7 +156,7 @@ public static class Selectors
     public const string FbisOtherPriorityAreas = "#priority-areas-other-section";
     public const string FbisPupilWorkforce = "#pupil-workforce-metrics-section";
     public const string FbisNextSteps = "#next-steps-section";
-    public const string KeyInformationContent = "ul.app-headline.app-headline-4 li";
+    public const string KeyInformationContent = "ul.app-headline.app-headline-3 li";
     public const string PriorityAreaTeachingSupportStaff = "#spending-priorities-teaching-and-teaching-support-staff";
     public const string PriorityAreaNonEducationSupportStaff = "#spending-priorities-non-educational-support-staff-and-services";
     public const string PriorityAreaAdministrativeSupplies = "#spending-priorities-administrative-supplies";

--- a/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingDetails.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingDetails.cs
@@ -3,7 +3,6 @@ using AngleSharp.Html.Dom;
 using AutoFixture;
 using Web.App.Domain;
 using Xunit;
-
 namespace Web.Integration.Tests.Pages.Schools;
 
 public class WhenViewingDetails(SchoolBenchmarkingWebAppClient client) : PageBase<SchoolBenchmarkingWebAppClient>(client)
@@ -63,7 +62,6 @@ public class WhenViewingDetails(SchoolBenchmarkingWebAppClient client) : PageBas
                 .With(x => x.FinanceType, financeType)
                 .With(x => x.TrustCompanyNumber, "1223545")
                 .With(x => x.TrustName, "Test Trust")
-                .With(x => x.OfstedDescription, "0")
                 .Create();
 
         var page = await Client

--- a/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingFinancialBenchmarkingInsightsSummary.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingFinancialBenchmarkingInsightsSummary.cs
@@ -228,7 +228,6 @@ public class WhenViewingFinancialBenchmarkingInsightsSummary(SchoolBenchmarkingW
         Assert.Equal([
             $"In year balance  £{balance.InYearBalance}",
             $"Revenue reserve  £{balance.RevenueReserve}",
-            $"Ofsted rating  {school.OfstedDescription}",
             $"School phase  {school.OverallPhase}"
         ], headlineFiguresTexts);
 

--- a/web/tests/Web.Tests/Infrastructure/Apis/Requests/GivenAPostSchoolComparatorsRequest.cs
+++ b/web/tests/Web.Tests/Infrastructure/Apis/Requests/GivenAPostSchoolComparatorsRequest.cs
@@ -258,40 +258,6 @@ public class GivenAPostSchoolComparatorsRequest
     }
 
     [Theory]
-    [InlineData("false", null, null)]
-    [InlineData("true", new[]
-    {
-        "Good"
-    }, new[]
-    {
-        "Good"
-    })]
-    [InlineData("true", new[]
-    {
-        "Requires improvement",
-        "Inadequate"
-    }, new[]
-    {
-        "Requires improvement",
-        "Inadequate"
-    })]
-    public void MapsOfstedDescription(string? selected, string[]? values, string[]? expected)
-    {
-        // arrange
-        var viewModel = new UserDefinedSchoolCharacteristicViewModel
-        {
-            OfstedRating = selected,
-            OfstedRatings = values ?? []
-        };
-
-        // act
-        var actual = new PostSchoolComparatorsRequest(LAName, viewModel).OfstedDescription;
-
-        // assert
-        Assert.Equal(expected, actual?.Values);
-    }
-
-    [Theory]
     [InlineData("false", null, null, null, null)]
     [InlineData("true", 123, 456, 123, 456)]
     public void MapsTotalPupils(string? selected, int? from, int? to, int? expectedFrom, int? expectedTo)


### PR DESCRIPTION
### Context
[AB#240745](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/240745) [AB#239852](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/239852)

### Change proposed in this pull request
This does not remove the fields from underlying domain models, as the response is still returned by the dependent APIs. Only the view models and views themselves, as well as tests, are affected.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

