### PR TITLE
Created `<CensusSection>` for use when historical trends feature flag enabled

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -101,7 +101,7 @@
     ></div>-->
     <!--<div id="compare-your-costs" data-type="school" data-id="143996"></div>-->
     <!--<div id="historic-data" data-type="school" data-id="990095"></div>-->
-    <div id="historic-data-2" data-type="school" data-id="990095" data-phase="Primary" data-finance-type="Maintained"></div>
+    <div id="historic-data-2" data-type="school" data-id="123456" data-phase="Primary" data-finance-type="Maintained"></div>
     <!--<div
       id="compare-your-costs"
       data-type="local-authority"

--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -101,7 +101,7 @@
     ></div>-->
     <!--<div id="compare-your-costs" data-type="school" data-id="143996"></div>-->
     <!--<div id="historic-data" data-type="school" data-id="990095"></div>-->
-    <div id="historic-data-2" data-type="school" data-id="123456" data-phase="Primary" data-finance-type="Maintained"></div>
+    <div id="historic-data-2" data-type="school" data-id="990095" data-phase="Primary" data-finance-type="Maintained"></div>
     <!--<div
       id="compare-your-costs"
       data-type="local-authority"

--- a/front-end-components/src/components/charts/data-warning/component.tsx
+++ b/front-end-components/src/components/charts/data-warning/component.tsx
@@ -1,0 +1,15 @@
+import { DataWarningProps } from "./types";
+
+export function DataWarning({ children }: DataWarningProps) {
+  return (
+    <div className="govuk-warning-text govuk-!-margin-0">
+      <span className="govuk-warning-text__icon" aria-hidden="true">
+        !
+      </span>
+      <strong className="govuk-warning-text__text">
+        <span className="govuk-visually-hidden">Warning</span>
+        {children}
+      </strong>
+    </div>
+  );
+}

--- a/front-end-components/src/components/charts/data-warning/index.tsx
+++ b/front-end-components/src/components/charts/data-warning/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/components/charts/data-warning/types";
+export * from "src/components/charts/data-warning/component";

--- a/front-end-components/src/components/charts/data-warning/types.tsx
+++ b/front-end-components/src/components/charts/data-warning/types.tsx
@@ -1,0 +1,3 @@
+import { PropsWithChildren } from "react";
+
+export interface DataWarningProps extends PropsWithChildren {}

--- a/front-end-components/src/components/charts/part-year-data-warning/component.tsx
+++ b/front-end-components/src/components/charts/part-year-data-warning/component.tsx
@@ -1,18 +1,13 @@
+import { DataWarning } from "../data-warning";
 import { PartYearDataWarningProps } from "./types";
 
 export function PartYearDataWarning({
   periodCoveredByReturn,
 }: PartYearDataWarningProps) {
   return (
-    <div className="govuk-warning-text govuk-!-margin-0">
-      <span className="govuk-warning-text__icon" aria-hidden="true">
-        !
-      </span>
-      <strong className="govuk-warning-text__text">
-        <span className="govuk-visually-hidden">Warning</span>
-        This school only has {periodCoveredByReturn}{" "}
-        {periodCoveredByReturn === 1 ? "month" : "months"} of data available.
-      </strong>
-    </div>
+    <DataWarning>
+      This school only has {periodCoveredByReturn}{" "}
+      {periodCoveredByReturn === 1 ? "month" : "months"} of data available.
+    </DataWarning>
   );
 }

--- a/front-end-components/src/composed/historic-chart-2-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-2-composed/component.tsx
@@ -89,9 +89,10 @@ export function HistoricChart2<TData extends SchoolHistoryBase>({
     },
     school: {
       label:
-        dimension.value === "PerUnit"
+        axisLabel ??
+        (dimension.value === "PerUnit"
           ? perUnitDimension.label
-          : dimension.label,
+          : dimension.label),
       visible: true,
     },
   };
@@ -112,9 +113,6 @@ export function HistoricChart2<TData extends SchoolHistoryBase>({
                 keyField="term"
                 margin={20}
                 seriesConfig={seriesConfig}
-                seriesLabel={
-                  axisLabel === undefined ? "" : (axisLabel ?? dimension.label)
-                }
                 seriesLabelField="term"
                 valueFormatter={shortValueFormatter}
                 valueUnit={valueUnit ?? dimension.unit}
@@ -126,7 +124,7 @@ export function HistoricChart2<TData extends SchoolHistoryBase>({
                         valueUnit: valueUnit ?? dimension.unit,
                       })
                     }
-                    dimension={dimension.heading}
+                    dimension={columnHeading ?? dimension.heading}
                   />
                 )}
                 legend={legend === undefined ? true : legend}

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -10,6 +10,7 @@ import {
   FindOrganisation,
   HistoricData,
   HistoricData2,
+  HistoricData2SectionName,
 } from "src/views";
 import {
   CompareCostsElementId,
@@ -73,9 +74,10 @@ if (historicDataElement) {
 
 const historicData2Element = document.getElementById(HistoricData2ElementId);
 if (historicData2Element) {
-  const { type, id, phase, financeType } = historicData2Element.dataset;
+  const { financeType, id, phase, type } = historicData2Element.dataset;
   if (type && id) {
     const root = ReactDOM.createRoot(historicData2Element);
+    const hash = window?.location.hash.replace("#", "");
     root.render(
       <React.StrictMode>
         <HistoricData2
@@ -83,6 +85,9 @@ if (historicData2Element) {
           id={id}
           overallPhase={phase}
           financeType={financeType}
+          preLoadSections={
+            hash ? [hash as HistoricData2SectionName] : undefined
+          }
         />
       </React.StrictMode>
     );

--- a/front-end-components/src/services/census-api.tsx
+++ b/front-end-components/src/services/census-api.tsx
@@ -1,4 +1,8 @@
-import { Census, CensusHistory } from "src/services/types";
+import {
+  Census,
+  CensusHistory,
+  SchoolHistoryComparison,
+} from "src/services/types";
 import { v4 as uuidv4 } from "uuid";
 
 export class CensusApi {
@@ -26,6 +30,36 @@ export class CensusApi {
 
         return res;
       });
+  }
+
+  static async historyComparison(
+    id: string,
+    dimension: string,
+    overallPhase?: string,
+    financeType?: string
+  ): Promise<SchoolHistoryComparison<CensusHistory>> {
+    const params = new URLSearchParams({
+      id: id,
+      dimension: dimension,
+      phase: overallPhase || "",
+      financeType: financeType || "",
+    });
+
+    const response = await fetch("/api/census/history/comparison?" + params, {
+      redirect: "manual",
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Correlation-ID": uuidv4(),
+      },
+    });
+
+    const json = await response.json();
+    if (json.error) {
+      throw json.error;
+    }
+
+    return json;
   }
 
   static async query(

--- a/front-end-components/src/services/census-api.tsx
+++ b/front-end-components/src/services/census-api.tsx
@@ -52,6 +52,7 @@ export class CensusApi {
         "Content-Type": "application/json",
         "X-Correlation-ID": uuidv4(),
       },
+      signal: AbortSignal.timeout(30_000),
     });
 
     const json = await response.json();

--- a/front-end-components/src/services/expenditure-api.tsx
+++ b/front-end-components/src/services/expenditure-api.tsx
@@ -74,6 +74,7 @@ export class ExpenditureApi {
           "Content-Type": "application/json",
           "X-Correlation-ID": uuidv4(),
         },
+        signal: AbortSignal.timeout(30_000),
       }
     );
 

