### PR TITLE
E2E tests for historic data tabs when feature flag is enabled

### DIFF
--- a/pipelines/web/steps/run-e2e-tests.yaml
+++ b/pipelines/web/steps/run-e2e-tests.yaml
@@ -31,6 +31,7 @@ steps:
     inputs:
       command: test
       projects: '${{ parameters.workspaceDir }}/e2e-tests-files/Web.E2ETests/Web.E2ETests.dll'
+      arguments: --filter Category!=HistoricalTrendsFlagEnabled
 
   - publish: ${{ parameters.workspaceDir }}/e2e-tests-files/Web.E2ETests/screenshots
     artifact: e2e-test-outputs-$(System.JobAttempt)

--- a/web/tests/Web.E2ETests/Features/School/HistoricData.feature
+++ b/web/tests/Web.E2ETests/Features/School/HistoricData.feature
@@ -4,13 +4,13 @@
         Given I am on '<tab>' history page for school with URN '777042'
         When I change '<tab>' dimension to '<dimension>'
         Then the '<tab>' dimension is '<dimension>'
-        
-    Examples:
-      | tab      | dimension   |
-      | spending | £ per pupil |
-      | income   | £ per pupil |
-      | balance  | £ per pupil |
-      | census   | headcount per FTE |
+
+        Examples:
+          | tab      | dimension         |
+          | spending | £ per pupil       |
+          | income   | £ per pupil       |
+          | balance  | £ per pupil       |
+          | census   | headcount per FTE |
 
     Scenario Outline: Show all should expand all sections
         Given I am on '<tab>' history page for school with URN '777042'
@@ -18,11 +18,11 @@
         Then all sections on '<tab>' tab are expanded
         And the show all text changes to hide all sections on '<tab>'
         And all '<tab>' sub categories are displayed on the page
-        
-    Examples:
-      | tab      |
-      | spending |
-      | income   |
+
+        Examples:
+          | tab      |
+          | spending |
+          | income   |
 
     Scenario Outline: Change all charts to table view
         Given I am on '<tab>' history page for school with URN '777042'
@@ -36,10 +36,24 @@
           | income   |
           | balance  |
           | census   |
-       
 
     Scenario: Hide single section
         Given I am on 'spending' history page for school with URN '777042'
         And all sections are shown on 'spending'
         When I click section link for 'non educational support staff'
         Then the section 'non educational support staff' is hidden
+
+    @HistoricalTrendsFlagEnabled
+    Scenario Outline: Change dimension of history data when historical trends flag enabled
+        Given I am on '<tab>' history page for school with URN '777042'
+        When I change '<tab>' dimension to '<dimension>'
+        Then the '<tab>' dimension is '<dimension>'
+        And the '<tab>' charts show the legend '<legend>' using separator ','
+
+        Examples:
+          | tab      | dimension         | legend                                                                         |
+          | spending | actuals           | national average across phase type, average across comparator set, actuals     |
+          | spending | £ per pupil       | national average across phase type, average across comparator set, £ per pupil |
+          | income   | £ per pupil       |                                                                                |
+          | balance  | £ per pupil       |                                                                                |
+          | census   | headcount per FTE |                                                                                |

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -53,7 +53,7 @@ public static class Selectors
     public const string SectionContent9 = "#accordion-content-9";
 
     public const string ToggleSectionText = ".govuk-accordion__section-toggle-text";
-    public const string Charts = ".recharts-surface";
+    public const string Charts = ".recharts-wrapper > .recharts-surface";
     public const string Table = "table";
     public const string Button = "button";
     public const string Aside = "aside";

--- a/web/tests/Web.E2ETests/Steps/School/HistoricDataSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/HistoricDataSteps.cs
@@ -1,8 +1,7 @@
-﻿using Reqnroll;
+﻿using Microsoft.Playwright;
 using Web.E2ETests.Drivers;
 using Web.E2ETests.Pages.School;
 using Xunit;
-
 namespace Web.E2ETests.Steps.School;
 
 [Binding]
