### PR TITLE
feat: extend Historical Trends VIEWs

### DIFF
--- a/core-infrastructure/src/db/Core.Database/Scripts/073-CreateSchoolExpenditureAvgPercentageOfExpenditureHistoricView.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/073-CreateSchoolExpenditureAvgPercentageOfExpenditureHistoricView.sql
@@ -9,7 +9,7 @@ CREATE VIEW SchoolExpenditureAvgPercentageOfExpenditureHistoric AS
        , Avg(TotalPremisesStaffServiceCosts) AS TotalPremisesStaffServiceCosts
     FROM SchoolExpenditurePercentageOfExpenditureHistoric
    GROUP
-      BY RunId
+      BY Year
        , FinanceType
        , OverallPhase
 GO

--- a/core-infrastructure/src/db/Core.Database/Scripts/077-RecreateSchoolExpenditureHistoricWithNullsView.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/077-RecreateSchoolExpenditureHistoricWithNullsView.sql
@@ -1,0 +1,194 @@
+DROP VIEW IF EXISTS SchoolExpenditureHistoricWithNulls
+GO
+
+CREATE VIEW SchoolExpenditureHistoricWithNulls AS
+  SELECT URN
+       , Year
+       , FinanceType
+       , OverallPhase
+       , CASE
+             WHEN TotalPupils IS NULL OR TotalPupils <= 0.0 THEN NULL
+             ELSE TotalPupils
+         END AS TotalPupils
+       , CASE
+             WHEN TotalInternalFloorArea IS NULL OR TotalInternalFloorArea <= 0.0 THEN NULL
+             ELSE TotalInternalFloorArea
+         END AS TotalInternalFloorArea
+       , CASE
+             WHEN TotalExpenditure IS NULL OR TotalExpenditure <= 0.0 THEN NULL
+             ELSE TotalExpenditure
+         END AS TotalExpenditure
+       , CASE
+             WHEN TotalIncome IS NULL OR TotalIncome <= 0.0 THEN NULL
+             ELSE TotalIncome
+         END AS TotalIncome
+       , CASE
+             WHEN TotalTeachingSupportStaffCosts IS NULL OR TotalTeachingSupportStaffCosts <= 0.0 THEN NULL
+             ELSE TotalTeachingSupportStaffCosts
+         END AS TotalTeachingSupportStaffCosts
+       , CASE
+             WHEN TeachingStaffCosts IS NULL OR TeachingStaffCosts <= 0.0 THEN NULL
+             ELSE TeachingStaffCosts
+         END AS TeachingStaffCosts
+       , CASE
+             WHEN SupplyTeachingStaffCosts IS NULL OR SupplyTeachingStaffCosts <= 0.0 THEN NULL
+             ELSE SupplyTeachingStaffCosts
+         END AS SupplyTeachingStaffCosts
+       , CASE
+             WHEN EducationalConsultancyCosts IS NULL OR EducationalConsultancyCosts <= 0.0 THEN NULL
+             ELSE EducationalConsultancyCosts
+         END AS EducationalConsultancyCosts
+       , CASE
+             WHEN EducationSupportStaffCosts IS NULL OR EducationSupportStaffCosts <= 0.0 THEN NULL
+             ELSE EducationSupportStaffCosts
+         END AS EducationSupportStaffCosts
+       , CASE
+             WHEN AgencySupplyTeachingStaffCosts IS NULL OR AgencySupplyTeachingStaffCosts <= 0.0 THEN NULL
+             ELSE AgencySupplyTeachingStaffCosts
+         END AS AgencySupplyTeachingStaffCosts
+       , CASE
+             WHEN TotalNonEducationalSupportStaffCosts IS NULL OR TotalNonEducationalSupportStaffCosts <= 0.0 THEN NULL
+             ELSE TotalNonEducationalSupportStaffCosts
+         END AS TotalNonEducationalSupportStaffCosts
+       , CASE
+             WHEN AdministrativeClericalStaffCosts IS NULL OR AdministrativeClericalStaffCosts <= 0.0 THEN NULL
+             ELSE AdministrativeClericalStaffCosts
+         END AS AdministrativeClericalStaffCosts
+       , CASE
+             WHEN AuditorsCosts IS NULL OR AuditorsCosts <= 0.0 THEN NULL
+             ELSE AuditorsCosts
+         END AS AuditorsCosts
+       , CASE
+             WHEN OtherStaffCosts IS NULL OR OtherStaffCosts <= 0.0 THEN NULL
+             ELSE OtherStaffCosts
+         END AS OtherStaffCosts
+       , CASE
+             WHEN ProfessionalServicesNonCurriculumCosts IS NULL OR ProfessionalServicesNonCurriculumCosts <= 0.0 THEN NULL
+             ELSE ProfessionalServicesNonCurriculumCosts
+         END AS ProfessionalServicesNonCurriculumCosts
+       , CASE
+             WHEN TotalEducationalSuppliesCosts IS NULL OR TotalEducationalSuppliesCosts <= 0.0 THEN NULL
+             ELSE TotalEducationalSuppliesCosts
+         END AS TotalEducationalSuppliesCosts
+       , CASE
+             WHEN ExaminationFeesCosts IS NULL OR ExaminationFeesCosts <= 0.0 THEN NULL
+             ELSE ExaminationFeesCosts
+         END AS ExaminationFeesCosts
+       , CASE
+             WHEN LearningResourcesNonIctCosts IS NULL OR LearningResourcesNonIctCosts <= 0.0 THEN NULL
+             ELSE LearningResourcesNonIctCosts
+         END AS LearningResourcesNonIctCosts
+       , CASE
+             WHEN LearningResourcesIctCosts IS NULL OR LearningResourcesIctCosts <= 0.0 THEN NULL
+             ELSE LearningResourcesIctCosts
+         END AS LearningResourcesIctCosts
+       , CASE
+             WHEN TotalGrossCateringCosts IS NULL OR TotalGrossCateringCosts <= 0.0 THEN NULL
+             ELSE TotalGrossCateringCosts
+         END AS TotalGrossCateringCosts
+       , CASE
+             WHEN TotalNetCateringCosts IS NULL OR TotalNetCateringCosts <= 0.0 THEN NULL
+             ELSE TotalNetCateringCosts
+         END AS TotalNetCateringCosts
+       , CASE
+             WHEN CateringStaffCosts IS NULL OR CateringStaffCosts <= 0.0 THEN NULL
+             ELSE CateringStaffCosts
+         END AS CateringStaffCosts
+       , CASE
+             WHEN CateringSuppliesCosts IS NULL OR CateringSuppliesCosts <= 0.0 THEN NULL
+             ELSE CateringSuppliesCosts
+         END AS CateringSuppliesCosts
+       , CASE
+             WHEN TotalOtherCosts IS NULL OR TotalOtherCosts <= 0.0 THEN NULL
+             ELSE TotalOtherCosts
+         END AS TotalOtherCosts
+       , CASE
+             WHEN DirectRevenueFinancingCosts IS NULL OR DirectRevenueFinancingCosts <= 0.0 THEN NULL
+             ELSE DirectRevenueFinancingCosts
+         END AS DirectRevenueFinancingCosts
+       , CASE
+             WHEN GroundsMaintenanceCosts IS NULL OR GroundsMaintenanceCosts <= 0.0 THEN NULL
+             ELSE GroundsMaintenanceCosts
+         END AS GroundsMaintenanceCosts
+       , CASE
+             WHEN IndirectEmployeeExpenses IS NULL OR IndirectEmployeeExpenses <= 0.0 THEN NULL
+             ELSE IndirectEmployeeExpenses
+         END AS IndirectEmployeeExpenses
+       , CASE
+             WHEN InterestChargesLoanBank IS NULL OR InterestChargesLoanBank <= 0.0 THEN NULL
+             ELSE InterestChargesLoanBank
+         END AS InterestChargesLoanBank
+       , CASE
+             WHEN OtherInsurancePremiumsCosts IS NULL OR OtherInsurancePremiumsCosts <= 0.0 THEN NULL
+             ELSE OtherInsurancePremiumsCosts
+         END AS OtherInsurancePremiumsCosts
+       , CASE
+             WHEN PrivateFinanceInitiativeCharges IS NULL OR PrivateFinanceInitiativeCharges <= 0.0 THEN NULL
+             ELSE PrivateFinanceInitiativeCharges
+         END AS PrivateFinanceInitiativeCharges
+       , CASE
+             WHEN RentRatesCosts IS NULL OR RentRatesCosts <= 0.0 THEN NULL
+             ELSE RentRatesCosts
+         END AS RentRatesCosts
+       , CASE
+             WHEN SpecialFacilitiesCosts IS NULL OR SpecialFacilitiesCosts <= 0.0 THEN NULL
+             ELSE SpecialFacilitiesCosts
+         END AS SpecialFacilitiesCosts
+       , CASE
+             WHEN StaffDevelopmentTrainingCosts IS NULL OR StaffDevelopmentTrainingCosts <= 0.0 THEN NULL
+             ELSE StaffDevelopmentTrainingCosts
+         END AS StaffDevelopmentTrainingCosts
+       , CASE
+             WHEN StaffRelatedInsuranceCosts IS NULL OR StaffRelatedInsuranceCosts <= 0.0 THEN NULL
+             ELSE StaffRelatedInsuranceCosts
+         END AS StaffRelatedInsuranceCosts
+       , CASE
+             WHEN SupplyTeacherInsurableCosts IS NULL OR SupplyTeacherInsurableCosts <= 0.0 THEN NULL
+             ELSE SupplyTeacherInsurableCosts
+         END AS SupplyTeacherInsurableCosts
+       , CASE
+             WHEN CommunityFocusedSchoolStaff IS NULL OR CommunityFocusedSchoolStaff <= 0.0 THEN NULL
+             ELSE CommunityFocusedSchoolStaff
+         END AS CommunityFocusedSchoolStaff
+       , CASE
+             WHEN CommunityFocusedSchoolCosts IS NULL OR CommunityFocusedSchoolCosts <= 0.0 THEN NULL
+             ELSE CommunityFocusedSchoolCosts
+         END AS CommunityFocusedSchoolCosts
+       , CASE
+             WHEN AdministrativeSuppliesNonEducationalCosts IS NULL OR AdministrativeSuppliesNonEducationalCosts <= 0.0 THEN NULL
+             ELSE AdministrativeSuppliesNonEducationalCosts
+         END AS AdministrativeSuppliesNonEducationalCosts
+       , CASE
+             WHEN TotalPremisesStaffServiceCosts IS NULL OR TotalPremisesStaffServiceCosts <= 0.0 THEN NULL
+             ELSE TotalPremisesStaffServiceCosts
+         END AS TotalPremisesStaffServiceCosts
+       , CASE
+             WHEN CleaningCaretakingCosts IS NULL OR CleaningCaretakingCosts <= 0.0 THEN NULL
+             ELSE CleaningCaretakingCosts
+         END AS CleaningCaretakingCosts
+       , CASE
+             WHEN MaintenancePremisesCosts IS NULL OR MaintenancePremisesCosts <= 0.0 THEN NULL
+             ELSE MaintenancePremisesCosts
+         END AS MaintenancePremisesCosts
+       , CASE
+             WHEN OtherOccupationCosts IS NULL OR OtherOccupationCosts <= 0.0 THEN NULL
+             ELSE OtherOccupationCosts
+         END AS OtherOccupationCosts
+       , CASE
+             WHEN PremisesStaffCosts IS NULL OR PremisesStaffCosts <= 0.0 THEN NULL
+             ELSE PremisesStaffCosts
+         END AS PremisesStaffCosts
+       , CASE
+             WHEN TotalUtilitiesCosts IS NULL OR TotalUtilitiesCosts <= 0.0 THEN NULL
+             ELSE TotalUtilitiesCosts
+         END AS TotalUtilitiesCosts
+       , CASE
+             WHEN EnergyCosts IS NULL OR EnergyCosts <= 0.0 THEN NULL
+             ELSE EnergyCosts
+         END AS EnergyCosts
+       , CASE
+             WHEN WaterSewerageCosts IS NULL OR WaterSewerageCosts <= 0.0 THEN NULL
+             ELSE WaterSewerageCosts
+         END AS WaterSewerageCosts
+    FROM SchoolExpenditureHistoric
+GO

