### PR TITLE
New version of historic view/composed chart/tooltip components that supports three series

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -101,7 +101,7 @@
     ></div>-->
     <!--<div id="compare-your-costs" data-type="school" data-id="143996"></div>-->
     <!--<div id="historic-data" data-type="school" data-id="990095"></div>-->
-    <div id="historic-data-2" data-type="school" data-id="123456"></div>
+    <div id="historic-data-2" data-type="school" data-id="123456" data-phase="Primary" data-finance-type="Maintained"></div>
     <!--<div
       id="compare-your-costs"
       data-type="local-authority"

--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -99,8 +99,8 @@
       data-id="02387916"
       data-phases='["Secondary","Primary","Post-16"]'
     ></div>-->
-   <div id="compare-your-costs" data-type="school" data-id="143996"></div>
-    <!--<div id="historic-data" data-type="school" data-id="990095"></div>-->
+    <!--<div id="compare-your-costs" data-type="school" data-id="143996"></div>-->
+    <div id="historic-data" data-type="school" data-id="123456"></div>
     <!--<div
       id="compare-your-costs"
       data-type="local-authority"

--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -100,7 +100,8 @@
       data-phases='["Secondary","Primary","Post-16"]'
     ></div>-->
     <!--<div id="compare-your-costs" data-type="school" data-id="143996"></div>-->
-    <div id="historic-data" data-type="school" data-id="123456"></div>
+    <!--<div id="historic-data" data-type="school" data-id="990095"></div>-->
+    <div id="historic-data-2" data-type="school" data-id="123456"></div>
     <!--<div
       id="compare-your-costs"
       data-type="local-authority"

--- a/front-end-components/src/components/charts/historic-data-tooltip/component.tsx
+++ b/front-end-components/src/components/charts/historic-data-tooltip/component.tsx
@@ -45,9 +45,11 @@ export function HistoricDataTooltip<
               {dimension}
             </th>
             <td className="govuk-table__cell">
-              {valueFormatter
-                ? valueFormatter(school, { valueUnit })
-                : String(school)}
+              {school === undefined
+                ? ""
+                : valueFormatter
+                  ? valueFormatter(school, { valueUnit })
+                  : String(school)}
             </td>
           </tr>
           <tr className="govuk-table__row">
@@ -55,9 +57,11 @@ export function HistoricDataTooltip<
               Average across comparator set
             </th>
             <td className="govuk-table__cell">
-              {valueFormatter
-                ? valueFormatter(comparatorSetAverage, { valueUnit })
-                : String(comparatorSetAverage)}
+              {comparatorSetAverage === undefined
+                ? ""
+                : valueFormatter
+                  ? valueFormatter(comparatorSetAverage, { valueUnit })
+                  : String(comparatorSetAverage)}
             </td>
           </tr>
           <tr className="govuk-table__row">
@@ -65,9 +69,11 @@ export function HistoricDataTooltip<
               National average across phase type
             </th>
             <td className="govuk-table__cell">
-              {valueFormatter
-                ? valueFormatter(nationalAverage, { valueUnit })
-                : String(nationalAverage)}
+              {nationalAverage === undefined
+                ? ""
+                : valueFormatter
+                  ? valueFormatter(nationalAverage, { valueUnit })
+                  : String(nationalAverage)}
             </td>
           </tr>
         </tbody>

--- a/front-end-components/src/components/charts/historic-data-tooltip/component.tsx
+++ b/front-end-components/src/components/charts/historic-data-tooltip/component.tsx
@@ -1,0 +1,77 @@
+import {
+  NameType,
+  ValueType,
+} from "recharts/types/component/DefaultTooltipContent";
+import { HistoricTooltipProps } from "src/components/charts/historic-data-tooltip";
+import { SchoolHistoryValue } from "src/composed/historic-chart-2-composed";
+import { ChartDataSeries } from "../types";
+
+export function HistoricDataTooltip<
+  TData extends ChartDataSeries,
+  TValue extends ValueType,
+  TName extends NameType,
+>({
+  active,
+  dimension,
+  payload,
+  valueFormatter,
+  valueUnit,
+}: HistoricTooltipProps<TData, TValue, TName>) {
+  if (!active || !payload || !payload.length) {
+    return null;
+  }
+
+  const { term, school, comparatorSetAverage, nationalAverage } = payload[0]
+    .payload as SchoolHistoryValue;
+  return (
+    <>
+      <table className="govuk-table govuk-table--small-text-until-tablet tooltip-table">
+        <caption className="govuk-table__caption govuk-table__caption--s">
+          {term}
+        </caption>
+        <thead className="govuk-table__head govuk-visually-hidden">
+          <tr className="govuk-table__row">
+            <th scope="col" className="govuk-table__header">
+              Item
+            </th>
+            <th scope="col" className="govuk-table__header">
+              Value
+            </th>
+          </tr>
+        </thead>
+        <tbody className="govuk-table__body">
+          <tr className="govuk-table__row">
+            <th scope="row" className="govuk-table__header">
+              {dimension}
+            </th>
+            <td className="govuk-table__cell">
+              {valueFormatter
+                ? valueFormatter(school, { valueUnit })
+                : String(school)}
+            </td>
+          </tr>
+          <tr className="govuk-table__row">
+            <th scope="row" className="govuk-table__header">
+              Average across comparator set
+            </th>
+            <td className="govuk-table__cell">
+              {valueFormatter
+                ? valueFormatter(comparatorSetAverage, { valueUnit })
+                : String(comparatorSetAverage)}
+            </td>
+          </tr>
+          <tr className="govuk-table__row">
+            <th scope="row" className="govuk-table__header">
+              National average across phase type
+            </th>
+            <td className="govuk-table__cell">
+              {valueFormatter
+                ? valueFormatter(nationalAverage, { valueUnit })
+                : String(nationalAverage)}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </>
+  );
+}

--- a/front-end-components/src/components/charts/historic-data-tooltip/index.tsx
+++ b/front-end-components/src/components/charts/historic-data-tooltip/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/components/charts/historic-data-tooltip/types";
+export * from "src/components/charts/historic-data-tooltip/component";

--- a/front-end-components/src/components/charts/historic-data-tooltip/types.tsx
+++ b/front-end-components/src/components/charts/historic-data-tooltip/types.tsx
@@ -1,0 +1,16 @@
+import { TooltipProps } from "recharts";
+import {
+  NameType,
+  ValueType,
+} from "recharts/types/component/DefaultTooltipContent";
+import { ChartDataSeries } from "../types";
+import { LineChartProps } from "../line-chart";
+
+export interface HistoricTooltipProps<
+  TData extends ChartDataSeries,
+  TValue extends ValueType,
+  TName extends NameType,
+> extends TooltipProps<TValue, TName>,
+    Pick<LineChartProps<TData>, "valueFormatter" | "valueUnit"> {
+  dimension: string;
+}

