### PR TITLE
feat: add new api endpoints for census historic trends. 

### DIFF
--- a/platform/src/apis/Platform.Api.Insight/Census/CensusFunctions.cs
+++ b/platform/src/apis/Platform.Api.Insight/Census/CensusFunctions.cs
@@ -244,7 +244,7 @@ public class CensusFunctions(
                     return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
                 }
 
-                var result = await service.GetHistoryAvgComparatorSetAsync(urn, queryParams);
+                var result = await service.GetHistoryAvgComparatorSetAsync(urn, queryParams.Dimension);
                 return await req.CreateJsonResponseAsync(result);
             }
             catch (Exception e)
@@ -288,7 +288,7 @@ public class CensusFunctions(
                     return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
                 }
 
-                var result = await service.GetHistoryAvgNationalAsync(queryParams);
+                var result = await service.GetHistoryAvgNationalAsync(queryParams.Dimension, queryParams.OverallPhase, queryParams.FinanceType);
                 return await req.CreateJsonResponseAsync(result);
             }
             catch (Exception e)

--- a/platform/src/apis/Platform.Api.Insight/Census/CensusNationalAvgParameters.cs
+++ b/platform/src/apis/Platform.Api.Insight/Census/CensusNationalAvgParameters.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Http;
+using Platform.Functions;
+namespace Platform.Api.Insight.Census;
+
+public record CensusNationalAvgParameters : QueryParameters
+{
+    public string Dimension { get; internal set; } = CensusDimensions.Total;
+    public string FinanceType { get; internal set; } = string.Empty;
+    public string OverallPhase { get; internal set; } = string.Empty;
+
+    public override void SetValues(IQueryCollection query)
+    {
+        if (query.TryGetValue("dimension", out var dimension) && !string.IsNullOrWhiteSpace(dimension))
+        {
+            Dimension = dimension.ToString();
+        }
+
+        if (query.TryGetValue("financeType", out var financeType) && !string.IsNullOrWhiteSpace(financeType))
+        {
+            FinanceType = financeType.ToString();
+        }
+
+        if (query.TryGetValue("phase", out var overallPhase) && !string.IsNullOrWhiteSpace(overallPhase))
+        {
+            OverallPhase = overallPhase.ToString();
+        }
+    }
+}

--- a/platform/src/apis/Platform.Api.Insight/Census/CensusService.cs
+++ b/platform/src/apis/Platform.Api.Insight/Census/CensusService.cs
@@ -8,8 +8,8 @@ namespace Platform.Api.Insight.Census;
 public interface ICensusService
 {
     Task<IEnumerable<CensusHistoryModel>> GetHistoryAsync(string urn);
-    Task<IEnumerable<CensusHistoryModel>> GetHistoryAvgComparatorSetAsync(string urn, CensusParameters queryParams);
-    Task<IEnumerable<CensusHistoryModel>> GetHistoryAvgNationalAsync(CensusNationalAvgParameters queryParams);
+    Task<IEnumerable<CensusHistoryModel>> GetHistoryAvgComparatorSetAsync(string urn, string dimension);
+    Task<IEnumerable<CensusHistoryModel>> GetHistoryAvgNationalAsync(string dimension, string overallPhase, string financeType);
     Task<IEnumerable<CensusModel>> QueryAsync(string[] urns, string? companyNumber, string? laCode, string? phase);
     Task<CensusModel?> GetAsync(string urn);
     Task<CensusModel?> GetCustomAsync(string urn, string identifier);
@@ -29,20 +29,20 @@ public class CensusService(IDatabaseFactory dbFactory) : ICensusService
         return await conn.QueryAsync<CensusHistoryModel>(sql, parameters);
     }
 
-    public async Task<IEnumerable<CensusHistoryModel>> GetHistoryAvgComparatorSetAsync(string urn, CensusParameters queryParams)
+    public async Task<IEnumerable<CensusHistoryModel>> GetHistoryAvgComparatorSetAsync(string urn, string dimension)
     {
         var parameters = new
         {
             URN = urn
         };
 
-        var sourceName = queryParams.Dimension switch
+        var sourceName = dimension switch
         {
             CensusDimensions.Total => "SchoolCensusAvgComparatorSet",
             CensusDimensions.HeadcountPerFte => "SchoolCensusAvgPerFteComparatorSet",
             CensusDimensions.PercentWorkforce => "SchoolCensusAvgPercentageOfWorkforceFteComparatorSet",
             CensusDimensions.PupilsPerStaffRole => "SchoolCensusAvgPupilsPerStaffComparatorSet",
-            _ => throw new ArgumentOutOfRangeException(nameof(queryParams))
+            _ => throw new ArgumentOutOfRangeException(nameof(dimension))
         };
 
         var sql = $"SELECT * FROM {sourceName} WHERE URN = @URN";
@@ -52,21 +52,21 @@ public class CensusService(IDatabaseFactory dbFactory) : ICensusService
         return await conn.QueryAsync<CensusHistoryModel>(sql, parameters);
     }
 