--- a/core-infrastructure/src/db/Core.Database/Scripts/078-RecreateSchoolExpenditureAvgHistoricView.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/078-RecreateSchoolExpenditureAvgHistoricView.sql
@@ -1,0 +1,59 @@
+DROP VIEW IF EXISTS SchoolExpenditureAvgHistoric
+GO
+
+CREATE VIEW SchoolExpenditureAvgHistoric AS
+  SELECT Year
+       , FinanceType
+       , OverallPhase
+       , Avg(TotalPupils)                               AS TotalPupils
+       , Avg(TotalInternalFloorArea)                    AS TotalInternalFloorArea
+       , Avg(TotalExpenditure)                          AS TotalExpenditure
+       , Avg(TotalIncome)                               AS TotalIncome
+       , Avg(TotalTeachingSupportStaffCosts)            AS TotalTeachingSupportStaffCosts
+       , Avg(TeachingStaffCosts)                        AS TeachingStaffCosts
+       , Avg(SupplyTeachingStaffCosts)                  AS SupplyTeachingStaffCosts
+       , Avg(EducationalConsultancyCosts)               AS EducationalConsultancyCosts
+       , Avg(EducationSupportStaffCosts)                AS EducationSupportStaffCosts
+       , Avg(AgencySupplyTeachingStaffCosts)            AS AgencySupplyTeachingStaffCosts
+       , Avg(TotalNonEducationalSupportStaffCosts)      AS TotalNonEducationalSupportStaffCosts
+       , Avg(AdministrativeClericalStaffCosts)          AS AdministrativeClericalStaffCosts
+       , Avg(AuditorsCosts)                             AS AuditorsCosts
+       , Avg(OtherStaffCosts)                           AS OtherStaffCosts
+       , Avg(ProfessionalServicesNonCurriculumCosts)    AS ProfessionalServicesNonCurriculumCosts
+       , Avg(TotalEducationalSuppliesCosts)             AS TotalEducationalSuppliesCosts
+       , Avg(ExaminationFeesCosts)                      AS ExaminationFeesCosts
+       , Avg(LearningResourcesNonIctCosts)              AS LearningResourcesNonIctCosts
+       , Avg(LearningResourcesIctCosts)                 AS LearningResourcesIctCosts
+       , Avg(TotalGrossCateringCosts)                   AS TotalGrossCateringCosts
+       , Avg(TotalNetCateringCosts)                     AS TotalNetCateringCosts
+       , Avg(CateringStaffCosts)                        AS CateringStaffCosts
+       , Avg(CateringSuppliesCosts)                     AS CateringSuppliesCosts
+       , Avg(TotalOtherCosts)                           AS TotalOtherCosts
+       , Avg(DirectRevenueFinancingCosts)               AS DirectRevenueFinancingCosts
+       , Avg(GroundsMaintenanceCosts)                   AS GroundsMaintenanceCosts
+       , Avg(IndirectEmployeeExpenses)                  AS IndirectEmployeeExpenses
+       , Avg(InterestChargesLoanBank)                   AS InterestChargesLoanBank
+       , Avg(OtherInsurancePremiumsCosts)               AS OtherInsurancePremiumsCosts
+       , Avg(PrivateFinanceInitiativeCharges)           AS PrivateFinanceInitiativeCharges
+       , Avg(RentRatesCosts)                            AS RentRatesCosts
+       , Avg(SpecialFacilitiesCosts)                    AS SpecialFacilitiesCosts
+       , Avg(StaffDevelopmentTrainingCosts)             AS StaffDevelopmentTrainingCosts
+       , Avg(StaffRelatedInsuranceCosts)                AS StaffRelatedInsuranceCosts
+       , Avg(SupplyTeacherInsurableCosts)               AS SupplyTeacherInsurableCosts
+       , Avg(CommunityFocusedSchoolStaff)               AS CommunityFocusedSchoolStaff
+       , Avg(CommunityFocusedSchoolCosts)               AS CommunityFocusedSchoolCosts
+       , Avg(AdministrativeSuppliesNonEducationalCosts) AS AdministrativeSuppliesNonEducationalCosts
+       , Avg(TotalPremisesStaffServiceCosts)            AS TotalPremisesStaffServiceCosts
+       , Avg(CleaningCaretakingCosts)                   AS CleaningCaretakingCosts
+       , Avg(MaintenancePremisesCosts)                  AS MaintenancePremisesCosts
+       , Avg(OtherOccupationCosts)                      AS OtherOccupationCosts
+       , Avg(PremisesStaffCosts)                        AS PremisesStaffCosts
+       , Avg(TotalUtilitiesCosts)                       AS TotalUtilitiesCosts
+       , Avg(EnergyCosts)                               AS EnergyCosts
+       , Avg(WaterSewerageCosts)                        AS WaterSewerageCosts
+    FROM SchoolExpenditureHistoricWithNulls
+   GROUP
+      BY Year
+       , FinanceType
+       , OverallPhase
+GO