--- a/front-end-components/src/services/types.tsx
+++ b/front-end-components/src/services/types.tsx
@@ -283,10 +283,11 @@ export type SchoolExpenditureHistory = AdministrativeSuppliesExpenditureBase &
   PremisesStaffServicesExpenditureBase &
   TeachingSupportStaffExpenditureBase &
   TotalExpenditureExpenditureBase &
-  UtilitiesExpenditureBase &
-  SchoolHistoryBase;
+  UtilitiesExpenditureBase & {
+    totalCateringCostsField: number;
+  } & SchoolHistoryBase;
 
-export type SchoolHistoryComparison<T extends SchoolHistoryBase> = {
+export type SchoolHistoryComparison<T> = {
   school?: T[];
   comparatorSetAverage?: T[];
   nationalAverage?: T[];

--- a/front-end-components/src/views/historic-data-2/partials/census-section.tsx
+++ b/front-end-components/src/views/historic-data-2/partials/census-section.tsx
@@ -11,7 +11,10 @@ import {
   SchoolHistoryComparison,
 } from "src/services";
 import { ChartDimensionContext, useChartModeContext } from "src/contexts";
-import { HistoricChart2 } from "src/composed/historic-chart-2-composed";
+import {
+  HistoricChart2,
+  HistoricChart2Props,
+} from "src/composed/historic-chart-2-composed";
 import { Loading } from "src/components/loading";
 import { HistoricData2Props } from "../types";
 import { censusCharts } from ".";
@@ -79,31 +82,41 @@ export const CensusSection: React.FC<HistoricData2Props> = ({
       {data.school?.length ? (
         censusCharts
           .filter((c) => c.type === undefined || c.type === type)
-          .map((chart) => (
-            <section key={chart.field}>
-              <HistoricChart2
-                chartName={chart.name}
-                data={data}
-                valueField={chart.field}
-                key={chart.field}
-                perUnitDimension={chart.perUnitDimension}
-              >
-                <h3 className="govuk-heading-s">{chart.name}</h3>
-              </HistoricChart2>
-              {chart.details && (
-                <details className="govuk-details">
-                  <summary className="govuk-details__summary">
-                    <span className="govuk-details__summary-text">
-                      {chart.details.label}
-                    </span>
-                  </summary>
-                  <div className="govuk-details__text">
-                    {chart.details.content}
-                  </div>
-                </details>
-              )}
-            </section>
-          ))
+          .map((chart) => {
+            const chartProps: Partial<HistoricChart2Props<CensusHistory>> = {};
+            if (chart.field === "totalPupils") {
+              chartProps.valueUnit = "amount";
+              chartProps.axisLabel = "total";
+              chartProps.columnHeading = "Total";
+            }
+
+            return (
+              <section key={chart.field}>
+                <HistoricChart2
+                  chartName={chart.name}
+                  data={data}
+                  valueField={chart.field}
+                  key={chart.field}
+                  perUnitDimension={chart.perUnitDimension}
+                  {...chartProps}
+                >
+                  <h2 className="govuk-heading-s">{chart.name}</h2>
+                </HistoricChart2>
+                {chart.details && (
+                  <details className="govuk-details">
+                    <summary className="govuk-details__summary">
+                      <span className="govuk-details__summary-text">
+                        {chart.details.label}
+                      </span>
+                    </summary>
+                    <div className="govuk-details__text">
+                      {chart.details.content}
+                    </div>
+                  </details>
+                )}
+              </section>
+            );
+          })
       ) : (
         <Loading />
       )}

--- a/front-end-components/src/views/historic-data-2/partials/census-section.tsx
+++ b/front-end-components/src/views/historic-data-2/partials/census-section.tsx
@@ -17,16 +17,21 @@ import { HistoricData2Props } from "../types";
 import { censusCharts } from ".";
 
 export const CensusSection: React.FC<HistoricData2Props> = ({
-  type,
-  id,
-  overallPhase,
   financeType,
+  id,
+  load,
+  overallPhase,
+  type,
 }) => {
   const defaultDimension = PupilsPerStaffRole;
   const { chartMode, setChartMode } = useChartModeContext();
   const [dimension, setDimension] = useState(defaultDimension);
   const [data, setData] = useState<SchoolHistoryComparison<CensusHistory>>({});
   const getData = useCallback(async () => {
+    if (!load) {
+      return {};
+    }
+
     setData({});
     return await CensusApi.historyComparison(
       id,
@@ -34,7 +39,7 @@ export const CensusSection: React.FC<HistoricData2Props> = ({
       overallPhase,
       financeType
     );
-  }, [id, dimension, overallPhase, financeType]);
+  }, [dimension.value, financeType, id, load, overallPhase]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -71,11 +76,11 @@ export const CensusSection: React.FC<HistoricData2Props> = ({
         </div>
       </div>
       <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-0" />
-      {censusCharts
-        .filter((c) => c.type === undefined || c.type === type)
-        .map((chart) => {
-          return data.school?.length ? (
-            <>
+      {data.school?.length ? (
+        censusCharts
+          .filter((c) => c.type === undefined || c.type === type)
+          .map((chart) => (
+            <section key={chart.field}>
               <HistoricChart2
                 chartName={chart.name}
                 data={data}
@@ -97,11 +102,11 @@ export const CensusSection: React.FC<HistoricData2Props> = ({
                   </div>
                 </details>
               )}
-            </>
-          ) : (
-            <Loading key={chart.field} />
-          );
-        })}
+            </section>
+          ))
+      ) : (
+        <Loading />
+      )}
     </ChartDimensionContext.Provider>
   );
 };

--- a/front-end-components/src/views/historic-data-2/partials/index.tsx
+++ b/front-end-components/src/views/historic-data-2/partials/index.tsx
@@ -271,6 +271,9 @@ export const censusCharts: HistoricData2SectionChart<CensusHistory>[] = [
     name: "Pupils on roll",
     field: "totalPupils",
     perUnitDimension: PupilsPerStaffRole,
+    valueUnit: "amount",
+    axisLabel: "total",
+    columnHeading: "Total",
   },
   {
     name: "School workforce (full time equivalent)",
@@ -320,6 +323,9 @@ export const censusCharts: HistoricData2SectionChart<CensusHistory>[] = [
         </p>
       ),
     },
+    valueUnit: "%",
+    axisLabel: "percentage",
+    columnHeading: "Percent",
   },
   {
     name: "Senior leadership (full time equivalent)",

--- a/front-end-components/src/views/historic-data-2/partials/index.tsx
+++ b/front-end-components/src/views/historic-data-2/partials/index.tsx
@@ -347,7 +347,7 @@ export const censusCharts: HistoricData2SectionChart<CensusHistory>[] = [
     field: "teachingAssistant",
     perUnitDimension: PupilsPerStaffRole,
     details: {
-      label: "More about senior leadership",
+      label: "More about teaching assistants",
       content: (
         <>
           <p>

--- a/front-end-components/src/views/historic-data-2/partials/index.tsx
+++ b/front-end-components/src/views/historic-data-2/partials/index.tsx
@@ -273,7 +273,7 @@ export const censusCharts: HistoricData2SectionChart<CensusHistory>[] = [
     perUnitDimension: PupilsPerStaffRole,
   },
   {
-    name: "Teaching staff costs",
+    name: "School workforce (full time equivalent)",
     field: "workforce",
     perUnitDimension: PupilsPerStaffRole,
     details: {
@@ -308,7 +308,7 @@ export const censusCharts: HistoricData2SectionChart<CensusHistory>[] = [
     },
   },
   {
-    name: "Teachers with qualified teacher status (%)",
+    name: "Teachers with qualified teacher status (percentage)",
     field: "percentTeacherWithQualifiedStatus",
     perUnitDimension: PupilsPerStaffRole,
     details: {

--- a/front-end-components/src/views/historic-data-2/partials/index.tsx
+++ b/front-end-components/src/views/historic-data-2/partials/index.tsx
@@ -1,9 +1,14 @@
-import { SchoolExpenditureHistory } from "src/services";
-import { HistoricData2Section } from "../types";
-import { PoundsPerMetreSq, PoundsPerPupil } from "src/components";
+import { CensusHistory, SchoolExpenditureHistory } from "src/services";
+import { HistoricData2Section, HistoricData2SectionChart } from "../types";
+import {
+  PoundsPerMetreSq,
+  PoundsPerPupil,
+  PupilsPerStaffRole,
+} from "src/components";
 
 /* eslint-disable react-refresh/only-export-components */
 export * from "src/views/historic-data-2/partials/spending-section.tsx";
+export * from "src/views/historic-data-2/partials/census-section.tsx";
 
 export const spendingSections: HistoricData2Section<SchoolExpenditureHistory>[] =
   [
@@ -260,3 +265,158 @@ export const spendingSections: HistoricData2Section<SchoolExpenditureHistory>[] 
       ],
     },
   ];
+
+export const censusCharts: HistoricData2SectionChart<CensusHistory>[] = [
+  {
+    name: "Pupils on roll",
+    field: "totalPupils",
+    perUnitDimension: PupilsPerStaffRole,
+  },
+  {
+    name: "Teaching staff costs",
+    field: "workforce",
+    perUnitDimension: PupilsPerStaffRole,
+    details: {
+      label: "More about school workforce",
+      content: (
+        <>
+          <p>
+            This includes non-classroom based support staff, and full-time
+            equivalent:{" "}
+          </p>
+          <ul className="govuk-list govuk-list--bullet">
+            <li>classroom teachers</li>
+            <li>senior leadership</li>
+            <li>teaching assistants</li>
+          </ul>
+        </>
+      ),
+    },
+  },
+  {
+    name: "Total number of teachers (full time equivalent)",
+    field: "teachers",
+    perUnitDimension: PupilsPerStaffRole,
+    details: {
+      label: "More about total number of teachers",
+      content: (
+        <p>
+          This is the full-time equivalent of all classroom and leadership
+          teachers.
+        </p>
+      ),
+    },
+  },
+  {
+    name: "Teachers with qualified teacher status (%)",
+    field: "percentTeacherWithQualifiedStatus",
+    perUnitDimension: PupilsPerStaffRole,
+    details: {
+      label: "More about teachers with qualified teacher status",
+      content: (
+        <p>
+          We divided the number of teachers with qualified teacher status by the
+          total number of teachers.
+        </p>
+      ),
+    },
+  },
+  {
+    name: "Senior leadership (full time equivalent)",
+    field: "seniorLeadership",
+    perUnitDimension: PupilsPerStaffRole,
+    details: {
+      label: "More about senior leadership",
+      content: (
+        <>
+          <p>
+            This is the full-time equivalent of senior leadership roles,
+            including:
+          </p>
+          <ul className="govuk-list govuk-list--bullet">
+            <li>headteachers</li>
+            <li>deputy headteachers</li>
+            <li>assistant headteachers</li>
+          </ul>
+        </>
+      ),
+    },
+  },
+  {
+    name: "Teaching assistants (full time equivalent)",
+    field: "teachingAssistant",
+    perUnitDimension: PupilsPerStaffRole,
+    details: {
+      label: "More about senior leadership",
+      content: (
+        <>
+          <p>
+            This is the full-time equivalent of teaching assistants, including:
+          </p>
+          <ul className="govuk-list govuk-list--bullet">
+            <li>teaching assistants</li>
+            <li>higher level teaching assistants</li>
+            <li>education needs support staff</li>
+          </ul>
+        </>
+      ),
+    },
+  },
+  {
+    name: "Non-classroom support staff - excluding auxiliary staff (full time equivalent)",
+    field: "nonClassroomSupportStaff",
+    perUnitDimension: PupilsPerStaffRole,
+    details: {
+      label: "More about non-classroom support staff",
+      content: (
+        <>
+          <p>
+            This is the full-time equivalent of non-classroom-based support
+            staff, excluding:
+          </p>
+          <ul className="govuk-list govuk-list--bullet">
+            <li>auxiliary staff</li>
+            <li>third party support staff</li>
+          </ul>
+        </>
+      ),
+    },
+  },
+  {
+    name: "Auxiliary staff (full time equivalent)",
+    field: "auxiliaryStaff",
+    perUnitDimension: PupilsPerStaffRole,
+    details: {
+      label: "More about auxiliary staff",
+      content: (
+        <>
+          <p>This is the full-time equivalent of auxiliary staff, including;</p>
+          <ul className="govuk-list govuk-list--bullet">
+            <li>catering</li>
+            <li>school maintenance staff</li>
+          </ul>
+        </>
+      ),
+    },
+  },
+  {
+    name: "School workforce (headcount)",
+    field: "workforceHeadcount",
+    perUnitDimension: PupilsPerStaffRole,
+    details: {
+      label: "More about school workforce (headcount)",
+      content: (
+        <>
+          <p>This is the total headcount of the school workforce, including:</p>
+          <ul className="govuk-list govuk-list--bullet">
+            <li>
+              full and part-time teachers (including school leadership teachers)
+            </li>
+            <li>teaching assistant</li>
+            <li>non-classroom based support staff</li>
+          </ul>
+        </>
+      ),
+    },
+  },
+];

--- a/front-end-components/src/views/historic-data-2/partials/spending-section.tsx
+++ b/front-end-components/src/views/historic-data-2/partials/spending-section.tsx
@@ -17,12 +17,14 @@ import { Loading } from "src/components/loading";
 import { HistoricData2Props } from "../types";
 import { CateringCostsHistoryChart } from "./catering-costs-history-chart";
 import { spendingSections } from ".";
+import classNames from "classnames";
 
 export const SpendingSection: React.FC<HistoricData2Props> = ({
-  type,
-  id,
-  overallPhase,
   financeType,
+  id,
+  load,
+  overallPhase,
+  type,
 }) => {
   const defaultDimension = Actual;
   const { chartMode, setChartMode } = useChartModeContext();
@@ -31,6 +33,10 @@ export const SpendingSection: React.FC<HistoricData2Props> = ({
     SchoolHistoryComparison<SchoolExpenditureHistory>
   >({});
   const getData = useCallback(async () => {
+    if (!load) {
+      return {};
+    }
+
     setData({});
     return await ExpenditureApi.historyComparison(
       type,
@@ -39,7 +45,7 @@ export const SpendingSection: React.FC<HistoricData2Props> = ({
       overallPhase,
       financeType
     );
-  }, [type, id, dimension, overallPhase, financeType]);
+  }, [dimension.value, financeType, id, load, overallPhase, type]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -77,19 +83,23 @@ export const SpendingSection: React.FC<HistoricData2Props> = ({
       </div>
       <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-0" />
       {data.school?.length ? (
-        <HistoricChart2
-          chartName="Total expenditure"
-          data={data}
-          valueField="totalExpenditure"
-          perUnitDimension={PoundsPerPupil}
-        >
-          <h2 className="govuk-heading-m">Total expenditure</h2>
-        </HistoricChart2>
+        <section>
+          <HistoricChart2
+            chartName="Total expenditure"
+            data={data}
+            valueField="totalExpenditure"
+            perUnitDimension={PoundsPerPupil}
+          >
+            <h2 className="govuk-heading-m">Total expenditure</h2>
+          </HistoricChart2>
+        </section>
       ) : (
         <Loading />
       )}
       <div
-        className="govuk-accordion"
+        className={classNames("govuk-accordion", {
+          "govuk-visually-hidden": !data.school?.length,
+        })}
         data-module="govuk-accordion"
         id="accordion-expenditure"
       >
@@ -111,13 +121,12 @@ export const SpendingSection: React.FC<HistoricData2Props> = ({
             >
               {section.charts
                 .filter((c) => c.type === undefined || c.type === type)
-                .map((chart) => {
-                  return data.school?.length ? (
-                    (chart.field as string) === "totalCateringCostsField" ? (
+                .map((chart) => (
+                  <section key={chart.field}>
+                    {(chart.field as string) === "totalCateringCostsField" ? (
                       <CateringCostsHistoryChart
                         chartName={chart.name}
                         data={data}
-                        key={chart.field}
                         perUnitDimension={chart.perUnitDimension}
                       />
                     ) : (
@@ -125,16 +134,13 @@ export const SpendingSection: React.FC<HistoricData2Props> = ({
                         chartName={chart.name}
                         data={data}
                         valueField={chart.field}
-                        key={chart.field}
                         perUnitDimension={chart.perUnitDimension}
                       >
                         <h3 className="govuk-heading-s">{chart.name}</h3>
                       </HistoricChart2>
-                    )
-                  ) : (
-                    <Loading key={chart.field} />
-                  );
-                })}
+                    )}
+                  </section>
+                ))}
             </div>
           </div>
         ))}

--- a/front-end-components/src/views/historic-data-2/partials/spending-section.tsx
+++ b/front-end-components/src/views/historic-data-2/partials/spending-section.tsx
@@ -18,6 +18,7 @@ import { HistoricData2Props } from "../types";
 import { CateringCostsHistoryChart } from "./catering-costs-history-chart";
 import { spendingSections } from ".";
 import classNames from "classnames";
+import { DataWarning } from "src/components/charts/data-warning";
 
 export const SpendingSection: React.FC<HistoricData2Props> = ({
   financeType,
@@ -32,11 +33,14 @@ export const SpendingSection: React.FC<HistoricData2Props> = ({
   const [data, setData] = useState<
     SchoolHistoryComparison<SchoolExpenditureHistory>
   >({});
+  const [loadError, setLoadError] = useState<string>();
+
   const getData = useCallback(async () => {
     if (!load) {
       return {};
     }
 
+    setLoadError(undefined);
     setData({});
     return await ExpenditureApi.historyComparison(
       type,
@@ -48,9 +52,14 @@ export const SpendingSection: React.FC<HistoricData2Props> = ({
   }, [dimension.value, financeType, id, load, overallPhase, type]);
 
   useEffect(() => {
-    getData().then((result) => {
-      setData(result);
-    });
+    getData()
+      .then((result) => {
+        setData(result);
+      })
+      .catch(() => {
+        setData({});
+        setLoadError("Unable to load historical spending data");
+      });
   }, [getData]);
 
   const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
@@ -93,6 +102,8 @@ export const SpendingSection: React.FC<HistoricData2Props> = ({
             <h2 className="govuk-heading-m">Total expenditure</h2>
           </HistoricChart2>
         </section>
+      ) : loadError ? (
+        <DataWarning>{loadError}</DataWarning>
       ) : (
         <Loading />
       )}

--- a/front-end-components/src/views/historic-data-2/partials/spending-section.tsx
+++ b/front-end-components/src/views/historic-data-2/partials/spending-section.tsx
@@ -113,7 +113,7 @@ export const SpendingSection: React.FC<HistoricData2Props> = ({
                 .filter((c) => c.type === undefined || c.type === type)
                 .map((chart) => {
                   return data.school?.length ? (
-                    chart.field === "totalCateringCostsField" ? (
+                    (chart.field as string) === "totalCateringCostsField" ? (
                       <CateringCostsHistoryChart
                         chartName={chart.name}
                         data={data}

--- a/front-end-components/src/views/historic-data-2/types.tsx
+++ b/front-end-components/src/views/historic-data-2/types.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
-import { Dimension } from "src/components";
 import { ResolvedStatProps } from "src/components/charts/resolved-stat";
+import { HistoricChart2Props } from "src/composed/historic-chart-2-composed";
 import { SchoolHistoryBase } from "src/services";
 
 export type HistoricData2Props = {
@@ -26,11 +26,13 @@ export type HistoricData2Section<T extends SchoolHistoryBase> = {
   charts: HistoricData2SectionChart<T>[];
 };
 
-export type HistoricData2SectionChart<T extends SchoolHistoryBase> = {
+export type HistoricData2SectionChart<T extends SchoolHistoryBase> = Pick<
+  HistoricChart2Props<T>,
+  "valueUnit" | "axisLabel" | "columnHeading" | "perUnitDimension"
+> & {
   name: string;
   field: ResolvedStatProps<T>["valueField"];
   type?: "school" | "trust" | "local-authority";
-  perUnitDimension: Dimension;
   details?: {
     label: string;
     content: ReactNode;

--- a/front-end-components/src/views/historic-data-2/types.tsx
+++ b/front-end-components/src/views/historic-data-2/types.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from "react";
 import { Dimension } from "src/components";
 import { ResolvedStatProps } from "src/components/charts/resolved-stat";
 import { SchoolHistoryBase } from "src/services";
@@ -14,9 +15,13 @@ export type HistoricData2Section<T extends SchoolHistoryBase> = {
   charts: HistoricData2SectionChart<T>[];
 };
 
-type HistoricData2SectionChart<T extends SchoolHistoryBase> = {
+export type HistoricData2SectionChart<T extends SchoolHistoryBase> = {
   name: string;
-  field: ResolvedStatProps<T>["valueField"] | "totalCateringCostsField";
+  field: ResolvedStatProps<T>["valueField"];
   type?: "school" | "trust" | "local-authority";
   perUnitDimension: Dimension;
+  details?: {
+    label: string;
+    content: ReactNode;
+  };
 };

--- a/front-end-components/src/views/historic-data-2/types.tsx
+++ b/front-end-components/src/views/historic-data-2/types.tsx
@@ -8,7 +8,18 @@ export type HistoricData2Props = {
   id: string;
   overallPhase?: string;
   financeType?: string;
+  load?: boolean;
 };
+
+export type HistoricData2ViewProps = Omit<HistoricData2Props, "load"> & {
+  preLoadSections?: HistoricData2SectionName[];
+};
+
+export type HistoricData2SectionName =
+  | "spending"
+  | "income"
+  | "balance"
+  | "census";
 
 export type HistoricData2Section<T extends SchoolHistoryBase> = {
   heading: string;

--- a/front-end-components/src/views/historic-data-2/view.tsx
+++ b/front-end-components/src/views/historic-data-2/view.tsx
@@ -1,9 +1,8 @@
+import { BalanceSection, IncomeSection } from "../historic-data/partials";
 import {
-  BalanceSection,
   CensusSection,
-  IncomeSection,
-} from "../historic-data/partials";
-import { SpendingSection } from "src/views/historic-data-2/partials";
+  SpendingSection,
+} from "src/views/historic-data-2/partials";
 import { HistoricData2Props } from "src/views/historic-data-2/types";
 import { SchoolEstablishment } from "src/constants";
 import { useGovUk } from "src/hooks/useGovUk";
@@ -60,7 +59,7 @@ export const HistoricData2: React.FC<HistoricData2Props> = (props) => {
             className="govuk-tabs__panel govuk-tabs__panel--hidden"
             id="census"
           >
-            <CensusSection id={props.id} />
+            <CensusSection {...props} />
           </div>
         )}
       </ChartModeProvider>

--- a/front-end-components/src/views/historic-data-2/view.tsx
+++ b/front-end-components/src/views/historic-data-2/view.tsx
@@ -3,36 +3,70 @@ import {
   CensusSection,
   SpendingSection,
 } from "src/views/historic-data-2/partials";
-import { HistoricData2Props } from "src/views/historic-data-2/types";
+import {
+  HistoricData2SectionName,
+  HistoricData2ViewProps,
+} from "src/views/historic-data-2/types";
 import { SchoolEstablishment } from "src/constants";
 import { useGovUk } from "src/hooks/useGovUk";
 import { ChartModeChart } from "src/components";
 import { ChartModeProvider } from "src/contexts";
+import { useState } from "react";
 
-export const HistoricData2: React.FC<HistoricData2Props> = (props) => {
+export const HistoricData2: React.FC<HistoricData2ViewProps> = ({
+  preLoadSections,
+  ...props
+}) => {
+  const [loadedSections, setLoadedSections] = useState<
+    HistoricData2SectionName[]
+  >(preLoadSections ?? ["spending"]);
   useGovUk();
+
+  const handleSectionLoad = (section: HistoricData2SectionName) => {
+    if (loadedSections.includes(section)) {
+      return;
+    }
+
+    setLoadedSections([...loadedSections, section]);
+  };
 
   return (
     <div className="govuk-tabs" data-module="govuk-tabs">
       <ul className="govuk-tabs__list">
         <li className="govuk-tabs__list-item govuk-tabs__list-item--selected">
-          <a className="govuk-tabs__tab" href="#spending">
+          <a
+            className="govuk-tabs__tab"
+            href="#spending"
+            onClick={() => handleSectionLoad("spending")}
+          >
             Spending
           </a>
         </li>
         <li className="govuk-tabs__list-item">
-          <a className="govuk-tabs__tab" href="#income">
+          <a
+            className="govuk-tabs__tab"
+            href="#income"
+            onClick={() => handleSectionLoad("income")}
+          >
             Income
           </a>
         </li>
         <li className="govuk-tabs__list-item">
-          <a className="govuk-tabs__tab" href="#balance">
+          <a
+            className="govuk-tabs__tab"
+            href="#balance"
+            onClick={() => handleSectionLoad("balance")}
+          >
             Balance
           </a>
         </li>
         {props.type === SchoolEstablishment && (
           <li className="govuk-tabs__list-item">
-            <a className="govuk-tabs__tab" href="#census">
+            <a
+              className="govuk-tabs__tab"
+              href="#census"
+              onClick={() => handleSectionLoad("census")}
+            >
               Pupil and workforce
             </a>
           </li>
@@ -40,26 +74,35 @@ export const HistoricData2: React.FC<HistoricData2Props> = (props) => {
       </ul>
       <ChartModeProvider initialValue={ChartModeChart}>
         <div className="govuk-tabs__panel" id="spending">
-          <SpendingSection {...props} />
+          <SpendingSection
+            {...props}
+            load={loadedSections.includes("spending")}
+          />
         </div>
         <div
           className="govuk-tabs__panel govuk-tabs__panel--hidden"
           id="income"
         >
-          <IncomeSection {...props} />
+          <IncomeSection {...props} load={loadedSections.includes("income")} />
         </div>
         <div
           className="govuk-tabs__panel govuk-tabs__panel--hidden"
           id="balance"
         >
-          <BalanceSection {...props} />
+          <BalanceSection
+            {...props}
+            load={loadedSections.includes("balance")}
+          />
         </div>
         {props.type === SchoolEstablishment && (
           <div
             className="govuk-tabs__panel govuk-tabs__panel--hidden"
             id="census"
           >
-            <CensusSection {...props} />
+            <CensusSection
+              {...props}
+              load={loadedSections.includes("census")}
+            />
           </div>
         )}
       </ChartModeProvider>

--- a/front-end-components/src/views/historic-data/partials/balance-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/balance-section.tsx
@@ -10,18 +10,23 @@ import { SchoolBalanceHistory, BalanceApi } from "src/services";
 import { HistoricChart } from "src/composed/historic-chart-composed";
 import { Loading } from "src/components/loading";
 
-export const BalanceSection: React.FC<{ type: string; id: string }> = ({
-  type,
-  id,
-}) => {
+export const BalanceSection: React.FC<{
+  type: string;
+  id: string;
+  load: boolean;
+}> = ({ type, id, load }) => {
   const defaultDimension = Actual;
   const { chartMode, setChartMode } = useChartModeContext();
   const [dimension, setDimension] = useState(defaultDimension);
   const [data, setData] = useState(new Array<SchoolBalanceHistory>());
   const getData = useCallback(async () => {
+    if (!load) {
+      return [];
+    }
+
     setData(new Array<SchoolBalanceHistory>());
     return await BalanceApi.history(type, id, dimension.value);
-  }, [type, id, dimension]);
+  }, [type, id, dimension, load]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/historic-data/partials/census-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/census-section.tsx
@@ -10,15 +10,22 @@ import { CensusHistory, CensusApi } from "src/services";
 import { HistoricChart } from "src/composed/historic-chart-composed";
 import { Loading } from "src/components/loading";
 
-export const CensusSection: React.FC<{ id: string }> = ({ id }) => {
+export const CensusSection: React.FC<{ id: string; load: boolean }> = ({
+  id,
+  load,
+}) => {
   const defaultDimension = PupilsPerStaffRole;
   const { chartMode, setChartMode } = useChartModeContext();
   const [dimension, setDimension] = useState(defaultDimension);
   const [data, setData] = useState(new Array<CensusHistory>());
   const getData = useCallback(async () => {
+    if (!load) {
+      return [];
+    }
+
     setData(new Array<CensusHistory>());
     return await CensusApi.history(id, dimension.value);
-  }, [id, dimension]);
+  }, [id, dimension, load]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/historic-data/partials/income-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/income-section.tsx
@@ -13,18 +13,23 @@ import { IncomeSectionSelfGenerated } from "src/views/historic-data/partials/inc
 import { IncomeSectionDirectRevenue } from "src/views/historic-data/partials/income-section-direct-revenue";
 import { HistoricChart } from "src/composed/historic-chart-composed";
 
-export const IncomeSection: React.FC<{ type: string; id: string }> = ({
-  type,
-  id,
-}) => {
+export const IncomeSection: React.FC<{
+  type: string;
+  id: string;
+  load: boolean;
+}> = ({ type, id, load }) => {
   const defaultDimension = Actual;
   const { chartMode, setChartMode } = useChartModeContext();
   const [dimension, setDimension] = useState(defaultDimension);
   const [data, setData] = useState(new Array<Income>());
   const getData = useCallback(async () => {
+    if (!load) {
+      return [];
+    }
+
     setData(new Array<Income>());
     return await IncomeApi.history(type, id, dimension.value);
-  }, [type, id, dimension]);
+  }, [type, id, dimension, load]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/historic-data/partials/spending-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section.tsx
@@ -19,18 +19,23 @@ import { SpendingSectionAdministrativeSupplies } from "src/views/historic-data/p
 import { SpendingSectionCateringServices } from "src/views/historic-data/partials/spending-section-catering-services";
 import { SpendingSectionOther } from "src/views/historic-data/partials/spending-section-other";
 
-export const SpendingSection: React.FC<{ type: string; id: string }> = ({
-  type,
-  id,
-}) => {
+export const SpendingSection: React.FC<{
+  type: string;
+  id: string;
+  load: boolean;
+}> = ({ type, id, load }) => {
   const defaultDimension = Actual;
   const { chartMode, setChartMode } = useChartModeContext();
   const [dimension, setDimension] = useState(defaultDimension);
   const [data, setData] = useState(new Array<SchoolExpenditureHistory>());
   const getData = useCallback(async () => {
+    if (!load) {
+      return [];
+    }
+
     setData(new Array<SchoolExpenditureHistory>());
     return await ExpenditureApi.history(type, id, dimension.value);
-  }, [type, id, dimension]);
+  }, [type, id, dimension, load]);
 
   useEffect(() => {
     getData().then((result) => {

--- a/front-end-components/src/views/historic-data/view.tsx
+++ b/front-end-components/src/views/historic-data/view.tsx
@@ -42,26 +42,26 @@ export const HistoricData: React.FC<HistoricDataViewProps> = (props) => {
       </ul>
       <ChartModeProvider initialValue={ChartModeChart}>
         <div className="govuk-tabs__panel" id="spending">
-          <SpendingSection type={type} id={id} />
+          <SpendingSection type={type} id={id} load />
         </div>
         <div
           className="govuk-tabs__panel govuk-tabs__panel--hidden"
           id="income"
         >
-          <IncomeSection type={type} id={id} />
+          <IncomeSection type={type} id={id} load />
         </div>
         <div
           className="govuk-tabs__panel govuk-tabs__panel--hidden"
           id="balance"
         >
-          <BalanceSection type={type} id={id} />
+          <BalanceSection type={type} id={id} load />
         </div>
         {type === SchoolEstablishment && (
           <div
             className="govuk-tabs__panel govuk-tabs__panel--hidden"
             id="census"
           >
-            <CensusSection id={id} />
+            <CensusSection id={id} load />
           </div>
         )}
       </ChartModeProvider>

--- a/web/src/Web.App/Controllers/SchoolController.cs
+++ b/web/src/Web.App/Controllers/SchoolController.cs
@@ -87,7 +87,7 @@ public class SchoolController(
                 ViewData[ViewDataKeys.Backlink] = HomeLink(urn);
 
                 var school = await School(urn);
-                var viewModel = new SchoolViewModel(school);
+                var viewModel = new SchoolHistoryViewModel(school);
                 return View(viewModel);
             }
             catch (Exception e)

--- a/web/src/Web.App/Domain/Insight/HistoryComparison.cs
+++ b/web/src/Web.App/Domain/Insight/HistoryComparison.cs
@@ -1,3 +1,4 @@
+// ReSharper disable UnusedAutoPropertyAccessor.Global
 namespace Web.App.Domain;
 
 public record HistoryComparison<T>

--- a/web/src/Web.App/ViewModels/SchoolHistoryViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolHistoryViewModel.cs
@@ -1,0 +1,10 @@
+using Web.App.Domain;
+namespace Web.App.ViewModels;
+
+public class SchoolHistoryViewModel(School school)
+{
+    public string? Name => school.SchoolName;
+    public string? Urn => school.URN;
+    public bool IsPartOfTrust => school.IsPartOfTrust;
+    public string? OverallPhase => school.OverallPhase;
+}

--- a/web/src/Web.App/Views/School/History.cshtml
+++ b/web/src/Web.App/Views/School/History.cshtml
@@ -1,6 +1,6 @@
 @using Microsoft.FeatureManagement.Mvc.TagHelpers
 @using Web.App.Domain
-@model Web.App.ViewModels.SchoolViewModel
+@model Web.App.ViewModels.SchoolHistoryViewModel
 
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.HistoricData;
@@ -27,7 +27,13 @@
 </div>
 
 <feature name="@FeatureFlags.HistoricalTrends">
-    <div id="historic-data-2" data-type="@OrganisationTypes.School" data-id="@Model.Urn" data-phase="@Model.OverallPhase" data-finance-type="@(Model.IsPartOfTrust ? EstablishmentTypes.Academies : EstablishmentTypes.Maintained)"></div>
+    <div
+        id="historic-data-2"
+        data-finance-type="@(Model.IsPartOfTrust ? EstablishmentTypes.Academies : EstablishmentTypes.Maintained)"
+        data-id="@Model.Urn"
+        data-phase="@Model.OverallPhase"
+        data-type="@OrganisationTypes.School">
+    </div>
 </feature>
 <feature negate="true" name="@FeatureFlags.HistoricalTrends">
     <div id="historic-data" data-type="@OrganisationTypes.School" data-id="@Model.Urn"></div>

--- a/web/terraform/variables.tf
+++ b/web/terraform/variables.tf
@@ -46,7 +46,7 @@ variable "configuration" {
         ForecastRisk                         = true
         TrustComparison                      = true
         FinancialBenchmarkingInsightsSummary = true
-        HistoricalTrends                     = false
+        HistoricalTrends                     = true
       },
       CacheOptions = {
         ReturnYears = {

--- a/web/tests/Web.E2ETests/Features/School/HistoricData.feature
+++ b/web/tests/Web.E2ETests/Features/School/HistoricData.feature
@@ -24,6 +24,18 @@
           | spending |
           | income   |
 
+    Scenario Outline: Expected number of charts are displayed
+        Given I am on '<tab>' history page for school with URN '777042'
+        And all sections are shown on '<tab>'
+        Then there should be '<charts>' charts displayed on '<tab>'
+
+        Examples:
+          | tab      | charts |
+          | spending | 42     |
+          | income   | 17     |
+          | balance  | 2      |
+          | census   | 9      |
+
     Scenario Outline: Change all charts to table view
         Given I am on '<tab>' history page for school with URN '777042'
         And all sections are shown on '<tab>'
@@ -52,13 +64,15 @@
         And the '<tab>' tab '<chart>' chart shows the legend '<legend>' using separator ','
 
         Examples:
-          | tab      | dimension         | chart                                   | legend                                                                         |
-          | spending | actuals           | Total expenditure                       | national average across phase type, average across comparator set, actuals     |
-          | spending | £ per pupil       | Total expenditure                       | national average across phase type, average across comparator set, £ per pupil |
-          | spending | £ per pupil       | Total premises staff and services costs | national average across phase type, average across comparator set, £ per m²    |
-          | income   | £ per pupil       | Total income                            |                                                                                |
-          | balance  | £ per pupil       | In-year balance                         |                                                                                |
-          | census   | headcount per FTE | Pupils on roll                          |                                                                                |
+          | tab      | dimension         | chart                                   | legend                                                                               |
+          | spending | actuals           | Total expenditure                       | national average across phase type, average across comparator set, actuals           |
+          | spending | £ per pupil       | Total expenditure                       | national average across phase type, average across comparator set, £ per pupil       |
+          | spending | £ per pupil       | Total premises staff and services costs | national average across phase type, average across comparator set, £ per m²          |
+          | income   | £ per pupil       | Total income                            |                                                                                      |
+          | balance  | £ per pupil       | In-year balance                         |                                                                                      |
+          | census   | total             | Pupils on roll                          | national average across phase type, average across comparator set, total             |
+          | census   | headcount per FTE | Pupils on roll                          | national average across phase type, average across comparator set, total             |
+          | census   | headcount per FTE | School workforce (full time equivalent) | national average across phase type, average across comparator set, headcount per FTE |
 
     @HistoricalTrendsFlagEnabled
     Scenario: Change Total expenditure chart to table view when historical trends flag enabled
@@ -85,3 +99,55 @@
           | 2019 to 2020 |        |                               |                                    |
           | 2020 to 2021 | £7,208 |                               | £10,704                            |
           | 2021 to 2022 | £7,487 | £8,127                        | £11,018                            |
+
+    @HistoricalTrendsFlagEnabled
+    Scenario: Change Pupils on roll census chart to table view when historical trends flag enabled and dimension set to headcount per FTE
+        Given I am on 'census' history page for school with URN '777042'
+        When I change 'census' dimension to 'headcount per FTE'
+        And I click on view as table on 'census' tab
+        Then the table on the 'census' tab 'Pupils on roll' chart contains:
+          | Year         | Total | Average across comparator set | National average across phase type |
+          | 2017 to 2018 |       |                               |                                    |
+          | 2018 to 2019 |       |                               |                                    |
+          | 2019 to 2020 |       |                               |                                    |
+          | 2020 to 2021 |       |                               |                                    |
+          | 2021 to 2022 | 350   |                               |                                    |
+
+    @HistoricalTrendsFlagEnabled
+    Scenario: Change School workforce (full time equivalent) census chart to table view when historical trends flag enabled and dimension set to per unit
+        Given I am on 'census' history page for school with URN '777042'
+        When I change 'census' dimension to 'headcount per FTE'
+        And I click on view as table on 'census' tab
+        Then the table on the 'census' tab 'School workforce (full time equivalent)' chart contains:
+          | Year         | Ratio | Average across comparator set | National average across phase type |
+          | 2017 to 2018 |       |                               |                                    |
+          | 2018 to 2019 |       |                               |                                    |
+          | 2019 to 2020 |       |                               |                                    |
+          | 2020 to 2021 |       |                               |                                    |
+          | 2021 to 2022 | 1.29  |                               |                                    |
+
+    @HistoricalTrendsFlagEnabled
+    Scenario: Change Pupils on roll census chart to table view when historical trends flag enabled and dimension set to percentage of workforce
+        Given I am on 'census' history page for school with URN '777042'
+        When I change 'census' dimension to 'percentage of workforce'
+        And I click on view as table on 'census' tab
+        Then the table on the 'census' tab 'Pupils on roll' chart contains:
+          | Year         | Total | Average across comparator set | National average across phase type |
+          | 2017 to 2018 |       |                               |                                    |
+          | 2018 to 2019 |       |                               |                                    |
+          | 2019 to 2020 |       |                               |                                    |
+          | 2020 to 2021 |       |                               |                                    |
+          | 2021 to 2022 | 350   |                               |                                    |
+
+    @HistoricalTrendsFlagEnabled
+    Scenario: Change Total number of teachers (full time equivalent) census chart to table view when historical trends flag enabled and dimension set to percentage of workforce
+        Given I am on 'census' history page for school with URN '777042'
+        When I change 'census' dimension to 'percentage of workforce'
+        And I click on view as table on 'census' tab
+        Then the table on the 'census' tab 'Total number of teachers (full time equivalent)' chart contains:
+          | Year         | Percentage  | Average across comparator set | National average across phase type |
+          | 2017 to 2018 |        |                               |                                    |
+          | 2018 to 2019 |        |                               |                                    |
+          | 2019 to 2020 |        |                               |                                    |
+          | 2020 to 2021 |        |                               |                                    |
+          | 2021 to 2022 | 284.4% |                               |                                    |

--- a/web/tests/Web.E2ETests/Pages/School/HistoricDataPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/HistoricDataPage.cs
@@ -20,6 +20,7 @@ public enum SpendingCategoriesNames
 
 public class HistoricDataPage(IPage page)
 {
+    // todo: move all categories to be asserted to feature
     private readonly string[] _balanceCategories =
     [
         "In-year balance",
@@ -209,8 +210,6 @@ public class HistoricDataPage(IPage page)
                 await SpendingChartsStats.First.ShouldBeVisible();
                 await AssertCategoryNames(_spendingCategories, selectedTab);
                 await ExpenditureDimension.ShouldHaveSelectedOption("actuals");
-                Assert.Equal(42, await AllSpendingCharts.Count());
-
                 break;
             case HistoryTabs.Income:
                 await IncomeDimension.ShouldBeVisible();
@@ -227,7 +226,6 @@ public class HistoricDataPage(IPage page)
                 await AllIncomeCharts.First.ShouldBeVisible();
                 await IncomeChartsStats.First.ShouldBeVisible();
                 await AssertCategoryNames(_incomeCategories, selectedTab);
-                Assert.Equal(17, await AllIncomeCharts.Count());
                 break;
             case HistoryTabs.Balance:
                 await BalanceDimension.ShouldBeVisible();
@@ -243,7 +241,6 @@ public class HistoricDataPage(IPage page)
                 await AreChartStatsVisible(selectedTab);
                 await AreChartsVisible(selectedTab);
                 await AssertCategoryNames(_balanceCategories, selectedTab);
-                Assert.Equal(2, await AllBalanceCharts.Count());
                 break;
             case HistoryTabs.Census:
                 await CensusDimension.ShouldBeVisible();
@@ -259,7 +256,6 @@ public class HistoricDataPage(IPage page)
                 await AreChartStatsVisible(selectedTab);
                 await AreChartsVisible(selectedTab);
                 await AssertCategoryNames(_censusCategories, selectedTab);
-                Assert.Equal(9, await AllCensusCharts.Count());
                 break;
         }
     }
@@ -335,6 +331,20 @@ public class HistoricDataPage(IPage page)
         await AreChartStatsVisible(tab);
         await AreChartsVisible(tab);
         Assert.Equal(expectedSubCategories, await GetSubCategoriesOfTab(tab));
+    }
+
+    public async Task HasChartCount(HistoryTabs tab, int count)
+    {
+        var charts = tab switch
+        {
+            HistoryTabs.Spending => AllSpendingCharts,
+            HistoryTabs.Income => AllIncomeCharts,
+            HistoryTabs.Balance => AllBalanceCharts,
+            HistoryTabs.Census => AllCensusCharts,
+            _ => throw new ArgumentOutOfRangeException(nameof(tab))
+        };
+
+        Assert.Equal(count, await charts.Count());
     }
 
     public async Task AreTablesShown(HistoryTabs tab)

--- a/web/tests/Web.E2ETests/Steps/School/HistoricDataSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/HistoricDataSteps.cs
@@ -64,7 +64,13 @@ public class HistoricDataSteps(PageDriver driver)
     {
         Assert.NotNull(_historicDataPage);
         await _historicDataPage.AreSubCategoriesVisible(TabNamesFromFriendlyNames(tab));
+    }
 
+    [Then("there should be '(.*)' charts displayed on '(.*)'")]
+    public async Task ThenThereShouldBeChartsDisplayedOn(string count, string tab)
+    {
+        Assert.NotNull(_historicDataPage);
+        await _historicDataPage.HasChartCount(TabNamesFromFriendlyNames(tab), int.Parse(count));
     }
 
     [Then("are showing table view on '(.*)' tab")]


### PR DESCRIPTION
### Context
[AB#241826](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/241826) [AB#237633](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/237633)

### Change proposed in this pull request
- Created new `<CensusSection>` component to support multiple series in the line charts, and wired up to v2 Historic view.
- Perform historical data `fetch` when each tab is loaded, rather than all tabs when view is rendered due to additional overheads from new API endpoints.
- Added abort config to `fetch` and display warning message on load timeout.
- Updated E2E tests for Historic Census tab when flag enabled, taking special care over 'total pupils' chart/table that should not be affected by Dimension changes.

### Guidance to review 
Use Vite dev server locally, or build and copy to Web in order to validate the changes directly. Alternatively, the updated E2E test run may be executed if the `HistoricalTrends` feature is enabled. 

> **NOTE:** when the API and underlying database views are present in `d02` the E2E features will need to be updated with the resolved values. At time of authoring this PR the values are left as empty in the `DataTable` definitions which matches what is returned via the Web API proxy.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