-    public async Task<IEnumerable<CensusHistoryModel>> GetHistoryAvgNationalAsync(CensusNationalAvgParameters queryParams)
+    public async Task<IEnumerable<CensusHistoryModel>> GetHistoryAvgNationalAsync(string dimension, string overallPhase, string financeType)
     {
         var parameters = new
         {
-            queryParams.OverallPhase,
-            queryParams.FinanceType
+            OverallPhase = overallPhase,
+            FinanceType = financeType
         };
 
-        var sourceName = queryParams.Dimension switch
+        var sourceName = dimension switch
         {
             CensusDimensions.Total => "SchoolCensusAvgHistoric",
             CensusDimensions.HeadcountPerFte => "SchoolCensusAvgPerFteHistoric",
             CensusDimensions.PercentWorkforce => "SchoolCensusAvgPercentageOfWorkforceFteHistoric",
             CensusDimensions.PupilsPerStaffRole => "SchoolCensusAvgPupilsPerStaffHistoric",
-            _ => throw new ArgumentOutOfRangeException(nameof(queryParams))
+            _ => throw new ArgumentOutOfRangeException(nameof(dimension))
         };
 
         var sql = $"SELECT * FROM {sourceName} WHERE FinanceType = @FinanceType AND OverallPhase = @OverallPhase";

--- a/platform/src/apis/Platform.Api.Insight/Configuration/Services.cs
+++ b/platform/src/apis/Platform.Api.Insight/Configuration/Services.cs
@@ -50,6 +50,7 @@ internal static class Services
             .AddTransient<IValidator<QueryTrustIncomeParameters>, QueryTrustIncomeParametersValidator>()
             .AddTransient<IValidator<MetricRagRatingsParameters>, MetricRagRatingsParametersValidator>()
             .AddTransient<IValidator<CensusParameters>, CensusParametersValidator>()
+            .AddTransient<IValidator<CensusNationalAvgParameters>, CensusNationalAvgParametersValidator>()
             .AddTransient<IValidator<QuerySchoolCensusParameters>, QuerySchoolCensusParametersValidator>();
 
         //TODO: Add serilog configuration AB#227696

--- a/platform/src/apis/Platform.Api.Insight/Expenditure/ExpenditureFunctions.cs
+++ b/platform/src/apis/Platform.Api.Insight/Expenditure/ExpenditureFunctions.cs
@@ -296,7 +296,7 @@ public class ExpenditureFunctions(
                     return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
                 }
 
-                var result = await service.GetSchoolHistoryAvgComparatorSetAsync(urn, queryParams);
+                var result = await service.GetSchoolHistoryAvgComparatorSetAsync(urn, queryParams.Dimension);
 
                 return await req.CreateJsonResponseAsync(result);
             }
@@ -341,7 +341,7 @@ public class ExpenditureFunctions(
                     return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
                 }
 
-                var result = await service.GetSchoolHistoryAvgNationalAsync(queryParams);
+                var result = await service.GetSchoolHistoryAvgNationalAsync(queryParams.Dimension, queryParams.OverallPhase, queryParams.FinanceType);
 
                 return await req.CreateJsonResponseAsync(result);
             }