--- a/core-infrastructure/src/db/Core.Database/Scripts/079-RecreateSchoolExpenditureAvgPerUnitHistoricView.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/079-RecreateSchoolExpenditureAvgPerUnitHistoricView.sql
@@ -1,0 +1,112 @@
+DROP VIEW IF EXISTS SchoolExpenditurePerUnitHistoric
+GO
+
+CREATE VIEW SchoolExpenditurePerUnitHistoric AS
+  SELECT URN
+       , Year
+       , FinanceType
+       , OverallPhase
+       , TotalExpenditure / TotalPupils                          AS TotalExpenditure
+       , TotalIncome / TotalPupils                               AS TotalIncome
+       , TotalTeachingSupportStaffCosts / TotalPupils            AS TotalTeachingSupportStaffCosts
+       , TeachingStaffCosts / TotalPupils                        AS TeachingStaffCosts
+       , SupplyTeachingStaffCosts / TotalPupils                  AS SupplyTeachingStaffCosts
+       , EducationalConsultancyCosts / TotalPupils               AS EducationalConsultancyCosts
+       , EducationSupportStaffCosts / TotalPupils                AS EducationSupportStaffCosts
+       , AgencySupplyTeachingStaffCosts / TotalPupils            AS AgencySupplyTeachingStaffCosts
+       , TotalNonEducationalSupportStaffCosts / TotalPupils      AS TotalNonEducationalSupportStaffCosts
+       , AdministrativeClericalStaffCosts / TotalPupils          AS AdministrativeClericalStaffCosts
+       , AuditorsCosts / TotalPupils                             AS AuditorsCosts
+       , OtherStaffCosts / TotalPupils                           AS OtherStaffCosts
+       , ProfessionalServicesNonCurriculumCosts / TotalPupils    AS ProfessionalServicesNonCurriculumCosts
+       , TotalEducationalSuppliesCosts / TotalPupils             AS TotalEducationalSuppliesCosts
+       , ExaminationFeesCosts / TotalPupils                      AS ExaminationFeesCosts
+       , LearningResourcesNonIctCosts / TotalPupils              AS LearningResourcesNonIctCosts
+       , LearningResourcesIctCosts / TotalPupils                 AS LearningResourcesIctCosts
+       , TotalGrossCateringCosts / TotalPupils                   AS TotalGrossCateringCosts
+       , TotalNetCateringCosts / TotalPupils                     AS TotalNetCateringCosts
+       , CateringStaffCosts / TotalPupils                        AS CateringStaffCosts
+       , CateringSuppliesCosts / TotalPupils                     AS CateringSuppliesCosts
+       , TotalOtherCosts / TotalPupils                           AS TotalOtherCosts
+       , DirectRevenueFinancingCosts / TotalPupils               AS DirectRevenueFinancingCosts
+       , GroundsMaintenanceCosts / TotalPupils                   AS GroundsMaintenanceCosts
+       , IndirectEmployeeExpenses / TotalPupils                  AS IndirectEmployeeExpenses
+       , InterestChargesLoanBank / TotalPupils                   AS InterestChargesLoanBank
+       , OtherInsurancePremiumsCosts / TotalPupils               AS OtherInsurancePremiumsCosts
+       , PrivateFinanceInitiativeCharges / TotalPupils           AS PrivateFinanceInitiativeCharges
+       , RentRatesCosts / TotalPupils                            AS RentRatesCosts
+       , SpecialFacilitiesCosts / TotalPupils                    AS SpecialFacilitiesCosts
+       , StaffDevelopmentTrainingCosts / TotalPupils             AS StaffDevelopmentTrainingCosts
+       , StaffRelatedInsuranceCosts / TotalPupils                AS StaffRelatedInsuranceCosts
+       , SupplyTeacherInsurableCosts / TotalPupils               AS SupplyTeacherInsurableCosts
+       , CommunityFocusedSchoolStaff / TotalPupils               AS CommunityFocusedSchoolStaff
+       , CommunityFocusedSchoolCosts / TotalPupils               AS CommunityFocusedSchoolCosts
+       , AdministrativeSuppliesNonEducationalCosts / TotalPupils AS AdministrativeSuppliesNonEducationalCosts
+       , TotalPremisesStaffServiceCosts / TotalInternalFloorArea AS TotalPremisesStaffServiceCosts
+       , CleaningCaretakingCosts / TotalInternalFloorArea        AS CleaningCaretakingCosts
+       , MaintenancePremisesCosts / TotalInternalFloorArea       AS MaintenancePremisesCosts
+       , OtherOccupationCosts / TotalInternalFloorArea           AS OtherOccupationCosts
+       , PremisesStaffCosts / TotalInternalFloorArea             AS PremisesStaffCosts
+       , TotalUtilitiesCosts / TotalInternalFloorArea            AS TotalUtilitiesCosts
+       , EnergyCosts / TotalInternalFloorArea                    AS EnergyCosts
+       , WaterSewerageCosts / TotalInternalFloorArea             AS WaterSewerageCosts
+    FROM SchoolExpenditureHistoricWithNulls
+GO
+
+DROP VIEW IF EXISTS SchoolExpenditureAvgPerUnitHistoric
+GO
+
+CREATE VIEW SchoolExpenditureAvgPerUnitHistoric AS
+  SELECT Year
+       , FinanceType
+       , OverallPhase
+       , Avg(TotalExpenditure)                           AS TotalExpenditure
+       , Avg(TotalIncome)                                AS TotalIncome
+       , Avg(TotalTeachingSupportStaffCosts)             AS TotalTeachingSupportStaffCosts
+       , Avg(TeachingStaffCosts)                         AS TeachingStaffCosts
+       , Avg(SupplyTeachingStaffCosts)                   AS SupplyTeachingStaffCosts
+       , Avg(EducationalConsultancyCosts)                AS EducationalConsultancyCosts
+       , Avg(EducationSupportStaffCosts)                 AS EducationSupportStaffCosts
+       , Avg(AgencySupplyTeachingStaffCosts)             AS AgencySupplyTeachingStaffCosts
+       , Avg(TotalNonEducationalSupportStaffCosts)       AS TotalNonEducationalSupportStaffCosts
+       , Avg(AdministrativeClericalStaffCosts)           AS AdministrativeClericalStaffCosts
+       , Avg(AuditorsCosts)                              AS AuditorsCosts
+       , Avg(OtherStaffCosts)                            AS OtherStaffCosts
+       , Avg(ProfessionalServicesNonCurriculumCosts)     AS ProfessionalServicesNonCurriculumCosts
+       , Avg(TotalEducationalSuppliesCosts)              AS TotalEducationalSuppliesCosts
+       , Avg(ExaminationFeesCosts)                       AS ExaminationFeesCosts
+       , Avg(LearningResourcesNonIctCosts)               AS LearningResourcesNonIctCosts
+       , Avg(LearningResourcesIctCosts)                  AS LearningResourcesIctCosts
+       , Avg(TotalGrossCateringCosts)                    AS TotalGrossCateringCosts
+       , Avg(TotalNetCateringCosts)                      AS TotalNetCateringCosts
+       , Avg(CateringStaffCosts)                         AS CateringStaffCosts
+       , Avg(CateringSuppliesCosts)                      AS CateringSuppliesCosts
+       , Avg(TotalOtherCosts)                            AS TotalOtherCosts
+       , Avg(DirectRevenueFinancingCosts)                AS DirectRevenueFinancingCosts
+       , Avg(GroundsMaintenanceCosts)                    AS GroundsMaintenanceCosts
+       , Avg(IndirectEmployeeExpenses)                   AS IndirectEmployeeExpenses
+       , Avg(InterestChargesLoanBank)                    AS InterestChargesLoanBank
+       , Avg(OtherInsurancePremiumsCosts)                AS OtherInsurancePremiumsCosts
+       , Avg(PrivateFinanceInitiativeCharges)            AS PrivateFinanceInitiativeCharges
+       , Avg(RentRatesCosts)                             AS RentRatesCosts
+       , Avg(SpecialFacilitiesCosts)                     AS SpecialFacilitiesCosts
+       , Avg(StaffDevelopmentTrainingCosts)              AS StaffDevelopmentTrainingCosts
+       , Avg(StaffRelatedInsuranceCosts)                 AS StaffRelatedInsuranceCosts
+       , Avg(SupplyTeacherInsurableCosts)                AS SupplyTeacherInsurableCosts
+       , Avg(CommunityFocusedSchoolStaff)                AS CommunityFocusedSchoolStaff
+       , Avg(CommunityFocusedSchoolCosts)                AS CommunityFocusedSchoolCosts
+       , Avg(AdministrativeSuppliesNonEducationalCosts)  AS AdministrativeSuppliesNonEducationalCosts
+       , Avg(TotalPremisesStaffServiceCosts)             AS TotalPremisesStaffServiceCosts
+       , Avg(CleaningCaretakingCosts)                    AS CleaningCaretakingCosts
+       , Avg(MaintenancePremisesCosts)                   AS MaintenancePremisesCosts
+       , Avg(OtherOccupationCosts)                       AS OtherOccupationCosts
+       , Avg(PremisesStaffCosts)                         AS PremisesStaffCosts
+       , Avg(TotalUtilitiesCosts)                        AS TotalUtilitiesCosts
+       , Avg(EnergyCosts)                                AS EnergyCosts
+       , Avg(WaterSewerageCosts)                         AS WaterSewerageCosts
+    FROM SchoolExpenditurePerUnitHistoric
+   GROUP
+      BY Year
+       , FinanceType
+       , OverallPhase
+GO

--- a/core-infrastructure/src/db/Core.Database/Scripts/080-RecreateSchoolExpenditureAvgComparatorSetView.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/080-RecreateSchoolExpenditureAvgComparatorSetView.sql
@@ -1,0 +1,143 @@
+DROP VIEW IF EXISTS SchoolExpenditureAvgComparatorSet
+GO
+
+CREATE VIEW SchoolExpenditureAvgComparatorSet AS
+  WITH pupilComparator AS (
+    SELECT RunId
+         , URN
+         , Comparator.value AS PupilComparatorURN
+      FROM ComparatorSet
+     CROSS APPLY Openjson(Pupil) Comparator
+     WHERE RunType = 'default'
+  ), buildingComparator AS (
+    SELECT RunId
+         , URN
+         , Comparator.value AS BuildingComparatorURN
+      FROM ComparatorSet
+     CROSS APPLY Openjson(Building) Comparator
+     WHERE RunType = 'default'
+  ), pupilExpenditureAvgComparatorSet AS (
+    SELECT pupilComparator.URN
+         , pupilComparator.RunId
+         , Avg(TotalExpenditure)                          AS TotalExpenditure
+         , Avg(TotalIncome)                               AS TotalIncome
+         , Avg(TotalTeachingSupportStaffCosts)            AS TotalTeachingSupportStaffCosts
+         , Avg(TeachingStaffCosts)                        AS TeachingStaffCosts
+         , Avg(SupplyTeachingStaffCosts)                  AS SupplyTeachingStaffCosts
+         , Avg(EducationalConsultancyCosts)               AS EducationalConsultancyCosts
+         , Avg(EducationSupportStaffCosts)                AS EducationSupportStaffCosts
+         , Avg(AgencySupplyTeachingStaffCosts)            AS AgencySupplyTeachingStaffCosts
+         , Avg(TotalNonEducationalSupportStaffCosts)      AS TotalNonEducationalSupportStaffCosts
+         , Avg(AdministrativeClericalStaffCosts)          AS AdministrativeClericalStaffCosts
+         , Avg(AuditorsCosts)                             AS AuditorsCosts
+         , Avg(OtherStaffCosts)                           AS OtherStaffCosts
+         , Avg(ProfessionalServicesNonCurriculumCosts)    AS ProfessionalServicesNonCurriculumCosts
+         , Avg(TotalEducationalSuppliesCosts)             AS TotalEducationalSuppliesCosts
+         , Avg(ExaminationFeesCosts)                      AS ExaminationFeesCosts
+         , Avg(LearningResourcesNonIctCosts)              AS LearningResourcesNonIctCosts
+         , Avg(LearningResourcesIctCosts)                 AS LearningResourcesIctCosts
+         , Avg(TotalGrossCateringCosts)                   AS TotalGrossCateringCosts
+         , Avg(TotalNetCateringCosts)                     AS TotalNetCateringCosts
+         , Avg(CateringStaffCosts)                        AS CateringStaffCosts
+         , Avg(CateringSuppliesCosts)                     AS CateringSuppliesCosts
+         , Avg(TotalOtherCosts)                           AS TotalOtherCosts
+         , Avg(DirectRevenueFinancingCosts)               AS DirectRevenueFinancingCosts
+         , Avg(GroundsMaintenanceCosts)                   AS GroundsMaintenanceCosts
+         , Avg(IndirectEmployeeExpenses)                  AS IndirectEmployeeExpenses
+         , Avg(InterestChargesLoanBank)                   AS InterestChargesLoanBank
+         , Avg(OtherInsurancePremiumsCosts)               AS OtherInsurancePremiumsCosts
+         , Avg(PrivateFinanceInitiativeCharges)           AS PrivateFinanceInitiativeCharges
+         , Avg(RentRatesCosts)                            AS RentRatesCosts
+         , Avg(SpecialFacilitiesCosts)                    AS SpecialFacilitiesCosts
+         , Avg(StaffDevelopmentTrainingCosts)             AS StaffDevelopmentTrainingCosts
+         , Avg(StaffRelatedInsuranceCosts)                AS StaffRelatedInsuranceCosts
+         , Avg(SupplyTeacherInsurableCosts)               AS SupplyTeacherInsurableCosts
+         , Avg(CommunityFocusedSchoolStaff)               AS CommunityFocusedSchoolStaff
+         , Avg(CommunityFocusedSchoolCosts)               AS CommunityFocusedSchoolCosts
+         , Avg(AdministrativeSuppliesNonEducationalCosts) AS AdministrativeSuppliesNonEducationalCosts
+      FROM pupilComparator
+     INNER
+      JOIN SchoolExpenditureHistoricWithNulls
+        ON (
+                 pupilComparator.PupilComparatorURN = SchoolExpenditureHistoricWithNulls.URN
+             AND pupilComparator.RunId = SchoolExpenditureHistoricWithNulls.Year
+           )
+     GROUP
+        BY pupilComparator.URN
+         , pupilComparator.RunId
+   ), buildingExpenditureAvgComparatorSet AS (
+    SELECT buildingComparator.URN
+         , buildingComparator.RunId
+         , Avg(TotalPremisesStaffServiceCosts) AS TotalPremisesStaffServiceCosts
+         , Avg(CleaningCaretakingCosts)        AS CleaningCaretakingCosts
+         , Avg(MaintenancePremisesCosts)       AS MaintenancePremisesCosts
+         , Avg(OtherOccupationCosts)           AS OtherOccupationCosts
+         , Avg(PremisesStaffCosts)             AS PremisesStaffCosts
+         , Avg(TotalUtilitiesCosts)            AS TotalUtilitiesCosts
+         , Avg(EnergyCosts)                    AS EnergyCosts
+         , Avg(WaterSewerageCosts)             AS WaterSewerageCosts
+      FROM buildingComparator
+     INNER
+      JOIN SchoolExpenditureHistoricWithNulls
+        ON (
+                 buildingComparator.BuildingComparatorURN = SchoolExpenditureHistoricWithNulls.URN
+             AND buildingComparator.RunId = SchoolExpenditureHistoricWithNulls.Year
+           )
+     GROUP
+        BY buildingComparator.URN
+         , buildingComparator.RunId
+    )
+  SELECT pupilExpenditureAvgComparatorSet.URN
+       , pupilExpenditureAvgComparatorSet.RunId AS Year
+       , TotalExpenditure
+       , TotalIncome
+       , TotalTeachingSupportStaffCosts
+       , TeachingStaffCosts
+       , SupplyTeachingStaffCosts
+       , EducationalConsultancyCosts
+       , EducationSupportStaffCosts
+       , AgencySupplyTeachingStaffCosts
+       , TotalNonEducationalSupportStaffCosts
+       , AdministrativeClericalStaffCosts
+       , AuditorsCosts
+       , OtherStaffCosts
+       , ProfessionalServicesNonCurriculumCosts
+       , TotalEducationalSuppliesCosts
+       , ExaminationFeesCosts
+       , LearningResourcesNonIctCosts
+       , LearningResourcesIctCosts
+       , TotalGrossCateringCosts
+       , TotalNetCateringCosts
+       , CateringStaffCosts
+       , CateringSuppliesCosts
+       , TotalOtherCosts
+       , DirectRevenueFinancingCosts
+       , GroundsMaintenanceCosts
+       , IndirectEmployeeExpenses
+       , InterestChargesLoanBank
+       , OtherInsurancePremiumsCosts
+       , PrivateFinanceInitiativeCharges
+       , RentRatesCosts
+       , SpecialFacilitiesCosts
+       , StaffDevelopmentTrainingCosts
+       , StaffRelatedInsuranceCosts
+       , SupplyTeacherInsurableCosts
+       , CommunityFocusedSchoolStaff
+       , CommunityFocusedSchoolCosts
+       , AdministrativeSuppliesNonEducationalCosts
+       , TotalPremisesStaffServiceCosts
+       , CleaningCaretakingCosts
+       , MaintenancePremisesCosts
+       , OtherOccupationCosts
+       , PremisesStaffCosts
+       , TotalUtilitiesCosts
+       , EnergyCosts
+       , WaterSewerageCosts
+    FROM pupilExpenditureAvgComparatorSet
+    FULL
+    JOIN buildingExpenditureAvgComparatorSet
+      ON (
+               pupilExpenditureAvgComparatorSet.URN = buildingExpenditureAvgComparatorSet.URN
+           AND pupilExpenditureAvgComparatorSet.RunId = buildingExpenditureAvgComparatorSet.RunId
+         )
+GO

