### PR TITLE
Allowed tabbing between 'dots' on line chart using keyboard

### DIFF
--- a/front-end-components/src/components/charts/line-chart-dot/component.tsx
+++ b/front-end-components/src/components/charts/line-chart-dot/component.tsx
@@ -1,0 +1,52 @@
+import classNames from "classnames";
+import { useState, useEffect } from "react";
+import { ChartLink } from "../chart-link";
+import { LineChartDotProps } from "./types";
+
+export function LineChartDot({
+  cx,
+  cy,
+  r,
+  onActiveIndexChanged,
+  index,
+  payload,
+  keyField,
+}: LineChartDotProps) {
+  const [focused, setFocused] = useState<boolean>(false);
+  useEffect(() => {
+    if (focused) {
+      onActiveIndexChanged(index); // index
+    } else {
+      onActiveIndexChanged(undefined);
+    }
+  }, [focused, onActiveIndexChanged, index]);
+  if (cx === +cx! && cy === +cy! && r === +r!) {
+    return (
+      <>
+        <ChartLink
+          href="#"
+          className="govuk-link govuk-link--no-visited-state"
+          aria-label={
+            payload && keyField
+              ? ((payload as never)[keyField] as string)
+              : undefined
+          }
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+          role="link"
+        >
+          <circle
+            className={classNames("recharts-dot", "recharts-line-dot", {
+              "recharts-line-dot-focus": focused,
+            })}
+            cx={cx}
+            cy={cy}
+            r={r}
+          ></circle>
+        </ChartLink>
+      </>
+    );
+  }
+
+  return null;
+}

--- a/front-end-components/src/components/charts/line-chart-dot/index.tsx
+++ b/front-end-components/src/components/charts/line-chart-dot/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/components/charts/line-chart-dot/types";
+export * from "src/components/charts/line-chart-dot/component";

--- a/front-end-components/src/components/charts/line-chart-dot/types.tsx
+++ b/front-end-components/src/components/charts/line-chart-dot/types.tsx
@@ -1,0 +1,18 @@
+import { FunctionComponent } from "react";
+import { DotProps } from "recharts";
+import {
+  ValueType,
+  NameType,
+  Payload,
+} from "recharts/types/component/DefaultTooltipContent";
+import { ContentType, TooltipProps } from "recharts/types/component/Tooltip";
+
+export interface LineChartDotProps extends DotProps {
+  tooltip?: FunctionComponent<TooltipProps<ValueType, NameType>>;
+  tooltipContent?: ContentType<ValueType, NameType>;
+  payload?: Payload<ValueType, NameType>;
+  dataKey?: string;
+  onActiveIndexChanged: (index: number | undefined) => void;
+  index?: number;
+  keyField?: string;
+}

--- a/front-end-components/src/components/charts/line-chart-tooltip/component.tsx
+++ b/front-end-components/src/components/charts/line-chart-tooltip/component.tsx
@@ -9,19 +9,23 @@ export function LineChartTooltip<
   TData extends ChartDataSeries,
   TValue extends ValueType,
   TName extends NameType,
->(props: LineChartTooltipProps<TData, TValue, TName>) {
-  const { active, payload, valueFormatter, valueUnit } = props;
-  if (active && payload && payload.length) {
-    return (
-      <div className="chart-active-tooltip">
-        <p className="govuk-body-s">
-          {valueFormatter
-            ? valueFormatter(payload[0].value, { valueUnit })
-            : String(payload[0].value)}
-        </p>
-      </div>
-    );
+>({
+  active,
+  payload,
+  valueFormatter,
+  valueUnit,
+}: LineChartTooltipProps<TData, TValue, TName>) {
+  if (!active || !payload || !payload.length) {
+    return null;
   }
 
-  return null;
+  return (
+    <div className="chart-active-tooltip">
+      <p className="govuk-body-s">
+        {valueFormatter
+          ? valueFormatter(payload[0].value, { valueUnit })
+          : String(payload[0].value)}
+      </p>
+    </div>
+  );
 }

--- a/front-end-components/src/components/charts/line-chart/component.tsx
+++ b/front-end-components/src/components/charts/line-chart/component.tsx
@@ -21,6 +21,7 @@ import {
 import { ChartDataSeries, ChartHandler } from "src/components";
 import classNames from "classnames";
 import { useDownloadPngImage } from "src/hooks/useDownloadImage";
+import { LineChartDot } from "../line-chart-dot";
 
 function LineChartInner<TData extends ChartDataSeries>(
   {
@@ -75,6 +76,41 @@ function LineChartInner<TData extends ChartDataSeries>(
   }, [data, keyField, seriesConfig, seriesLabelField]);
 
   const margin = _margin || 5;
+
+  // https://github.com/recharts/recharts/issues/1231#issuecomment-1237958802
+  const handleDotActiveIndexChanged = (itemIndex?: number) => {
+    if (itemIndex === undefined) {
+      rechartsRef.current?.setState({
+        isTooltipActive: false,
+      });
+      return;
+    }
+
+    const activeItem =
+      rechartsRef.current?.state.formattedGraphicalItems?.[0].props.points[
+        itemIndex
+      ];
+    if (!activeItem) {
+      return;
+    }
+
+    activeItem.value = activeItem.value || 0;
+    const mouseEnterArgs = {
+      tooltipPayload: [activeItem],
+      tooltipPosition: {
+        x: activeItem.x,
+        y: activeItem.y,
+      },
+    };
+    rechartsRef.current?.setState(
+      {
+        activeTooltipIndex: itemIndex,
+      },
+      () => {
+        rechartsRef.current?.handleItemMouseEnter(mouseEnterArgs);
+      }
+    );
+  };
 
   const renderLabel = ({
     x,
@@ -131,6 +167,16 @@ function LineChartInner<TData extends ChartDataSeries>(
             ...props,
             className: `chart-label-series-${seriesIndex}`,
           })
+        }
+        dot={
+          tooltip ? (
+            <LineChartDot
+              onActiveIndexChanged={handleDotActiveIndexChanged}
+              keyField={keyField as string}
+            />
+          ) : (
+            true
+          )
         }
       ></Line>
     );


### PR DESCRIPTION
### Context
[AB#241600](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/241600) [AB#225945](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/225945)

### Change proposed in this pull request
Accessible tooltips on line charts so that 'dots' can be tabbed through. Compatible with both versions of the historical data composed charts, as well as BFR (that has no tooltips). Implementation tips from [this issue](https://github.com/recharts/recharts/issues/1231).

### Guidance to review 
Build and run the local Vite dev server to validate behaviour.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