--- a/platform/src/apis/Platform.Api.Insight/Validators/CensusNationalAvgParametersValidator.cs
+++ b/platform/src/apis/Platform.Api.Insight/Validators/CensusNationalAvgParametersValidator.cs
@@ -1,0 +1,27 @@
+using FluentValidation;
+using Platform.Api.Insight.Census;
+using Platform.Api.Insight.Domain;
+using Platform.Api.Insight.Expenditure;
+namespace Platform.Api.Insight.Validators;
+
+public class CensusNationalAvgParametersValidator : AbstractValidator<CensusNationalAvgParameters>
+{
+    public CensusNationalAvgParametersValidator()
+    {
+        RuleFor(x => x.Dimension)
+            .Must(BeAValidDimension)
+            .WithMessage($"{{PropertyName}} must be empty or one of the supported values: {string.Join(", ", CensusDimensions.All)}");
+
+        RuleFor(x => x.OverallPhase)
+            .Must(BeAValidPhase)
+            .WithMessage($"{{PropertyName}} must one of the supported values: {string.Join(", ", OverallPhase.All)}");
+
+        RuleFor(x => x.FinanceType)
+            .Must(BeAValidFinanceType)
+            .WithMessage($"{{PropertyName}} must be one of the supported values: {string.Join(", ", FinanceType.All)}");
+    }
+
+    private static bool BeAValidDimension(string? dimension) => CensusDimensions.IsValid(dimension);
+    private static bool BeAValidPhase(string? phase) => OverallPhase.IsValid(phase);
+    private static bool BeAValidFinanceType(string? financeType) => FinanceType.IsValid(financeType);
+}

--- a/platform/src/apis/Platform.Api.Insight/Validators/CensusNationalAvgParametersValidator.cs
+++ b/platform/src/apis/Platform.Api.Insight/Validators/CensusNationalAvgParametersValidator.cs
@@ -14,7 +14,7 @@ public class CensusNationalAvgParametersValidator : AbstractValidator<CensusNati
 
         RuleFor(x => x.OverallPhase)
             .Must(BeAValidPhase)
-            .WithMessage($"{{PropertyName}} must one of the supported values: {string.Join(", ", OverallPhase.All)}");
+            .WithMessage($"{{PropertyName}} must be one of the supported values: {string.Join(", ", OverallPhase.All)}");
 
         RuleFor(x => x.FinanceType)
             .Must(BeAValidFinanceType)

--- a/platform/src/apis/Platform.Api.Insight/Validators/ExpenditureNationalAvgParametersValidator.cs
+++ b/platform/src/apis/Platform.Api.Insight/Validators/ExpenditureNationalAvgParametersValidator.cs
@@ -13,7 +13,7 @@ public class ExpenditureNationalAvgParametersValidator : AbstractValidator<Expen
 
         RuleFor(x => x.OverallPhase)
             .Must(BeAValidPhase)
-            .WithMessage($"{{PropertyName}} must one of the supported values: {string.Join(", ", OverallPhase.All)}");
+            .WithMessage($"{{PropertyName}} must be one of the supported values: {string.Join(", ", OverallPhase.All)}");
 
         RuleFor(x => x.FinanceType)
             .Must(BeAValidFinanceType)

--- a/platform/tests/Platform.Tests/Insight/Census/CensusFunctionsTestBase.cs
+++ b/platform/tests/Platform.Tests/Insight/Census/CensusFunctionsTestBase.cs
@@ -8,12 +8,20 @@ public class CensusFunctionsTestBase : FunctionsTestBase
 {
     protected readonly CensusFunctions Functions;
     protected readonly Mock<ICensusService> Service;
+    protected readonly Mock<IValidator<CensusParameters>> CensusParametersValidator;
+    protected readonly Mock<IValidator<CensusNationalAvgParameters>> CensusNationalAvgParametersValidator;
 
     protected CensusFunctionsTestBase()
     {
-        InlineValidator<CensusParameters> censusParametersValidator = new();
+        CensusParametersValidator = new Mock<IValidator<CensusParameters>>();
+        CensusNationalAvgParametersValidator = new Mock<IValidator<CensusNationalAvgParameters>>();
         InlineValidator<QuerySchoolCensusParameters> querySchoolCensusParametersValidator = new();
         Service = new Mock<ICensusService>();
-        Functions = new CensusFunctions(new NullLogger<CensusFunctions>(), Service.Object, censusParametersValidator, querySchoolCensusParametersValidator);
+        Functions = new CensusFunctions(
+            new NullLogger<CensusFunctions>(),
+            Service.Object,
+            CensusParametersValidator.Object,
+            CensusNationalAvgParametersValidator.Object,
+            querySchoolCensusParametersValidator);
     }
 }

