### PR TITLE
feat: adds new platform api endpoints for school expenditure historic trends

### DIFF
--- a/platform/src/apis/Platform.Api.Insight/Configuration/Services.cs
+++ b/platform/src/apis/Platform.Api.Insight/Configuration/Services.cs
@@ -42,6 +42,7 @@ internal static class Services
 
         serviceCollection
             .AddTransient<IValidator<ExpenditureParameters>, ExpenditureParametersValidator>()
+            .AddTransient<IValidator<ExpenditureNationalAvgParameters>, ExpenditureNationalAvgParametersValidator>()
             .AddTransient<IValidator<QuerySchoolExpenditureParameters>, QuerySchoolExpenditureParametersValidator>()
             .AddTransient<IValidator<QueryTrustExpenditureParameters>, QueryTrustExpenditureParametersValidator>()
             .AddTransient<IValidator<IncomeParameters>, IncomeParametersValidator>()

--- a/platform/src/apis/Platform.Api.Insight/Domain/FinanceType.cs
+++ b/platform/src/apis/Platform.Api.Insight/Domain/FinanceType.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Linq;
+namespace Platform.Api.Insight.Domain;
+
+public static class FinanceType
+{
+    private const string Academy = "Academy";
+    private const string Maintained = "Maintained";
+
+    public static readonly string[] All =
+    [
+        Academy,
+        Maintained
+    ];
+
+    public static bool IsValid(string? type) => All.Any(a => a.Equals(type, StringComparison.OrdinalIgnoreCase));
+}

