### PR TITLE
test: add api tests for insight census historic trends

### DIFF
--- a/platform/tests/Platform.ApiTests/Features/InsightCensus.feature
+++ b/platform/tests/Platform.ApiTests/Features/InsightCensus.feature
@@ -109,3 +109,117 @@
         Then the census query result should be ok and contain:
           | SchoolName             | SchoolType        | LAName                 | AuxiliaryStaff | NonClassroomSupportStaff | PercentTeacherWithQualifiedStatus | SeniorLeadership | Teachers | TeachingAssistant | TotalPupils | URN    | Workforce | WorkforceHeadcount |
           | Test academy school 93 | Academy converter | Hammersmith and Fulham | 5.00           | 0.00                     | 1.00                              | 19.00            | 128.00   | 1.00              | 350.00      | 777055 | 45.00     | 58.00              |
+
+    Scenario: Sending a valid school average across comparator set census history request with dimension Total
+        Given a school average across comparator set census history request with urn '990000' and dimension 'Total'
+        When I submit the insights census request
+        Then the census history result should be ok and contain:
+          | Year | Term         | URN    | TotalPupils | Workforce | WorkforceHeadcount | Teachers | SeniorLeadership | TeachingAssistant | NonClassroomSupportStaff | AuxiliaryStaff | PercentTeacherWithQualifiedStatus |
+          | 2022 | 2021 to 2022 | 990000 | 268.633333  | 47.8      | 56.233333          | 1.133333 | 1                | 25.2              | 50.633333                | 3.7            | 1.033333                          |
+
+    Scenario: Sending a valid school average across comparator set census history request with dimension HeadcountPerFte
+        Given a school average across comparator set census history request with urn '990000' and dimension 'HeadcountPerFte'
+        When I submit the insights census request
+        Then the census history result should be ok and contain:
+          | Year | Term         | URN    | TotalPupils | Workforce             | WorkforceHeadcount    | Teachers              | SeniorLeadership      | TeachingAssistant      | AuxiliaryStaff        | PercentTeacherWithQualifiedStatus |
+          | 2022 | 2021 to 2022 | 990000 | 268.633333  | 1.2454354735846555320 | 1.0000000000000000000 | 0.0090565029104613964 | 0.1168831168831168830 | 25.2000000000000000000 | 1.0492063492063492063 | 1.033333                          |
+
+    Scenario: Sending a valid school average across comparator set census history request with dimension PercentWorkforce
+        Given a school average across comparator set census history request with urn '990000' and dimension 'PercentWorkforce'
+        When I submit the insights census request
+        Then the census history result should be ok and contain:
+          | Year | Term         | URN    | TotalPupils | Workforce              | WorkforceHeadcount     | Teachers               | SeniorLeadership      | TeachingAssistant    | AuxiliaryStaff        | PercentTeacherWithQualifiedStatus |
+          | 2022 | 2021 to 2022 | 990000 | 268.633333  | 100.000000000000000000 | 124.543547358465553203 | 490.534045780128272232 | 50.793106165302500259 | 3.884367879357122409 | 10.195699860404623272 | 1.033333                          |
+
+    Scenario: Sending a valid school average across comparator set census history request with dimension PupilsPerStaffRole
+        Given a school average across comparator set census history request with urn '990000' and dimension 'PupilsPerStaffRole'
+        When I submit the insights census request
+        Then the census history result should be ok and contain:
+          | Year | Term         | URN    | TotalPupils | Workforce             | WorkforceHeadcount    | Teachers              | SeniorLeadership       | TeachingAssistant       | AuxiliaryStaff         | PercentTeacherWithQualifiedStatus |
+          | 2022 | 2021 to 2022 | 990000 | 268.633333  | 7.2173904580668970625 | 5.8673804361619042791 | 2.2898520957463768590 | 14.8307257448787915306 | 268.6333333333333333333 | 79.4421957671957671957 | 1.033333                          |
+
+    Scenario: Sending an invalid school average across comparator set census history request
+        Given a school average across comparator set census history request with urn '990000' and dimension 'invalid'
+        When I submit the insights census request
+        Then the census result should be bad request
+
+    Scenario: Sending a valid school national average census history request with dimension Total, phase Primary, financeType Maintained
+        Given a school average across comparator set census history request with dimension 'Total', phase 'Primary', financeType 'Maintained'
+        When I submit the insights census request
+        Then the census history result should be ok and contain:
+          | Year | Term         | TotalPupils | Workforce | WorkforceHeadcount | Teachers | TeachingAssistant | NonClassroomSupportStaff | AuxiliaryStaff | PercentTeacherWithQualifiedStatus |
+          | 2018 | 2017 to 2018 |             |           |                    |          |                   |                          |                |                                   |
+          | 2019 | 2018 to 2019 |             |           |                    |          |                   |                          |                |                                   |
+          | 2020 | 2019 to 2020 |             |           |                    |          |                   |                          |                |                                   |
+          | 2021 | 2020 to 2021 |             |           |                    |          |                   |                          |                |                                   |
+          | 2022 | 2021 to 2022 | 308.019801  | 36.80693  | 47.376237          | 1.163366 | 16.430693         | 49.861386                | 3.643564       | 1.024752                          |
+
+    Scenario: Sending a valid school national average census history request with dimension HeadcountPerFte, phase Primary, financeType Maintained
+        Given a school average across comparator set census history request with dimension 'HeadcountPerFte', phase 'Primary', financeType 'Maintained'
+        When I submit the insights census request
+        Then the census history result should be ok and contain:
+          | Year | Term         | TotalPupils | Workforce             | WorkforceHeadcount    | Teachers              | TeachingAssistant      | AuxiliaryStaff        | PercentTeacherWithQualifiedStatus |
+          | 2018 | 2017 to 2018 |             |                       |                       |                       |                        |                       |                                   |
+          | 2019 | 2018 to 2019 |             |                       |                       |                       |                        |                       |                                   |
+          | 2020 | 2019 to 2020 |             |                       |                       |                       |                        |                       |                                   |
+          | 2021 | 2020 to 2021 |             |                       |                       |                       |                        |                       |                                   |
+          | 2022 | 2021 to 2022 | 308.019801  | 1.2992935951022364958 | 1.0000000000000000000 | 0.0088508541685603504 | 16.3910891089108910891 | 1.0766867043847241867 | 1.024752                          |
+
+    Scenario: Sending a valid school national average census history request with dimension PercentWorkforce, phase Primary, financeType Maintained
+        Given a school average across comparator set census history request with dimension 'PercentWorkforce', phase 'Primary', financeType 'Maintained'
+        When I submit the insights census request
+        Then the census history result should be ok and contain:
+          | Year | Term         | TotalPupils | Workforce              | WorkforceHeadcount     | Teachers               | TeachingAssistant    | AuxiliaryStaff       | PercentTeacherWithQualifiedStatus |
+          | 2018 | 2017 to 2018 |             |                        |                        |                        |                      |                      |                                   |
+          | 2019 | 2018 to 2019 |             |                        |                        |                        |                      |                      |                                   |
+          | 2020 | 2019 to 2020 |             |                        |                        |                        |                      |                      |                                   |
+          | 2021 | 2020 to 2021 |             |                        |                        |                        |                      |                      |                                   |
+          | 2022 | 2021 to 2022 | 308.019801  | 100.000000000000000000 | 129.929359510223649589 | 422.090092731097664571 | 3.234154307234142991 | 9.787430203141995055 | 1.024752                          |
+
+    Scenario: Sending a valid school national average census history request with dimension PupilsPerStaffRole, phase Primary, financeType Maintained
+        Given a school average across comparator set census history request with dimension 'PupilsPerStaffRole', phase 'Primary', financeType 'Maintained'
+        When I submit the insights census request
+        Then the census history result should be ok and contain:
+          | Year | Term         | TotalPupils | Workforce             | WorkforceHeadcount    | Teachers              | TeachingAssistant       | AuxiliaryStaff         | PercentTeacherWithQualifiedStatus |
+          | 2018 | 2017 to 2018 |             |                       |                       |                       |                         |                        |                                   |
+          | 2019 | 2018 to 2019 |             |                       |                       |                       |                         |                        |                                   |
+          | 2020 | 2019 to 2020 |             |                       |                       |                       |                         |                        |                                   |
+          | 2021 | 2020 to 2021 |             |                       |                       |                       |                         |                        |                                   |
+          | 2022 | 2021 to 2022 | 308.019801  | 8.4625263705554415226 | 6.6432385984097354055 | 2.4337378342010643450 | 307.3490099009900990099 | 99.4556793179317931793 | 1.024752                          |
+
+    Scenario: Sending a valid school national average census history request with dimension Total, phase Secondary, financeType Academy
+        Given a school average across comparator set census history request with dimension 'Total', phase 'Secondary', financeType 'Academy'
+        When I submit the insights census request
+        Then the census history result should be ok and contain:
+          | Year | Term         | TotalPupils | Workforce | WorkforceHeadcount | Teachers | TeachingAssistant | NonClassroomSupportStaff | AuxiliaryStaff | PercentTeacherWithQualifiedStatus |
+          | 2018 | 2017 to 2018 |             |           |                    |          |                   |                          |                |                                   |
+          | 2019 | 2018 to 2019 |             |           |                    |          |                   |                          |                |                                   |
+          | 2020 | 2019 to 2020 |             |           |                    |          |                   |                          |                |                                   |
+          | 2021 | 2020 to 2021 |             |           |                    |          |                   |                          |                |                                   |
+          | 2022 | 2021 to 2022 | 371.210000  | 47.000000 | 58.190000          | 1.200000 | 22.040000         | 49.850000                | 3.900000       | 1.020000                          |
+
+    Scenario: Sending a valid school national average census history request with dimension HeadcountPerFte, phase Special, financeType Academy
+        Given a school average across comparator set census history request with dimension 'HeadcountPerFte', phase 'Special', financeType 'Academy'
+        When I submit the insights census request
+        Then the census history result should be ok and contain:
+          | Year | Term         | TotalPupils | Workforce             | WorkforceHeadcount    | Teachers              | TeachingAssistant      | NonClassroomSupportStaff | AuxiliaryStaff        | PercentTeacherWithQualifiedStatus |
+          | 2018 | 2017 to 2018 |             |                       |                       |                       |                        |                          |                       |                                   |
+          | 2019 | 2018 to 2019 |             |                       |                       |                       |                        |                          |                       |                                   |
+          | 2020 | 2019 to 2020 |             |                       |                       |                       |                        |                          |                       |                                   |
+          | 2021 | 2020 to 2021 |             |                       |                       |                       |                        |                          |                       |                                   |
+          | 2022 | 2021 to 2022 | 348.829787  | 1.2830559767184912978 | 1.0000000000000000000 | 0.0088612061184511927 | 24.2340425531914893617 |                          | 1.0878465506125080593 | 1.074468                          |
+
+    Scenario: Sending an invalid school average across comparator set census history request with invalid dimension, phase Primary, financeType Maintained
+        Given a school average across comparator set census history request with dimension 'invalid', phase 'Primary', financeType 'Maintained'
+        When I submit the insights census request
+        Then the census result should be bad request
+
+    Scenario: Sending an invalid school average across comparator set census history request with dimension Total, invalid phase, financeType Maintained
+        Given a school average across comparator set census history request with dimension 'Total', phase 'invalid', financeType 'Maintained'
+        When I submit the insights census request
+        Then the census result should be bad request
+
+    Scenario: Sending an invalid school average across comparator set census history request with dimension Total, phase Primary, invalid financeType
+        Given a school average across comparator set census history request with dimension 'Total', phase 'Primary', financeType 'invalid'
+        When I submit the insights census request
+        Then the census result should be bad request