@@ -10,6 +9,7 @@ namespace Web.E2ETests.Steps.School;
 public class HistoricDataSteps(PageDriver driver)
 {
     private HistoricDataPage? _historicDataPage;
+
     [Given("I am on '(.*)' history page for school with URN '(.*)'")]
     public async Task GivenIAmOnHistoryPageForSchoolWithUrn(string tab, string urn)
     {
@@ -17,6 +17,7 @@ public class HistoricDataSteps(PageDriver driver)
         var page = await driver.Current;
         await page.GotoAndWaitForLoadAsync(url);
         await page.ReloadAsync();
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
         _historicDataPage = new HistoricDataPage(page);
         await _historicDataPage.IsDisplayed(TabNamesFromFriendlyNames(tab));
@@ -24,7 +25,7 @@ public class HistoricDataSteps(PageDriver driver)
 
     [Given("all sections are shown on '(.*)'")]
     [When("I click on show all sections on '(.*)'")]
-    public async Task WhenIClickOnShowAllSections(string tab)
+    public async Task WhenIClickOnShowAllSectionsOn(string tab)
     {
         Assert.NotNull(_historicDataPage);
         await _historicDataPage.ClickShowAllSections(TabNamesFromFriendlyNames(tab));
@@ -45,14 +46,14 @@ public class HistoricDataSteps(PageDriver driver)
     }
 
     [Then("all sections on '(.*)' tab are expanded")]
-    public async Task ThenAllSectionsOnThePageAreExpanded(string tab)
+    public async Task ThenAllSectionsOnTabAreExpanded(string tab)
     {
         Assert.NotNull(_historicDataPage);
         await _historicDataPage.AreSectionsExpanded(TabNamesFromFriendlyNames(tab));
     }
 
     [Then("the show all text changes to hide all sections on '(.*)'")]
-    public async Task ThenTheShowAllTextChangesToHideAllSectionsOnTab(string tab)
+    public async Task ThenTheShowAllTextChangesToHideAllSectionsOn(string tab)
     {
         Assert.NotNull(_historicDataPage);
         await _historicDataPage.IsShowHideAllSectionsText(TabNamesFromFriendlyNames(tab), "Hide all sections");
@@ -94,6 +95,13 @@ public class HistoricDataSteps(PageDriver driver)
         await _historicDataPage.IsSectionVisible(ExpenditureCategoryFromFriendlyName(chartName), false, "Show", "chart");
     }
 
+    [Then("the '(.*)' charts show the legend '(.*)' using separator '(.*)'")]
+    public async Task ThenTheChartsShowTheLegendUsingSeparator(string tab, string legend, string separator)
+    {
+        Assert.NotNull(_historicDataPage);
+        await _historicDataPage.ChartLegendContains(TabNamesFromFriendlyNames(tab), legend, separator);
+    }
+
     private static SpendingCategoriesNames ExpenditureCategoryFromFriendlyName(string chartName)
     {
         return chartName switch
@@ -102,7 +110,9 @@ public class HistoricDataSteps(PageDriver driver)
             _ => throw new ArgumentOutOfRangeException(nameof(chartName))
         };
     }
+
     private static string FindWaysToSpendLessUrl(string tab, string urn) => $"{TestConfiguration.ServiceUrl}/school/{urn}/history#{tab}";
+
     private static HistoryTabs TabNamesFromFriendlyNames(string tab)
     {
         return tab switch
@@ -114,5 +124,4 @@ public class HistoricDataSteps(PageDriver driver)
             _ => throw new ArgumentOutOfRangeException(nameof(tab))
         };
     }
-
 }


### PR DESCRIPTION
### Context
[AB#240731](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/240731) [AB#237633](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/237633)

### Change proposed in this pull request
For the time being, intentionally excluded from pipeline E2E run via trait filter. Once feature stable, and enabled in automated test environment, this filter may be removed.

### Guidance to review 
Enable the `HistoricalTrends` feature flag locally and configure Web against `d02` before running E2E. 

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