--- a/core-infrastructure/src/db/Core.Database/Scripts/081-RecreateSchoolExpenditureAvgPerUnitComparatorSetView.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/081-RecreateSchoolExpenditureAvgPerUnitComparatorSetView.sql
@@ -1,0 +1,143 @@
+DROP VIEW IF EXISTS SchoolExpenditureAvgPerUnitComparatorSet
+GO
+
+CREATE VIEW SchoolExpenditureAvgPerUnitComparatorSet AS
+  WITH pupilComparator AS (
+    SELECT RunId
+         , URN
+         , Comparator.value AS PupilComparatorURN
+      FROM ComparatorSet
+     CROSS APPLY Openjson(Pupil) Comparator
+     WHERE RunType = 'default'
+  ), buildingComparator AS (
+    SELECT RunId
+         , URN
+         , Comparator.value AS BuildingComparatorURN
+      FROM ComparatorSet
+     CROSS APPLY Openjson(Building) Comparator
+     WHERE RunType = 'default'
+  ), pupilExpenditureAvgPerMetricComparatorSet AS (
+    SELECT pupilComparator.URN
+         , pupilComparator.RunId
+         , Avg(TotalExpenditure)                          AS TotalExpenditure
+         , Avg(TotalIncome)                               AS TotalIncome
+         , Avg(TotalTeachingSupportStaffCosts)            AS TotalTeachingSupportStaffCosts
+         , Avg(TeachingStaffCosts)                        AS TeachingStaffCosts
+         , Avg(SupplyTeachingStaffCosts)                  AS SupplyTeachingStaffCosts
+         , Avg(EducationalConsultancyCosts)               AS EducationalConsultancyCosts
+         , Avg(EducationSupportStaffCosts)                AS EducationSupportStaffCosts
+         , Avg(AgencySupplyTeachingStaffCosts)            AS AgencySupplyTeachingStaffCosts
+         , Avg(TotalNonEducationalSupportStaffCosts)      AS TotalNonEducationalSupportStaffCosts
+         , Avg(AdministrativeClericalStaffCosts)          AS AdministrativeClericalStaffCosts
+         , Avg(AuditorsCosts)                             AS AuditorsCosts
+         , Avg(OtherStaffCosts)                           AS OtherStaffCosts
+         , Avg(ProfessionalServicesNonCurriculumCosts)    AS ProfessionalServicesNonCurriculumCosts
+         , Avg(TotalEducationalSuppliesCosts)             AS TotalEducationalSuppliesCosts
+         , Avg(ExaminationFeesCosts)                      AS ExaminationFeesCosts
+         , Avg(LearningResourcesNonIctCosts)              AS LearningResourcesNonIctCosts
+         , Avg(LearningResourcesIctCosts)                 AS LearningResourcesIctCosts
+         , Avg(TotalGrossCateringCosts)                   AS TotalGrossCateringCosts
+         , Avg(TotalNetCateringCosts)                     AS TotalNetCateringCosts
+         , Avg(CateringStaffCosts)                        AS CateringStaffCosts
+         , Avg(CateringSuppliesCosts)                     AS CateringSuppliesCosts
+         , Avg(TotalOtherCosts)                           AS TotalOtherCosts
+         , Avg(DirectRevenueFinancingCosts)               AS DirectRevenueFinancingCosts
+         , Avg(GroundsMaintenanceCosts)                   AS GroundsMaintenanceCosts
+         , Avg(IndirectEmployeeExpenses)                  AS IndirectEmployeeExpenses
+         , Avg(InterestChargesLoanBank)                   AS InterestChargesLoanBank
+         , Avg(OtherInsurancePremiumsCosts)               AS OtherInsurancePremiumsCosts
+         , Avg(PrivateFinanceInitiativeCharges)           AS PrivateFinanceInitiativeCharges
+         , Avg(RentRatesCosts)                            AS RentRatesCosts
+         , Avg(SpecialFacilitiesCosts)                    AS SpecialFacilitiesCosts
+         , Avg(StaffDevelopmentTrainingCosts)             AS StaffDevelopmentTrainingCosts
+         , Avg(StaffRelatedInsuranceCosts)                AS StaffRelatedInsuranceCosts
+         , Avg(SupplyTeacherInsurableCosts)               AS SupplyTeacherInsurableCosts
+         , Avg(CommunityFocusedSchoolStaff)               AS CommunityFocusedSchoolStaff
+         , Avg(CommunityFocusedSchoolCosts)               AS CommunityFocusedSchoolCosts
+         , Avg(AdministrativeSuppliesNonEducationalCosts) AS AdministrativeSuppliesNonEducationalCosts
+      FROM pupilComparator
+     INNER
+      JOIN SchoolExpenditurePerUnitHistoric
+        ON (
+                 pupilComparator.PupilComparatorURN = SchoolExpenditurePerUnitHistoric.URN
+             AND pupilComparator.RunId = SchoolExpenditurePerUnitHistoric.Year
+           )
+     GROUP
+        BY pupilComparator.URN
+         , pupilComparator.RunId
+   ), buildingExpenditureAvgPerMetricComparatorSet AS (
+    SELECT buildingComparator.URN
+         , buildingComparator.RunId
+         , Avg(TotalPremisesStaffServiceCosts) AS TotalPremisesStaffServiceCosts
+         , Avg(CleaningCaretakingCosts)        AS CleaningCaretakingCosts
+         , Avg(MaintenancePremisesCosts)       AS MaintenancePremisesCosts
+         , Avg(OtherOccupationCosts)           AS OtherOccupationCosts
+         , Avg(PremisesStaffCosts)             AS PremisesStaffCosts
+         , Avg(TotalUtilitiesCosts)            AS TotalUtilitiesCosts
+         , Avg(EnergyCosts)                    AS EnergyCosts
+         , Avg(WaterSewerageCosts)             AS WaterSewerageCosts
+      FROM buildingComparator
+     INNER
+      JOIN SchoolExpenditurePerUnitHistoric
+        ON (
+                 buildingComparator.BuildingComparatorURN = SchoolExpenditurePerUnitHistoric.URN
+             AND buildingComparator.RunId = SchoolExpenditurePerUnitHistoric.Year
+           )
+     GROUP
+        BY buildingComparator.URN
+         , buildingComparator.RunId
+    )
+  SELECT pupilExpenditureAvgPerMetricComparatorSet.URN
+       , pupilExpenditureAvgPerMetricComparatorSet.RunId AS Year
+       , TotalExpenditure
+       , TotalIncome
+       , TotalTeachingSupportStaffCosts
+       , TeachingStaffCosts
+       , SupplyTeachingStaffCosts
+       , EducationalConsultancyCosts
+       , EducationSupportStaffCosts
+       , AgencySupplyTeachingStaffCosts
+       , TotalNonEducationalSupportStaffCosts
+       , AdministrativeClericalStaffCosts
+       , AuditorsCosts
+       , OtherStaffCosts
+       , ProfessionalServicesNonCurriculumCosts
+       , TotalEducationalSuppliesCosts
+       , ExaminationFeesCosts
+       , LearningResourcesNonIctCosts
+       , LearningResourcesIctCosts
+       , TotalGrossCateringCosts
+       , TotalNetCateringCosts
+       , CateringStaffCosts
+       , CateringSuppliesCosts
+       , TotalOtherCosts
+       , DirectRevenueFinancingCosts
+       , GroundsMaintenanceCosts
+       , IndirectEmployeeExpenses
+       , InterestChargesLoanBank
+       , OtherInsurancePremiumsCosts
+       , PrivateFinanceInitiativeCharges
+       , RentRatesCosts
+       , SpecialFacilitiesCosts
+       , StaffDevelopmentTrainingCosts
+       , StaffRelatedInsuranceCosts
+       , SupplyTeacherInsurableCosts
+       , CommunityFocusedSchoolStaff
+       , CommunityFocusedSchoolCosts
+       , AdministrativeSuppliesNonEducationalCosts
+       , TotalPremisesStaffServiceCosts
+       , CleaningCaretakingCosts
+       , MaintenancePremisesCosts
+       , OtherOccupationCosts
+       , PremisesStaffCosts
+       , TotalUtilitiesCosts
+       , EnergyCosts
+       , WaterSewerageCosts
+    FROM pupilExpenditureAvgPerMetricComparatorSet
+    FULL
+    JOIN buildingExpenditureAvgPerMetricComparatorSet
+      ON (
+               pupilExpenditureAvgPerMetricComparatorSet.URN = buildingExpenditureAvgPerMetricComparatorSet.URN
+           AND pupilExpenditureAvgPerMetricComparatorSet.RunId = buildingExpenditureAvgPerMetricComparatorSet.RunId
+         )
+GO

