### PR TITLE
Tests for insight expenditure historic trends methods

### DIFF
--- a/platform/src/apis/Platform.Api.Insight/Expenditure/ExpenditureFunctions.cs
+++ b/platform/src/apis/Platform.Api.Insight/Expenditure/ExpenditureFunctions.cs
@@ -318,8 +318,7 @@ public class ExpenditureFunctions(
     [OpenApiResponseWithBody(HttpStatusCode.BadRequest, "application/json", typeof(ValidationError[]))]
     [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
     public async Task<HttpResponseData> SchoolExpenditureHistoryAvgNationalAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, "get", Route = "expenditure/school/history/national-average")] HttpRequestData req,
-        string urn)
+        [HttpTrigger(AuthorizationLevel.Admin, "get", Route = "expenditure/school/history/national-average")] HttpRequestData req)
     {
         var correlationId = req.GetCorrelationId();
         var queryParams = req.GetParameters<ExpenditureNationalAvgParameters>();

--- a/platform/src/apis/Platform.Api.Insight/Expenditure/ExpenditureNationalAvgParameters.cs
+++ b/platform/src/apis/Platform.Api.Insight/Expenditure/ExpenditureNationalAvgParameters.cs
@@ -5,9 +5,9 @@ namespace Platform.Api.Insight.Expenditure;
 
 public record ExpenditureNationalAvgParameters : QueryParameters
 {
-    public string Dimension { get; private set; } = ExpenditureDimensions.Actuals;
-    public string FinanceType { get; private set; } = string.Empty;
-    public string OverallPhase { get; private set; } = string.Empty;
+    public string Dimension { get; internal set; } = ExpenditureDimensions.Actuals;
+    public string FinanceType { get; internal set; } = string.Empty;
+    public string OverallPhase { get; internal set; } = string.Empty;
 
     public override void SetValues(IQueryCollection query)
     {

--- a/platform/tests/Platform.Tests/Insight/Expenditure/ExpenditureFunctionsTestBase.cs
+++ b/platform/tests/Platform.Tests/Insight/Expenditure/ExpenditureFunctionsTestBase.cs
@@ -8,19 +8,21 @@ public class ExpenditureFunctionsTestBase : FunctionsTestBase
 {
     protected readonly ExpenditureFunctions Functions;
     protected readonly Mock<IExpenditureService> Service;
+    protected readonly Mock<IValidator<ExpenditureParameters>> ExpenditureParametersValidator;
+    protected readonly Mock<IValidator<ExpenditureNationalAvgParameters>> ExpenditureNationalAvgParametersValidator;
 
     protected ExpenditureFunctionsTestBase()
     {
-        InlineValidator<ExpenditureParameters> expenditureParametersValidator = new();
-        InlineValidator<ExpenditureNationalAvgParameters> expenditureNationalAvgParametersValidator = new();
         InlineValidator<QuerySchoolExpenditureParameters> querySchoolExpenditureParametersValidator = new();
         InlineValidator<QueryTrustExpenditureParameters> queryTrustExpenditureParametersValidator = new();
+        ExpenditureParametersValidator = new Mock<IValidator<ExpenditureParameters>>();
+        ExpenditureNationalAvgParametersValidator = new Mock<IValidator<ExpenditureNationalAvgParameters>>();
         Service = new Mock<IExpenditureService>();
         Functions = new ExpenditureFunctions(
             new NullLogger<ExpenditureFunctions>(),
             Service.Object,
-            expenditureParametersValidator,
-            expenditureNationalAvgParametersValidator,
+            ExpenditureParametersValidator.Object,
+            ExpenditureNationalAvgParametersValidator.Object,
             querySchoolExpenditureParametersValidator,
             queryTrustExpenditureParametersValidator);
     }

--- a/platform/tests/Platform.Tests/Insight/Expenditure/WhenExpenditureNationalAvgParametersSetsValues.cs
+++ b/platform/tests/Platform.Tests/Insight/Expenditure/WhenExpenditureNationalAvgParametersSetsValues.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Platform.Api.Insight.Expenditure;
+using Xunit;
+namespace Platform.Tests.Insight.Expenditure;
+
+public class ExpenditureNationalAvgParametersSetsValues
+{
+    [Theory]
+    [InlineData("Actuals", "Primary", "Academy", "Actuals", "Primary", "Academy")]
+    [InlineData(null, null, null, "Actuals", "", "")]
+    [InlineData("Invalid", "Invalid", "Invalid", "Invalid", "Invalid", "Invalid")]
+    public void ShouldSetValuesFromIQueryCollection(
+        string? dimension,
+        string? phase,
+        string? financeType,
+        string expectedDimension,
+        string expectedPhase,
+        string expectedFinanceType)
+    {
+        var parameters = new ExpenditureNationalAvgParameters();
+        var query = new QueryCollection(new Dictionary<string, StringValues>
+        {
+            {
+                "dimension", dimension
+            },
+            {
+                "phase", phase
+            },
+            {
+                "financeType", financeType
+            }
+        });
+
+        parameters.SetValues(query);
+
+        Assert.Equal(expectedDimension, parameters.Dimension);
+        Assert.Equal(expectedPhase, parameters.OverallPhase);
+        Assert.Equal(expectedFinanceType, parameters.FinanceType);
+    }
+}

--- a/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryRequest.cs
@@ -1,0 +1,64 @@
+using System.Net;
+using FluentValidation.Results;
+using Moq;
+using Platform.Api.Insight.Expenditure;
+using Xunit;
+namespace Platform.Tests.Insight.Expenditure;
+
+public class WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryRequest : ExpenditureFunctionsTestBase
+{
+    [Fact]
+    public async Task ShouldReturn200OnValidRequest()
+    {
+        ExpenditureParametersValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<ExpenditureParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
+        Service
+            .Setup(d => d.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), new ExpenditureParameters()))
+            .ReturnsAsync(Array.Empty<SchoolExpenditureHistoryModel>());
+
+        var result = await Functions.SchoolExpenditureHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");
+
+        Assert.NotNull(result);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+    }
+
+    [Fact]
+    public async Task ShouldReturn400OnValidationError()
+    {
+        ExpenditureParametersValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<ExpenditureParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult(new[]
+            {
+                new ValidationFailure(nameof(ExpenditureParameters.Dimension), "error message")
+            }));
+
+        Service
+            .Setup(d => d.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), new ExpenditureParameters()));
+
+        var result = await Functions.SchoolExpenditureHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");
+
+        Assert.NotNull(result);
+        Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
+        Service.Verify(
+            x => x.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), new ExpenditureParameters()), Times.Never());
+    }
+
+    [Fact]
+    public async Task ShouldReturn500OnError()
+    {
+        ExpenditureParametersValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<ExpenditureParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
+        Service
+            .Setup(d => d.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), new ExpenditureParameters()))
+            .Throws(new Exception());
+
+        var result = await Functions.SchoolExpenditureHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");
+
+        Assert.NotNull(result);
+        Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);
+    }
+}