--- a/platform/tests/Platform.Tests/Insight/Census/WhenCensusNationalAvgParametersSetsValues.cs
+++ b/platform/tests/Platform.Tests/Insight/Census/WhenCensusNationalAvgParametersSetsValues.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Platform.Api.Insight.Census;
+using Xunit;
+namespace Platform.Tests.Insight.Census;
+
+public class CensusNationalAvgParametersSetsValues
+{
+    [Theory]
+    [InlineData("Total", "Primary", "Academy", "Total", "Primary", "Academy")]
+    [InlineData(null, null, null, "Total", "", "")]
+    [InlineData("Invalid", "Invalid", "Invalid", "Invalid", "Invalid", "Invalid")]
+    public void ShouldSetValuesFromIQueryCollection(
+        string? dimension,
+        string? phase,
+        string? financeType,
+        string expectedDimension,
+        string expectedPhase,
+        string expectedFinanceType)
+    {
+        var parameters = new CensusNationalAvgParameters();
+        var query = new QueryCollection(new Dictionary<string, StringValues>
+        {
+            {
+                "dimension", dimension
+            },
+            {
+                "phase", phase
+            },
+            {
+                "financeType", financeType
+            }
+        });
+
+        parameters.SetValues(query);
+
+        Assert.Equal(expectedDimension, parameters.Dimension);
+        Assert.Equal(expectedPhase, parameters.OverallPhase);
+        Assert.Equal(expectedFinanceType, parameters.FinanceType);
+    }
+}