--- a/platform/src/apis/Platform.Api.Insight/Expenditure/ExpenditureFunctions.cs
+++ b/platform/src/apis/Platform.Api.Insight/Expenditure/ExpenditureFunctions.cs
@@ -19,6 +19,7 @@ public class ExpenditureFunctions(
     ILogger<ExpenditureFunctions> logger,
     IExpenditureService service,
     IValidator<ExpenditureParameters> expenditureParametersValidator,
+    IValidator<ExpenditureNationalAvgParameters> expenditureNationalAvgValidator,
     IValidator<QuerySchoolExpenditureParameters> querySchoolExpenditureParametersValidator,
     IValidator<QueryTrustExpenditureParameters> queryTrustExpenditureParametersValidator)
 {
@@ -257,6 +258,97 @@ public class ExpenditureFunctions(
             catch (Exception e)
             {
                 logger.LogError(e, "Failed to get school expenditure history");
+                return req.CreateErrorResponse();
+            }
+        }
+    }
+
+    [Function(nameof(SchoolExpenditureHistoryAvgComparatorSetAsync))]
+    [OpenApiOperation(nameof(SchoolExpenditureHistoryAvgComparatorSetAsync), "Expenditure")]
+    [OpenApiParameter("urn", Type = typeof(string), Required = true)]
+    [OpenApiParameter("dimension", In = ParameterLocation.Query, Description = "Dimension for response values", Type = typeof(string), Required = true, Example = typeof(ExampleExpenditureDimension))]
+    [OpenApiSecurityHeader]
+    [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(SchoolExpenditureHistoryResponse[]))]
+    [OpenApiResponseWithBody(HttpStatusCode.BadRequest, "application/json", typeof(ValidationError[]))]
+    [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
+    public async Task<HttpResponseData> SchoolExpenditureHistoryAvgComparatorSetAsync(
+        [HttpTrigger(AuthorizationLevel.Admin, "get", Route = "expenditure/school/{urn}/history/comparator-set-average")] HttpRequestData req,
+        string urn)
+    {
+        var correlationId = req.GetCorrelationId();
+        var queryParams = req.GetParameters<ExpenditureParameters>();
+
+        using (logger.BeginScope(new Dictionary<string, object>
+               {
+                   {
+                       "Application", Constants.ApplicationName
+                   },
+                   {
+                       "CorrelationID", correlationId
+                   }
+               }))
+        {
+            try
+            {
+                var validationResult = await expenditureParametersValidator.ValidateAsync(queryParams);
+                if (!validationResult.IsValid)
+                {
+                    return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+                }
+
+                var result = await service.GetSchoolHistoryAvgComparatorSetAsync(urn, queryParams);
+
+                return await req.CreateJsonResponseAsync(result);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Failed to get school comparator set average expenditure history");
+                return req.CreateErrorResponse();
+            }
+        }
+    }
+
+    [Function(nameof(SchoolExpenditureHistoryAvgNationalAsync))]
+    [OpenApiOperation(nameof(SchoolExpenditureHistoryAvgNationalAsync), "Expenditure")]
+    [OpenApiParameter("dimension", In = ParameterLocation.Query, Description = "Dimension for response values", Type = typeof(string), Required = true, Example = typeof(ExampleExpenditureDimension))]
+    [OpenApiParameter("phase", In = ParameterLocation.Query, Description = "Overall phase for response values", Type = typeof(string), Required = true, Example = typeof(ExampleOverallPhase))]
+    [OpenApiParameter("financeType", In = ParameterLocation.Query, Description = "Finance type for response values", Type = typeof(string), Required = true, Example = typeof(ExampleFinanceTypes))]
+    [OpenApiSecurityHeader]
+    [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(SchoolExpenditureHistoryResponse[]))]
+    [OpenApiResponseWithBody(HttpStatusCode.BadRequest, "application/json", typeof(ValidationError[]))]
+    [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
+    public async Task<HttpResponseData> SchoolExpenditureHistoryAvgNationalAsync(
+        [HttpTrigger(AuthorizationLevel.Admin, "get", Route = "expenditure/school/history/national-average")] HttpRequestData req,
+        string urn)
+    {
+        var correlationId = req.GetCorrelationId();
+        var queryParams = req.GetParameters<ExpenditureNationalAvgParameters>();
+
+        using (logger.BeginScope(new Dictionary<string, object>
+               {
+                   {
+                       "Application", Constants.ApplicationName
+                   },
+                   {
+                       "CorrelationID", correlationId
+                   }
+               }))
+        {
+            try
+            {
+                var validationResult = await expenditureNationalAvgValidator.ValidateAsync(queryParams);
+                if (!validationResult.IsValid)
+                {
+                    return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+                }
+
+                var result = await service.GetSchoolHistoryAvgNationalAsync(queryParams);
+
+                return await req.CreateJsonResponseAsync(result);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Failed to get school national average expenditure history");
                 return req.CreateErrorResponse();
             }
         }

--- a/platform/src/apis/Platform.Api.Insight/Expenditure/ExpenditureNationalAvgParameters.cs
+++ b/platform/src/apis/Platform.Api.Insight/Expenditure/ExpenditureNationalAvgParameters.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Http;
+using Platform.Functions;
+
+namespace Platform.Api.Insight.Expenditure;
+
+public record ExpenditureNationalAvgParameters : QueryParameters
+{
+    public string Dimension { get; private set; } = ExpenditureDimensions.Actuals;
+    public string FinanceType { get; private set; } = string.Empty;
+    public string OverallPhase { get; private set; } = string.Empty;
+
+    public override void SetValues(IQueryCollection query)
+    {
+        if (query.TryGetValue("dimension", out var dimension) && !string.IsNullOrWhiteSpace(dimension))
+        {
+            Dimension = dimension.ToString();
+        }
+
+        if (query.TryGetValue("financeType", out var financeType) && !string.IsNullOrWhiteSpace(financeType))
+        {
+            FinanceType = financeType.ToString();
+        }
+
+        if (query.TryGetValue("phase", out var overallPhase) && !string.IsNullOrWhiteSpace(overallPhase))
+        {
+            OverallPhase = overallPhase.ToString();
+        }
+    }
+}

--- a/platform/src/apis/Platform.Api.Insight/OpenApi/Examples/ExpenditureExamples.cs
+++ b/platform/src/apis/Platform.Api.Insight/OpenApi/Examples/ExpenditureExamples.cs
@@ -62,3 +62,18 @@ internal class ExampleRagStatuses : OpenApiExample<string>
         return this;
     }
 }
+
+[ExcludeFromCodeCoverage]
+internal class ExampleFinanceTypes : OpenApiExample<string>
+{
+    public override IOpenApiExample<string> Build(NamingStrategy namingStrategy = null!)
+    {
+        foreach (var type in FinanceType.All)
+        {
+            Examples.Add(OpenApiExampleResolver.Resolve(type, type, namingStrategy));
+
+        }
+
+        return this;
+    }
+}