--- a/front-end-components/src/components/charts/line-chart/component.tsx
+++ b/front-end-components/src/components/charts/line-chart/component.tsx
@@ -35,6 +35,7 @@ function LineChartInner<TData extends ChartDataSeries>(
     keyField,
     labels,
     legend,
+    legendIconSize,
     legendIconType,
     legendHorizontalAlign,
     legendVerticalAlign,
@@ -203,7 +204,7 @@ function LineChartInner<TData extends ChartDataSeries>(
               formatter={(value) =>
                 (seriesConfig && seriesConfig[value]?.label) || value
               }
-              iconSize={30}
+              iconSize={legendIconSize || 30}
               iconType={
                 legendIconType
                   ? legendIconType == "default"

--- a/front-end-components/src/components/charts/line-chart/component.tsx
+++ b/front-end-components/src/components/charts/line-chart/component.tsx
@@ -23,11 +23,9 @@ import classNames from "classnames";
 import { useDownloadPngImage } from "src/hooks/useDownloadImage";
 
 function LineChartInner<TData extends ChartDataSeries>(
-  props: LineChartProps<TData>,
-  ref: ForwardedRef<ChartHandler>
-) {
-  const {
+  {
     chartName,
+    className,
     curveType,
     data,
     grid,
@@ -37,6 +35,9 @@ function LineChartInner<TData extends ChartDataSeries>(
     keyField,
     labels,
     legend,
+    legendIconType,
+    legendHorizontalAlign,
+    legendVerticalAlign,
     margin: _margin,
     multiLineAxisLabel,
     onImageLoading,
@@ -48,8 +49,9 @@ function LineChartInner<TData extends ChartDataSeries>(
     valueFormatter,
     valueLabel,
     valueUnit,
-  } = props;
-
+  }: LineChartProps<TData>,
+  ref: ForwardedRef<ChartHandler>
+) {
   const { downloadPng, ref: rechartsRef } = useDownloadPngImage({
     fileName: `${chartName}.png`,
     onImageLoading,
@@ -152,7 +154,7 @@ function LineChartInner<TData extends ChartDataSeries>(
             left: margin,
           }}
           ref={rechartsRef}
-          className="recharts-wrapper-line-chart"
+          className={classNames("recharts-wrapper-line-chart", className)}
         >
           {grid && <CartesianGrid vertical={false} />}
           <XAxis
@@ -196,13 +198,19 @@ function LineChartInner<TData extends ChartDataSeries>(
           {visibleSeriesNames.map(renderLine)}
           {legend && (
             <Legend
-              align="right"
-              verticalAlign="top"
+              align={legendHorizontalAlign || "right"}
+              verticalAlign={legendVerticalAlign || "top"}
               formatter={(value) =>
                 (seriesConfig && seriesConfig[value]?.label) || value
               }
               iconSize={30}
-              iconType="plainline"
+              iconType={
+                legendIconType
+                  ? legendIconType == "default"
+                    ? undefined
+                    : legendIconType
+                  : "plainline"
+              }
             />
           )}
         </RechartsLineChart>

--- a/front-end-components/src/components/charts/types.tsx
+++ b/front-end-components/src/components/charts/types.tsx
@@ -1,5 +1,10 @@
 import { Ref, SVGProps } from "react";
 import {
+  HorizontalAlignmentType,
+  IconType,
+  VerticalAlignmentType,
+} from "recharts/types/component/DefaultLegendContent";
+import {
   NameType,
   ValueType,
 } from "recharts/types/component/DefaultTooltipContent";
@@ -10,6 +15,7 @@ export interface ChartProps<TData extends ChartDataSeries>
   extends ValueFormatterProps {
   barCategoryGap?: string | number;
   chartName: string;
+  className?: string;
   data: TData[];
   grid?: boolean;
   hideXAxis?: boolean;
@@ -20,6 +26,9 @@ export interface ChartProps<TData extends ChartDataSeries>
   keyField: keyof TData;
   labels?: boolean;
   legend?: boolean;
+  legendIconType?: IconType | "default";
+  legendHorizontalAlign?: HorizontalAlignmentType;
+  legendVerticalAlign?: VerticalAlignmentType;
   margin?: number;
   multiLineAxisLabel?: boolean;
   onImageLoading?: (loading: boolean) => void;

--- a/front-end-components/src/components/charts/types.tsx
+++ b/front-end-components/src/components/charts/types.tsx
@@ -26,6 +26,7 @@ export interface ChartProps<TData extends ChartDataSeries>
   keyField: keyof TData;
   labels?: boolean;
   legend?: boolean;
+  legendIconSize?: number;
   legendIconType?: IconType | "default";
   legendHorizontalAlign?: HorizontalAlignmentType;
   legendVerticalAlign?: VerticalAlignmentType;

--- a/front-end-components/src/composed/historic-chart-2-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-2-composed/component.tsx
@@ -9,7 +9,7 @@ import {
   shortValueFormatter,
   fullValueFormatter,
 } from "src/components/charts/utils.ts";
-import { ChartProps, ValueFormatterValue } from "src/components/charts/types";
+import { ChartProps } from "src/components/charts/types";
 import { ChartDimensionContext, useChartModeContext } from "src/contexts";
 import { SchoolHistoryBase } from "src/services";
 import { HistoricDataTooltip } from "src/components/charts/historic-data-tooltip";
@@ -47,13 +47,22 @@ export function HistoricChart2<TData extends SchoolHistoryBase>({
       result.push({
         year,
         term: s.term,
-        school: !schoolValue || isNaN(schoolValue) ? undefined : schoolValue,
+        school:
+          schoolValue === undefined ||
+          schoolValue === null ||
+          isNaN(schoolValue)
+            ? undefined
+            : schoolValue,
         comparatorSetAverage:
-          !comparatorSetAverageValue || isNaN(comparatorSetAverageValue)
+          comparatorSetAverageValue === undefined ||
+          comparatorSetAverageValue === null ||
+          isNaN(comparatorSetAverageValue)
             ? undefined
             : comparatorSetAverageValue,
         nationalAverage:
-          !nationalAverageValue || isNaN(nationalAverageValue)
+          nationalAverageValue === undefined ||
+          nationalAverageValue === null ||
+          isNaN(nationalAverageValue)
             ? undefined
             : nationalAverageValue,
       });
@@ -120,28 +129,77 @@ export function HistoricChart2<TData extends SchoolHistoryBase>({
             <table className="govuk-table">
               <thead className="govuk-table__head">
                 <tr className="govuk-table__row">
-                  <th className="govuk-table__header govuk-!-width-one-half">
-                    Year
-                  </th>
+                  <th className="govuk-table__header">Year</th>
                   <th className="govuk-table__header">
                     {columnHeading ?? dimension.heading}
+                  </th>
+                  <th className="govuk-table__header">
+                    Average across comparator set
+                  </th>
+                  <th className="govuk-table__header">
+                    National average across phase type
                   </th>
                 </tr>
               </thead>
               <tbody className="govuk-table__body">
-                {data.school?.map((item) => (
-                  <tr className="govuk-table__row" key={item.year}>
-                    <td className="govuk-table__cell">{String(item.term)}</td>
-                    <td className="govuk-table__cell">
-                      {fullValueFormatter(
-                        item[valueField] as ValueFormatterValue,
-                        {
-                          valueUnit: valueUnit ?? dimension.unit,
-                        }
-                      )}
-                    </td>
-                  </tr>
-                ))}
+                {data.school?.map((item) => {
+                  const year = item.year;
+                  const schoolValue = item[valueField] as number;
+                  const comparatorSetAverage = data.comparatorSetAverage?.find(
+                    (c) => c.year == year
+                  );
+                  const comparatorSetAverageValue = comparatorSetAverage
+                    ? (comparatorSetAverage[valueField] as number)
+                    : undefined;
+                  const nationalAverage = data.nationalAverage?.find(
+                    (c) => c.year == year
+                  );
+                  const nationalAverageValue = nationalAverage
+                    ? (nationalAverage[valueField] as number)
+                    : undefined;
+
+                  return (
+                    <tr className="govuk-table__row" key={year}>
+                      <td className="govuk-table__cell">{String(item.term)}</td>
+                      <td className="govuk-table__cell">
+                        {fullValueFormatter(
+                          schoolValue === undefined ||
+                            schoolValue === null ||
+                            isNaN(schoolValue)
+                            ? undefined
+                            : schoolValue,
+                          {
+                            valueUnit: valueUnit ?? dimension.unit,
+                          }
+                        )}
+                      </td>
+                      <td className="govuk-table__cell">
+                        {fullValueFormatter(
+                          comparatorSetAverageValue === undefined ||
+                            comparatorSetAverageValue === null ||
+                            isNaN(comparatorSetAverageValue)
+                            ? undefined
+                            : comparatorSetAverageValue,
+                          {
+                            valueUnit: valueUnit ?? dimension.unit,
+                          }
+                        )}
+                      </td>
+                      <td className="govuk-table__cell">
+                        {fullValueFormatter(
+                          nationalAverageValue === undefined ||
+                            nationalAverageValue === null ||
+                            isNaN(nationalAverageValue)
+                            ? undefined
+                            : nationalAverageValue,
+                          {
+                            valueUnit: valueUnit ?? dimension.unit,
+                          }
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>

--- a/front-end-components/src/composed/historic-chart-2-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-2-composed/component.tsx
@@ -8,11 +8,13 @@ import { LineChart } from "src/components/charts/line-chart";
 import {
   shortValueFormatter,
   fullValueFormatter,
+  statValueFormatter,
 } from "src/components/charts/utils.ts";
 import { ChartProps } from "src/components/charts/types";
 import { ChartDimensionContext, useChartModeContext } from "src/contexts";
 import { SchoolHistoryBase } from "src/services";
 import { HistoricDataTooltip } from "src/components/charts/historic-data-tooltip";
+import { ResolvedStat } from "src/components/charts/resolved-stat";
 
 export function HistoricChart2<TData extends SchoolHistoryBase>({
   axisLabel,
@@ -22,6 +24,7 @@ export function HistoricChart2<TData extends SchoolHistoryBase>({
   data,
   legend,
   legendHorizontalAlign,
+  legendIconSize,
   legendIconType,
   legendVerticalAlign,
   valueField,
@@ -75,16 +78,16 @@ export function HistoricChart2<TData extends SchoolHistoryBase>({
   }, [data, valueField]);
 
   const seriesConfig: ChartProps<SchoolHistoryValue>["seriesConfig"] = {
-    school: {
-      label: dimension.label,
+    nationalAverage: {
+      label: "national average across phase type",
       visible: true,
     },
     comparatorSetAverage: {
       label: "average across comparator set",
       visible: true,
     },
-    nationalAverage: {
-      label: "national average across phase type",
+    school: {
+      label: dimension.label,
       visible: true,
     },
   };
@@ -123,6 +126,7 @@ export function HistoricChart2<TData extends SchoolHistoryBase>({
                   />
                 )}
                 legend={legend === undefined ? true : legend}
+                legendIconSize={legendIconSize || 24}
                 legendIconType={
                   legend === undefined ? "default" : legendIconType
                 }
@@ -139,22 +143,36 @@ export function HistoricChart2<TData extends SchoolHistoryBase>({
               />
             </div>
           </div>
-          <aside className="govuk-grid-column-one-quarter"></aside>
+          <aside className="govuk-grid-column-one-quarter">
+            <ResolvedStat
+              chartName={`Most recent ${chartName.toLowerCase()}`}
+              className="chart-stat-line-chart"
+              compactValue
+              data={data.school || []}
+              displayIndex={(data.school?.length || 0) - 1}
+              seriesLabelField="term"
+              valueField={valueField}
+              valueFormatter={statValueFormatter}
+              valueUnit={valueUnit ?? dimension.unit}
+            />
+          </aside>
         </div>
       ) : (
         <div className="govuk-grid-row">
-          <div className="govuk-grid-column-three-quarters">
+          <div className="govuk-grid-column-full">
             <table className="govuk-table">
               <thead className="govuk-table__head">
                 <tr className="govuk-table__row">
-                  <th className="govuk-table__header">Year</th>
-                  <th className="govuk-table__header">
+                  <th className="govuk-table__header govuk-!-width-one-quarter">
+                    Year
+                  </th>
+                  <th className="govuk-table__header govuk-!-width-one-quarter">
                     {columnHeading ?? dimension.heading}
                   </th>
-                  <th className="govuk-table__header">
+                  <th className="govuk-table__header govuk-!-width-one-quarter">
                     Average across comparator set
                   </th>
-                  <th className="govuk-table__header">
+                  <th className="govuk-table__header govuk-!-width-one-quarter">
                     National average across phase type
                   </th>
                 </tr>

--- a/front-end-components/src/composed/historic-chart-2-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-2-composed/component.tsx
@@ -15,14 +15,17 @@ import { SchoolHistoryBase } from "src/services";
 import { HistoricDataTooltip } from "src/components/charts/historic-data-tooltip";
 
 export function HistoricChart2<TData extends SchoolHistoryBase>({
-  chartName,
-  data,
-  valueField,
-  children,
-  valueUnit,
   axisLabel,
+  chartName,
+  children,
   columnHeading,
-  ...props
+  data,
+  legend,
+  legendHorizontalAlign,
+  legendIconType,
+  legendVerticalAlign,
+  valueField,
+  valueUnit,
 }: HistoricChart2Props<TData>) {
   const { chartMode } = useChartModeContext();
   const dimension = useContext(ChartDimensionContext);
@@ -102,7 +105,9 @@ export function HistoricChart2<TData extends SchoolHistoryBase>({
                 keyField="term"
                 margin={20}
                 seriesConfig={seriesConfig}
-                seriesLabel={axisLabel ?? dimension.label}
+                seriesLabel={
+                  axisLabel === undefined ? "" : (axisLabel ?? dimension.label)
+                }
                 seriesLabelField="term"
                 valueFormatter={shortValueFormatter}
                 valueUnit={valueUnit ?? dimension.unit}
@@ -117,7 +122,20 @@ export function HistoricChart2<TData extends SchoolHistoryBase>({
                     dimension={dimension.heading}
                   />
                 )}
-                {...props}
+                legend={legend === undefined ? true : legend}
+                legendIconType={
+                  legend === undefined ? "default" : legendIconType
+                }
+                legendHorizontalAlign={
+                  legendHorizontalAlign === undefined
+                    ? "center"
+                    : legendHorizontalAlign
+                }
+                legendVerticalAlign={
+                  legendVerticalAlign === undefined
+                    ? "bottom"
+                    : legendVerticalAlign
+                }
               />
             </div>
           </div>

--- a/front-end-components/src/composed/historic-chart-2-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-2-composed/component.tsx
@@ -9,10 +9,10 @@ import {
   shortValueFormatter,
   fullValueFormatter,
 } from "src/components/charts/utils.ts";
-//import { LineChartTooltip } from "src/components/charts/line-chart-tooltip";
 import { ChartProps, ValueFormatterValue } from "src/components/charts/types";
 import { ChartDimensionContext, useChartModeContext } from "src/contexts";
 import { SchoolHistoryBase } from "src/services";
+import { HistoricDataTooltip } from "src/components/charts/historic-data-tooltip";
 
 export function HistoricChart2<TData extends SchoolHistoryBase>({
   chartName,
@@ -97,18 +97,17 @@ export function HistoricChart2<TData extends SchoolHistoryBase>({
                 seriesLabelField="term"
                 valueFormatter={shortValueFormatter}
                 valueUnit={valueUnit ?? dimension.unit}
-                tooltip={
-                  () => null /*TODO (t) => (
-                  <LineChartTooltip
+                tooltip={(t) => (
+                  <HistoricDataTooltip
                     {...t}
                     valueFormatter={(v) =>
                       shortValueFormatter(v, {
                         valueUnit: valueUnit ?? dimension.unit,
                       })
                     }
+                    dimension={dimension.heading}
                   />
-                )*/
-                }
+                )}
                 {...props}
               />
             </div>

--- a/front-end-components/src/composed/historic-chart-2-composed/index.tsx
+++ b/front-end-components/src/composed/historic-chart-2-composed/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/composed/historic-chart-2-composed/types";
+export * from "src/composed/historic-chart-2-composed/component";

--- a/front-end-components/src/composed/historic-chart-2-composed/types.tsx
+++ b/front-end-components/src/composed/historic-chart-2-composed/types.tsx
@@ -11,6 +11,7 @@ export interface HistoricChart2Props<T extends SchoolHistoryBase>
   extends Pick<
     LineChartProps<T>,
     | "legend"
+    | "legendIconSize"
     | "legendIconType"
     | "legendHorizontalAlign"
     | "legendVerticalAlign"

--- a/front-end-components/src/composed/historic-chart-2-composed/types.tsx
+++ b/front-end-components/src/composed/historic-chart-2-composed/types.tsx
@@ -1,0 +1,31 @@
+import { ReactNode } from "react";
+import {
+  ChartSeriesValue,
+  ChartSeriesValueUnit,
+} from "src/components/charts/types";
+import { ResolvedStatProps } from "src/components/charts/resolved-stat";
+import { SchoolHistoryBase, SchoolHistoryComparison } from "src/services";
+import { LineChartProps } from "src/components/charts/line-chart";
+
+export interface HistoricChart2Props<T extends SchoolHistoryBase>
+  extends Pick<
+    LineChartProps<T>,
+    | "legend"
+    | "legendIconType"
+    | "legendHorizontalAlign"
+    | "legendVerticalAlign"
+  > {
+  chartName: string;
+  data: SchoolHistoryComparison<T>;
+  valueField: ResolvedStatProps<T>["valueField"];
+  children?: ReactNode;
+  valueUnit?: ChartSeriesValueUnit;
+  axisLabel?: string;
+  columnHeading?: string;
+}
+
+export type SchoolHistoryValue = SchoolHistoryBase & {
+  school?: ChartSeriesValue;
+  comparatorSetAverage?: ChartSeriesValue;
+  nationalAverage?: ChartSeriesValue;
+};

--- a/front-end-components/src/composed/historic-chart-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/component.tsx
@@ -87,7 +87,7 @@ export function HistoricChart<TData extends ChartDataSeries>({
               </thead>
               <tbody className="govuk-table__body">
                 {data.map((item) => (
-                  <tr className="govuk-table__row">
+                  <tr className="govuk-table__row" key={item.year as string}>
                     <td className="govuk-table__cell">{String(item.term)}</td>
                     <td className="govuk-table__cell">
                       {fullValueFormatter(item[valueField], {

--- a/front-end-components/src/constants.tsx
+++ b/front-end-components/src/constants.tsx
@@ -10,6 +10,7 @@ export const LineChart2SeriesElementId = "line-chart-2-series";
 export const VerticalBarChart2SeriesElementId = "vertical-chart-2-series";
 export const VerticalBarChart3SeriesElementId = "vertical-chart-3-series";
 export const HistoricDataElementId = "historic-data";
+export const HistoricData2ElementId = "historic-data-2";
 export const SpendingAndCostsComposedElementId = "spending-and-costs-composed";
 export const FindOrganisationElementId = "find-organisation";
 export const SchoolEstablishment = "school";

--- a/front-end-components/src/index.css
+++ b/front-end-components/src/index.css
@@ -28,6 +28,9 @@
   --focus-colour: #fd0;
   --warning-colour: #f47738;
   --warning-colour-bg: #ffe4c4;
+  --historic-chart-2-series-0-colour: #156082;
+  --historic-chart-2-series-1-colour: #e97132;
+  --historic-chart-2-series-2-colour: #196b24;
 }
 
 .govuk-table {
@@ -161,6 +164,31 @@
   stroke-width: 5;
 }
 
+.recharts-wrapper .chart-line.chart-line-series-2 path,
+.recharts-wrapper .chart-line.chart-line-series-2 .recharts-line-dot,
+.recharts-wrapper .recharts-default-legend .legend-item-2 line {
+  stroke: var(--series-2-colour);
+  stroke-width: 5;
+}
+
+.recharts-wrapper.historic-chart-2 .chart-line.chart-line-series-0 path,
+.recharts-wrapper.historic-chart-2 .chart-line.chart-line-series-0 .recharts-line-dot,
+.recharts-wrapper.historic-chart-2 .recharts-default-legend .legend-item-0 path {
+  stroke: var(--historic-chart-2-series-0-colour);
+}
+
+.recharts-wrapper.historic-chart-2 .chart-line.chart-line-series-1 path,
+.recharts-wrapper.historic-chart-2 .chart-line.chart-line-series-1 .recharts-line-dot,
+.recharts-wrapper.historic-chart-2 .recharts-default-legend .legend-item-1 path {
+  stroke: var(--historic-chart-2-series-1-colour);
+}
+
+.recharts-wrapper.historic-chart-2 .chart-line.chart-line-series-2 path,
+.recharts-wrapper.historic-chart-2 .chart-line.chart-line-series-2 .recharts-line-dot,
+.recharts-wrapper.historic-chart-2 .recharts-default-legend .legend-item-2 path {
+  stroke: var(--historic-chart-2-series-2-colour);
+}
+
 .recharts-wrapper .recharts-default-legend .recharts-legend-item-text {
   color: var(--label-colour) !important;
 }
@@ -173,6 +201,24 @@
 .recharts-wrapper .chart-active-dot.chart-active-dot-series-1,
 .recharts-wrapper .recharts-label-list .chart-label-series-1 {
   fill: var(--series-1-colour);
+}
+
+.recharts-wrapper.historic-chart-2 .chart-active-dot.chart-active-dot-series-0,
+.recharts-wrapper.historic-chart-2 .recharts-label-list .chart-label-series-0,
+.recharts-wrapper.historic-chart-2 .recharts-default-legend .legend-item-0 path  {
+  fill: var(--historic-chart-2-series-0-colour);
+}
+
+.recharts-wrapper.historic-chart-2 .chart-active-dot.chart-active-dot-series-1,
+.recharts-wrapper.historic-chart-2 .recharts-label-list .chart-label-series-1,
+.recharts-wrapper.historic-chart-2 .recharts-default-legend .legend-item-1 path {
+  fill: var(--historic-chart-2-series-1-colour);
+}
+
+.recharts-wrapper.historic-chart-2 .chart-active-dot.chart-active-dot-series-2,
+.recharts-wrapper.historic-chart-2 .recharts-label-list .chart-label-series-2,
+.recharts-wrapper.historic-chart-2 .recharts-default-legend .legend-item-2 path {
+  fill: var(--historic-chart-2-series-2-colour);
 }
 
 .recharts-wrapper .chart-active-tooltip {

--- a/front-end-components/src/index.css
+++ b/front-end-components/src/index.css
@@ -28,9 +28,9 @@
   --focus-colour: #fd0;
   --warning-colour: #f47738;
   --warning-colour-bg: #ffe4c4;
-  --historic-chart-2-series-0-colour: #156082;
+  --historic-chart-2-series-0-colour: #196b24;
   --historic-chart-2-series-1-colour: #e97132;
-  --historic-chart-2-series-2-colour: #196b24;
+  --historic-chart-2-series-2-colour: #156082;
 }
 
 .govuk-table {
@@ -177,6 +177,12 @@
   stroke: var(--historic-chart-2-series-0-colour);
 }
 
+.recharts-wrapper.historic-chart-2 .chart-line.chart-line-series-0 path,
+.recharts-wrapper.historic-chart-2 .chart-line.chart-line-series-1 path,
+.recharts-wrapper.historic-chart-2 .chart-line.chart-line-series-2 path {
+  stroke-opacity: 75%;
+}
+
 .recharts-wrapper.historic-chart-2 .chart-line.chart-line-series-1 path,
 .recharts-wrapper.historic-chart-2 .chart-line.chart-line-series-1 .recharts-line-dot,
 .recharts-wrapper.historic-chart-2 .recharts-default-legend .legend-item-1 path {
@@ -191,6 +197,12 @@
 
 .recharts-wrapper .recharts-default-legend .recharts-legend-item-text {
   color: var(--label-colour) !important;
+}
+
+.recharts-wrapper.historic-chart-2 .recharts-default-legend{
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: center;
 }
 
 .recharts-wrapper .chart-active-dot.chart-active-dot-series-0,

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -73,12 +73,17 @@ if (historicDataElement) {
 
 const historicData2Element = document.getElementById(HistoricData2ElementId);
 if (historicData2Element) {
-  const { type, id } = historicData2Element.dataset;
+  const { type, id, phase, financeType } = historicData2Element.dataset;
   if (type && id) {
     const root = ReactDOM.createRoot(historicData2Element);
     root.render(
       <React.StrictMode>
-        <HistoricData2 type={type} id={id} />
+        <HistoricData2
+          type={type}
+          id={id}
+          overallPhase={phase}
+          financeType={financeType}
+        />
       </React.StrictMode>
     );
   }

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -9,6 +9,7 @@ import {
   DeploymentPlan,
   FindOrganisation,
   HistoricData,
+  HistoricData2,
 } from "src/views";
 import {
   CompareCostsElementId,
@@ -16,6 +17,7 @@ import {
   DeploymentPlanElementId,
   FindOrganisationElementId,
   HistoricDataElementId,
+  HistoricData2ElementId,
   HorizontalBarChart1SeriesElementId,
   LineChart1SeriesElementId,
   SpendingAndCostsComposedElementId,
@@ -64,6 +66,19 @@ if (historicDataElement) {
     root.render(
       <React.StrictMode>
         <HistoricData type={type} id={id} />
+      </React.StrictMode>
+    );
+  }
+}
+
+const historicData2Element = document.getElementById(HistoricData2ElementId);
+if (historicData2Element) {
+  const { type, id } = historicData2Element.dataset;
+  if (type && id) {
+    const root = ReactDOM.createRoot(historicData2Element);
+    root.render(
+      <React.StrictMode>
+        <HistoricData2 type={type} id={id} />
       </React.StrictMode>
     );
   }

--- a/front-end-components/src/services/expenditure-api.tsx
+++ b/front-end-components/src/services/expenditure-api.tsx
@@ -61,31 +61,24 @@ export class ExpenditureApi {
       );
     }
 
-    const response = await fetch("/api/expenditure/history?" + params, {
-      redirect: "manual",
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Correlation-ID": uuidv4(),
-      },
-    });
+    const response = await fetch(
+      "/api/expenditure/history/comparison?" + params,
+      {
+        redirect: "manual",
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Correlation-ID": uuidv4(),
+        },
+      }
+    );
 
     const json = await response.json();
     if (json.error) {
       throw json.error;
     }
 
-    const school = json as SchoolExpenditureHistory[];
-    return {
-      school,
-      // for demo purposes
-      comparatorSetAverage: school.map((s, i) => {
-        return { ...s, totalExpenditure: s.totalExpenditure * i * 2 };
-      }),
-      nationalAverage: school.map((s, i) => {
-        return { ...s, totalExpenditure: (s.totalExpenditure * i) / 2 };
-      }),
-    };
+    return json;
   }
 
   static async query<T extends SchoolExpenditure>(

--- a/front-end-components/src/services/expenditure-api.tsx
+++ b/front-end-components/src/services/expenditure-api.tsx
@@ -47,12 +47,16 @@ export class ExpenditureApi {
     type: string,
     id: string,
     dimension: string,
+    overallPhase?: string,
+    financeType?: string,
     excludeCentralServices?: boolean
   ): Promise<SchoolHistoryComparison<SchoolExpenditureHistory>> {
     const params = new URLSearchParams({
       type: type,
       id: id,
       dimension: dimension,
+      phase: overallPhase || "",
+      financeType: financeType || "",
     });
     if (excludeCentralServices !== undefined) {
       params.append(

--- a/front-end-components/src/services/types.tsx
+++ b/front-end-components/src/services/types.tsx
@@ -283,10 +283,19 @@ export type SchoolExpenditureHistory = AdministrativeSuppliesExpenditureBase &
   PremisesStaffServicesExpenditureBase &
   TeachingSupportStaffExpenditureBase &
   TotalExpenditureExpenditureBase &
-  UtilitiesExpenditureBase & {
-    year: number;
-    term: string;
-  };
+  UtilitiesExpenditureBase &
+  SchoolHistoryBase;
+
+export type SchoolHistoryComparison<T extends SchoolHistoryBase> = {
+  school?: T[];
+  comparatorSetAverage?: T[];
+  nationalAverage?: T[];
+};
+
+export type SchoolHistoryBase = {
+  year: number;
+  term: string;
+};
 
 type BalanceBase = {
   inYearBalance: number;
@@ -311,10 +320,7 @@ export type TrustBalance = TrustBalanceBase & {
   trustName: string;
 };
 
-export type SchoolBalanceHistory = BalanceBase & {
-  year: number;
-  term: string;
-};
+export type SchoolBalanceHistory = BalanceBase & SchoolHistoryBase;
 
 type CensusBase = {
   urn: string;
@@ -335,10 +341,7 @@ export type Census = CensusBase & {
   laName: string;
 };
 
-export type CensusHistory = CensusBase & {
-  year: string;
-  term: string;
-};
+export type CensusHistory = CensusBase & SchoolHistoryBase;
 
 export type Income = {
   yearEnd: string;

--- a/front-end-components/src/views/historic-data-2/index.tsx
+++ b/front-end-components/src/views/historic-data-2/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/views/historic-data-2/types";
+export * from "src/views/historic-data-2/view";

--- a/front-end-components/src/views/historic-data-2/partials/index.tsx
+++ b/front-end-components/src/views/historic-data-2/partials/index.tsx
@@ -1,0 +1,2 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/views/historic-data-2/partials/spending-section.tsx";

--- a/front-end-components/src/views/historic-data-2/partials/spending-section-premises-services.tsx
+++ b/front-end-components/src/views/historic-data-2/partials/spending-section-premises-services.tsx
@@ -1,0 +1,30 @@
+import { HistoricChart2 } from "src/composed/historic-chart-2-composed";
+import {
+  SchoolExpenditureHistory,
+  SchoolHistoryComparison,
+} from "src/services";
+import { Loading } from "src/components/loading";
+
+export const SpendingSectionPremisesServices: React.FC<{
+  data: SchoolHistoryComparison<SchoolExpenditureHistory>;
+}> = ({ data }) => {
+  return (
+    <>
+      {data.school?.length ? (
+        <>
+          <HistoricChart2
+            chartName="Total premises staff and services costs"
+            data={data}
+            valueField="totalPremisesStaffServiceCosts"
+          >
+            <h3 className="govuk-heading-s">
+              Total premises staff and services costs
+            </h3>
+          </HistoricChart2>
+        </>
+      ) : (
+        <Loading />
+      )}
+    </>
+  );
+};

--- a/front-end-components/src/views/historic-data-2/partials/spending-section.tsx
+++ b/front-end-components/src/views/historic-data-2/partials/spending-section.tsx
@@ -13,6 +13,7 @@ import {
 import { ChartDimensionContext, useChartModeContext } from "src/contexts";
 import { HistoricChart2 } from "src/composed/historic-chart-2-composed";
 import { Loading } from "src/components/loading";
+import { SpendingSectionPremisesServices } from "./spending-section-premises-services";
 
 export const SpendingSection: React.FC<{ type: string; id: string }> = ({
   type,
@@ -69,17 +70,36 @@ export const SpendingSection: React.FC<{ type: string; id: string }> = ({
           chartName="Total expenditure"
           data={data}
           valueField="totalExpenditure"
-          legend
-          legendIconType="default"
-          legendHorizontalAlign="center"
-          legendVerticalAlign="bottom"
-          axisLabel=""
         >
           <h2 className="govuk-heading-m">Total expenditure</h2>
         </HistoricChart2>
       ) : (
         <Loading />
       )}
+      <div
+        className="govuk-accordion"
+        data-module="govuk-accordion"
+        id="accordion-expenditure"
+      >
+        <div className="govuk-accordion__section">
+          <div className="govuk-accordion__section-header">
+            <h2 className="govuk-accordion__section-heading">
+              <span
+                className="govuk-accordion__section-button"
+                id="accordion-expenditure-heading-1"
+              >
+                Premises staff and services
+              </span>
+            </h2>
+          </div>
+          <div
+            id="accordion-expenditure-content-1"
+            className="govuk-accordion__section-content"
+          >
+            <SpendingSectionPremisesServices data={data} />
+          </div>
+        </div>
+      </div>
     </ChartDimensionContext.Provider>
   );
 };

--- a/front-end-components/src/views/historic-data-2/partials/spending-section.tsx
+++ b/front-end-components/src/views/historic-data-2/partials/spending-section.tsx
@@ -1,0 +1,85 @@
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  Actual,
+  ChartDimensions,
+  ChartMode,
+  CostCategories,
+} from "src/components";
+import {
+  ExpenditureApi,
+  SchoolExpenditureHistory,
+  SchoolHistoryComparison,
+} from "src/services";
+import { ChartDimensionContext, useChartModeContext } from "src/contexts";
+import { HistoricChart2 } from "src/composed/historic-chart-2-composed";
+import { Loading } from "src/components/loading";
+
+export const SpendingSection: React.FC<{ type: string; id: string }> = ({
+  type,
+  id,
+}) => {
+  const defaultDimension = Actual;
+  const { chartMode, setChartMode } = useChartModeContext();
+  const [dimension, setDimension] = useState(defaultDimension);
+  const [data, setData] = useState<
+    SchoolHistoryComparison<SchoolExpenditureHistory>
+  >({});
+  const getData = useCallback(async () => {
+    setData({});
+    return await ExpenditureApi.historyComparison(type, id, dimension.value);
+  }, [type, id, dimension]);
+
+  useEffect(() => {
+    getData().then((result) => {
+      setData(result);
+    });
+  }, [getData]);
+
+  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
+    event
+  ) => {
+    const dimension =
+      CostCategories.find((x) => x.value === event.target.value) ??
+      defaultDimension;
+    setDimension(dimension);
+  };
+
+  return (
+    <ChartDimensionContext.Provider value={dimension}>
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-two-thirds">
+          <ChartDimensions
+            dimensions={CostCategories}
+            handleChange={handleSelectChange}
+            elementId="expenditure"
+            value={dimension.value}
+          />
+        </div>
+        <div className="govuk-grid-column-one-third">
+          <ChartMode
+            chartMode={chartMode}
+            handleChange={setChartMode}
+            prefix="expenditure"
+          />
+        </div>
+      </div>
+      <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-0" />
+      {data.school?.length ? (
+        <HistoricChart2
+          chartName="Total expenditure"
+          data={data}
+          valueField="totalExpenditure"
+          legend
+          legendIconType="default"
+          legendHorizontalAlign="center"
+          legendVerticalAlign="bottom"
+          axisLabel=""
+        >
+          <h2 className="govuk-heading-m">Total expenditure</h2>
+        </HistoricChart2>
+      ) : (
+        <Loading />
+      )}
+    </ChartDimensionContext.Provider>
+  );
+};

--- a/front-end-components/src/views/historic-data-2/partials/spending-section.tsx
+++ b/front-end-components/src/views/historic-data-2/partials/spending-section.tsx
@@ -14,10 +14,13 @@ import { ChartDimensionContext, useChartModeContext } from "src/contexts";
 import { HistoricChart2 } from "src/composed/historic-chart-2-composed";
 import { Loading } from "src/components/loading";
 import { SpendingSectionPremisesServices } from "./spending-section-premises-services";
+import { HistoricData2Props } from "../types";
 
-export const SpendingSection: React.FC<{ type: string; id: string }> = ({
+export const SpendingSection: React.FC<HistoricData2Props> = ({
   type,
   id,
+  overallPhase,
+  financeType,
 }) => {
   const defaultDimension = Actual;
   const { chartMode, setChartMode } = useChartModeContext();
@@ -27,8 +30,14 @@ export const SpendingSection: React.FC<{ type: string; id: string }> = ({
   >({});
   const getData = useCallback(async () => {
     setData({});
-    return await ExpenditureApi.historyComparison(type, id, dimension.value);
-  }, [type, id, dimension]);
+    return await ExpenditureApi.historyComparison(
+      type,
+      id,
+      dimension.value,
+      overallPhase,
+      financeType
+    );
+  }, [type, id, dimension, overallPhase, financeType]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/historic-data-2/types.tsx
+++ b/front-end-components/src/views/historic-data-2/types.tsx
@@ -1,4 +1,6 @@
-export type HistoricData2ViewProps = {
+export type HistoricData2Props = {
   type: string;
   id: string;
+  overallPhase?: string;
+  financeType?: string;
 };

--- a/front-end-components/src/views/historic-data-2/types.tsx
+++ b/front-end-components/src/views/historic-data-2/types.tsx
@@ -1,0 +1,4 @@
+export type HistoricData2ViewProps = {
+  type: string;
+  id: string;
+};

--- a/front-end-components/src/views/historic-data-2/view.tsx
+++ b/front-end-components/src/views/historic-data-2/view.tsx
@@ -1,0 +1,27 @@
+import { SpendingSection } from "src/views/historic-data-2/partials";
+import { HistoricData2ViewProps } from "src/views/historic-data-2/types";
+import { useGovUk } from "src/hooks/useGovUk";
+import { ChartModeChart } from "src/components";
+import { ChartModeProvider } from "src/contexts";
+
+export const HistoricData2: React.FC<HistoricData2ViewProps> = (props) => {
+  const { type, id } = props;
+  useGovUk();
+
+  return (
+    <div className="govuk-tabs" data-module="govuk-tabs">
+      <ul className="govuk-tabs__list">
+        <li className="govuk-tabs__list-item govuk-tabs__list-item--selected">
+          <a className="govuk-tabs__tab" href="#spending">
+            Spending
+          </a>
+        </li>
+      </ul>
+      <ChartModeProvider initialValue={ChartModeChart}>
+        <div className="govuk-tabs__panel" id="spending">
+          <SpendingSection type={type} id={id} />
+        </div>
+      </ChartModeProvider>
+    </div>
+  );
+};

--- a/front-end-components/src/views/historic-data-2/view.tsx
+++ b/front-end-components/src/views/historic-data-2/view.tsx
@@ -1,11 +1,10 @@
 import { SpendingSection } from "src/views/historic-data-2/partials";
-import { HistoricData2ViewProps } from "src/views/historic-data-2/types";
+import { HistoricData2Props } from "src/views/historic-data-2/types";
 import { useGovUk } from "src/hooks/useGovUk";
 import { ChartModeChart } from "src/components";
 import { ChartModeProvider } from "src/contexts";
 
-export const HistoricData2: React.FC<HistoricData2ViewProps> = (props) => {
-  const { type, id } = props;
+export const HistoricData2: React.FC<HistoricData2Props> = (props) => {
   useGovUk();
 
   return (
@@ -19,7 +18,7 @@ export const HistoricData2: React.FC<HistoricData2ViewProps> = (props) => {
       </ul>
       <ChartModeProvider initialValue={ChartModeChart}>
         <div className="govuk-tabs__panel" id="spending">
-          <SpendingSection type={type} id={id} />
+          <SpendingSection {...props} />
         </div>
       </ChartModeProvider>
     </div>

--- a/front-end-components/src/views/historic-data/partials/income-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/income-section.tsx
@@ -98,9 +98,7 @@ export const IncomeSection: React.FC<{ type: string; id: string }> = ({
             id="accordion-income-content-1"
             className="govuk-accordion__section-content"
           >
-            <p className="govuk-body">
-              <IncomeSectionGrantFunding data={data} />
-            </p>
+            <IncomeSectionGrantFunding data={data} />
           </div>
         </div>
         <div className="govuk-accordion__section">
@@ -118,9 +116,7 @@ export const IncomeSection: React.FC<{ type: string; id: string }> = ({
             id="accordion-income-content-2"
             className="govuk-accordion__section-content"
           >
-            <p className="govuk-body">
-              <IncomeSectionSelfGenerated data={data} />
-            </p>
+            <IncomeSectionSelfGenerated data={data} />
           </div>
         </div>
         {type === "school" && (
@@ -139,9 +135,7 @@ export const IncomeSection: React.FC<{ type: string; id: string }> = ({
               id="accordion-income-content-3"
               className="govuk-accordion__section-content"
             >
-              <p className="govuk-body">
-                <IncomeSectionDirectRevenue data={data} />
-              </p>
+              <IncomeSectionDirectRevenue data={data} />
             </div>
           </div>
         )}

--- a/front-end-components/src/views/historic-data/partials/spending-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section.tsx
@@ -104,9 +104,7 @@ export const SpendingSection: React.FC<{ type: string; id: string }> = ({
             id="accordion-expenditure-content-1"
             className="govuk-accordion__section-content"
           >
-            <p className="govuk-body">
-              <SpendingSectionTeachingCosts data={data} />
-            </p>
+            <SpendingSectionTeachingCosts data={data} />
           </div>
         </div>
         <div className="govuk-accordion__section">
@@ -124,9 +122,7 @@ export const SpendingSection: React.FC<{ type: string; id: string }> = ({
             id="accordion-expenditure-content-2"
             className="govuk-accordion__section-content"
           >
-            <p className="govuk-body">
-              <SpendingSectionNonEducationalStaffCosts data={data} />
-            </p>
+            <SpendingSectionNonEducationalStaffCosts data={data} />
           </div>
         </div>
         <div className="govuk-accordion__section">
@@ -144,9 +140,7 @@ export const SpendingSection: React.FC<{ type: string; id: string }> = ({
             id="accordion-expenditure-content-3"
             className="govuk-accordion__section-content"
           >
-            <p className="govuk-body">
-              <SpendingSectionEducationalSupplies data={data} />
-            </p>
+            <SpendingSectionEducationalSupplies data={data} />
           </div>
         </div>
         <div className="govuk-accordion__section">
@@ -164,9 +158,7 @@ export const SpendingSection: React.FC<{ type: string; id: string }> = ({
             id="accordion-expenditure-content-4"
             className="govuk-accordion__section-content"
           >
-            <p className="govuk-body">
-              <SpendingSectionEducationalIct data={data} />
-            </p>
+            <SpendingSectionEducationalIct data={data} />
           </div>
         </div>
         <div className="govuk-accordion__section">
@@ -184,9 +176,7 @@ export const SpendingSection: React.FC<{ type: string; id: string }> = ({
             id="accordion-expenditure-content-5"
             className="govuk-accordion__section-content"
           >
-            <p className="govuk-body">
-              <SpendingSectionPremisesServices data={data} />
-            </p>
+            <SpendingSectionPremisesServices data={data} />
           </div>
         </div>
         <div className="govuk-accordion__section">
@@ -204,9 +194,7 @@ export const SpendingSection: React.FC<{ type: string; id: string }> = ({
             id="accordion-expenditure-content-6"
             className="govuk-accordion__section-content"
           >
-            <p className="govuk-body">
-              <SpendingSectionUtilities data={data} />
-            </p>
+            <SpendingSectionUtilities data={data} />
           </div>
         </div>
         <div className="govuk-accordion__section">
@@ -224,9 +212,7 @@ export const SpendingSection: React.FC<{ type: string; id: string }> = ({
             id="accordion-expenditure-content-7"
             className="govuk-accordion__section-content"
           >
-            <p className="govuk-body">
-              <SpendingSectionAdministrativeSupplies data={data} />
-            </p>
+            <SpendingSectionAdministrativeSupplies data={data} />
           </div>
         </div>
         <div className="govuk-accordion__section">
@@ -244,9 +230,7 @@ export const SpendingSection: React.FC<{ type: string; id: string }> = ({
             id="accordion-expenditure-content-8"
             className="govuk-accordion__section-content"
           >
-            <p className="govuk-body">
-              <SpendingSectionCateringServices data={data} />
-            </p>
+            <SpendingSectionCateringServices data={data} />
           </div>
         </div>
         <div className="govuk-accordion__section">
@@ -264,9 +248,7 @@ export const SpendingSection: React.FC<{ type: string; id: string }> = ({
             id="accordion-expenditure-content-9"
             className="govuk-accordion__section-content"
           >
-            <p className="govuk-body">
-              <SpendingSectionOther data={data} type={type} />
-            </p>
+            <SpendingSectionOther data={data} type={type} />
           </div>
         </div>
       </div>

--- a/front-end-components/src/views/index.tsx
+++ b/front-end-components/src/views/index.tsx
@@ -3,5 +3,6 @@ export * from "src/views/compare-your-costs";
 export * from "src/views/compare-your-trust";
 export * from "src/views/compare-your-census";
 export * from "src/views/historic-data";
+export * from "src/views/historic-data-2";
 export * from "src/views/deployment-plan";
 export * from "src/views/find-organisation";


### PR DESCRIPTION
### Context
[AB#240729](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/240729) [AB#237633](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/237633) [AB#240730](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/240730)

### Change proposed in this pull request
Display 'Total Expenditure' historic chart and table with three series: school, comparator set average and national average (within phase and finance type). Dummy data intentionally used at this stage for demo purposes while backend implementation ongoing.

![image](https://github.com/user-attachments/assets/9a387e8a-75ed-4edd-b8f2-2c8181879416)

![image](https://github.com/user-attachments/assets/78159c6a-350d-4af1-a556-4e824cf21a62)

### Guidance to review 
Run the `vite` dev server to preview the changes. Nothing consumes the new components as yet, but existing charts/tables should be unaffected. 

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