--- a/platform/tests/Platform.ApiTests/Steps/InsightCensusSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/InsightCensusSteps.cs
@@ -92,6 +92,28 @@ public class InsightCensusSteps(InsightApiDriver api)
         });
     }
 
+    [Given("a school average across comparator set census history request with urn '(.*)' and dimension '(.*)'")]
+    public void GivenASchoolCensusHistoryAvgComparatorSetRequest(string urn, string dimension)
+    {
+        api.CreateRequest(CensusKey, new HttpRequestMessage
+        {
+            RequestUri = new Uri($"/api/census/{urn}/history/comparator-set-average?dimension={dimension}",
+                UriKind.Relative),
+            Method = HttpMethod.Get
+        });
+    }
+
+    [Given("a school average across comparator set census history request with dimension '(.*)', phase '(.*)', financeType '(.*)'")]
+    public void GivenASchoolCensusHistoryAvgNationalRequest(string dimension, string phase, string financeType)
+    {
+        api.CreateRequest(CensusKey, new HttpRequestMessage
+        {
+            RequestUri = new Uri($"/api/census/history/national-average?dimension={dimension}&phase={phase}&financeType={financeType}",
+                UriKind.Relative),
+            Method = HttpMethod.Get
+        });
+    }
+
     [When("I submit the insights census request")]
     public async Task WhenISubmitTheInsightsCensusRequest()
     {
@@ -190,6 +212,15 @@ public class InsightCensusSteps(InsightApiDriver api)
         var content = await response.Content.ReadAsByteArrayAsync();
         var result = content.FromJson<CensusResponse[]>();
         table.CompareToSet(result);
+    }
+
+    [Then("the census result should be bad request")]
+    public void ThenTheCensusResultShouldBeBadRequest()
+    {
+        var response = api[CensusKey].Response;
+
+        response.Should().NotBeNull();
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     private static IEnumerable<string> GetFirstColumnsFromTableRowsAsString(DataTable table)


### PR DESCRIPTION
### Context
[AB#237633](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/237633)
[AB#242608](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/242608)

### Change proposed in this pull request
adds api tests to `InsightsCensusEndpointsFeature` to cover behaviour of the the new census historic trends endpoints

### Guidance to review 
N/A

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