--- a/core-infrastructure/src/db/Core.Database/Scripts/082-RecreateSchoolExpenditurePercentageOfExpenditureHistoricView.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/082-RecreateSchoolExpenditurePercentageOfExpenditureHistoricView.sql
@@ -1,0 +1,54 @@
+DROP VIEW IF EXISTS SchoolExpenditurePercentageOfExpenditureHistoric
+GO
+
+CREATE VIEW SchoolExpenditurePercentageOfExpenditureHistoric AS
+  SELECT Year
+       , URN
+       , FinanceType
+       , OverallPhase
+       , (TotalExpenditure / TotalExpenditure) * 100                          AS TotalExpenditure
+       , (TotalIncome / TotalExpenditure) * 100                               AS TotalIncome
+       , (TotalTeachingSupportStaffCosts / TotalExpenditure) * 100            AS TotalTeachingSupportStaffCosts
+       , (TeachingStaffCosts / TotalExpenditure) * 100                        AS TeachingStaffCosts
+       , (SupplyTeachingStaffCosts / TotalExpenditure) * 100                  AS SupplyTeachingStaffCosts
+       , (EducationalConsultancyCosts / TotalExpenditure) * 100               AS EducationalConsultancyCosts
+       , (EducationSupportStaffCosts / TotalExpenditure) * 100                AS EducationSupportStaffCosts
+       , (AgencySupplyTeachingStaffCosts / TotalExpenditure) * 100            AS AgencySupplyTeachingStaffCosts
+       , (TotalNonEducationalSupportStaffCosts / TotalExpenditure) * 100      AS TotalNonEducationalSupportStaffCosts
+       , (AdministrativeClericalStaffCosts / TotalExpenditure) * 100          AS AdministrativeClericalStaffCosts
+       , (AuditorsCosts / TotalExpenditure) * 100                             AS AuditorsCosts
+       , (OtherStaffCosts / TotalExpenditure) * 100                           AS OtherStaffCosts
+       , (ProfessionalServicesNonCurriculumCosts / TotalExpenditure) * 100    AS ProfessionalServicesNonCurriculumCosts
+       , (TotalEducationalSuppliesCosts / TotalExpenditure) * 100             AS TotalEducationalSuppliesCosts
+       , (ExaminationFeesCosts / TotalExpenditure) * 100                      AS ExaminationFeesCosts
+       , (LearningResourcesNonIctCosts / TotalExpenditure) * 100              AS LearningResourcesNonIctCosts
+       , (LearningResourcesIctCosts / TotalExpenditure) * 100                 AS LearningResourcesIctCosts
+       , (TotalGrossCateringCosts / TotalExpenditure) * 100                   AS TotalGrossCateringCosts
+       , (TotalNetCateringCosts / TotalExpenditure) * 100                     AS TotalNetCateringCosts
+       , (CateringStaffCosts / TotalExpenditure) * 100                        AS CateringStaffCosts
+       , (CateringSuppliesCosts / TotalExpenditure) * 100                     AS CateringSuppliesCosts
+       , (TotalOtherCosts / TotalExpenditure) * 100                           AS TotalOtherCosts
+       , (DirectRevenueFinancingCosts / TotalExpenditure) * 100               AS DirectRevenueFinancingCosts
+       , (GroundsMaintenanceCosts / TotalExpenditure) * 100                   AS GroundsMaintenanceCosts
+       , (IndirectEmployeeExpenses / TotalExpenditure) * 100                  AS IndirectEmployeeExpenses
+       , (InterestChargesLoanBank / TotalExpenditure) * 100                   AS InterestChargesLoanBank
+       , (OtherInsurancePremiumsCosts / TotalExpenditure) * 100               AS OtherInsurancePremiumsCosts
+       , (PrivateFinanceInitiativeCharges / TotalExpenditure) * 100           AS PrivateFinanceInitiativeCharges
+       , (RentRatesCosts / TotalExpenditure) * 100                            AS RentRatesCosts
+       , (SpecialFacilitiesCosts / TotalExpenditure) * 100                    AS SpecialFacilitiesCosts
+       , (StaffDevelopmentTrainingCosts / TotalExpenditure) * 100             AS StaffDevelopmentTrainingCosts
+       , (StaffRelatedInsuranceCosts / TotalExpenditure) * 100                AS StaffRelatedInsuranceCosts
+       , (SupplyTeacherInsurableCosts / TotalExpenditure) * 100               AS SupplyTeacherInsurableCosts
+       , (CommunityFocusedSchoolStaff / TotalExpenditure) * 100               AS CommunityFocusedSchoolStaff
+       , (CommunityFocusedSchoolCosts / TotalExpenditure) * 100               AS CommunityFocusedSchoolCosts
+       , (AdministrativeSuppliesNonEducationalCosts / TotalExpenditure) * 100 AS AdministrativeSuppliesNonEducationalCosts
+       , (TotalPremisesStaffServiceCosts / TotalExpenditure) * 100            AS TotalPremisesStaffServiceCosts
+       , (CleaningCaretakingCosts / TotalExpenditure) * 100                   AS CleaningCaretakingCosts
+       , (MaintenancePremisesCosts / TotalExpenditure) * 100                  AS MaintenancePremisesCosts
+       , (OtherOccupationCosts / TotalExpenditure) * 100                      AS OtherOccupationCosts
+       , (PremisesStaffCosts / TotalExpenditure) * 100                        AS PremisesStaffCosts
+       , (TotalUtilitiesCosts / TotalExpenditure) * 100                       AS TotalUtilitiesCosts
+       , (EnergyCosts / TotalExpenditure) * 100                               AS EnergyCosts
+       , (WaterSewerageCosts / TotalExpenditure) * 100                        AS WaterSewerageCosts
+    FROM SchoolExpenditureHistoricWithNulls
+GO

--- a/core-infrastructure/src/db/Core.Database/Scripts/083-RecreateSchoolExpenditurePercentageOfIncomeHistoricView.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/083-RecreateSchoolExpenditurePercentageOfIncomeHistoricView.sql
@@ -1,0 +1,54 @@
+DROP VIEW IF EXISTS SchoolExpenditurePercentageOfIncomeHistoric
+GO
+
+CREATE VIEW SchoolExpenditurePercentageOfIncomeHistoric AS
+  SELECT Year
+       , URN
+       , FinanceType
+       , OverallPhase
+       , (TotalExpenditure / TotalIncome) * 100                          AS TotalExpenditure
+       , (TotalIncome / TotalIncome) * 100                               AS TotalIncome
+       , (TotalTeachingSupportStaffCosts / TotalIncome) * 100            AS TotalTeachingSupportStaffCosts
+       , (TeachingStaffCosts / TotalIncome) * 100                        AS TeachingStaffCosts
+       , (SupplyTeachingStaffCosts / TotalIncome) * 100                  AS SupplyTeachingStaffCosts
+       , (EducationalConsultancyCosts / TotalIncome) * 100               AS EducationalConsultancyCosts
+       , (EducationSupportStaffCosts / TotalIncome) * 100                AS EducationSupportStaffCosts
+       , (AgencySupplyTeachingStaffCosts / TotalIncome) * 100            AS AgencySupplyTeachingStaffCosts
+       , (TotalNonEducationalSupportStaffCosts / TotalIncome) * 100      AS TotalNonEducationalSupportStaffCosts
+       , (AdministrativeClericalStaffCosts / TotalIncome) * 100          AS AdministrativeClericalStaffCosts
+       , (AuditorsCosts / TotalIncome) * 100                             AS AuditorsCosts
+       , (OtherStaffCosts / TotalIncome) * 100                           AS OtherStaffCosts
+       , (ProfessionalServicesNonCurriculumCosts / TotalIncome) * 100    AS ProfessionalServicesNonCurriculumCosts
+       , (TotalEducationalSuppliesCosts / TotalIncome) * 100             AS TotalEducationalSuppliesCosts
+       , (ExaminationFeesCosts / TotalIncome) * 100                      AS ExaminationFeesCosts
+       , (LearningResourcesNonIctCosts / TotalIncome) * 100              AS LearningResourcesNonIctCosts
+       , (LearningResourcesIctCosts / TotalIncome) * 100                 AS LearningResourcesIctCosts
+       , (TotalGrossCateringCosts / TotalIncome) * 100                   AS TotalGrossCateringCosts
+       , (TotalNetCateringCosts / TotalIncome) * 100                     AS TotalNetCateringCosts
+       , (CateringStaffCosts / TotalIncome) * 100                        AS CateringStaffCosts
+       , (CateringSuppliesCosts / TotalIncome) * 100                     AS CateringSuppliesCosts
+       , (TotalOtherCosts / TotalIncome) * 100                           AS TotalOtherCosts
+       , (DirectRevenueFinancingCosts / TotalIncome) * 100               AS DirectRevenueFinancingCosts
+       , (GroundsMaintenanceCosts / TotalIncome) * 100                   AS GroundsMaintenanceCosts
+       , (IndirectEmployeeExpenses / TotalIncome) * 100                  AS IndirectEmployeeExpenses
+       , (InterestChargesLoanBank / TotalIncome) * 100                   AS InterestChargesLoanBank
+       , (OtherInsurancePremiumsCosts / TotalIncome) * 100               AS OtherInsurancePremiumsCosts
+       , (PrivateFinanceInitiativeCharges / TotalIncome) * 100           AS PrivateFinanceInitiativeCharges
+       , (RentRatesCosts / TotalIncome) * 100                            AS RentRatesCosts
+       , (SpecialFacilitiesCosts / TotalIncome) * 100                    AS SpecialFacilitiesCosts
+       , (StaffDevelopmentTrainingCosts / TotalIncome) * 100             AS StaffDevelopmentTrainingCosts
+       , (StaffRelatedInsuranceCosts / TotalIncome) * 100                AS StaffRelatedInsuranceCosts
+       , (SupplyTeacherInsurableCosts / TotalIncome) * 100               AS SupplyTeacherInsurableCosts
+       , (CommunityFocusedSchoolStaff / TotalIncome) * 100               AS CommunityFocusedSchoolStaff
+       , (CommunityFocusedSchoolCosts / TotalIncome) * 100               AS CommunityFocusedSchoolCosts
+       , (AdministrativeSuppliesNonEducationalCosts / TotalIncome) * 100 AS AdministrativeSuppliesNonEducationalCosts
+       , (TotalPremisesStaffServiceCosts / TotalIncome) * 100            AS TotalPremisesStaffServiceCosts
+       , (CleaningCaretakingCosts / TotalIncome) * 100                   AS CleaningCaretakingCosts
+       , (MaintenancePremisesCosts / TotalIncome) * 100                  AS MaintenancePremisesCosts
+       , (OtherOccupationCosts / TotalIncome) * 100                      AS OtherOccupationCosts
+       , (PremisesStaffCosts / TotalIncome) * 100                        AS PremisesStaffCosts
+       , (TotalUtilitiesCosts / TotalIncome) * 100                       AS TotalUtilitiesCosts
+       , (EnergyCosts / TotalIncome) * 100                               AS EnergyCosts
+       , (WaterSewerageCosts / TotalIncome) * 100                        AS WaterSewerageCosts
+    FROM SchoolExpenditureHistoricWithNulls
+GO

