### PR TITLE
Publish documentation to SharePoint using PowerShell PnP

### DIFF
--- a/pipelines/common/publish-sharepoint-artifacts.yaml
+++ b/pipelines/common/publish-sharepoint-artifacts.yaml
@@ -1,0 +1,29 @@
+parameters:
+  ArtifactName: ''
+  ArtifactPattern: '**'
+  TargetPath: ''
+  SiteUrl: ''
+  ClientId: ''
+  ClientSecret: ''
+
+steps:
+  - task: DownloadPipelineArtifact@2
+    displayName: 'Download build artifacts'
+    inputs:
+      buildType: current
+      targetPath: $(Agent.TempDirectory)/artifacts
+      artifactName: ${{ parameters.ArtifactName }}
+      itemPattern: ${{ parameters.ArtifactPattern }}
+  
+  - task: PowerShell@2
+    displayName: 'Upload files to SharePoint'
+    inputs:
+      targetType: 'filePath'
+      filePath: $(Build.SourcesDirectory)/pipelines/common/scripts/UploadToSharePoint.ps1
+      arguments: > 
+        -SiteUrl "${{ parameters.SiteUrl }}"
+        -ClientId "${{ parameters.ClientId }}"
+        -ClientSecret "${{ parameters.ClientSecret }}"
+        -LibraryName "Documents"
+        -SourceFolderPath: "$(Agent.TempDirectory)/artifacts"
+        -TargetFolderPath "${{ parameters.TargetPath }}"