--- a/platform/tests/Platform.Tests/Insight/Census/WhenCensusServiceQueriesAsync.cs
+++ b/platform/tests/Platform.Tests/Insight/Census/WhenCensusServiceQueriesAsync.cs
@@ -198,10 +198,6 @@ public class WhenCensusServiceQueriesAsync
     public async Task ShouldQueryAsyncWhenGetHistoryAvgComparatorSetAsync(string dimension, string expectedSource)
     {
         const string urn = "123";
-        var queryParams = new CensusParameters
-        {
-            Dimension = dimension
-        };
         var expected = new List<CensusHistoryModel>
         {
             new()
@@ -220,7 +216,7 @@ public class WhenCensusServiceQueriesAsync
 
         var expectedSql = $"SELECT * FROM {expectedSource} WHERE URN = @URN";
 
-        var actual = await _service.GetHistoryAvgComparatorSetAsync(urn, queryParams);
+        var actual = await _service.GetHistoryAvgComparatorSetAsync(urn, dimension);
 
         Assert.Equal(expected, actual);
         Assert.Equal(expectedSql, actualSql);
@@ -234,10 +230,6 @@ public class WhenCensusServiceQueriesAsync
     public async Task ShouldThrowOnInvalidDimensionWhenGetHistoryAvgComparatorSetAsync()
     {
         const string urn = "123";
-        var queryParams = new CensusParameters
-        {
-            Dimension = "Invalid"
-        };
         var result = new List<CensusHistoryModel>
         {
             new()
@@ -248,7 +240,7 @@ public class WhenCensusServiceQueriesAsync
             .ReturnsAsync(result);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
-            _service.GetHistoryAvgComparatorSetAsync(urn, queryParams));
+            _service.GetHistoryAvgComparatorSetAsync(urn, "invalid"));
         _connection.Verify(c => c.QueryAsync<CensusHistoryModel>(It.IsAny<string>(), It.IsAny<object>()), Times.Never());
     }
 
@@ -264,12 +256,6 @@ public class WhenCensusServiceQueriesAsync
     [Theory]
     public async Task ShouldQueryAsyncWhenGetHistoryAvgNationalAsync(string dimension, string phase, string financeType, string expectedSource)
     {
-        var queryParams = new CensusNationalAvgParameters
-        {
-            Dimension = dimension,
-            OverallPhase = phase,
-            FinanceType = financeType
-        };
         var expected = new List<CensusHistoryModel>
         {
             new()
@@ -288,7 +274,7 @@ public class WhenCensusServiceQueriesAsync
 
         var expectedSql = $"SELECT * FROM {expectedSource} WHERE FinanceType = @FinanceType AND OverallPhase = @OverallPhase";
 
-        var actual = await _service.GetHistoryAvgNationalAsync(queryParams);
+        var actual = await _service.GetHistoryAvgNationalAsync(dimension, phase, financeType);
 
         Assert.Equal(expected, actual);
         Assert.Equal(expectedSql, actualSql);
@@ -302,10 +288,6 @@ public class WhenCensusServiceQueriesAsync
     [Fact]
     public async Task ShouldThrowOnInvalidDimensionWhenGetHistoryAvgNationalAsync()
     {
-        var queryParams = new CensusNationalAvgParameters()
-        {
-            Dimension = "Invalid"
-        };
         var result = new List<CensusHistoryModel>
         {
             new()
@@ -316,7 +298,7 @@ public class WhenCensusServiceQueriesAsync
             .ReturnsAsync(result);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
-            _service.GetHistoryAvgNationalAsync(queryParams));
+            _service.GetHistoryAvgNationalAsync("Invalid", "Primary", "Maintained"));
         _connection.Verify(c => c.QueryAsync<CensusHistoryModel>(It.IsAny<string>(), It.IsAny<object>()), Times.Never());
     }
 }

--- a/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetCensusRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetCensusRequest.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using FluentValidation.Results;
 using Microsoft.Extensions.Primitives;
 using Moq;
 using Platform.Api.Insight.Census;
@@ -12,6 +13,10 @@ public class WhenFunctionReceivesGetCensusRequest : CensusFunctionsTestBase
     [Fact]
     public async Task ShouldReturn200OnValidRequest()
     {
+        CensusParametersValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<CensusParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
         Service
             .Setup(d => d.GetAsync(Urn))
             .ReturnsAsync(new CensusModel());
@@ -28,6 +33,10 @@ public class WhenFunctionReceivesGetCensusRequest : CensusFunctionsTestBase
     [InlineData(CensusCategories.TeachersFte, CensusDimensions.HeadcountPerFte)]
     public async Task ShouldTryParseQueryString(string? category, string? dimension)
     {
+        CensusParametersValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<CensusParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
         Service.Setup(d => d.GetAsync(Urn)).Verifiable();
 
         var query = new Dictionary<string, StringValues>
@@ -47,6 +56,10 @@ public class WhenFunctionReceivesGetCensusRequest : CensusFunctionsTestBase
     [Fact]
     public async Task ShouldReturn404OnNotFound()
     {
+        CensusParametersValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<CensusParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
         Service
             .Setup(d => d.GetAsync(Urn))
             .ReturnsAsync((CensusModel?)null);
@@ -60,6 +73,10 @@ public class WhenFunctionReceivesGetCensusRequest : CensusFunctionsTestBase
     [Fact]
     public async Task ShouldReturn500OnError()
     {
+        CensusParametersValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<CensusParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
         Service
             .Setup(d => d.GetAsync(Urn))
             .Throws(new Exception());

--- a/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetComparatorSetAverageCensusRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetComparatorSetAverageCensusRequest.cs
@@ -1,0 +1,64 @@
+using System.Net;
+using FluentValidation.Results;
+using Moq;
+using Platform.Api.Insight.Census;
+using Xunit;
+namespace Platform.Tests.Insight.Census;
+
+public class WhenFunctionReceivesGetComparatorSetAverageCensusHistoryRequest : CensusFunctionsTestBase
+{
+    [Fact]
+    public async Task ShouldReturn200OnValidRequest()
+    {
+        CensusParametersValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<CensusParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
+        Service
+            .Setup(d => d.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), new CensusParameters()))
+            .ReturnsAsync(Array.Empty<CensusHistoryModel>());
+
+        var result = await Functions.CensusHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");
+
+        Assert.NotNull(result);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+    }
+
+    [Fact]
+    public async Task ShouldReturn400OnValidationError()
+    {
+        CensusParametersValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<CensusParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult(new[]
+            {
+                new ValidationFailure(nameof(CensusParameters.Dimension), "error message")
+            }));
+
+        Service
+            .Setup(d => d.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), new CensusParameters()));
+
+        var result = await Functions.CensusHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");
+
+        Assert.NotNull(result);
+        Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
+        Service.Verify(
+            x => x.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), new CensusParameters()), Times.Never());
+    }
+
+    [Fact]
+    public async Task ShouldReturn500OnError()
+    {
+        CensusParametersValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<CensusParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
+        Service
+            .Setup(d => d.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), new CensusParameters()))
+            .Throws(new Exception());
+
+        var result = await Functions.CensusHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");
+
+        Assert.NotNull(result);
+        Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);
+    }
+}

--- a/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetComparatorSetAverageCensusRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetComparatorSetAverageCensusRequest.cs
@@ -15,7 +15,7 @@ public class WhenFunctionReceivesGetComparatorSetAverageCensusHistoryRequest : C
             .ReturnsAsync(new ValidationResult());
 
         Service