--- a/core-infrastructure/src/db/Core.Database/Scripts/084-RecreateSchoolExpenditureAvgPercentageOfExpenditureHistoricView.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/084-RecreateSchoolExpenditureAvgPercentageOfExpenditureHistoricView.sql
@@ -1,0 +1,57 @@
+DROP VIEW IF EXISTS SchoolExpenditureAvgPercentageOfExpenditureHistoric
+GO
+
+CREATE VIEW SchoolExpenditureAvgPercentageOfExpenditureHistoric AS
+  SELECT Year
+       , FinanceType
+       , OverallPhase
+       , Avg(TotalExpenditure)                          AS TotalExpenditure
+       , Avg(TotalIncome)                               AS TotalIncome
+       , Avg(TotalTeachingSupportStaffCosts)            AS TotalTeachingSupportStaffCosts
+       , Avg(TeachingStaffCosts)                        AS TeachingStaffCosts
+       , Avg(SupplyTeachingStaffCosts)                  AS SupplyTeachingStaffCosts
+       , Avg(EducationalConsultancyCosts)               AS EducationalConsultancyCosts
+       , Avg(EducationSupportStaffCosts)                AS EducationSupportStaffCosts
+       , Avg(AgencySupplyTeachingStaffCosts)            AS AgencySupplyTeachingStaffCosts
+       , Avg(TotalNonEducationalSupportStaffCosts)      AS TotalNonEducationalSupportStaffCosts
+       , Avg(AdministrativeClericalStaffCosts)          AS AdministrativeClericalStaffCosts
+       , Avg(AuditorsCosts)                             AS AuditorsCosts
+       , Avg(OtherStaffCosts)                           AS OtherStaffCosts
+       , Avg(ProfessionalServicesNonCurriculumCosts)    AS ProfessionalServicesNonCurriculumCosts
+       , Avg(TotalEducationalSuppliesCosts)             AS TotalEducationalSuppliesCosts
+       , Avg(ExaminationFeesCosts)                      AS ExaminationFeesCosts
+       , Avg(LearningResourcesNonIctCosts)              AS LearningResourcesNonIctCosts
+       , Avg(LearningResourcesIctCosts)                 AS LearningResourcesIctCosts
+       , Avg(TotalGrossCateringCosts)                   AS TotalGrossCateringCosts
+       , Avg(TotalNetCateringCosts)                     AS TotalNetCateringCosts
+       , Avg(CateringStaffCosts)                        AS CateringStaffCosts
+       , Avg(CateringSuppliesCosts)                     AS CateringSuppliesCosts
+       , Avg(TotalOtherCosts)                           AS TotalOtherCosts
+       , Avg(DirectRevenueFinancingCosts)               AS DirectRevenueFinancingCosts
+       , Avg(GroundsMaintenanceCosts)                   AS GroundsMaintenanceCosts
+       , Avg(IndirectEmployeeExpenses)                  AS IndirectEmployeeExpenses
+       , Avg(InterestChargesLoanBank)                   AS InterestChargesLoanBank
+       , Avg(OtherInsurancePremiumsCosts)               AS OtherInsurancePremiumsCosts
+       , Avg(PrivateFinanceInitiativeCharges)           AS PrivateFinanceInitiativeCharges
+       , Avg(RentRatesCosts)                            AS RentRatesCosts
+       , Avg(SpecialFacilitiesCosts)                    AS SpecialFacilitiesCosts
+       , Avg(StaffDevelopmentTrainingCosts)             AS StaffDevelopmentTrainingCosts
+       , Avg(StaffRelatedInsuranceCosts)                AS StaffRelatedInsuranceCosts
+       , Avg(SupplyTeacherInsurableCosts)               AS SupplyTeacherInsurableCosts
+       , Avg(CommunityFocusedSchoolStaff)               AS CommunityFocusedSchoolStaff
+       , Avg(CommunityFocusedSchoolCosts)               AS CommunityFocusedSchoolCosts
+       , Avg(AdministrativeSuppliesNonEducationalCosts) AS AdministrativeSuppliesNonEducationalCosts
+       , Avg(TotalPremisesStaffServiceCosts)            AS TotalPremisesStaffServiceCosts
+       , Avg(CleaningCaretakingCosts)                   AS CleaningCaretakingCosts
+       , Avg(MaintenancePremisesCosts)                  AS MaintenancePremisesCosts
+       , Avg(OtherOccupationCosts)                      AS OtherOccupationCosts
+       , Avg(PremisesStaffCosts)                        AS PremisesStaffCosts
+       , Avg(TotalUtilitiesCosts)                       AS TotalUtilitiesCosts
+       , Avg(EnergyCosts)                               AS EnergyCosts
+       , Avg(WaterSewerageCosts)                        AS WaterSewerageCosts
+    FROM SchoolExpenditurePercentageOfExpenditureHistoric
+   GROUP
+      BY Year
+       , FinanceType
+       , OverallPhase
+GO

--- a/core-infrastructure/src/db/Core.Database/Scripts/085-RecreateSchoolExpenditureAvgPercentageOfIncomeHistoricView.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/085-RecreateSchoolExpenditureAvgPercentageOfIncomeHistoricView.sql
@@ -1,0 +1,57 @@
+DROP VIEW IF EXISTS SchoolExpenditureAvgPercentageOfIncomeHistoric
+GO
+
+CREATE VIEW SchoolExpenditureAvgPercentageOfIncomeHistoric AS
+  SELECT Year
+       , FinanceType
+       , OverallPhase
+       , Avg(TotalExpenditure)                          AS TotalExpenditure
+       , Avg(TotalIncome)                               AS TotalIncome
+       , Avg(TotalTeachingSupportStaffCosts)            AS TotalTeachingSupportStaffCosts
+       , Avg(TeachingStaffCosts)                        AS TeachingStaffCosts
+       , Avg(SupplyTeachingStaffCosts)                  AS SupplyTeachingStaffCosts
+       , Avg(EducationalConsultancyCosts)               AS EducationalConsultancyCosts
+       , Avg(EducationSupportStaffCosts)                AS EducationSupportStaffCosts
+       , Avg(AgencySupplyTeachingStaffCosts)            AS AgencySupplyTeachingStaffCosts
+       , Avg(TotalNonEducationalSupportStaffCosts)      AS TotalNonEducationalSupportStaffCosts
+       , Avg(AdministrativeClericalStaffCosts)          AS AdministrativeClericalStaffCosts
+       , Avg(AuditorsCosts)                             AS AuditorsCosts
+       , Avg(OtherStaffCosts)                           AS OtherStaffCosts
+       , Avg(ProfessionalServicesNonCurriculumCosts)    AS ProfessionalServicesNonCurriculumCosts
+       , Avg(TotalEducationalSuppliesCosts)             AS TotalEducationalSuppliesCosts
+       , Avg(ExaminationFeesCosts)                      AS ExaminationFeesCosts
+       , Avg(LearningResourcesNonIctCosts)              AS LearningResourcesNonIctCosts
+       , Avg(LearningResourcesIctCosts)                 AS LearningResourcesIctCosts
+       , Avg(TotalGrossCateringCosts)                   AS TotalGrossCateringCosts
+       , Avg(TotalNetCateringCosts)                     AS TotalNetCateringCosts
+       , Avg(CateringStaffCosts)                        AS CateringStaffCosts
+       , Avg(CateringSuppliesCosts)                     AS CateringSuppliesCosts
+       , Avg(TotalOtherCosts)                           AS TotalOtherCosts
+       , Avg(DirectRevenueFinancingCosts)               AS DirectRevenueFinancingCosts
+       , Avg(GroundsMaintenanceCosts)                   AS GroundsMaintenanceCosts
+       , Avg(IndirectEmployeeExpenses)                  AS IndirectEmployeeExpenses
+       , Avg(InterestChargesLoanBank)                   AS InterestChargesLoanBank
+       , Avg(OtherInsurancePremiumsCosts)               AS OtherInsurancePremiumsCosts
+       , Avg(PrivateFinanceInitiativeCharges)           AS PrivateFinanceInitiativeCharges
+       , Avg(RentRatesCosts)                            AS RentRatesCosts
+       , Avg(SpecialFacilitiesCosts)                    AS SpecialFacilitiesCosts
+       , Avg(StaffDevelopmentTrainingCosts)             AS StaffDevelopmentTrainingCosts
+       , Avg(StaffRelatedInsuranceCosts)                AS StaffRelatedInsuranceCosts
+       , Avg(SupplyTeacherInsurableCosts)               AS SupplyTeacherInsurableCosts
+       , Avg(CommunityFocusedSchoolStaff)               AS CommunityFocusedSchoolStaff
+       , Avg(CommunityFocusedSchoolCosts)               AS CommunityFocusedSchoolCosts
+       , Avg(AdministrativeSuppliesNonEducationalCosts) AS AdministrativeSuppliesNonEducationalCosts
+       , Avg(TotalPremisesStaffServiceCosts)            AS TotalPremisesStaffServiceCosts
+       , Avg(CleaningCaretakingCosts)                   AS CleaningCaretakingCosts
+       , Avg(MaintenancePremisesCosts)                  AS MaintenancePremisesCosts
+       , Avg(OtherOccupationCosts)                      AS OtherOccupationCosts
+       , Avg(PremisesStaffCosts)                        AS PremisesStaffCosts
+       , Avg(TotalUtilitiesCosts)                       AS TotalUtilitiesCosts
+       , Avg(EnergyCosts)                               AS EnergyCosts
+       , Avg(WaterSewerageCosts)                        AS WaterSewerageCosts
+    FROM SchoolExpenditurePercentageOfIncomeHistoric
+   GROUP
+      BY Year
+       , FinanceType
+       , OverallPhase
+GO

