### PR TITLE
fix: aggregate contextual data for federations before rag costs are generated

### DIFF
--- a/data-pipeline/src/pipeline/pre_processing.py
+++ b/data-pipeline/src/pipeline/pre_processing.py
@@ -1116,6 +1116,8 @@ def build_maintained_school_data(
         config.income_category_map["maintained_schools"],
     )
 
+    maintained_schools = maintained_pipeline.join_federations(maintained_schools)
+
     maintained_schools = maintained_pipeline.calc_rag_cost_series(
         maintained_schools, config.rag_category_settings
     )
@@ -1132,8 +1134,6 @@ def build_maintained_school_data(
     maintained_schools = part_year.common.map_has_building_comparator_data(
         maintained_schools
     )
-
-    maintained_schools = maintained_pipeline.join_federations(maintained_schools)
 
     return maintained_schools.set_index("URN")
 


### PR DESCRIPTION
### Context
[AB#241716](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/241716) 
[AB#242851](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/242851)

### Change proposed in this pull request
aggregate contextual data for federations before rag costs are generated

`join_federations` before `calc_rag_cost_series`

### Guidance to review 
Run data pipeline locally for 2024 (aar 2023, cfr 2024, bfr 2023) and verify the MetricRAG table now contains the correct values for the example URN provided in the ticket

New

|Category|SubCategory|Value|
|---|---|---|
|Educational ICT|Total|129.83|
|Non-educational support staff and services|Total|663.22|
|Teaching and Teaching support staff|Total|4686.15|

Original

|Category|SubCategory|Value|
|---|---|---|
|Educational ICT|Total|178.30|
|Non-educational support staff and services|Total|910.80|
|Teaching and Teaching support staff|Total|6435.51|



### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