-            .Setup(d => d.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), new CensusParameters()))
+            .Setup(d => d.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync(Array.Empty<CensusHistoryModel>());
 
         var result = await Functions.CensusHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");
@@ -35,14 +35,14 @@ public class WhenFunctionReceivesGetComparatorSetAverageCensusHistoryRequest : C
             }));
 
         Service
-            .Setup(d => d.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), new CensusParameters()));
+            .Setup(d => d.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>()));
 
         var result = await Functions.CensusHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
         Service.Verify(
-            x => x.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), new CensusParameters()), Times.Never());
+            x => x.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public class WhenFunctionReceivesGetComparatorSetAverageCensusHistoryRequest : C
             .ReturnsAsync(new ValidationResult());
 
         Service
-            .Setup(d => d.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), new CensusParameters()))
+            .Setup(d => d.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>()))
             .Throws(new Exception());
 
         var result = await Functions.CensusHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");

--- a/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetNationalAverageCensusRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetNationalAverageCensusRequest.cs
@@ -1,0 +1,64 @@
+using System.Net;
+using FluentValidation.Results;
+using Moq;
+using Platform.Api.Insight.Census;
+using Xunit;
+namespace Platform.Tests.Insight.Census;
+
+public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : CensusFunctionsTestBase
+{
+    [Fact]
+    public async Task ShouldReturn200OnValidRequest()
+    {
+        CensusNationalAvgParametersValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<CensusNationalAvgParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
+        Service
+            .Setup(d => d.GetHistoryAvgNationalAsync(new CensusNationalAvgParameters()))
+            .ReturnsAsync(Array.Empty<CensusHistoryModel>());
+
+        var result = await Functions.CensusHistoryAvgNationalAsync(CreateHttpRequestData());
+
+        Assert.NotNull(result);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+    }
+
+    [Fact]
+    public async Task ShouldReturn400OnValidationError()
+    {
+        CensusNationalAvgParametersValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<CensusNationalAvgParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult(new[]
+            {
+                new ValidationFailure(nameof(CensusNationalAvgParameters.Dimension), "error message")
+            }));
+
+        Service
+            .Setup(d => d.GetHistoryAvgNationalAsync(new CensusNationalAvgParameters()));
+
+        var result = await Functions.CensusHistoryAvgNationalAsync(CreateHttpRequestData());
+
+        Assert.NotNull(result);
+        Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
+        Service.Verify(
+            x => x.GetHistoryAvgNationalAsync(new CensusNationalAvgParameters()), Times.Never());
+    }
+
+    [Fact]
+    public async Task ShouldReturn500OnError()
+    {
+        CensusNationalAvgParametersValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<CensusNationalAvgParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
+        Service
+            .Setup(d => d.GetHistoryAvgNationalAsync(new CensusNationalAvgParameters()))
+            .Throws(new Exception());
+
+        var result = await Functions.CensusHistoryAvgNationalAsync(CreateHttpRequestData());
+
+        Assert.NotNull(result);
+        Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);
+    }
+}

--- a/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetNationalAverageCensusRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetNationalAverageCensusRequest.cs
@@ -15,7 +15,7 @@ public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : C
             .ReturnsAsync(new ValidationResult());
 
         Service
-            .Setup(d => d.GetHistoryAvgNationalAsync(new CensusNationalAvgParameters()))
+            .Setup(d => d.GetHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync(Array.Empty<CensusHistoryModel>());
 
         var result = await Functions.CensusHistoryAvgNationalAsync(CreateHttpRequestData());
@@ -35,14 +35,14 @@ public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : C
             }));
 
         Service
-            .Setup(d => d.GetHistoryAvgNationalAsync(new CensusNationalAvgParameters()));
+            .Setup(d => d.GetHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()));
 
         var result = await Functions.CensusHistoryAvgNationalAsync(CreateHttpRequestData());
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
         Service.Verify(
-            x => x.GetHistoryAvgNationalAsync(new CensusNationalAvgParameters()), Times.Never());
+            x => x.GetHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never());
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : C
             .ReturnsAsync(new ValidationResult());
 
         Service