--- a/core-infrastructure/src/db/Core.Database/Scripts/086-RecreateSchoolExpenditureAvgPercentageOfExpenditureComparatorSetView.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/086-RecreateSchoolExpenditureAvgPercentageOfExpenditureComparatorSetView.sql
@@ -1,0 +1,143 @@
+DROP VIEW IF EXISTS SchoolExpenditureAvgPercentageOfExpenditureComparatorSet
+GO
+
+CREATE VIEW SchoolExpenditureAvgPercentageOfExpenditureComparatorSet AS
+  WITH pupilComparator AS (
+    SELECT RunId
+         , URN
+         , Comparator.value AS PupilComparatorURN
+      FROM ComparatorSet
+     CROSS APPLY Openjson(Pupil) Comparator
+     WHERE RunType = 'default'
+  ), buildingComparator AS (
+    SELECT RunId
+         , URN
+         , Comparator.value AS BuildingComparatorURN
+      FROM ComparatorSet
+     CROSS APPLY Openjson(Building) Comparator
+     WHERE RunType = 'default'
+  ), pupilExpenditureAvgOfPercentageOfExpenditureComparatorSet AS (
+    SELECT pupilComparator.URN
+         , pupilComparator.RunId
+         , Avg(TotalExpenditure)                          AS TotalExpenditure
+         , Avg(TotalIncome)                               AS TotalIncome
+         , Avg(TotalTeachingSupportStaffCosts)            AS TotalTeachingSupportStaffCosts
+         , Avg(TeachingStaffCosts)                        AS TeachingStaffCosts
+         , Avg(SupplyTeachingStaffCosts)                  AS SupplyTeachingStaffCosts
+         , Avg(EducationalConsultancyCosts)               AS EducationalConsultancyCosts
+         , Avg(EducationSupportStaffCosts)                AS EducationSupportStaffCosts
+         , Avg(AgencySupplyTeachingStaffCosts)            AS AgencySupplyTeachingStaffCosts
+         , Avg(TotalNonEducationalSupportStaffCosts)      AS TotalNonEducationalSupportStaffCosts
+         , Avg(AdministrativeClericalStaffCosts)          AS AdministrativeClericalStaffCosts
+         , Avg(AuditorsCosts)                             AS AuditorsCosts
+         , Avg(OtherStaffCosts)                           AS OtherStaffCosts
+         , Avg(ProfessionalServicesNonCurriculumCosts)    AS ProfessionalServicesNonCurriculumCosts
+         , Avg(TotalEducationalSuppliesCosts)             AS TotalEducationalSuppliesCosts
+         , Avg(ExaminationFeesCosts)                      AS ExaminationFeesCosts
+         , Avg(LearningResourcesNonIctCosts)              AS LearningResourcesNonIctCosts
+         , Avg(LearningResourcesIctCosts)                 AS LearningResourcesIctCosts
+         , Avg(TotalGrossCateringCosts)                   AS TotalGrossCateringCosts
+         , Avg(TotalNetCateringCosts)                     AS TotalNetCateringCosts
+         , Avg(CateringStaffCosts)                        AS CateringStaffCosts
+         , Avg(CateringSuppliesCosts)                     AS CateringSuppliesCosts
+         , Avg(TotalOtherCosts)                           AS TotalOtherCosts
+         , Avg(DirectRevenueFinancingCosts)               AS DirectRevenueFinancingCosts
+         , Avg(GroundsMaintenanceCosts)                   AS GroundsMaintenanceCosts
+         , Avg(IndirectEmployeeExpenses)                  AS IndirectEmployeeExpenses
+         , Avg(InterestChargesLoanBank)                   AS InterestChargesLoanBank
+         , Avg(OtherInsurancePremiumsCosts)               AS OtherInsurancePremiumsCosts
+         , Avg(PrivateFinanceInitiativeCharges)           AS PrivateFinanceInitiativeCharges
+         , Avg(RentRatesCosts)                            AS RentRatesCosts
+         , Avg(SpecialFacilitiesCosts)                    AS SpecialFacilitiesCosts
+         , Avg(StaffDevelopmentTrainingCosts)             AS StaffDevelopmentTrainingCosts
+         , Avg(StaffRelatedInsuranceCosts)                AS StaffRelatedInsuranceCosts
+         , Avg(SupplyTeacherInsurableCosts)               AS SupplyTeacherInsurableCosts
+         , Avg(CommunityFocusedSchoolStaff)               AS CommunityFocusedSchoolStaff
+         , Avg(CommunityFocusedSchoolCosts)               AS CommunityFocusedSchoolCosts
+         , Avg(AdministrativeSuppliesNonEducationalCosts) AS AdministrativeSuppliesNonEducationalCosts
+      FROM pupilComparator
+     INNER
+      JOIN SchoolExpenditurePercentageOfExpenditureHistoric
+        ON (
+                 pupilComparator.PupilComparatorURN = SchoolExpenditurePercentageOfExpenditureHistoric.URN
+             AND pupilComparator.RunId = SchoolExpenditurePercentageOfExpenditureHistoric.Year
+           )
+     GROUP
+        BY pupilComparator.URN
+         , pupilComparator.RunId
+   ), buildingExpenditureAvgOfPercentageOfExpenditureComparatorSet AS (
+    SELECT buildingComparator.URN
+         , buildingComparator.RunId
+         , Avg(TotalPremisesStaffServiceCosts) AS TotalPremisesStaffServiceCosts
+         , Avg(CleaningCaretakingCosts)        AS CleaningCaretakingCosts
+         , Avg(MaintenancePremisesCosts)       AS MaintenancePremisesCosts
+         , Avg(OtherOccupationCosts)           AS OtherOccupationCosts
+         , Avg(PremisesStaffCosts)             AS PremisesStaffCosts
+         , Avg(TotalUtilitiesCosts)            AS TotalUtilitiesCosts
+         , Avg(EnergyCosts)                    AS EnergyCosts
+         , Avg(WaterSewerageCosts)             AS WaterSewerageCosts
+      FROM buildingComparator
+     INNER
+      JOIN SchoolExpenditurePercentageOfExpenditureHistoric
+        ON (
+                 buildingComparator.BuildingComparatorURN = SchoolExpenditurePercentageOfExpenditureHistoric.URN
+             AND buildingComparator.RunId = SchoolExpenditurePercentageOfExpenditureHistoric.Year
+           )
+     GROUP
+        BY buildingComparator.URN
+         , buildingComparator.RunId
+    )
+  SELECT pupilExpenditureAvgOfPercentageOfExpenditureComparatorSet.URN
+       , pupilExpenditureAvgOfPercentageOfExpenditureComparatorSet.RunId AS Year
+       , TotalExpenditure
+       , TotalIncome
+       , TotalTeachingSupportStaffCosts
+       , TeachingStaffCosts
+       , SupplyTeachingStaffCosts
+       , EducationalConsultancyCosts
+       , EducationSupportStaffCosts
+       , AgencySupplyTeachingStaffCosts
+       , TotalNonEducationalSupportStaffCosts
+       , AdministrativeClericalStaffCosts
+       , AuditorsCosts
+       , OtherStaffCosts
+       , ProfessionalServicesNonCurriculumCosts
+       , TotalEducationalSuppliesCosts
+       , ExaminationFeesCosts
+       , LearningResourcesNonIctCosts
+       , LearningResourcesIctCosts
+       , TotalGrossCateringCosts
+       , TotalNetCateringCosts
+       , CateringStaffCosts
+       , CateringSuppliesCosts
+       , TotalOtherCosts
+       , DirectRevenueFinancingCosts
+       , GroundsMaintenanceCosts
+       , IndirectEmployeeExpenses
+       , InterestChargesLoanBank
+       , OtherInsurancePremiumsCosts
+       , PrivateFinanceInitiativeCharges
+       , RentRatesCosts
+       , SpecialFacilitiesCosts
+       , StaffDevelopmentTrainingCosts
+       , StaffRelatedInsuranceCosts
+       , SupplyTeacherInsurableCosts
+       , CommunityFocusedSchoolStaff
+       , CommunityFocusedSchoolCosts
+       , AdministrativeSuppliesNonEducationalCosts
+       , TotalPremisesStaffServiceCosts
+       , CleaningCaretakingCosts
+       , MaintenancePremisesCosts
+       , OtherOccupationCosts
+       , PremisesStaffCosts
+       , TotalUtilitiesCosts
+       , EnergyCosts
+       , WaterSewerageCosts
+    FROM pupilExpenditureAvgOfPercentageOfExpenditureComparatorSet
+    FULL
+    JOIN buildingExpenditureAvgOfPercentageOfExpenditureComparatorSet
+      ON (
+               pupilExpenditureAvgOfPercentageOfExpenditureComparatorSet.URN = buildingExpenditureAvgOfPercentageOfExpenditureComparatorSet.URN
+           AND pupilExpenditureAvgOfPercentageOfExpenditureComparatorSet.RunId = buildingExpenditureAvgOfPercentageOfExpenditureComparatorSet.RunId
+         )
+GO