--- a/pipelines/common/scripts/UploadToSharePoint.ps1
+++ b/pipelines/common/scripts/UploadToSharePoint.ps1
@@ -1,0 +1,104 @@
+<#
+    .SYNOPSIS
+        Uploads files to SharePoint
+
+    .PARAMETER SiteUrl
+        The Url of the site collection or subsite to connect to, i.e. tenant.sharepoint.com, https://tenant.sharepoint.com, tenant.sharepoint.com/sites/hr, etc.
+
+    .PARAMETER ClientId
+        The Client ID of the Azure AD Application.
+
+    .PARAMETER ClientSecret
+        The client secret to use. When using this, technically an Azure Access Control Service (ACS) authentication will take place. This effectively means only cmdlets that are connecting to SharePoint Online will work. Cmdlets using Microsoft Graph or any other API behind the scenes will not work.
+
+    .PARAMETER LibraryName
+        Target library to where files should be uploaded.
+
+    .PARAMETER TargetFolderPath
+        Target path within library to where files should be uploaded.
+
+    .PARAMETER SourceFolderPath
+        Path containing source files to upload.
+#>
+
+Param (
+    [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()]
+    [String] $SiteUrl,
+    [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()]
+    [String] $ClientId,
+    [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()]
+    [String] $ClientSecret,
+    [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()]
+    [String] $LibraryName,
+    [Parameter(Mandatory = $false)][ValidateNotNullOrEmpty()]
+    [String] $TargetFolderPath,
+    [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()]
+    [String] $SourceFolderPath
+)
+
+Install-Module -Name PnP.PowerShell -Force -AllowClobber -Scope CurrentUser
+Import-Module PnP.PowerShell
+
+# see: https://www.sharepointdiary.com/2019/03/sharepoint-online-migrate-folder-with-files-subfolders-using-powershell.html
+$TargetFolderURL = ""
+$ItemName = ""
+Try {
+    Write-Host "Connecting to $SiteUrl"
+    Connect-PnPOnline -Url $SiteUrl -ClientId $ClientId -ClientSecret $ClientSecret -WarningAction Ignore 
+
+    # Get the Target Folder to Upload
+    Write-Host "Resolving list $LibraryName"
+    $Web = Get-PnPWeb
+    $List = Get-PnPList $LibraryName -Includes RootFolder
+    $TargetFolder = $List.RootFolder
+    $TargetFolderSiteRelativeURL = $TargetFolder.ServerRelativeURL.Replace($Web.ServerRelativeUrl, [string]::Empty)
+
+    If ($TargetFolderPath) {
+        $TargetFolderSiteRelativeURL += "/" + $TargetFolderPath.Replace("\", "/")
+    }
+
+    # Get All Items from the Source
+    Write-Host "Getting source files from $SourceFolderPath"
+    $Source = Get-ChildItem -Path $SourceFolderPath -Recurse
+    $SourceItems = $Source | Select-Object FullName, PSIsContainer, @{Label = 'TargetItemURL'; Expression = { $_.FullName.Replace($SourceFolderPath, $TargetFolderSiteRelativeURL).Replace("\", "/") } }
+    Write-Host "$($SourceItems.Count) files(s) found to upload"
+
+    # Upload Source Items from Fileshare to Target SharePoint Online document library
+    $Counter = 1
+    $SourceItems | ForEach-Object {
+        # Calculate Target Folder URL
+        $TargetFolderURL = (Split-Path $_.TargetItemURL -Parent).Replace("\", "/")
+        $ItemName = Split-Path $_.FullName -leaf
+                
+        # Replace Invalid Characters
+        $ItemName = [RegEx]::Replace($ItemName, "[{0}]" -f ([RegEx]::Escape([String]'\*:<>?/\|')), '_')
+
+        # Display Progress bar
+        $Status = "uploading '" + $ItemName + "' to " + $TargetFolderURL + " ($($Counter) of $($SourceItems.Count))"
+        Write-Progress -Activity "Uploading ..." -Status $Status -PercentComplete (($Counter / $SourceItems.Count) * 100)
+
+        If ($_.PSIsContainer) {
+            # Ensure Folder
+            $null = Resolve-PnPFolder -SiteRelativePath ($TargetFolderURL + "/" + $ItemName)
+            Write-Host "Ensured folder '$($ItemName)' exists at $($Web.Url)/$TargetFolderURL"
+        }
+        Else {
+            # Upload File
+            If ($TargetFolderURL.StartsWith("/")) { 
+                $TargetFolderURL = $TargetFolderURL.Remove(0, 1) 
+            }
+
+            $null = Add-PnPFile -Path $_.FullName -Folder $TargetFolderURL
+            Write-Host "Uploaded '$($_.FullName)' to $($Web.Url)/$TargetFolderURL"
+        }
+        
+        $Counter++
+    }
+}
+Catch {
+    If ($ItemName) {
+        Write-Host "$ItemName could not be uploaded to $($Web.Url)/$TargetFolderURL" -ForegroundColor Red
+    }
+
+    Write-Error "Unable to upload file(s): $_"
+}

--- a/pipelines/documentation/build.yaml
+++ b/pipelines/documentation/build.yaml
@@ -21,6 +21,7 @@ variables:
     value: '$(System.DefaultWorkingDirectory)/$(WorkingDir)'
   - name: DataDir
     value: '$(FullWorkingDir)/tools'
+  - group: 'sharepoint'
 
 stages:
   - stage: Validate
@@ -117,3 +118,18 @@ stages:
               targetPath: '$(WorkingDir)/pub'
               artifact: 'docs'
               publishLocation: 'pipeline'
+              
+      - job: SharePointPublish
+        displayName: 'Publish artifacts to SharePoint'
+        dependsOn: [ BuildDocumentation ]
+        steps:
+          - checkout: self
+
+          - template: ..\common\publish-sharepoint-artifacts.yaml
+            parameters:
+              ArtifactName: 'docs'
+              ArtifactPattern: '**/*.pdf'
+              TargetPath: 'FBIT support\Documentation'
+              SiteUrl: $(SharePoint_SiteUrl)
+              ClientId: $(SharePoint_ClientId)
+              ClientSecret: $(SharePoint_ClientSecret)


### PR DESCRIPTION
### Context
[AB#238665](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/238665) [AB#209098](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/209098)

### Change proposed in this pull request
Documentation pipeline addition to push `.pdf` artifacts to SharePoint using the Enterprise Application credentials maintained in the `sharepoint` variable library.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~~Your code builds clean without any errors or warnings~~
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