-            .Setup(d => d.GetHistoryAvgNationalAsync(new CensusNationalAvgParameters()))
+            .Setup(d => d.GetHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
             .Throws(new Exception());
 
         var result = await Functions.CensusHistoryAvgNationalAsync(CreateHttpRequestData());

--- a/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetWorkforceHistoryRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetWorkforceHistoryRequest.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using FluentValidation.Results;
 using Moq;
 using Platform.Api.Insight.Census;
 using Xunit;
@@ -9,6 +10,10 @@ public class WhenFunctionReceivesGetWorkforceHistoryRequest : CensusFunctionsTes
     [Fact]
     public async Task ShouldReturn200OnValidRequest()
     {
+        CensusParametersValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<CensusParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
         Service
             .Setup(d => d.GetHistoryAsync(It.IsAny<string>()))
             .ReturnsAsync(Array.Empty<CensusHistoryModel>());
@@ -22,6 +27,10 @@ public class WhenFunctionReceivesGetWorkforceHistoryRequest : CensusFunctionsTes
     [Fact]
     public async Task ShouldReturn500OnError()
     {
+        CensusParametersValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<CensusParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
         Service
             .Setup(d => d.GetHistoryAsync(It.IsAny<string>()))
             .Throws(new Exception());

--- a/platform/tests/Platform.Tests/Insight/Expenditure/WhenExpenditureServiceQueriesAsync.cs
+++ b/platform/tests/Platform.Tests/Insight/Expenditure/WhenExpenditureServiceQueriesAsync.cs
@@ -334,10 +334,6 @@ public class WhenExpenditureServiceQueriesAsync
     public async Task ShouldQueryAsyncWhenGetSchoolHistoryAvgComparatorSetAsync(string dimension, string expectedSource)
     {
         const string urn = "123";
-        var queryParams = new ExpenditureParameters
-        {
-            Dimension = dimension
-        };
         var expected = new List<SchoolExpenditureHistoryModel>
         {
             new()
@@ -356,7 +352,7 @@ public class WhenExpenditureServiceQueriesAsync
 
         var expectedSql = $"SELECT * FROM {expectedSource} WHERE URN = @URN";
 
-        var actual = await _service.GetSchoolHistoryAvgComparatorSetAsync(urn, queryParams);
+        var actual = await _service.GetSchoolHistoryAvgComparatorSetAsync(urn, dimension);
 
         Assert.Equal(expected, actual);
         Assert.Equal(expectedSql, actualSql);
@@ -370,10 +366,6 @@ public class WhenExpenditureServiceQueriesAsync
     public async Task ShouldThrowOnInvalidDimensionWhenGetSchoolHistoryAvgComparatorSetAsync()
     {
         const string urn = "123";
-        var queryParams = new ExpenditureParameters
-        {
-            Dimension = "Invalid"
-        };
         var result = new List<SchoolExpenditureHistoryModel>
         {
             new()
@@ -384,7 +376,7 @@ public class WhenExpenditureServiceQueriesAsync
             .ReturnsAsync(result);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
-            _service.GetSchoolHistoryAvgComparatorSetAsync(urn, queryParams));
+            _service.GetSchoolHistoryAvgComparatorSetAsync(urn, "invalid"));
         _connection.Verify(c => c.QueryAsync<SchoolExpenditureHistoryModel>(It.IsAny<string>(), It.IsAny<object>()), Times.Never());
     }
 
@@ -400,12 +392,6 @@ public class WhenExpenditureServiceQueriesAsync
     [Theory]
     public async Task ShouldQueryAsyncWhenGetSchoolHistoryAvgNationalAsync(string dimension, string phase, string financeType, string expectedSource)
     {
-        var queryParams = new ExpenditureNationalAvgParameters
-        {
-            Dimension = dimension,
-            OverallPhase = phase,
-            FinanceType = financeType
-        };
         var expected = new List<SchoolExpenditureHistoryModel>
         {
             new()
@@ -424,7 +410,7 @@ public class WhenExpenditureServiceQueriesAsync
 
         var expectedSql = $"SELECT * FROM {expectedSource} WHERE FinanceType = @FinanceType AND OverallPhase = @OverallPhase";
 
-        var actual = await _service.GetSchoolHistoryAvgNationalAsync(queryParams);
+        var actual = await _service.GetSchoolHistoryAvgNationalAsync(dimension, phase, financeType);
 
         Assert.Equal(expected, actual);
         Assert.Equal(expectedSql, actualSql);
@@ -452,7 +438,7 @@ public class WhenExpenditureServiceQueriesAsync
             .ReturnsAsync(result);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
-            _service.GetSchoolHistoryAvgNationalAsync(queryParams));
+            _service.GetSchoolHistoryAvgNationalAsync("invalid", "Primary", "Maintained"));
         _connection.Verify(c => c.QueryAsync<SchoolExpenditureHistoryModel>(It.IsAny<string>(), It.IsAny<object>()), Times.Never());
     }
 }

--- a/platform/tests/Platform.Tests/Insight/Expenditure/WhenExpenditureServiceQueriesAsync.cs
+++ b/platform/tests/Platform.Tests/Insight/Expenditure/WhenExpenditureServiceQueriesAsync.cs
@@ -400,7 +400,6 @@ public class WhenExpenditureServiceQueriesAsync
     [Theory]
     public async Task ShouldQueryAsyncWhenGetSchoolHistoryAvgNationalAsync(string dimension, string phase, string financeType, string expectedSource)
     {
-        const string urn = "123";
         var queryParams = new ExpenditureNationalAvgParameters
         {
             Dimension = dimension,

--- a/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryRequest.cs
@@ -15,7 +15,7 @@ public class WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryReques
             .ReturnsAsync(new ValidationResult());
 
         Service
-            .Setup(d => d.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), new ExpenditureParameters()))
+            .Setup(d => d.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync(Array.Empty<SchoolExpenditureHistoryModel>());
 
         var result = await Functions.SchoolExpenditureHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");
@@ -35,14 +35,14 @@ public class WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryReques
             }));
 
         Service
