### PR TITLE
Resolve 'current' BFR year based on metrics rather than `LatestBFRYear` value from `Parameters` table

### DIFF
--- a/web/src/Web.App/Controllers/Api/BudgetForecastProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/BudgetForecastProxyController.cs
@@ -25,8 +25,15 @@ public class BudgetForecastProxyController(ILogger<BudgetForecastProxyController
         {
             try
             {
-                var bfrYear = await budgetForecastApi.GetCurrentBudgetForecastYear(companyNumber).GetResultOrDefault(Constants.CurrentYear - 1);
-                var query = new ApiQuery().AddIfNotNull("runId", bfrYear.ToString());
+                var metrics = await budgetForecastApi
+                    .BudgetForecastReturnsMetrics(companyNumber)
+                    .GetResultOrDefault<BudgetForecastReturnMetric[]>() ?? [];
+                var metricsYear = metrics
+                    .Select(x => x.Year)
+                    .OrderDescending()
+                    .FirstOrDefault() ?? Constants.CurrentYear - 1;
+
+                var query = new ApiQuery().AddIfNotNull("runId", metricsYear.ToString());
                 var result = await budgetForecastApi
                     .BudgetForecastReturns(companyNumber, query)
                     .GetResultOrDefault<BudgetForecastReturn[]>();

--- a/web/src/Web.App/Views/TrustForecast/Index.cshtml
+++ b/web/src/Web.App/Views/TrustForecast/Index.cshtml
@@ -24,7 +24,7 @@ else
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">
             <span class="govuk-visually-hidden">Warning</span>
-            Forecast and risks could not be found for this trust.
+            This trust has no submission for the current period.
         </strong>
     </div>
 }

--- a/web/tests/Web.Tests/Controllers/Api/BudgetForecast/WhenBudgetForecastApiReceivesRequest.cs
+++ b/web/tests/Web.Tests/Controllers/Api/BudgetForecast/WhenBudgetForecastApiReceivesRequest.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Web.App.Controllers.Api;
+using Web.App.Domain;
+using Web.App.Infrastructure.Apis;
+using Xunit;
+namespace Web.Tests.Controllers.Api.BudgetForecast;
+
+public class WhenBudgetForecastApiReceivesRequest
+{
+    private readonly BudgetForecastProxyController _api;
+    private readonly Mock<IBudgetForecastApi> _budgetForecastApi = new();
+    private readonly NullLogger<BudgetForecastProxyController> _logger = new();
+
+    public WhenBudgetForecastApiReceivesRequest()
+    {
+        _api = new BudgetForecastProxyController(_logger, _budgetForecastApi.Object);
+    }
+
+    [Theory]
+    [InlineData("companyNumber", 2023, "?runId=2023")]
+    public async Task ShouldGetBudgetForecastReturns(string companyNumber, int year, string expectedQuery)
+    {
+        // arrange
+        var metrics = new BudgetForecastReturnMetric[]
+        {
+            new()
+            {
+                Year = year - 1
+            },
+            new()
+            {
+                Year = year
+            },
+            new()
+            {
+                Year = year - 2
+            }
+        };
+
+        var results = Array.Empty<BudgetForecastReturn>();
+        var actualQuery = string.Empty;
+
+        _budgetForecastApi
+            .Setup(e => e.BudgetForecastReturnsMetrics(companyNumber, null))
+            .ReturnsAsync(ApiResult.Ok(metrics));
+        _budgetForecastApi
+            .Setup(e => e.BudgetForecastReturns(companyNumber, It.IsAny<ApiQuery?>()))
+            .Callback<string, ApiQuery?>((_, query) =>
+            {
+                actualQuery = query?.ToQueryString();
+            })
+            .ReturnsAsync(ApiResult.Ok(results));
+
+        // act
+        var actual = await _api.Index(companyNumber);
+
+        // assert
+        var json = Assert.IsType<JsonResult>(actual).Value;
+        Assert.Equal(results, json);
+        Assert.Equal(expectedQuery, actualQuery);
+    }
+}


### PR DESCRIPTION
### Context
[AB#241480](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/241480) [AB#236233](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/236233)

### Change proposed in this pull request
If the Trust does not have a BFR for the most recent year, instead show for the most recent year identified from the underlying BFR metrics. If this is also not available then show a (reworded) warning message.

Also moved API controller tests from `Wen.Integration.Tests` to `Web.Tests` and increased BFR test coverage.

### Guidance to review 
Trusts with BFR data for current year, a previous year, or not at all should may all be validated when spinning up `web` locally.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