--- a/platform/src/apis/Platform.Api.Insight/Validators/ExpenditureNationalAvgParametersValidator.cs
+++ b/platform/src/apis/Platform.Api.Insight/Validators/ExpenditureNationalAvgParametersValidator.cs
@@ -1,0 +1,26 @@
+﻿using FluentValidation;
+using Platform.Api.Insight.Domain;
+using Platform.Api.Insight.Expenditure;
+namespace Platform.Api.Insight.Validators;
+
+public class ExpenditureNationalAvgParametersValidator : AbstractValidator<ExpenditureNationalAvgParameters>
+{
+    public ExpenditureNationalAvgParametersValidator()
+    {
+        RuleFor(x => x.Dimension)
+            .Must(BeAValidDimension)
+            .WithMessage($"{{PropertyName}} must be empty or one of the supported values: {string.Join(", ", ExpenditureDimensions.All)}");
+
+        RuleFor(x => x.OverallPhase)
+            .Must(BeAValidPhase)
+            .WithMessage($"{{PropertyName}} must one of the supported values: {string.Join(", ", OverallPhase.All)}");
+
+        RuleFor(x => x.FinanceType)
+            .Must(BeAValidFinanceType)
+            .WithMessage($"{{PropertyName}} must be one of the supported values: {string.Join(", ", FinanceType.All)}");
+    }
+
+    private static bool BeAValidDimension(string? dimension) => ExpenditureDimensions.IsValid(dimension);
+    private static bool BeAValidPhase(string? phase) => OverallPhase.IsValid(phase);
+    private static bool BeAValidFinanceType(string? financeType) => FinanceType.IsValid(financeType);
+}

--- a/platform/tests/Platform.Tests/Insight/Expenditure/ExpenditureFunctionsTestBase.cs
+++ b/platform/tests/Platform.Tests/Insight/Expenditure/ExpenditureFunctionsTestBase.cs
@@ -12,9 +12,16 @@ public class ExpenditureFunctionsTestBase : FunctionsTestBase
     protected ExpenditureFunctionsTestBase()
     {
         InlineValidator<ExpenditureParameters> expenditureParametersValidator = new();
+        InlineValidator<ExpenditureNationalAvgParameters> expenditureNationalAvgParametersValidator = new();
         InlineValidator<QuerySchoolExpenditureParameters> querySchoolExpenditureParametersValidator = new();
         InlineValidator<QueryTrustExpenditureParameters> queryTrustExpenditureParametersValidator = new();
         Service = new Mock<IExpenditureService>();
-        Functions = new ExpenditureFunctions(new NullLogger<ExpenditureFunctions>(), Service.Object, expenditureParametersValidator, querySchoolExpenditureParametersValidator, queryTrustExpenditureParametersValidator);
+        Functions = new ExpenditureFunctions(
+            new NullLogger<ExpenditureFunctions>(),
+            Service.Object,
+            expenditureParametersValidator,
+            expenditureNationalAvgParametersValidator,
+            querySchoolExpenditureParametersValidator,
+            queryTrustExpenditureParametersValidator);
     }
 }


### PR DESCRIPTION
### Context
[AB#237633](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/237633)
[AB#240724](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/240724)

### Change proposed in this pull request
- Adds two new end points
    -  `expenditure/school/history/national-average`
        - based on `queryParams.Dimension` different views are queried 
            - actuals - `SchoolExpenditureAvgHistoric`
            - perUnit - `SchoolExpenditureAvgPerUnitHistoric`
            - percentIncome - `SchoolExpenditureAvgPercentageOfIncomeComparatorSet`
            - percentExpenditure - `SchoolExpenditureAvgPercentageOfExpenditureComparatorSet`
          - `queryParams.OverallPhase` and `queryParams.FinanceType` are used to build the sql query strings
            - new validator added for these parameters.
    
    - `expenditure/school/{urn}/history/comparator-set-average`
      - based on `queryParams.Dimension` different views are queried 
          - actuals - `SchoolExpenditureAvgComparatorSet`
          - perUnit - `SchoolExpenditureAvgPerUnitComparatorSet`
          - percentIncome - `SchoolExpenditureAvgPercentageOfIncomeHistoric`
          - percentExpenditure - `SchoolExpenditureAvgPercentageOfExpenditureHistoric`

- tests to follow in a future PR

### Guidance to review 
deployed (platform only) to d15

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