--- a/core-infrastructure/src/db/Core.Database/Scripts/087-RecreateSchoolExpenditureAvgPercentageOfIncomeComparatorSetView.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/087-RecreateSchoolExpenditureAvgPercentageOfIncomeComparatorSetView.sql
@@ -1,0 +1,143 @@
+DROP VIEW IF EXISTS SchoolExpenditureAvgPercentageOfIncomeComparatorSet
+GO
+
+CREATE VIEW SchoolExpenditureAvgPercentageOfIncomeComparatorSet AS
+  WITH pupilComparator AS (
+    SELECT RunId
+         , URN
+         , Comparator.value AS PupilComparatorURN
+      FROM ComparatorSet
+     CROSS APPLY Openjson(Pupil) Comparator
+     WHERE RunType = 'default'
+  ), buildingComparator AS (
+    SELECT RunId
+         , URN
+         , Comparator.value AS BuildingComparatorURN
+      FROM ComparatorSet
+     CROSS APPLY Openjson(Building) Comparator
+     WHERE RunType = 'default'
+  ), pupilExpenditureAvgOfPercentageOfIncomeComparatorSet AS (
+    SELECT pupilComparator.URN
+         , pupilComparator.RunId
+         , Avg(TotalExpenditure)                          AS TotalExpenditure
+         , Avg(TotalIncome)                               AS TotalIncome
+         , Avg(TotalTeachingSupportStaffCosts)            AS TotalTeachingSupportStaffCosts
+         , Avg(TeachingStaffCosts)                        AS TeachingStaffCosts
+         , Avg(SupplyTeachingStaffCosts)                  AS SupplyTeachingStaffCosts
+         , Avg(EducationalConsultancyCosts)               AS EducationalConsultancyCosts
+         , Avg(EducationSupportStaffCosts)                AS EducationSupportStaffCosts
+         , Avg(AgencySupplyTeachingStaffCosts)            AS AgencySupplyTeachingStaffCosts
+         , Avg(TotalNonEducationalSupportStaffCosts)      AS TotalNonEducationalSupportStaffCosts
+         , Avg(AdministrativeClericalStaffCosts)          AS AdministrativeClericalStaffCosts
+         , Avg(AuditorsCosts)                             AS AuditorsCosts
+         , Avg(OtherStaffCosts)                           AS OtherStaffCosts
+         , Avg(ProfessionalServicesNonCurriculumCosts)    AS ProfessionalServicesNonCurriculumCosts
+         , Avg(TotalEducationalSuppliesCosts)             AS TotalEducationalSuppliesCosts
+         , Avg(ExaminationFeesCosts)                      AS ExaminationFeesCosts
+         , Avg(LearningResourcesNonIctCosts)              AS LearningResourcesNonIctCosts
+         , Avg(LearningResourcesIctCosts)                 AS LearningResourcesIctCosts
+         , Avg(TotalGrossCateringCosts)                   AS TotalGrossCateringCosts
+         , Avg(TotalNetCateringCosts)                     AS TotalNetCateringCosts
+         , Avg(CateringStaffCosts)                        AS CateringStaffCosts
+         , Avg(CateringSuppliesCosts)                     AS CateringSuppliesCosts
+         , Avg(TotalOtherCosts)                           AS TotalOtherCosts
+         , Avg(DirectRevenueFinancingCosts)               AS DirectRevenueFinancingCosts
+         , Avg(GroundsMaintenanceCosts)                   AS GroundsMaintenanceCosts
+         , Avg(IndirectEmployeeExpenses)                  AS IndirectEmployeeExpenses
+         , Avg(InterestChargesLoanBank)                   AS InterestChargesLoanBank
+         , Avg(OtherInsurancePremiumsCosts)               AS OtherInsurancePremiumsCosts
+         , Avg(PrivateFinanceInitiativeCharges)           AS PrivateFinanceInitiativeCharges
+         , Avg(RentRatesCosts)                            AS RentRatesCosts
+         , Avg(SpecialFacilitiesCosts)                    AS SpecialFacilitiesCosts
+         , Avg(StaffDevelopmentTrainingCosts)             AS StaffDevelopmentTrainingCosts
+         , Avg(StaffRelatedInsuranceCosts)                AS StaffRelatedInsuranceCosts
+         , Avg(SupplyTeacherInsurableCosts)               AS SupplyTeacherInsurableCosts
+         , Avg(CommunityFocusedSchoolStaff)               AS CommunityFocusedSchoolStaff
+         , Avg(CommunityFocusedSchoolCosts)               AS CommunityFocusedSchoolCosts
+         , Avg(AdministrativeSuppliesNonEducationalCosts) AS AdministrativeSuppliesNonEducationalCosts
+      FROM pupilComparator
+     INNER
+      JOIN SchoolExpenditurePercentageOfIncomeHistoric
+        ON (
+                 pupilComparator.PupilComparatorURN = SchoolExpenditurePercentageOfIncomeHistoric.URN
+             AND pupilComparator.RunId = SchoolExpenditurePercentageOfIncomeHistoric.Year
+           )
+     GROUP
+        BY pupilComparator.URN
+         , pupilComparator.RunId
+   ), buildingExpenditureAvgOfPercentageOfIncomeComparatorSet AS (
+    SELECT buildingComparator.URN
+         , buildingComparator.RunId
+         , Avg(TotalPremisesStaffServiceCosts) AS TotalPremisesStaffServiceCosts
+         , Avg(CleaningCaretakingCosts)        AS CleaningCaretakingCosts
+         , Avg(MaintenancePremisesCosts)       AS MaintenancePremisesCosts
+         , Avg(OtherOccupationCosts)           AS OtherOccupationCosts
+         , Avg(PremisesStaffCosts)             AS PremisesStaffCosts
+         , Avg(TotalUtilitiesCosts)            AS TotalUtilitiesCosts
+         , Avg(EnergyCosts)                    AS EnergyCosts
+         , Avg(WaterSewerageCosts)             AS WaterSewerageCosts
+      FROM buildingComparator
+     INNER
+      JOIN SchoolExpenditurePercentageOfIncomeHistoric
+        ON (
+                 buildingComparator.BuildingComparatorURN = SchoolExpenditurePercentageOfIncomeHistoric.URN
+             AND buildingComparator.RunId = SchoolExpenditurePercentageOfIncomeHistoric.Year
+           )
+     GROUP
+        BY buildingComparator.URN
+         , buildingComparator.RunId
+    )
+  SELECT pupilExpenditureAvgOfPercentageOfIncomeComparatorSet.URN
+       , pupilExpenditureAvgOfPercentageOfIncomeComparatorSet.RunId AS Year
+       , TotalExpenditure
+       , TotalIncome
+       , TotalTeachingSupportStaffCosts
+       , TeachingStaffCosts
+       , SupplyTeachingStaffCosts
+       , EducationalConsultancyCosts
+       , EducationSupportStaffCosts
+       , AgencySupplyTeachingStaffCosts
+       , TotalNonEducationalSupportStaffCosts
+       , AdministrativeClericalStaffCosts
+       , AuditorsCosts
+       , OtherStaffCosts
+       , ProfessionalServicesNonCurriculumCosts
+       , TotalEducationalSuppliesCosts
+       , ExaminationFeesCosts
+       , LearningResourcesNonIctCosts
+       , LearningResourcesIctCosts
+       , TotalGrossCateringCosts
+       , TotalNetCateringCosts
+       , CateringStaffCosts
+       , CateringSuppliesCosts
+       , TotalOtherCosts
+       , DirectRevenueFinancingCosts
+       , GroundsMaintenanceCosts
+       , IndirectEmployeeExpenses
+       , InterestChargesLoanBank
+       , OtherInsurancePremiumsCosts
+       , PrivateFinanceInitiativeCharges
+       , RentRatesCosts
+       , SpecialFacilitiesCosts
+       , StaffDevelopmentTrainingCosts
+       , StaffRelatedInsuranceCosts
+       , SupplyTeacherInsurableCosts
+       , CommunityFocusedSchoolStaff
+       , CommunityFocusedSchoolCosts
+       , AdministrativeSuppliesNonEducationalCosts
+       , TotalPremisesStaffServiceCosts
+       , CleaningCaretakingCosts
+       , MaintenancePremisesCosts
+       , OtherOccupationCosts
+       , PremisesStaffCosts
+       , TotalUtilitiesCosts
+       , EnergyCosts
+       , WaterSewerageCosts
+    FROM pupilExpenditureAvgOfPercentageOfIncomeComparatorSet
+    FULL
+    JOIN buildingExpenditureAvgOfPercentageOfIncomeComparatorSet
+      ON (
+               pupilExpenditureAvgOfPercentageOfIncomeComparatorSet.URN = buildingExpenditureAvgOfPercentageOfIncomeComparatorSet.URN
+           AND pupilExpenditureAvgOfPercentageOfIncomeComparatorSet.RunId = buildingExpenditureAvgOfPercentageOfIncomeComparatorSet.RunId
+         )
+GO


### PR DESCRIPTION
### Context

Following #1655 and appropriate sign-off, the VIEWs created therein have been extended to include _all_ required columns.

[AB#237633](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/237633)

### Change proposed in this pull request

recreate the following VIEWs with all required columns:

- `SchoolExpenditureHistoricWithNullsView`
- `SchoolExpenditureAvgHistoricView`
- `SchoolExpenditureAvgPerUnitHistoricView`
- `SchoolExpenditureAvgComparatorSetView`
- `SchoolExpenditureAvgPerUnitComparatorSetView`
- `SchoolExpenditurePercentageOfExpenditureHistoricView`
- `SchoolExpenditurePercentageOfIncomeHistoricView`
- `SchoolExpenditureAvgPercentageOfExpenditureHistoricView`
- `SchoolExpenditureAvgPercentageOfIncomeHistoricView`
- `SchoolExpenditureAvgPercentageOfExpenditureComparatorSetView`
- `SchoolExpenditureAvgPercentageOfIncomeComparatorSet`

### Guidance to review 

all VIEWs recreated in d15 and verified that each runs without error when queried.

Note: they aren't hugely performant when queried without a `WHERE` clause.

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~You have run all unit/integration tests and they pass~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~You have reviewed with UX/Design~

