### PR TITLE
fix: maximum decimal places for percentages

### DIFF
--- a/front-end-components/src/components/charts/utils.test.ts
+++ b/front-end-components/src/components/charts/utils.test.ts
@@ -220,13 +220,14 @@ describe("Chart utils", () => {
 
     describe("with percent option", () => {
       const theories: { input: ValueFormatterValue; expected: string }[] = [
-        { input: -987.65, expected: "-988%" },
+        { input: -987.65, expected: "-987.7%" },
         { input: 0, expected: "0%" },
         { input: 1, expected: "1%" },
-        { input: 2.3456789, expected: "2%" },
-        { input: 12345.67, expected: "12,346%" },
+        { input: 2.3456789, expected: "2.3%" },
+        { input: 12345.67, expected: "12,345.7%" },
         { input: 890123456, expected: "890,123,456%" },
         { input: "not-a-number", expected: "not-a-number" },
+        { input: 0.28, expected: "0.3%" },
       ];
 
       const options: Partial<ValueFormatterOptions> = { valueUnit: "%" };

--- a/front-end-components/src/components/charts/utils.ts
+++ b/front-end-components/src/components/charts/utils.ts
@@ -71,7 +71,8 @@ export function statValueFormatter(
           : undefined,
     currency: options?.valueUnit === "currency" ? "GBP" : undefined,
     currencyDisplay: options?.currencyAsName ? "name" : "symbol",
-    maximumFractionDigits: options?.compact ? undefined : 0,
+    maximumFractionDigits:
+      options?.valueUnit === "%" ? 1 : options?.compact ? undefined : 0,
   })
     .format(options?.valueUnit === "%" ? value / 100 : value)
     .toLowerCase();

--- a/web/src/Web.App/Extensions/DecimalExtensions.cs
+++ b/web/src/Web.App/Extensions/DecimalExtensions.cs
@@ -14,7 +14,7 @@ public static class DecimalExtensions
 
     public static string ToPercent(this decimal? value) => value.HasValue ? value.Value.ToPercent() : string.Empty;
 
-    public static string ToPercent(this decimal value) => $"{value:0.##}%";
+    public static string ToPercent(this decimal value) => $"{value:0.#}%";
 
     public static string ToAge(this decimal? value) => value.HasValue ? value.Value.ToAge() : string.Empty;
     public static string ToAge(this decimal value)

--- a/web/tests/Web.E2ETests/Features/School/SchoolFinancialBenchmarkingInsightsSummary.feature
+++ b/web/tests/Web.E2ETests/Features/School/SchoolFinancialBenchmarkingInsightsSummary.feature
@@ -14,12 +14,12 @@ So that I can see how my school is performing from a financial point of view and
         And I should see the following boxes displayed under Spend in priority areas
           | Name                                | Tag           | Value                                                  |
           | Teaching and teaching support staff | High priority | £6,315 per pupil; higher than 99% of similar schools.  |
-          | Non-educational support staff       | High priority | £845 per pupil; higher than 95.67% of similar schools. |
+          | Non-educational support staff       | High priority | £845 per pupil; higher than 95.7% of similar schools. |
           | Administrative supplies             | High priority | £429 per pupil; higher than 99% of similar schools.    |
         And I should see the following top 3 spending priorities for my school under Other top spending priorities
           | Name                        | Tag           | Value                                                  |
           | Educational supplies        | High priority | £407 per pupil; higher than 99% of similar schools.    |
-          | Catering staff and supplies | High priority | £363 per pupil; higher than 92.33% of similar schools. |
+          | Catering staff and supplies | High priority | £363 per pupil; higher than 92.3% of similar schools. |
           | Premises staff and services | High priority | £93 per sq. metre; higher than 99% of similar schools. |
         And I should see the following boxes displayed under Pupil and workforce metrics
           | Name                                   | Value                                      | Comparison                                                                  |

--- a/web/tests/Web.E2ETests/Features/School/SchoolHome.feature
+++ b/web/tests/Web.E2ETests/Features/School/SchoolHome.feature
@@ -55,7 +55,7 @@
         Then the RAG commentary for each priority category is
           | Name                                | Commentary                                                                               |
           | Teaching and Teaching support staff | High priority Spends £6,315 per pupil — Spending is higher than 99% of similar schools.  |
-          | Non-educational support staff       | High priority Spends £845 per pupil — Spending is higher than 95.67% of similar schools. |
+          | Non-educational support staff       | High priority Spends £845 per pupil — Spending is higher than 95.7% of similar schools. |
           | Administrative supplies             | High priority Spends £429 per pupil — Spending is higher than 99% of similar schools.    |
 
     Scenario: RAG guidance is displayed

--- a/web/tests/Web.E2ETests/Features/School/SpendingCosts.feature
+++ b/web/tests/Web.E2ETests/Features/School/SpendingCosts.feature
@@ -18,13 +18,13 @@
         Then the RAG commentary for each category is
           | Name                                | Commentary                                         |
           | Teaching and Teaching support staff | Spending is higher than 99% of similar schools.    |
-          | Non-educational support staff       | Spending is higher than 95.67% of similar schools. |
+          | Non-educational support staff       | Spending is higher than 95.7% of similar schools. |
           | Administrative supplies             | Spending is higher than 99% of similar schools.    |
           | Educational supplies                | Spending is higher than 99% of similar schools.    |
-          | Catering staff and supplies         | Spending is higher than 92.33% of similar schools. |
+          | Catering staff and supplies         | Spending is higher than 92.3% of similar schools. |
           | Premises staff and services         | Spending is higher than 99% of similar schools.    |
           | Utilities                           | Spending is higher than 39% of similar schools.    |
-          | Educational ICT                     | Spending is less than 77.67% of similar schools.   |
+          | Educational ICT                     | Spending is less than 77.7% of similar schools.   |
 
     Scenario: Categories have the correct commercial resources
         Given I am on spending and costs page for school with URN '777042'


### PR DESCRIPTION
### Context
[AB#217223](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/217223) - [AB#240769](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/240769)

### Change proposed in this pull request
web
- updates `ToPercent` extension method to return a maximum of one decimal place.
- updates E2E tests following the above change

front-end-components
- updates  `statValueFormatter` to return maximum of one decimal place when `options.valueUnit` is `"%"`
- updates unit tests following the above change

### Guidance to review 
Following these changes the key information section for the school home page and the priority headline for each chart on the spending and costs page should correctly show percentages to a maximum of one decimal place. 

Also for the historic page the `chart-stat-value` div of the `historic-chart-composed` component should now also only show to a maximum of one decimal place when viewing by a % dimension, matching the tooltip already shown on the chart itself.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

