### PR TITLE
Added `census/history/comparison` endpoint to Web proxy API

### DIFF
--- a/web/src/Web.App/Domain/Insight/Expenditure.cs
+++ b/web/src/Web.App/Domain/Insight/Expenditure.cs
@@ -161,10 +161,3 @@ public record ExpenditureHistory : ExpenditureBase
     public int? Year { get; set; }
     public string? Term { get; set; }
 }
-
-public record HistoryComparison<T> where T : ExpenditureBase
-{
-    public T[]? School { get; set; }
-    public T[]? ComparatorSetAverage { get; set; }
-    public T[]? NationalAverage { get; set; }
-}

--- a/web/src/Web.App/Domain/Insight/HistoryComparison.cs
+++ b/web/src/Web.App/Domain/Insight/HistoryComparison.cs
@@ -1,0 +1,8 @@
+namespace Web.App.Domain;
+
+public record HistoryComparison<T>
+{
+    public T[]? School { get; set; }
+    public T[]? ComparatorSetAverage { get; set; }
+    public T[]? NationalAverage { get; set; }
+}

--- a/web/src/Web.App/Infrastructure/Apis/Insight/Api.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Insight/Api.cs
@@ -18,19 +18,21 @@ public static class Api
     public static class Census
     {
         public static string Schools => "api/census";
+        public static string SchoolHistoryNationalAverage => "api/census/history/national-average"; // proposed endpoint
         public static string School(string? urn) => $"api/census/{urn}";
         public static string SchoolCustom(string? urn, string? identifier) => $"api/census/{urn}/custom/{identifier}";
         public static string SchoolHistory(string? urn) => $"api/census/{urn}/history";
+        public static string SchoolHistoryComparatorSetAverage(string? urn) => $"api/census/{urn}/history/comparator-set-average"; // proposed endpoint
     }
 
     public static class Expenditure
     {
         public static string Schools => "api/expenditure/schools";
         public static string Trusts => "api/expenditure/trusts";
-        public static string SchoolHistoryNationalAverage => "api/expenditure/school/history/national-average"; // proposed endpoint
+        public static string SchoolHistoryNationalAverage => "api/expenditure/school/history/national-average";
         public static string School(string? urn) => $"api/expenditure/school/{urn}";
         public static string SchoolHistory(string? urn) => $"api/expenditure/school/{urn}/history";
-        public static string SchoolHistoryComparatorSetAverage(string? urn) => $"api/expenditure/school/{urn}/history/comparator-set-average"; // proposed endpoint
+        public static string SchoolHistoryComparatorSetAverage(string? urn) => $"api/expenditure/school/{urn}/history/comparator-set-average";
         public static string SchoolCustom(string? urn, string? identifier) => $"api/expenditure/school/{urn}/custom/{identifier}";
         public static string Trust(string? companyNo) => $"api/expenditure/trust/{companyNo}";
         public static string TrustHistory(string? companyNo) => $"api/expenditure/trust/{companyNo}/history";

--- a/web/src/Web.App/Infrastructure/Apis/Insight/CensusApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Insight/CensusApi.cs
@@ -4,7 +4,9 @@ public interface ICensusApi
 {
     Task<ApiResult> Get(string? urn, ApiQuery? query = null);
     Task<ApiResult> GetCustom(string? urn, string? identifier, ApiQuery? query = null);
-    Task<ApiResult> History(string? urn, ApiQuery? query = null);
+    Task<ApiResult> SchoolHistory(string? urn, ApiQuery? query = null);
+    Task<ApiResult> SchoolHistoryComparatorSetAverage(string? urn, ApiQuery? query = null);
+    Task<ApiResult> SchoolHistoryNationalAverage(ApiQuery? query = null);
     Task<ApiResult> Query(ApiQuery? query = null);
 }
 
@@ -12,6 +14,8 @@ public class CensusApi(HttpClient httpClient, string? key = default) : ApiBase(h
 {
     public async Task<ApiResult> Get(string? urn, ApiQuery? query = null) => await GetAsync($"{Api.Census.School(urn)}{query?.ToQueryString()}");
     public async Task<ApiResult> GetCustom(string? urn, string? identifier, ApiQuery? query = null) => await GetAsync($"{Api.Census.SchoolCustom(urn, identifier)}{query?.ToQueryString()}");
-    public async Task<ApiResult> History(string? urn, ApiQuery? query = null) => await GetAsync($"{Api.Census.SchoolHistory(urn)}{query?.ToQueryString()}");
+    public async Task<ApiResult> SchoolHistory(string? urn, ApiQuery? query = null) => await GetAsync($"{Api.Census.SchoolHistory(urn)}{query?.ToQueryString()}");
+    public async Task<ApiResult> SchoolHistoryComparatorSetAverage(string? urn, ApiQuery? query = null) => await GetAsync($"{Api.Census.SchoolHistoryComparatorSetAverage(urn)}{query?.ToQueryString()}");
+    public async Task<ApiResult> SchoolHistoryNationalAverage(ApiQuery? query = null) => await GetAsync($"{Api.Census.SchoolHistoryNationalAverage}{query?.ToQueryString()}");
     public async Task<ApiResult> Query(ApiQuery? query = null) => await GetAsync($"{Api.Census.Schools}{query?.ToQueryString()}");
 }

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -204,7 +204,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     public BenchmarkingWebAppClient SetupCensusWithException()
     {
         CensusApi.Reset();
-        CensusApi.Setup(api => api.History(It.IsAny<string?>(), It.IsAny<ApiQuery?>())).Throws(new Exception());
+        CensusApi.Setup(api => api.SchoolHistory(It.IsAny<string?>(), It.IsAny<ApiQuery?>())).Throws(new Exception());
         CensusApi.Setup(api => api.Query(It.IsAny<ApiQuery?>())).Throws(new Exception());
         return this;
     }

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -201,6 +201,15 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         return this;
     }
 
+    public BenchmarkingWebAppClient SetupCensus(School school, CensusHistory[] historySchool, CensusHistory[]? historyComparatorSet = null, CensusHistory[]? historyNational = null)
+    {
+        CensusApi.Reset();
+        CensusApi.Setup(api => api.SchoolHistory(school.URN, It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(historySchool));
+        CensusApi.Setup(api => api.SchoolHistoryComparatorSetAverage(school.URN, It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(historyComparatorSet));
+        CensusApi.Setup(api => api.SchoolHistoryNationalAverage(It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(historyNational));
+        return this;
+    }
+
     public BenchmarkingWebAppClient SetupCensusWithException()
     {
         CensusApi.Reset();
@@ -343,6 +352,15 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         ExpenditureApi
             .Setup(api => api.SchoolCustom(school.URN, identifier, It.IsAny<ApiQuery?>()))
             .ReturnsAsync(ApiResult.Ok(expenditure));
+        return this;
+    }
+
+    public BenchmarkingWebAppClient SetupExpenditure(School school, ExpenditureHistory[] historySchool, ExpenditureHistory[]? historyComparatorSet = null, ExpenditureHistory[]? historyNational = null)
+    {
+        ExpenditureApi.Reset();
+        ExpenditureApi.Setup(api => api.SchoolHistory(school.URN, It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(historySchool));
+        ExpenditureApi.Setup(api => api.SchoolHistoryComparatorSetAverage(school.URN, It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(historyComparatorSet));
+        ExpenditureApi.Setup(api => api.SchoolHistoryNationalAverage(It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(historyNational));
         return this;
     }
 

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -96,7 +96,9 @@ public static class Paths
 
     public static string ApiSuggest(string search, string type) => $"api/suggest?search={search}&type={type}";
     public static string ApiExpenditure(string? type, string? id, string category, string dimension) => $"api/expenditure?type={type}&id={id}&category={category}&dimension={dimension}";
+    public static string ApiExpenditureHistoryComparison(string? type, string? id, string dimension, string? phase, string? financeType) => $"api/expenditure/history/comparison?type={type}&id={id}&dimension={dimension}&phase={phase}&financeType={financeType}";
     public static string ApiCensus(string id, string type, string category, string dimension) => $"api/census?id={id}&type={type}&category={category}&dimension={dimension}";
+    public static string ApiCensusHistoryComparison(string id, string dimension, string? phase, string? financeType) => $"api/census/history/comparison?id={id}&dimension={dimension}&phase={phase}&financeType={financeType}";
     public static string LocalAuthorityHome(string? code) => $"/local-authority/{code}";
     public static string LocalAuthorityResources(string? code) => $"/local-authority/{code}/find-ways-to-spend-less";
     public static string SchoolResources(string? urn) => $"/school/{urn}/find-ways-to-spend-less";

--- a/web/tests/Web.Integration.Tests/Proxy/WhenRequestingCensusHistoryComparison.cs
+++ b/web/tests/Web.Integration.Tests/Proxy/WhenRequestingCensusHistoryComparison.cs
@@ -1,0 +1,69 @@
+using System.Net;
+using AutoFixture;
+using Newtonsoft.Json;
+using Web.App.Domain;
+using Xunit;
+namespace Web.Integration.Tests.Proxy;
+
+public class WhenRequestingCensusHistoryComparison(SchoolBenchmarkingWebAppClient client) : IClassFixture<SchoolBenchmarkingWebAppClient>
+{
+    private static readonly Fixture Fixture = new();
+    private static readonly CensusHistory[] HistorySchool = Fixture.CreateMany<CensusHistory>().ToArray();
+    private static readonly CensusHistory[] HistoryComparatorSet = Fixture.CreateMany<CensusHistory>().ToArray();
+    private static readonly CensusHistory[] HistoryNational = Fixture.CreateMany<CensusHistory>().ToArray();
+
+    public static IEnumerable<object?[]> CensusHistoryTestData =>
+        new List<object?[]>
+        {
+            new object?[]
+            {
+                "urn",
+                "dimension",
+                null,
+                null,
+                new HistoryComparison<CensusHistory>
+                {
+                    School = HistorySchool,
+                    ComparatorSetAverage = HistoryComparatorSet,
+                    NationalAverage = HistoryNational
+                }
+            },
+            new object?[]
+            {
+                "urn",
+                "dimension",
+                "phase",
+                "financeType",
+                new HistoryComparison<CensusHistory>
+                {
+                    School = HistorySchool,
+                    ComparatorSetAverage = HistoryComparatorSet,
+                    NationalAverage = HistoryNational
+                }
+            }
+        };
+
+    [Theory]
+    [MemberData(nameof(CensusHistoryTestData))]
+    public async Task CanReturnCorrectResponseForSchool(string urn, string dimension, string? phase, string? financeType, HistoryComparison<CensusHistory> expected)
+    {
+        var school = new School
+        {
+            URN = urn,
+            OverallPhase = phase,
+            FinanceType = financeType
+        };
+
+        var response = await client
+            .SetupEstablishment(school)
+            .SetupCensus(school, HistorySchool, HistoryComparatorSet, HistoryNational)
+            .Get(Paths.ApiCensusHistoryComparison(urn, dimension, phase, financeType));
+
+        Assert.IsType<HttpResponseMessage>(response);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var resultContent = await response.Content.ReadAsStringAsync();
+        var actual = JsonConvert.DeserializeObject<HistoryComparison<CensusHistory>>(resultContent);
+        Assert.Equivalent(expected, actual);
+    }
+}

--- a/web/tests/Web.Integration.Tests/Proxy/WhenRequestingExpenditureHistoryComparison.cs
+++ b/web/tests/Web.Integration.Tests/Proxy/WhenRequestingExpenditureHistoryComparison.cs
@@ -1,0 +1,69 @@
+using System.Net;
+using AutoFixture;
+using Newtonsoft.Json;
+using Web.App.Domain;
+using Xunit;
+namespace Web.Integration.Tests.Proxy;
+
+public class WhenRequestingExpenditureHistoryComparison(SchoolBenchmarkingWebAppClient client) : IClassFixture<SchoolBenchmarkingWebAppClient>
+{
+    private static readonly Fixture Fixture = new();
+    private static readonly ExpenditureHistory[] HistorySchool = Fixture.CreateMany<ExpenditureHistory>().ToArray();
+    private static readonly ExpenditureHistory[] HistoryComparatorSet = Fixture.CreateMany<ExpenditureHistory>().ToArray();
+    private static readonly ExpenditureHistory[] HistoryNational = Fixture.CreateMany<ExpenditureHistory>().ToArray();
+
+    public static IEnumerable<object?[]> ExpenditureHistoryTestData =>
+        new List<object?[]>
+        {
+            new object?[]
+            {
+                "urn",
+                "dimension",
+                null,
+                null,
+                new HistoryComparison<ExpenditureHistory>
+                {
+                    School = HistorySchool,
+                    ComparatorSetAverage = HistoryComparatorSet,
+                    NationalAverage = HistoryNational
+                }
+            },
+            new object?[]
+            {
+                "urn",
+                "dimension",
+                "phase",
+                "financeType",
+                new HistoryComparison<ExpenditureHistory>
+                {
+                    School = HistorySchool,
+                    ComparatorSetAverage = HistoryComparatorSet,
+                    NationalAverage = HistoryNational
+                }
+            }
+        };
+
+    [Theory]
+    [MemberData(nameof(ExpenditureHistoryTestData))]
+    public async Task CanReturnCorrectResponseForSchool(string urn, string dimension, string? phase, string? financeType, HistoryComparison<ExpenditureHistory> expected)
+    {
+        var school = new School
+        {
+            URN = urn,
+            OverallPhase = phase,
+            FinanceType = financeType
+        };
+
+        var response = await client
+            .SetupEstablishment(school)
+            .SetupExpenditure(school, HistorySchool, HistoryComparatorSet, HistoryNational)
+            .Get(Paths.ApiExpenditureHistoryComparison("school", urn, dimension, phase, financeType));
+
+        Assert.IsType<HttpResponseMessage>(response);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var resultContent = await response.Content.ReadAsStringAsync();
+        var actual = JsonConvert.DeserializeObject<HistoryComparison<ExpenditureHistory>>(resultContent);
+        Assert.Equivalent(expected, actual);
+    }
+}

--- a/web/tests/Web.Tests/Controllers/Api/Census/WhenCensusApiReceivesHistoryComparisonRequest.cs
+++ b/web/tests/Web.Tests/Controllers/Api/Census/WhenCensusApiReceivesHistoryComparisonRequest.cs
@@ -1,0 +1,131 @@
+using AutoFixture;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Web.App.Controllers.Api;
+using Web.App.Domain;
+using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Apis.Establishment;
+using Web.App.Infrastructure.Apis.Insight;
+using Web.App.Services;
+using Xunit;
+namespace Web.Tests.Controllers.Api.Census;
+
+public class WhenCensusApiReceivesHistoryComparisonRequest
+{
+    private readonly CensusProxyController _api;
+    private readonly Mock<ICensusApi> _censusApi = new();
+    private readonly Mock<IEstablishmentApi> _establishmentApi = new();
+    private readonly Fixture _fixture;
+    private readonly NullLogger<CensusProxyController> _logger = new();
+    private readonly Mock<ISchoolComparatorSetService> _schoolComparatorSetService = new();
+    private readonly Mock<IUserDataService> _userDataService = new();
+
+    public WhenCensusApiReceivesHistoryComparisonRequest()
+    {
+        _api = new CensusProxyController(_logger, _establishmentApi.Object, _censusApi.Object, _schoolComparatorSetService.Object, _userDataService.Object);
+        _fixture = new Fixture();
+    }
+
+    [Theory]
+    [InlineData("urn", "dimension", null, null, "?dimension=dimension")]
+    public async Task ShouldGetCensusHistoryFromApiForSchool(string urn, string dimension, string? phase, string? financeType, string expectedQuery)
+    {
+        // arrange
+        var results = Array.Empty<CensusHistory>();
+        var actualQuery = string.Empty;
+
+        var school = _fixture.Build<School>()
+            .With(s => s.URN, urn)
+            .Create();
+        _establishmentApi
+            .Setup(e => e.GetSchool(urn))
+            .ReturnsAsync(ApiResult.Ok(school));
+
+        _censusApi
+            .Setup(e => e.SchoolHistory(urn, It.IsAny<ApiQuery?>()))
+            .Callback<string, ApiQuery?>((_, query) =>
+            {
+                actualQuery = query?.ToQueryString();
+            })
+            .ReturnsAsync(ApiResult.Ok(results));
+
+        // act
+        var actual = await _api.HistoryComparison(urn, dimension, phase, financeType);
+
+        // assert
+        dynamic? json = Assert.IsType<JsonResult>(actual).Value;
+        Assert.Equal(results, json?.School as CensusHistory[]);
+        Assert.Equal(expectedQuery, actualQuery);
+    }
+
+    [Theory]
+    [InlineData("urn", "dimension", null, null, "?dimension=dimension")]
+    public async Task ShouldGetCensusHistoryComparatorSetAverageFromApiForSchool(string urn, string dimension, string? phase, string? financeType, string expectedQuery)
+    {
+        // arrange
+        var results = Array.Empty<CensusHistory>();
+        var actualQuery = string.Empty;
+
+        var school = _fixture.Build<School>()
+            .With(s => s.URN, urn)
+            .Create();
+        _establishmentApi
+            .Setup(e => e.GetSchool(urn))
+            .ReturnsAsync(ApiResult.Ok(school));
+
+        _censusApi
+            .Setup(e => e.SchoolHistoryComparatorSetAverage(urn, It.IsAny<ApiQuery?>()))
+            .Callback<string, ApiQuery?>((_, query) =>
+            {
+                actualQuery = query?.ToQueryString();
+            })
+            .ReturnsAsync(ApiResult.Ok(results));
+
+        // act
+        var actual = await _api.HistoryComparison(urn, dimension, phase, financeType);
+
+        // assert
+        dynamic? json = Assert.IsType<JsonResult>(actual).Value;
+        Assert.Equal(results, json?.ComparatorSetAverage as CensusHistory[]);
+        Assert.Equal(expectedQuery, actualQuery);
+    }
+
+    [Theory]
+    [InlineData("urn", "dimension", null, null, "schoolFinanceType", "schoolOverallPhase", "?dimension=dimension&financeType=schoolFinanceType&phase=schoolOverallPhase")]
+    [InlineData("urn", "dimension", "financeType", null, "schoolFinanceType", "schoolOverallPhase", "?dimension=dimension&financeType=schoolFinanceType&phase=schoolOverallPhase")]
+    [InlineData("urn", "dimension", null, "phase", "schoolFinanceType", "schoolOverallPhase", "?dimension=dimension&financeType=schoolFinanceType&phase=schoolOverallPhase")]
+    [InlineData("urn", "dimension", "financeType", "phase", "schoolFinanceType", "schoolOverallPhase", "?dimension=dimension&financeType=financeType&phase=phase")]
+    public async Task ShouldGetCensusHistoryNationalAverageFromApiForSchool(string urn, string dimension, string? financeType, string? phase, string schoolFinanceType, string schoolOverallPhase, string expectedQuery)
+    {
+        // arrange
+        var results = Array.Empty<CensusHistory>();
+        var actualQuery = string.Empty;
+
+        var school = new School
+        {
+            URN = urn,
+            FinanceType = schoolFinanceType,
+            OverallPhase = schoolOverallPhase
+        };
+        _establishmentApi
+            .Setup(e => e.GetSchool(urn))
+            .ReturnsAsync(ApiResult.Ok(school));
+
+        _censusApi
+            .Setup(e => e.SchoolHistoryNationalAverage(It.IsAny<ApiQuery?>()))
+            .Callback<ApiQuery?>(query =>
+            {
+                actualQuery = query?.ToQueryString();
+            })
+            .ReturnsAsync(ApiResult.Ok(results));
+
+        // act
+        var actual = await _api.HistoryComparison(urn, dimension, phase, financeType);
+
+        // assert
+        dynamic? json = Assert.IsType<JsonResult>(actual).Value;
+        Assert.Equal(results, json?.NationalAverage as CensusHistory[]);
+        Assert.Equal(expectedQuery, actualQuery);
+    }
+}

--- a/web/tests/Web.Tests/Controllers/Api/Census/WhenCensusApiReceivesHistoryRequest.cs
+++ b/web/tests/Web.Tests/Controllers/Api/Census/WhenCensusApiReceivesHistoryRequest.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Web.App.Controllers.Api;
+using Web.App.Domain;
+using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Apis.Establishment;
+using Web.App.Infrastructure.Apis.Insight;
+using Web.App.Services;
+using Xunit;
+namespace Web.Tests.Controllers.Api.Census;
+
+public class WhenCensusApiReceivesHistoryRequest
+{
+    private readonly CensusProxyController _api;
+    private readonly Mock<ICensusApi> _censusApi = new();
+    private readonly Mock<IEstablishmentApi> _establishmentApi = new();
+    private readonly NullLogger<CensusProxyController> _logger = new();
+    private readonly Mock<ISchoolComparatorSetService> _schoolComparatorSetService = new();
+    private readonly Mock<IUserDataService> _userDataService = new();
+
+    public WhenCensusApiReceivesHistoryRequest()
+    {
+        _api = new CensusProxyController(_logger, _establishmentApi.Object, _censusApi.Object, _schoolComparatorSetService.Object, _userDataService.Object);
+    }
+
+    [Theory]
+    [InlineData("urn", "dimension", "?dimension=dimension")]
+    public async Task ShouldGetCensusHistoryFromApiForSchool(string urn, string dimension, string expectedQuery)
+    {
+        // arrange
+        var results = Array.Empty<ExpenditureHistory>();
+        var actualQuery = string.Empty;
+
+        _censusApi
+            .Setup(e => e.SchoolHistory(urn, It.IsAny<ApiQuery?>()))
+            .Callback<string, ApiQuery?>((_, query) =>
+            {
+                actualQuery = query?.ToQueryString();
+            })
+            .ReturnsAsync(ApiResult.Ok(results));
+
+        // act
+        var actual = await _api.History(urn, dimension);
+
+        // assert
+        var json = Assert.IsType<JsonResult>(actual).Value;
+        Assert.Equal(results, json);
+        Assert.Equal(expectedQuery, actualQuery);
+    }
+}

--- a/web/tests/Web.Tests/Controllers/Api/Census/WhenCensusApiReceivesQueryRequest.cs
+++ b/web/tests/Web.Tests/Controllers/Api/Census/WhenCensusApiReceivesQueryRequest.cs
@@ -4,6 +4,7 @@ using Moq;
 using Web.App;
 using Web.App.Controllers.Api;
 using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Apis.Establishment;
 using Web.App.Infrastructure.Apis.Insight;
 using Web.App.Services;
 using Xunit;
@@ -13,13 +14,14 @@ public class WhenCensusApiReceivesQueryRequest
 {
     private readonly CensusProxyController _api;
     private readonly Mock<ICensusApi> _censusApi = new();
+    private readonly Mock<IEstablishmentApi> _establishmentApi = new();
     private readonly NullLogger<CensusProxyController> _logger = new();
     private readonly Mock<ISchoolComparatorSetService> _schoolComparatorSetService = new();
     private readonly Mock<IUserDataService> _userDataService = new();
 
     public WhenCensusApiReceivesQueryRequest()
     {
-        _api = new CensusProxyController(_logger, _censusApi.Object, _schoolComparatorSetService.Object, _userDataService.Object);
+        _api = new CensusProxyController(_logger, _establishmentApi.Object, _censusApi.Object, _schoolComparatorSetService.Object, _userDataService.Object);
     }
 
     [Theory]

--- a/web/tests/Web.Tests/Infrastructure/GivenACensusApi.cs
+++ b/web/tests/Web.Tests/Infrastructure/GivenACensusApi.cs
@@ -18,7 +18,7 @@ public class GivenACensusApi(ITestOutputHelper testOutputHelper) : ApiClientTest
     {
         var api = new CensusApi(HttpClient);
 
-        await api.History("123213");
+        await api.SchoolHistory("123213");
 
         VerifyCall(HttpMethod.Get, "api/census/123213/history");
     }


### PR DESCRIPTION
### Context
[AB#241827](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/241827) [AB#237633](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/237633)

### Change proposed in this pull request
New endpoint in Web API, proxying to proposed new endpoints in Insight API to support census historic trends.

### Guidance to review 
Not yet wired up to anything, but may be validated by browsing locally directly to a URL such as `https://localhost:7095/api/census/history/comparison?id=123456&dimension=HeadcountPerFte`. This will gracefully fail until the new dependent Platform endpoints are ready.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