-            .Setup(d => d.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), new ExpenditureParameters()));
+            .Setup(d => d.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>()));
 
         var result = await Functions.SchoolExpenditureHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
         Service.Verify(
-            x => x.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), new ExpenditureParameters()), Times.Never());
+            x => x.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public class WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryReques
             .ReturnsAsync(new ValidationResult());
 
         Service
-            .Setup(d => d.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), new ExpenditureParameters()))
+            .Setup(d => d.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>()))
             .Throws(new Exception());
 
         var result = await Functions.SchoolExpenditureHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");

--- a/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetExpenditureHistoryRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetExpenditureHistoryRequest.cs
@@ -27,6 +27,10 @@ public class WhenFunctionReceivesGetExpenditureHistoryRequest : ExpenditureFunct
     [Fact]
     public async Task ShouldReturn500OnError()
     {
+        ExpenditureParametersValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<ExpenditureParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
         Service
             .Setup(d => d.GetSchoolHistoryAsync(It.IsAny<string>()))
             .Throws(new Exception());

--- a/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest.cs
@@ -15,7 +15,7 @@ public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : E
             .ReturnsAsync(new ValidationResult());
 
         Service
-            .Setup(d => d.GetSchoolHistoryAvgNationalAsync(new ExpenditureNationalAvgParameters()))
+            .Setup(d => d.GetSchoolHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync(Array.Empty<SchoolExpenditureHistoryModel>());
 
         var result = await Functions.SchoolExpenditureHistoryAvgNationalAsync(CreateHttpRequestData());
@@ -35,14 +35,14 @@ public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : E
             }));
 
         Service
-            .Setup(d => d.GetSchoolHistoryAvgNationalAsync(new ExpenditureNationalAvgParameters()));
+            .Setup(d => d.GetSchoolHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()));
 
         var result = await Functions.SchoolExpenditureHistoryAvgNationalAsync(CreateHttpRequestData());
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
         Service.Verify(
-            x => x.GetSchoolHistoryAvgNationalAsync(new ExpenditureNationalAvgParameters()), Times.Never());
+            x => x.GetSchoolHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never());
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : E
             .ReturnsAsync(new ValidationResult());
 
         Service
-            .Setup(d => d.GetSchoolHistoryAvgNationalAsync(new ExpenditureNationalAvgParameters()))
+            .Setup(d => d.GetSchoolHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
             .Throws(new Exception());
 
         var result = await Functions.SchoolExpenditureHistoryAvgNationalAsync(CreateHttpRequestData());


### PR DESCRIPTION
### Context
[AB#237633](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/237633)
[AB#241828](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/241828)

### Change proposed in this pull request
Adds two new endpoints for census historic trends
- `census/{urn}/history/comparator-set-average`
- `census/history/national-average`
- updates existing tests following changes to validation setup in the tests
- adds new tests

### Guidance to review 
Currently contains proposed views which are not yet provisioned. Until there are in place these endpoints will not return data.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main