--- a/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetExpenditureHistoryRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetExpenditureHistoryRequest.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using FluentValidation.Results;
 using Moq;
 using Platform.Api.Insight.Expenditure;
 using Xunit;
@@ -9,6 +10,10 @@ public class WhenFunctionReceivesGetExpenditureHistoryRequest : ExpenditureFunct
     [Fact]
     public async Task ShouldReturn200OnValidRequest()
     {
+        ExpenditureParametersValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<ExpenditureParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
         Service
             .Setup(d => d.GetSchoolHistoryAsync(It.IsAny<string>()))
             .ReturnsAsync(Array.Empty<SchoolExpenditureHistoryModel>());

--- a/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest.cs
@@ -1,0 +1,64 @@
+using System.Net;
+using FluentValidation.Results;
+using Moq;
+using Platform.Api.Insight.Expenditure;
+using Xunit;
+namespace Platform.Tests.Insight.Expenditure;
+
+public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : ExpenditureFunctionsTestBase
+{
+    [Fact]
+    public async Task ShouldReturn200OnValidRequest()
+    {
+        ExpenditureNationalAvgParametersValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<ExpenditureNationalAvgParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
+        Service
+            .Setup(d => d.GetSchoolHistoryAvgNationalAsync(new ExpenditureNationalAvgParameters()))
+            .ReturnsAsync(Array.Empty<SchoolExpenditureHistoryModel>());
+
+        var result = await Functions.SchoolExpenditureHistoryAvgNationalAsync(CreateHttpRequestData());
+
+        Assert.NotNull(result);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+    }
+
+    [Fact]
+    public async Task ShouldReturn400OnValidationError()
+    {
+        ExpenditureNationalAvgParametersValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<ExpenditureNationalAvgParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult(new[]
+            {
+                new ValidationFailure(nameof(ExpenditureParameters.Dimension), "error message")
+            }));
+
+        Service
+            .Setup(d => d.GetSchoolHistoryAvgNationalAsync(new ExpenditureNationalAvgParameters()));
+
+        var result = await Functions.SchoolExpenditureHistoryAvgNationalAsync(CreateHttpRequestData());
+
+        Assert.NotNull(result);
+        Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
+        Service.Verify(
+            x => x.GetSchoolHistoryAvgNationalAsync(new ExpenditureNationalAvgParameters()), Times.Never());
+    }
+
+    [Fact]
+    public async Task ShouldReturn500OnError()
+    {
+        ExpenditureNationalAvgParametersValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<ExpenditureNationalAvgParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
+        Service
+            .Setup(d => d.GetSchoolHistoryAvgNationalAsync(new ExpenditureNationalAvgParameters()))
+            .Throws(new Exception());
+
+        var result = await Functions.SchoolExpenditureHistoryAvgNationalAsync(CreateHttpRequestData());
+
+        Assert.NotNull(result);
+        Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);
+    }
+}


### PR DESCRIPTION
### Context
[AB#237633](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/237633)
[AB#241662](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/241662)

### Change proposed in this pull request
Adds tests to cover behaviour of #1658

Corrections to an unused parameter in one of the endpoint methods and changes the scope of the props for the expected parameters.

### Guidance to review 
To allow mocking of validation `ExpenditureFunctionsTestBase` has been amended to mock the relevant `IValidator` rather than the existing `InlineValidator`. This results in a slight change to existing tests in `WhenFunctionReceivesGetExpenditureHistoryRequest`.

Happy to create a new test base for the new tests if the reviewer thinks that would be a better approach.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
