### PR TITLE
Added `CancellationToken` support to Historical Expenditure/Census endpoints in API

### DIFF
--- a/platform/src/abstractions/Platform.Functions/Middleware/ExceptionHandlingMiddleware.cs
+++ b/platform/src/abstractions/Platform.Functions/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,0 +1,46 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Azure.Functions.Worker.Middleware;
+using Microsoft.Extensions.Logging;
+using Platform.Functions.Extensions;
+// ReSharper disable ClassNeverInstantiated.Global
+namespace Platform.Functions.Middleware;
+
+[ExcludeFromCodeCoverage]
+public sealed class ExceptionHandlingMiddleware(ILogger<ExceptionHandlingMiddleware> logger) : IFunctionsWorkerMiddleware
+{
+    public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
+    {
+        try
+        {
+            await next(context);
+        }
+        catch (TaskCanceledException ex)
+        {
+            logger.LogInformation(ex, "The request was cancelled upon request by the client");
+
+            // ideally the unofficial status code 499 (Client Closed Request) would be set but
+            // `HttpResponseData.StatusCode` is a `HttpStatusCode` rather than `StatusCode` or `int` 
+            await WriteErrorResponse(context, "Client Closed Request");
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Failed to complete request");
+            await WriteErrorResponse(context);
+        }
+    }
+
+    private static async Task WriteErrorResponse(FunctionContext context, string? content = null)
+    {
+        var request = await context.GetHttpRequestDataAsync();
+        var response = request!.CreateErrorResponse();
+
+        if (!string.IsNullOrWhiteSpace(content))
+        {
+            await response.WriteStringAsync(content);
+        }
+
+        context.GetInvocationResult().Value = response;
+    }
+}

--- a/platform/src/abstractions/Platform.Sql/DatabaseConnection.cs
+++ b/platform/src/abstractions/Platform.Sql/DatabaseConnection.cs
@@ -2,7 +2,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Dapper;
 using Microsoft.Data.SqlClient;
-
 namespace Platform.Sql;
 
 [ExcludeFromCodeCoverage]
@@ -45,13 +44,17 @@ public class DatabaseConnection(SqlConnection connection) : IDatabaseConnection,
 
     public ConnectionState State => connection.State;
 
-    public Task<IEnumerable<T>> QueryAsync<T>(string sql, object? param = null) => connection.QueryAsync<T>(sql, param);
+    public Task<IEnumerable<T>> QueryAsync<T>(string sql, object? param = null, CancellationToken cancellationToken = default)
+        => connection.QueryAsync<T>(new CommandDefinition(sql, param, cancellationToken: cancellationToken));
 
-    public Task<T?> QueryFirstOrDefaultAsync<T>(string sql, object? param = null) => connection.QueryFirstOrDefaultAsync<T>(sql, param);
+    public Task<T?> QueryFirstOrDefaultAsync<T>(string sql, object? param = null, CancellationToken cancellationToken = default)
+        => connection.QueryFirstOrDefaultAsync<T>(new CommandDefinition(sql, param, cancellationToken: cancellationToken));
 
-    public Task<T?> ExecuteScalarAsync<T>(string sql, object? param = null) => connection.ExecuteScalarAsync<T>(sql, param);
+    public Task<T?> ExecuteScalarAsync<T>(string sql, object? param = null, CancellationToken cancellationToken = default)
+        => connection.ExecuteScalarAsync<T>(new CommandDefinition(sql, param, cancellationToken: cancellationToken));
 
-    public Task<T> QueryFirstAsync<T>(string sql, object? param = null) => connection.QueryFirstAsync<T>(sql, param);
+    public Task<T> QueryFirstAsync<T>(string sql, object? param = null, CancellationToken cancellationToken = default)
+        => connection.QueryFirstAsync<T>(new CommandDefinition(sql, param, cancellationToken: cancellationToken));
 
     public Task OpenAsync() => connection.OpenAsync();
 }
@@ -64,12 +67,13 @@ public interface IDatabaseConnection : IDbConnection
     /// <typeparam name="T">The type of results to return.</typeparam>
     /// <param name="sql">The SQL to execute for the query.</param>
     /// <param name="param">The parameters to pass, if any.</param>
+    /// <param name="cancellationToken">The cancellation token for this command.</param>
     /// <returns>
     ///     A sequence of data of <typeparamref name="T" />; if a basic type (int, string, etc) is queried then the data from
     ///     the first column in assumed, otherwise an instance is
     ///     created per row, and a direct column-name===member-name mapping is assumed (case insensitive).
     /// </returns>
-    Task<IEnumerable<T>> QueryAsync<T>(string sql, object? param = null);
+    Task<IEnumerable<T>> QueryAsync<T>(string sql, object? param = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Execute a single-row query asynchronously using Task.
@@ -77,7 +81,8 @@ public interface IDatabaseConnection : IDbConnection
     /// <typeparam name="T">The type of result to return.</typeparam>
     /// <param name="sql">The SQL to execute for the query.</param>
     /// <param name="param">The parameters to pass, if any.</param>
-    Task<T?> QueryFirstOrDefaultAsync<T>(string sql, object? param = null);
+    /// <param name="cancellationToken">The cancellation token for this command.</param>
+    Task<T?> QueryFirstOrDefaultAsync<T>(string sql, object? param = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Execute parameterized SQL that selects a single value.
@@ -85,9 +90,9 @@ public interface IDatabaseConnection : IDbConnection
     /// <typeparam name="T">The type to return.</typeparam>
     /// <param name="sql">The SQL to execute.</param>
     /// <param name="param">The parameters to use for this command.</param>
+    /// <param name="cancellationToken">The cancellation token for this command.</param>
     /// <returns>The first cell returned, as <typeparamref name="T" />.</returns>
-    Task<T?> ExecuteScalarAsync<T>(string sql, object? param = null);
-
+    Task<T?> ExecuteScalarAsync<T>(string sql, object? param = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Execute a single-row query asynchronously using Task.
@@ -95,5 +100,6 @@ public interface IDatabaseConnection : IDbConnection
     /// <typeparam name="T">The type of result to return.</typeparam>
     /// <param name="sql">The SQL to execute for the query.</param>
     /// <param name="param">The parameters to pass, if any.</param>
-    Task<T> QueryFirstAsync<T>(string sql, object? param = null);
+    /// <param name="cancellationToken">The cancellation token for this command.</param>
+    Task<T> QueryFirstAsync<T>(string sql, object? param = null, CancellationToken cancellationToken = default);
 }

--- a/platform/src/apis/Platform.Api.Insight/Census/CensusFunctions.cs
+++ b/platform/src/apis/Platform.Api.Insight/Census/CensusFunctions.cs
@@ -194,22 +194,14 @@ public class CensusFunctions(
                    }
                }))
         {
-            try
+            var validationResult = await censusParametersValidator.ValidateAsync(queryParams, cancellationToken);
+            if (!validationResult.IsValid)
             {
-                var validationResult = await censusParametersValidator.ValidateAsync(queryParams, cancellationToken);
-                if (!validationResult.IsValid)
-                {
-                    return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
-                }
+                return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            }
 
-                var result = await service.GetHistoryAsync(urn, cancellationToken);
-                return await req.CreateJsonResponseAsync(result.Select(x => CensusResponseFactory.Create(x, queryParams.Dimension)));
-            }
-            catch (Exception e)
-            {
-                logger.LogError(e, "Failed to get census history");
-                return req.CreateErrorResponse();
-            }
+            var result = await service.GetHistoryAsync(urn, cancellationToken);
+            return await req.CreateJsonResponseAsync(result.Select(x => CensusResponseFactory.Create(x, queryParams.Dimension)));
         }
     }
 
@@ -239,22 +231,14 @@ public class CensusFunctions(
                    }
                }))
         {
-            try
+            var validationResult = await censusParametersValidator.ValidateAsync(queryParams, token);
+            if (!validationResult.IsValid)
             {
-                var validationResult = await censusParametersValidator.ValidateAsync(queryParams, token);
-                if (!validationResult.IsValid)
-                {
-                    return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
-                }
+                return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            }
 
-                var result = await service.GetHistoryAvgComparatorSetAsync(urn, queryParams.Dimension, token);
-                return await req.CreateJsonResponseAsync(result);
-            }
-            catch (Exception e)
-            {
-                logger.LogError(e, "Failed to get comparator set average census history");
-                return req.CreateErrorResponse();
-            }
+            var result = await service.GetHistoryAvgComparatorSetAsync(urn, queryParams.Dimension, token);
+            return await req.CreateJsonResponseAsync(result);
         }
     }
 
@@ -284,22 +268,14 @@ public class CensusFunctions(
                    }
                }))
         {
-            try
+            var validationResult = await censusNationalAvgValidator.ValidateAsync(queryParams, token);
+            if (!validationResult.IsValid)
             {
-                var validationResult = await censusNationalAvgValidator.ValidateAsync(queryParams, token);
-                if (!validationResult.IsValid)
-                {
-                    return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
-                }
+                return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            }
 
-                var result = await service.GetHistoryAvgNationalAsync(queryParams.Dimension, queryParams.OverallPhase, queryParams.FinanceType, token);
-                return await req.CreateJsonResponseAsync(result);
-            }
-            catch (Exception e)
-            {
-                logger.LogError(e, "Failed to get national average census history");
-                return req.CreateErrorResponse();
-            }
+            var result = await service.GetHistoryAvgNationalAsync(queryParams.Dimension, queryParams.OverallPhase, queryParams.FinanceType, token);
+            return await req.CreateJsonResponseAsync(result);
         }
     }
 

--- a/platform/src/apis/Platform.Api.Insight/Census/CensusService.cs
+++ b/platform/src/apis/Platform.Api.Insight/Census/CensusService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Dapper;
 using Platform.Sql;
@@ -7,9 +8,9 @@ namespace Platform.Api.Insight.Census;
 
 public interface ICensusService
 {
-    Task<IEnumerable<CensusHistoryModel>> GetHistoryAsync(string urn);
-    Task<IEnumerable<CensusHistoryResponse>> GetHistoryAvgComparatorSetAsync(string urn, string dimension);
-    Task<IEnumerable<CensusHistoryResponse>> GetHistoryAvgNationalAsync(string dimension, string overallPhase, string financeType);
+    Task<IEnumerable<CensusHistoryModel>> GetHistoryAsync(string urn, CancellationToken cancellationToken = default);
+    Task<IEnumerable<CensusHistoryResponse>> GetHistoryAvgComparatorSetAsync(string urn, string dimension, CancellationToken cancellationToken = default);
+    Task<IEnumerable<CensusHistoryResponse>> GetHistoryAvgNationalAsync(string dimension, string overallPhase, string financeType, CancellationToken cancellationToken = default);
     Task<IEnumerable<CensusModel>> QueryAsync(string[] urns, string? companyNumber, string? laCode, string? phase);
     Task<CensusModel?> GetAsync(string urn);
     Task<CensusModel?> GetCustomAsync(string urn, string identifier);
@@ -17,7 +18,7 @@ public interface ICensusService
 
 public class CensusService(IDatabaseFactory dbFactory) : ICensusService
 {
-    public async Task<IEnumerable<CensusHistoryModel>> GetHistoryAsync(string urn)
+    public async Task<IEnumerable<CensusHistoryModel>> GetHistoryAsync(string urn, CancellationToken cancellationToken = default)
     {
         const string sql = "SELECT * from SchoolCensusHistoric WHERE URN = @URN";
         var parameters = new
@@ -26,10 +27,10 @@ public class CensusService(IDatabaseFactory dbFactory) : ICensusService
         };
 
         using var conn = await dbFactory.GetConnection();
-        return await conn.QueryAsync<CensusHistoryModel>(sql, parameters);
+        return await conn.QueryAsync<CensusHistoryModel>(sql, parameters, cancellationToken);
     }
 
-    public async Task<IEnumerable<CensusHistoryResponse>> GetHistoryAvgComparatorSetAsync(string urn, string dimension)
+    public async Task<IEnumerable<CensusHistoryResponse>> GetHistoryAvgComparatorSetAsync(string urn, string dimension, CancellationToken cancellationToken = default)
     {
         var parameters = new
         {
@@ -49,10 +50,10 @@ public class CensusService(IDatabaseFactory dbFactory) : ICensusService
 
 
         using var conn = await dbFactory.GetConnection();
-        return await conn.QueryAsync<CensusHistoryResponse>(sql, parameters);
+        return await conn.QueryAsync<CensusHistoryResponse>(sql, parameters, cancellationToken);
     }
 
-    public async Task<IEnumerable<CensusHistoryResponse>> GetHistoryAvgNationalAsync(string dimension, string overallPhase, string financeType)
+    public async Task<IEnumerable<CensusHistoryResponse>> GetHistoryAvgNationalAsync(string dimension, string overallPhase, string financeType, CancellationToken cancellationToken = default)
     {
         var parameters = new
         {
@@ -72,7 +73,7 @@ public class CensusService(IDatabaseFactory dbFactory) : ICensusService
         var sql = $"SELECT * FROM {sourceName} WHERE FinanceType = @FinanceType AND OverallPhase = @OverallPhase";
 
         using var conn = await dbFactory.GetConnection();
-        return await conn.QueryAsync<CensusHistoryResponse>(sql, parameters);
+        return await conn.QueryAsync<CensusHistoryResponse>(sql, parameters, cancellationToken);
     }
 
     public async Task<IEnumerable<CensusModel>> QueryAsync(string[] urns, string? companyNumber, string? laCode, string? phase)

--- a/platform/src/apis/Platform.Api.Insight/Configuration/Worker.cs
+++ b/platform/src/apis/Platform.Api.Insight/Configuration/Worker.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Hosting;
-using Platform.Functions;
 using Platform.Functions.Middleware;
 namespace Platform.Api.Insight.Configuration;
 
@@ -16,6 +15,8 @@ internal static class Worker
             // We want to use this middleware only for http trigger invocations.
             return context.FunctionDefinition.InputBindings.Values.First(a => a.Type.EndsWith("Trigger")).Type == "httpTrigger";
         });
+
+        builder.UseMiddleware<ExceptionHandlingMiddleware>();
     }
 
     internal static void Options(WorkerOptions options)

--- a/platform/src/apis/Platform.Api.Insight/Expenditure/ExpenditureFunctions.cs
+++ b/platform/src/apis/Platform.Api.Insight/Expenditure/ExpenditureFunctions.cs
@@ -246,22 +246,14 @@ public class ExpenditureFunctions(
                    }
                }))
         {
-            try
+            var validationResult = await expenditureParametersValidator.ValidateAsync(queryParams, cancellationToken);
+            if (!validationResult.IsValid)
             {
-                var validationResult = await expenditureParametersValidator.ValidateAsync(queryParams, cancellationToken);
-                if (!validationResult.IsValid)
-                {
-                    return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
-                }
+                return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            }
 
-                var result = await service.GetSchoolHistoryAsync(urn, cancellationToken);
-                return await req.CreateJsonResponseAsync(result.Select(x => ExpenditureResponseFactory.Create(x, queryParams)));
-            }
-            catch (Exception e)
-            {
-                logger.LogError(e, "Failed to get school expenditure history");
-                return req.CreateErrorResponse();
-            }
+            var result = await service.GetSchoolHistoryAsync(urn, cancellationToken);
+            return await req.CreateJsonResponseAsync(result.Select(x => ExpenditureResponseFactory.Create(x, queryParams)));
         }
     }
 
@@ -291,23 +283,15 @@ public class ExpenditureFunctions(
                    }
                }))
         {
-            try
+            var validationResult = await expenditureParametersValidator.ValidateAsync(queryParams, cancellationToken);
+            if (!validationResult.IsValid)
             {
-                var validationResult = await expenditureParametersValidator.ValidateAsync(queryParams, cancellationToken);
-                if (!validationResult.IsValid)
-                {
-                    return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
-                }
-
-                var result = await service.GetSchoolHistoryAvgComparatorSetAsync(urn, queryParams.Dimension, cancellationToken);
-
-                return await req.CreateJsonResponseAsync(result);
+                return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
             }
-            catch (Exception e)
-            {
-                logger.LogError(e, "Failed to get school comparator set average expenditure history");
-                return req.CreateErrorResponse();
-            }
+
+            var result = await service.GetSchoolHistoryAvgComparatorSetAsync(urn, queryParams.Dimension, cancellationToken);
+
+            return await req.CreateJsonResponseAsync(result);
         }
     }
 
@@ -337,23 +321,15 @@ public class ExpenditureFunctions(
                    }
                }))
         {
-            try
+            var validationResult = await expenditureNationalAvgValidator.ValidateAsync(queryParams, cancellationToken);
+            if (!validationResult.IsValid)
             {
-                var validationResult = await expenditureNationalAvgValidator.ValidateAsync(queryParams, cancellationToken);
-                if (!validationResult.IsValid)
-                {
-                    return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
-                }
-
-                var result = await service.GetSchoolHistoryAvgNationalAsync(queryParams.Dimension, queryParams.OverallPhase, queryParams.FinanceType, cancellationToken);
-
-                return await req.CreateJsonResponseAsync(result);
+                return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
             }
-            catch (Exception e)
-            {
-                logger.LogError(e, "Failed to get school national average expenditure history");
-                return req.CreateErrorResponse();
-            }
+
+            var result = await service.GetSchoolHistoryAvgNationalAsync(queryParams.Dimension, queryParams.OverallPhase, queryParams.FinanceType, cancellationToken);
+
+            return await req.CreateJsonResponseAsync(result);
         }
     }
 

--- a/platform/src/apis/Platform.Api.Insight/Expenditure/ExpenditureFunctions.cs
+++ b/platform/src/apis/Platform.Api.Insight/Expenditure/ExpenditureFunctions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentValidation;
 using Microsoft.Azure.Functions.Worker;
@@ -229,7 +230,8 @@ public class ExpenditureFunctions(
     [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
     public async Task<HttpResponseData> SchoolExpenditureHistoryAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "get", Route = "expenditure/school/{urn}/history")] HttpRequestData req,
-        string urn)
+        string urn,
+        CancellationToken cancellationToken)
     {
         var correlationId = req.GetCorrelationId();
         var queryParams = req.GetParameters<ExpenditureParameters>();
@@ -246,13 +248,13 @@ public class ExpenditureFunctions(
         {
             try
             {
-                var validationResult = await expenditureParametersValidator.ValidateAsync(queryParams);
+                var validationResult = await expenditureParametersValidator.ValidateAsync(queryParams, cancellationToken);
                 if (!validationResult.IsValid)
                 {
                     return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
                 }
 
-                var result = await service.GetSchoolHistoryAsync(urn);
+                var result = await service.GetSchoolHistoryAsync(urn, cancellationToken);
                 return await req.CreateJsonResponseAsync(result.Select(x => ExpenditureResponseFactory.Create(x, queryParams)));
             }
             catch (Exception e)
@@ -273,7 +275,8 @@ public class ExpenditureFunctions(
     [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
     public async Task<HttpResponseData> SchoolExpenditureHistoryAvgComparatorSetAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "get", Route = "expenditure/school/{urn}/history/comparator-set-average")] HttpRequestData req,
-        string urn)
+        string urn,
+        CancellationToken cancellationToken)
     {
         var correlationId = req.GetCorrelationId();
         var queryParams = req.GetParameters<ExpenditureParameters>();
@@ -290,13 +293,13 @@ public class ExpenditureFunctions(
         {
             try
             {
-                var validationResult = await expenditureParametersValidator.ValidateAsync(queryParams);
+                var validationResult = await expenditureParametersValidator.ValidateAsync(queryParams, cancellationToken);
                 if (!validationResult.IsValid)
                 {
                     return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
                 }
 
-                var result = await service.GetSchoolHistoryAvgComparatorSetAsync(urn, queryParams.Dimension);
+                var result = await service.GetSchoolHistoryAvgComparatorSetAsync(urn, queryParams.Dimension, cancellationToken);
 
                 return await req.CreateJsonResponseAsync(result);
             }
@@ -318,7 +321,8 @@ public class ExpenditureFunctions(
     [OpenApiResponseWithBody(HttpStatusCode.BadRequest, "application/json", typeof(ValidationError[]))]
     [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
     public async Task<HttpResponseData> SchoolExpenditureHistoryAvgNationalAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, "get", Route = "expenditure/school/history/national-average")] HttpRequestData req)
+        [HttpTrigger(AuthorizationLevel.Admin, "get", Route = "expenditure/school/history/national-average")] HttpRequestData req,
+        CancellationToken cancellationToken)
     {
         var correlationId = req.GetCorrelationId();
         var queryParams = req.GetParameters<ExpenditureNationalAvgParameters>();
@@ -335,13 +339,13 @@ public class ExpenditureFunctions(
         {
             try
             {
-                var validationResult = await expenditureNationalAvgValidator.ValidateAsync(queryParams);
+                var validationResult = await expenditureNationalAvgValidator.ValidateAsync(queryParams, cancellationToken);
                 if (!validationResult.IsValid)
                 {
                     return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
                 }
 
-                var result = await service.GetSchoolHistoryAvgNationalAsync(queryParams.Dimension, queryParams.OverallPhase, queryParams.FinanceType);
+                var result = await service.GetSchoolHistoryAvgNationalAsync(queryParams.Dimension, queryParams.OverallPhase, queryParams.FinanceType, cancellationToken);
 
                 return await req.CreateJsonResponseAsync(result);
             }

--- a/platform/src/apis/Platform.Api.Insight/Expenditure/ExpenditureService.cs
+++ b/platform/src/apis/Platform.Api.Insight/Expenditure/ExpenditureService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Dapper;
 using Platform.Sql;
@@ -9,9 +10,9 @@ public interface IExpenditureService
 {
     Task<SchoolExpenditureModel?> GetSchoolAsync(string urn);
     Task<TrustExpenditureModel?> GetTrustAsync(string companyNumber);
-    Task<IEnumerable<SchoolExpenditureHistoryModel>> GetSchoolHistoryAsync(string urn);
-    Task<IEnumerable<SchoolExpenditureHistoryResponse>> GetSchoolHistoryAvgComparatorSetAsync(string urn, string dimension);
-    Task<IEnumerable<SchoolExpenditureHistoryResponse>> GetSchoolHistoryAvgNationalAsync(string dimension, string overallPhase, string financeType);
+    Task<IEnumerable<SchoolExpenditureHistoryModel>> GetSchoolHistoryAsync(string urn, CancellationToken cancellationToken = default);
+    Task<IEnumerable<SchoolExpenditureHistoryResponse>> GetSchoolHistoryAvgComparatorSetAsync(string urn, string dimension, CancellationToken cancellationToken = default);
+    Task<IEnumerable<SchoolExpenditureHistoryResponse>> GetSchoolHistoryAvgNationalAsync(string dimension, string overallPhase, string financeType, CancellationToken cancellationToken = default);
     Task<IEnumerable<TrustExpenditureHistoryModel>> GetTrustHistoryAsync(string companyNumber);
     Task<IEnumerable<SchoolExpenditureModel>> QuerySchoolsAsync(string[] urns, string? companyNumber, string? laCode, string? phase);
     Task<IEnumerable<TrustExpenditureModel>> QueryTrustsAsync(string[] companyNumbers);
@@ -57,7 +58,7 @@ public class ExpenditureService(IDatabaseFactory dbFactory) : IExpenditureServic
         return await conn.QueryFirstOrDefaultAsync<TrustExpenditureModel>(sql, parameters);
     }
 
-    public async Task<IEnumerable<SchoolExpenditureHistoryModel>> GetSchoolHistoryAsync(string urn)
+    public async Task<IEnumerable<SchoolExpenditureHistoryModel>> GetSchoolHistoryAsync(string urn, CancellationToken cancellationToken = default)
     {
         const string sql = "SELECT * FROM SchoolExpenditureHistoric WHERE URN = @URN";
         var parameters = new
@@ -66,10 +67,10 @@ public class ExpenditureService(IDatabaseFactory dbFactory) : IExpenditureServic
         };
 
         using var conn = await dbFactory.GetConnection();
-        return await conn.QueryAsync<SchoolExpenditureHistoryModel>(sql, parameters);
+        return await conn.QueryAsync<SchoolExpenditureHistoryModel>(sql, parameters, cancellationToken);
     }
 
-    public async Task<IEnumerable<SchoolExpenditureHistoryResponse>> GetSchoolHistoryAvgComparatorSetAsync(string urn, string dimension)
+    public async Task<IEnumerable<SchoolExpenditureHistoryResponse>> GetSchoolHistoryAvgComparatorSetAsync(string urn, string dimension, CancellationToken cancellationToken = default)
     {
         var parameters = new
         {
@@ -89,10 +90,10 @@ public class ExpenditureService(IDatabaseFactory dbFactory) : IExpenditureServic
 
 
         using var conn = await dbFactory.GetConnection();
-        return await conn.QueryAsync<SchoolExpenditureHistoryResponse>(sql, parameters);
+        return await conn.QueryAsync<SchoolExpenditureHistoryResponse>(sql, parameters, cancellationToken);
     }
 
-    public async Task<IEnumerable<SchoolExpenditureHistoryResponse>> GetSchoolHistoryAvgNationalAsync(string dimension, string overallPhase, string financeType)
+    public async Task<IEnumerable<SchoolExpenditureHistoryResponse>> GetSchoolHistoryAvgNationalAsync(string dimension, string overallPhase, string financeType, CancellationToken cancellationToken = default)
     {
         var parameters = new
         {
@@ -112,7 +113,7 @@ public class ExpenditureService(IDatabaseFactory dbFactory) : IExpenditureServic
         var sql = $"SELECT * FROM {sourceName} WHERE FinanceType = @FinanceType AND OverallPhase = @OverallPhase";
 
         using var conn = await dbFactory.GetConnection();
-        return await conn.QueryAsync<SchoolExpenditureHistoryResponse>(sql, parameters);
+        return await conn.QueryAsync<SchoolExpenditureHistoryResponse>(sql, parameters, cancellationToken);
     }
 
     public async Task<IEnumerable<TrustExpenditureHistoryModel>> GetTrustHistoryAsync(string companyNumber)

--- a/platform/tests/Platform.Tests/Insight/Balance/WhenBalanceServiceQueriesAsync.cs
+++ b/platform/tests/Platform.Tests/Insight/Balance/WhenBalanceServiceQueriesAsync.cs
@@ -32,8 +32,8 @@ public class WhenBalanceServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<SchoolBalanceHistoryModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<SchoolBalanceHistoryModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -65,8 +65,8 @@ public class WhenBalanceServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<SchoolBalanceModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<SchoolBalanceModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -95,8 +95,8 @@ public class WhenBalanceServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryFirstOrDefaultAsync<SchoolBalanceModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryFirstOrDefaultAsync<SchoolBalanceModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -128,8 +128,8 @@ public class WhenBalanceServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<TrustBalanceHistoryModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<TrustBalanceHistoryModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -161,8 +161,8 @@ public class WhenBalanceServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<TrustBalanceModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<TrustBalanceModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -191,8 +191,8 @@ public class WhenBalanceServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryFirstOrDefaultAsync<TrustBalanceModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryFirstOrDefaultAsync<TrustBalanceModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;

--- a/platform/tests/Platform.Tests/Insight/BudgetForecast/WhenBudgetForecastServiceQueriesAsync.cs
+++ b/platform/tests/Platform.Tests/Insight/BudgetForecast/WhenBudgetForecastServiceQueriesAsync.cs
@@ -32,8 +32,8 @@ public class WhenBudgetForecastServiceQueriesAsync
         var actualParam = new Dictionary<string, object>();
 
         _connection
-            .Setup(c => c.QueryAsync<BudgetForecastReturnModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<BudgetForecastReturnModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = TestDatabase.GetDictionaryFromDynamicParameters(param, "CompanyNumber", "RunType", "Category", "RunId");
@@ -79,12 +79,12 @@ public class WhenBudgetForecastServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryFirstOrDefaultAsync<int>(It.IsAny<string>(), It.IsAny<object>()))
+            .Setup(c => c.QueryFirstOrDefaultAsync<int>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(2021);
 
         _connection
-            .Setup(c => c.QueryAsync<BudgetForecastReturnMetricModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<BudgetForecastReturnMetricModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -108,14 +108,14 @@ public class WhenBudgetForecastServiceQueriesAsync
     }
 
     [Fact]
-    public async Task ShouldExecuteScalarAsyncWhenGetBudgetForecastCurrentYear()
+    public async Task ShouldQueryFirstOrDefaultAsyncWhenGetBudgetForecastCurrentYear()
     {
         // arrange
         string? actualSql = null;
 
         _connection
-            .Setup(c => c.QueryFirstOrDefaultAsync<int?>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? _) =>
+            .Setup(c => c.QueryFirstOrDefaultAsync<int?>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? _, CancellationToken _) =>
             {
                 actualSql = sql;
             })

--- a/platform/tests/Platform.Tests/Insight/Census/WhenCensusServiceQueriesAsync.cs
+++ b/platform/tests/Platform.Tests/Insight/Census/WhenCensusServiceQueriesAsync.cs
@@ -32,8 +32,8 @@ public class WhenCensusServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<CensusHistoryModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<CensusHistoryModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -65,8 +65,8 @@ public class WhenCensusServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<CensusModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<CensusModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = TestDatabase.GetDictionaryFromDynamicParameters(param, "URNS");
@@ -102,8 +102,8 @@ public class WhenCensusServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<CensusModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<CensusModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = TestDatabase.GetDictionaryFromDynamicParameters(param, "CompanyNumber", "Phase");
@@ -138,8 +138,8 @@ public class WhenCensusServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryFirstOrDefaultAsync<CensusModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryFirstOrDefaultAsync<CensusModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -169,8 +169,8 @@ public class WhenCensusServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryFirstOrDefaultAsync<CensusModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryFirstOrDefaultAsync<CensusModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -206,8 +206,8 @@ public class WhenCensusServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<CensusHistoryResponse>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<CensusHistoryResponse>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -222,7 +222,7 @@ public class WhenCensusServiceQueriesAsync
         Assert.Equal(expectedSql, actualSql);
         Assert.Equivalent(new
         {
-            URN = urn,
+            URN = urn
         }, actualParam, true);
     }
 
@@ -236,12 +236,12 @@ public class WhenCensusServiceQueriesAsync
         };
 
         _connection
-            .Setup(c => c.QueryAsync<CensusHistoryResponse>(It.IsAny<string>(), It.IsAny<object>()))
+            .Setup(c => c.QueryAsync<CensusHistoryResponse>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(result);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
             _service.GetHistoryAvgComparatorSetAsync(urn, "invalid"));
-        _connection.Verify(c => c.QueryAsync<CensusHistoryResponse>(It.IsAny<string>(), It.IsAny<object>()), Times.Never());
+        _connection.Verify(c => c.QueryAsync<CensusHistoryResponse>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()), Times.Never());
     }
 
     [InlineData(CensusDimensions.Total, "Primary", "Maintained", "SchoolCensusAvgHistoric")]
@@ -264,8 +264,8 @@ public class WhenCensusServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<CensusHistoryResponse>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<CensusHistoryResponse>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -294,11 +294,11 @@ public class WhenCensusServiceQueriesAsync
         };
 
         _connection
-            .Setup(c => c.QueryAsync<CensusHistoryResponse>(It.IsAny<string>(), It.IsAny<object>()))
+            .Setup(c => c.QueryAsync<CensusHistoryResponse>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(result);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
             _service.GetHistoryAvgNationalAsync("Invalid", "Primary", "Maintained"));
-        _connection.Verify(c => c.QueryAsync<CensusHistoryResponse>(It.IsAny<string>(), It.IsAny<object>()), Times.Never());
+        _connection.Verify(c => c.QueryAsync<CensusHistoryResponse>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()), Times.Never());
     }
 }

--- a/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetComparatorSetAverageCensusRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetComparatorSetAverageCensusRequest.cs
@@ -15,7 +15,7 @@ public class WhenFunctionReceivesGetComparatorSetAverageCensusHistoryRequest : C
             .ReturnsAsync(new ValidationResult());
 
         Service
-            .Setup(d => d.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(d => d.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<CensusHistoryResponse>());
 
         var result = await Functions.CensusHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");
@@ -35,14 +35,14 @@ public class WhenFunctionReceivesGetComparatorSetAverageCensusHistoryRequest : C
             }));
 
         Service
-            .Setup(d => d.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>()));
+            .Setup(d => d.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()));
 
         var result = await Functions.CensusHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
         Service.Verify(
-            x => x.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            x => x.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never());
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public class WhenFunctionReceivesGetComparatorSetAverageCensusHistoryRequest : C
             .ReturnsAsync(new ValidationResult());
 
         Service
-            .Setup(d => d.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(d => d.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Throws(new Exception());
 
         var result = await Functions.CensusHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");

--- a/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetComparatorSetAverageCensusRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetComparatorSetAverageCensusRequest.cs
@@ -54,13 +54,14 @@ public class WhenFunctionReceivesGetComparatorSetAverageCensusHistoryRequest : C
             .Setup(v => v.ValidateAsync(It.IsAny<CensusParameters>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ValidationResult());
 
+        var exception = new Exception();
         Service
             .Setup(d => d.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Throws(new Exception());
+            .Throws(exception);
 
-        var result = await Functions.CensusHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1", _cancellationToken);
+        // exception handled by middleware
+        var result = await Assert.ThrowsAsync<Exception>(() => Functions.CensusHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1", _cancellationToken));
 
-        Assert.NotNull(result);
-        Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);
+        Assert.Equal(exception, result);
     }
 }

--- a/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetComparatorSetAverageCensusRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetComparatorSetAverageCensusRequest.cs
@@ -7,6 +7,8 @@ namespace Platform.Tests.Insight.Census;
 
 public class WhenFunctionReceivesGetComparatorSetAverageCensusHistoryRequest : CensusFunctionsTestBase
 {
+    private readonly CancellationToken _cancellationToken = CancellationToken.None;
+
     [Fact]
     public async Task ShouldReturn200OnValidRequest()
     {
@@ -18,7 +20,7 @@ public class WhenFunctionReceivesGetComparatorSetAverageCensusHistoryRequest : C
             .Setup(d => d.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<CensusHistoryResponse>());
 
-        var result = await Functions.CensusHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");
+        var result = await Functions.CensusHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1", _cancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
@@ -37,7 +39,7 @@ public class WhenFunctionReceivesGetComparatorSetAverageCensusHistoryRequest : C
         Service
             .Setup(d => d.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()));
 
-        var result = await Functions.CensusHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");
+        var result = await Functions.CensusHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1", _cancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
@@ -56,7 +58,7 @@ public class WhenFunctionReceivesGetComparatorSetAverageCensusHistoryRequest : C
             .Setup(d => d.GetHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Throws(new Exception());
 
-        var result = await Functions.CensusHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");
+        var result = await Functions.CensusHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1", _cancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);

--- a/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetNationalAverageCensusRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetNationalAverageCensusRequest.cs
@@ -7,6 +7,8 @@ namespace Platform.Tests.Insight.Census;
 
 public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : CensusFunctionsTestBase
 {
+    private readonly CancellationToken _cancellationToken = CancellationToken.None;
+
     [Fact]
     public async Task ShouldReturn200OnValidRequest()
     {
@@ -18,7 +20,7 @@ public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : C
             .Setup(d => d.GetHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<CensusHistoryResponse>());
 
-        var result = await Functions.CensusHistoryAvgNationalAsync(CreateHttpRequestData());
+        var result = await Functions.CensusHistoryAvgNationalAsync(CreateHttpRequestData(), _cancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
@@ -37,7 +39,7 @@ public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : C
         Service
             .Setup(d => d.GetHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()));
 
-        var result = await Functions.CensusHistoryAvgNationalAsync(CreateHttpRequestData());
+        var result = await Functions.CensusHistoryAvgNationalAsync(CreateHttpRequestData(), _cancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
@@ -56,7 +58,7 @@ public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : C
             .Setup(d => d.GetHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Throws(new Exception());
 
-        var result = await Functions.CensusHistoryAvgNationalAsync(CreateHttpRequestData());
+        var result = await Functions.CensusHistoryAvgNationalAsync(CreateHttpRequestData(), _cancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);

--- a/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetNationalAverageCensusRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetNationalAverageCensusRequest.cs
@@ -15,7 +15,7 @@ public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : C
             .ReturnsAsync(new ValidationResult());
 
         Service
-            .Setup(d => d.GetHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(d => d.GetHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<CensusHistoryResponse>());
 
         var result = await Functions.CensusHistoryAvgNationalAsync(CreateHttpRequestData());
@@ -35,14 +35,14 @@ public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : C
             }));
 
         Service
-            .Setup(d => d.GetHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()));
+            .Setup(d => d.GetHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()));
 
         var result = await Functions.CensusHistoryAvgNationalAsync(CreateHttpRequestData());
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
         Service.Verify(
-            x => x.GetHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            x => x.GetHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never());
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : C
             .ReturnsAsync(new ValidationResult());
 
         Service
-            .Setup(d => d.GetHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(d => d.GetHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Throws(new Exception());
 
         var result = await Functions.CensusHistoryAvgNationalAsync(CreateHttpRequestData());

--- a/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetNationalAverageCensusRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetNationalAverageCensusRequest.cs
@@ -54,13 +54,14 @@ public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : C
             .Setup(v => v.ValidateAsync(It.IsAny<CensusNationalAvgParameters>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ValidationResult());
 
+        var exception = new Exception();
         Service
             .Setup(d => d.GetHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Throws(new Exception());
+            .Throws(exception);
 
-        var result = await Functions.CensusHistoryAvgNationalAsync(CreateHttpRequestData(), _cancellationToken);
+        // exception handled by middleware
+        var result = await Assert.ThrowsAsync<Exception>(() => Functions.CensusHistoryAvgNationalAsync(CreateHttpRequestData(), _cancellationToken));
 
-        Assert.NotNull(result);
-        Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);
+        Assert.Equal(exception, result);
     }
 }

--- a/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetWorkforceHistoryRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetWorkforceHistoryRequest.cs
@@ -15,7 +15,7 @@ public class WhenFunctionReceivesGetWorkforceHistoryRequest : CensusFunctionsTes
             .ReturnsAsync(new ValidationResult());
 
         Service
-            .Setup(d => d.GetHistoryAsync(It.IsAny<string>()))
+            .Setup(d => d.GetHistoryAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<CensusHistoryModel>());
 
         var result = await Functions.CensusHistoryAsync(CreateHttpRequestData(), "1");
@@ -32,7 +32,7 @@ public class WhenFunctionReceivesGetWorkforceHistoryRequest : CensusFunctionsTes
             .ReturnsAsync(new ValidationResult());
 
         Service
-            .Setup(d => d.GetHistoryAsync(It.IsAny<string>()))
+            .Setup(d => d.GetHistoryAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Throws(new Exception());
 
         var result = await Functions.CensusHistoryAsync(CreateHttpRequestData(), "1");

--- a/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetWorkforceHistoryRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetWorkforceHistoryRequest.cs
@@ -33,13 +33,14 @@ public class WhenFunctionReceivesGetWorkforceHistoryRequest : CensusFunctionsTes
             .Setup(v => v.ValidateAsync(It.IsAny<CensusParameters>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ValidationResult());
 
+        var exception = new Exception();
         Service
             .Setup(d => d.GetHistoryAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Throws(new Exception());
+            .Throws(exception);
 
-        var result = await Functions.CensusHistoryAsync(CreateHttpRequestData(), "1", _cancellationToken);
+        // exception handled by middleware
+        var result = await Assert.ThrowsAsync<Exception>(() => Functions.CensusHistoryAsync(CreateHttpRequestData(), "1", _cancellationToken));
 
-        Assert.NotNull(result);
-        Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);
+        Assert.Equal(exception, result);
     }
 }

--- a/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetWorkforceHistoryRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Census/WhenFunctionReceivesGetWorkforceHistoryRequest.cs
@@ -7,6 +7,8 @@ namespace Platform.Tests.Insight.Census;
 
 public class WhenFunctionReceivesGetWorkforceHistoryRequest : CensusFunctionsTestBase
 {
+    private readonly CancellationToken _cancellationToken = CancellationToken.None;
+
     [Fact]
     public async Task ShouldReturn200OnValidRequest()
     {
@@ -18,7 +20,7 @@ public class WhenFunctionReceivesGetWorkforceHistoryRequest : CensusFunctionsTes
             .Setup(d => d.GetHistoryAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<CensusHistoryModel>());
 
-        var result = await Functions.CensusHistoryAsync(CreateHttpRequestData(), "1");
+        var result = await Functions.CensusHistoryAsync(CreateHttpRequestData(), "1", _cancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
@@ -35,7 +37,7 @@ public class WhenFunctionReceivesGetWorkforceHistoryRequest : CensusFunctionsTes
             .Setup(d => d.GetHistoryAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Throws(new Exception());
 
-        var result = await Functions.CensusHistoryAsync(CreateHttpRequestData(), "1");
+        var result = await Functions.CensusHistoryAsync(CreateHttpRequestData(), "1", _cancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);

--- a/platform/tests/Platform.Tests/Insight/Expenditure/WhenExpenditureServiceQueriesAsync.cs
+++ b/platform/tests/Platform.Tests/Insight/Expenditure/WhenExpenditureServiceQueriesAsync.cs
@@ -32,8 +32,8 @@ public class WhenExpenditureServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<SchoolExpenditureHistoryModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<SchoolExpenditureHistoryModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -65,8 +65,8 @@ public class WhenExpenditureServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<SchoolExpenditureModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<SchoolExpenditureModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = TestDatabase.GetDictionaryFromDynamicParameters(param, "URNS");
@@ -102,8 +102,8 @@ public class WhenExpenditureServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<SchoolExpenditureModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<SchoolExpenditureModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = TestDatabase.GetDictionaryFromDynamicParameters(param, "CompanyNumber", "Phase");
@@ -142,8 +142,8 @@ public class WhenExpenditureServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<SchoolExpenditureModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<SchoolExpenditureModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = TestDatabase.GetDictionaryFromDynamicParameters(param, "LaCode", "Phase");
@@ -178,8 +178,8 @@ public class WhenExpenditureServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryFirstOrDefaultAsync<SchoolExpenditureModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryFirstOrDefaultAsync<SchoolExpenditureModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -211,8 +211,8 @@ public class WhenExpenditureServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<TrustExpenditureHistoryModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<TrustExpenditureHistoryModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -244,8 +244,8 @@ public class WhenExpenditureServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<TrustExpenditureModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<TrustExpenditureModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -274,8 +274,8 @@ public class WhenExpenditureServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryFirstOrDefaultAsync<TrustExpenditureModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryFirstOrDefaultAsync<TrustExpenditureModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -305,8 +305,8 @@ public class WhenExpenditureServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryFirstOrDefaultAsync<SchoolExpenditureModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryFirstOrDefaultAsync<SchoolExpenditureModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -342,8 +342,8 @@ public class WhenExpenditureServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<SchoolExpenditureHistoryResponse>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<SchoolExpenditureHistoryResponse>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -358,7 +358,7 @@ public class WhenExpenditureServiceQueriesAsync
         Assert.Equal(expectedSql, actualSql);
         Assert.Equivalent(new
         {
-            URN = urn,
+            URN = urn
         }, actualParam, true);
     }
 
@@ -372,12 +372,12 @@ public class WhenExpenditureServiceQueriesAsync
         };
 
         _connection
-            .Setup(c => c.QueryAsync<SchoolExpenditureHistoryResponse>(It.IsAny<string>(), It.IsAny<object>()))
+            .Setup(c => c.QueryAsync<SchoolExpenditureHistoryResponse>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(result);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
             _service.GetSchoolHistoryAvgComparatorSetAsync(urn, "invalid"));
-        _connection.Verify(c => c.QueryAsync<SchoolExpenditureHistoryResponse>(It.IsAny<string>(), It.IsAny<object>()), Times.Never());
+        _connection.Verify(c => c.QueryAsync<SchoolExpenditureHistoryResponse>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()), Times.Never());
     }
 
     [InlineData(ExpenditureDimensions.Actuals, "Primary", "Maintained", "SchoolExpenditureAvgHistoric")]
@@ -400,8 +400,8 @@ public class WhenExpenditureServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<SchoolExpenditureHistoryResponse>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<SchoolExpenditureHistoryResponse>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -424,7 +424,7 @@ public class WhenExpenditureServiceQueriesAsync
     [Fact]
     public async Task ShouldThrowOnInvalidDimensionWhenGetSchoolHistoryAvgNationalAsync()
     {
-        var queryParams = new ExpenditureNationalAvgParameters()
+        var queryParams = new ExpenditureNationalAvgParameters
         {
             Dimension = "Invalid"
         };
@@ -434,11 +434,11 @@ public class WhenExpenditureServiceQueriesAsync
         };
 
         _connection
-            .Setup(c => c.QueryAsync<SchoolExpenditureHistoryResponse>(It.IsAny<string>(), It.IsAny<object>()))
+            .Setup(c => c.QueryAsync<SchoolExpenditureHistoryResponse>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(result);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
             _service.GetSchoolHistoryAvgNationalAsync("invalid", "Primary", "Maintained"));
-        _connection.Verify(c => c.QueryAsync<SchoolExpenditureHistoryResponse>(It.IsAny<string>(), It.IsAny<object>()), Times.Never());
+        _connection.Verify(c => c.QueryAsync<SchoolExpenditureHistoryResponse>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()), Times.Never());
     }
 }

--- a/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryRequest.cs
@@ -8,7 +8,7 @@ namespace Platform.Tests.Insight.Expenditure;
 public class WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryRequest : ExpenditureFunctionsTestBase
 {
     private readonly CancellationToken _cancellationToken = CancellationToken.None;
-    
+
     [Fact]
     public async Task ShouldReturn200OnValidRequest()
     {
@@ -48,19 +48,20 @@ public class WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryReques
     }
 
     [Fact]
-    public async Task ShouldReturn500OnError()
+    public async Task ShouldThrowExceptionOnError()
     {
         ExpenditureParametersValidator
             .Setup(v => v.ValidateAsync(It.IsAny<ExpenditureParameters>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ValidationResult());
 
+        var exception = new Exception();
         Service
             .Setup(d => d.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Throws(new Exception());
+            .Throws(exception);
 
-        var result = await Functions.SchoolExpenditureHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1", _cancellationToken);
+        // exception handled by middleware
+        var result = await Assert.ThrowsAsync<Exception>(() => Functions.SchoolExpenditureHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1", _cancellationToken));
 
-        Assert.NotNull(result);
-        Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);
+        Assert.Equal(exception, result);
     }
 }

--- a/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryRequest.cs
@@ -15,7 +15,7 @@ public class WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryReques
             .ReturnsAsync(new ValidationResult());
 
         Service
-            .Setup(d => d.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(d => d.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<SchoolExpenditureHistoryResponse>());
 
         var result = await Functions.SchoolExpenditureHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");
@@ -35,14 +35,14 @@ public class WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryReques
             }));
 
         Service
-            .Setup(d => d.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>()));
+            .Setup(d => d.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()));
 
         var result = await Functions.SchoolExpenditureHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
         Service.Verify(
-            x => x.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            x => x.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never());
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public class WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryReques
             .ReturnsAsync(new ValidationResult());
 
         Service
-            .Setup(d => d.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(d => d.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Throws(new Exception());
 
         var result = await Functions.SchoolExpenditureHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");

--- a/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryRequest.cs
@@ -7,6 +7,8 @@ namespace Platform.Tests.Insight.Expenditure;
 
 public class WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryRequest : ExpenditureFunctionsTestBase
 {
+    private readonly CancellationToken _cancellationToken = CancellationToken.None;
+    
     [Fact]
     public async Task ShouldReturn200OnValidRequest()
     {
@@ -18,7 +20,7 @@ public class WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryReques
             .Setup(d => d.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<SchoolExpenditureHistoryResponse>());
 
-        var result = await Functions.SchoolExpenditureHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");
+        var result = await Functions.SchoolExpenditureHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1", _cancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
@@ -37,7 +39,7 @@ public class WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryReques
         Service
             .Setup(d => d.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()));
 
-        var result = await Functions.SchoolExpenditureHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");
+        var result = await Functions.SchoolExpenditureHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1", _cancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
@@ -56,7 +58,7 @@ public class WhenFunctionReceivesGetComparatorSetAverageExpenditureHistoryReques
             .Setup(d => d.GetSchoolHistoryAvgComparatorSetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Throws(new Exception());
 
-        var result = await Functions.SchoolExpenditureHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1");
+        var result = await Functions.SchoolExpenditureHistoryAvgComparatorSetAsync(CreateHttpRequestData(), "1", _cancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);

--- a/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetExpenditureHistoryRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetExpenditureHistoryRequest.cs
@@ -15,7 +15,7 @@ public class WhenFunctionReceivesGetExpenditureHistoryRequest : ExpenditureFunct
             .ReturnsAsync(new ValidationResult());
 
         Service
-            .Setup(d => d.GetSchoolHistoryAsync(It.IsAny<string>()))
+            .Setup(d => d.GetSchoolHistoryAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<SchoolExpenditureHistoryModel>());
 
         var result = await Functions.SchoolExpenditureHistoryAsync(CreateHttpRequestData(), "1");
@@ -32,7 +32,7 @@ public class WhenFunctionReceivesGetExpenditureHistoryRequest : ExpenditureFunct
             .ReturnsAsync(new ValidationResult());
 
         Service
-            .Setup(d => d.GetSchoolHistoryAsync(It.IsAny<string>()))
+            .Setup(d => d.GetSchoolHistoryAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Throws(new Exception());
 
         var result = await Functions.SchoolExpenditureHistoryAsync(CreateHttpRequestData(), "1");

--- a/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetExpenditureHistoryRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetExpenditureHistoryRequest.cs
@@ -7,6 +7,8 @@ namespace Platform.Tests.Insight.Expenditure;
 
 public class WhenFunctionReceivesGetExpenditureHistoryRequest : ExpenditureFunctionsTestBase
 {
+    private readonly CancellationToken _cancellationToken = CancellationToken.None;
+    
     [Fact]
     public async Task ShouldReturn200OnValidRequest()
     {
@@ -18,7 +20,7 @@ public class WhenFunctionReceivesGetExpenditureHistoryRequest : ExpenditureFunct
             .Setup(d => d.GetSchoolHistoryAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<SchoolExpenditureHistoryModel>());
 
-        var result = await Functions.SchoolExpenditureHistoryAsync(CreateHttpRequestData(), "1");
+        var result = await Functions.SchoolExpenditureHistoryAsync(CreateHttpRequestData(), "1", _cancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
@@ -35,7 +37,7 @@ public class WhenFunctionReceivesGetExpenditureHistoryRequest : ExpenditureFunct
             .Setup(d => d.GetSchoolHistoryAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Throws(new Exception());
 
-        var result = await Functions.SchoolExpenditureHistoryAsync(CreateHttpRequestData(), "1");
+        var result = await Functions.SchoolExpenditureHistoryAsync(CreateHttpRequestData(), "1", _cancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);

--- a/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetExpenditureHistoryRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetExpenditureHistoryRequest.cs
@@ -8,7 +8,7 @@ namespace Platform.Tests.Insight.Expenditure;
 public class WhenFunctionReceivesGetExpenditureHistoryRequest : ExpenditureFunctionsTestBase
 {
     private readonly CancellationToken _cancellationToken = CancellationToken.None;
-    
+
     [Fact]
     public async Task ShouldReturn200OnValidRequest()
     {
@@ -27,19 +27,20 @@ public class WhenFunctionReceivesGetExpenditureHistoryRequest : ExpenditureFunct
     }
 
     [Fact]
-    public async Task ShouldReturn500OnError()
+    public async Task ShouldThrowExceptionOnError()
     {
         ExpenditureParametersValidator
             .Setup(v => v.ValidateAsync(It.IsAny<ExpenditureParameters>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ValidationResult());
 
+        var exception = new Exception();
         Service
             .Setup(d => d.GetSchoolHistoryAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Throws(new Exception());
+            .Throws(exception);
 
-        var result = await Functions.SchoolExpenditureHistoryAsync(CreateHttpRequestData(), "1", _cancellationToken);
+        // exception handled by middleware
+        var result = await Assert.ThrowsAsync<Exception>(() => Functions.SchoolExpenditureHistoryAsync(CreateHttpRequestData(), "1", _cancellationToken));
 
-        Assert.NotNull(result);
-        Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);
+        Assert.Equal(exception, result);
     }
 }

--- a/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest.cs
@@ -7,6 +7,8 @@ namespace Platform.Tests.Insight.Expenditure;
 
 public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : ExpenditureFunctionsTestBase
 {
+    private readonly CancellationToken _cancellationToken = CancellationToken.None;
+
     [Fact]
     public async Task ShouldReturn200OnValidRequest()
     {
@@ -18,7 +20,7 @@ public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : E
             .Setup(d => d.GetSchoolHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<SchoolExpenditureHistoryResponse>());
 
-        var result = await Functions.SchoolExpenditureHistoryAvgNationalAsync(CreateHttpRequestData());
+        var result = await Functions.SchoolExpenditureHistoryAvgNationalAsync(CreateHttpRequestData(), _cancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
@@ -37,7 +39,7 @@ public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : E
         Service
             .Setup(d => d.GetSchoolHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()));
 
-        var result = await Functions.SchoolExpenditureHistoryAvgNationalAsync(CreateHttpRequestData());
+        var result = await Functions.SchoolExpenditureHistoryAvgNationalAsync(CreateHttpRequestData(), _cancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
@@ -56,7 +58,7 @@ public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : E
             .Setup(d => d.GetSchoolHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Throws(new Exception());
 
-        var result = await Functions.SchoolExpenditureHistoryAvgNationalAsync(CreateHttpRequestData());
+        var result = await Functions.SchoolExpenditureHistoryAvgNationalAsync(CreateHttpRequestData(), _cancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);

--- a/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest.cs
@@ -48,19 +48,20 @@ public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : E
     }
 
     [Fact]
-    public async Task ShouldReturn500OnError()
+    public async Task ShouldThrowExceptionOnError()
     {
         ExpenditureNationalAvgParametersValidator
             .Setup(v => v.ValidateAsync(It.IsAny<ExpenditureNationalAvgParameters>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ValidationResult());
 
+        var exception = new Exception();
         Service
             .Setup(d => d.GetSchoolHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Throws(new Exception());
+            .Throws(exception);
 
-        var result = await Functions.SchoolExpenditureHistoryAvgNationalAsync(CreateHttpRequestData(), _cancellationToken);
+        // exception handled by middleware
+        var result = await Assert.ThrowsAsync<Exception>(() => Functions.SchoolExpenditureHistoryAvgNationalAsync(CreateHttpRequestData(), _cancellationToken));
 
-        Assert.NotNull(result);
-        Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);
+        Assert.Equal(exception, result);
     }
 }

--- a/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest.cs
+++ b/platform/tests/Platform.Tests/Insight/Expenditure/WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest.cs
@@ -15,7 +15,7 @@ public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : E
             .ReturnsAsync(new ValidationResult());
 
         Service
-            .Setup(d => d.GetSchoolHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(d => d.GetSchoolHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<SchoolExpenditureHistoryResponse>());
 
         var result = await Functions.SchoolExpenditureHistoryAvgNationalAsync(CreateHttpRequestData());
@@ -35,14 +35,14 @@ public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : E
             }));
 
         Service
-            .Setup(d => d.GetSchoolHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()));
+            .Setup(d => d.GetSchoolHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()));
 
         var result = await Functions.SchoolExpenditureHistoryAvgNationalAsync(CreateHttpRequestData());
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
         Service.Verify(
-            x => x.GetSchoolHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            x => x.GetSchoolHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never());
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public class WhenFunctionReceivesGetNationalAverageExpenditureHistoryRequest : E
             .ReturnsAsync(new ValidationResult());
 
         Service
-            .Setup(d => d.GetSchoolHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(d => d.GetSchoolHistoryAvgNationalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Throws(new Exception());
 
         var result = await Functions.SchoolExpenditureHistoryAvgNationalAsync(CreateHttpRequestData());

--- a/platform/tests/Platform.Tests/Insight/Income/WhenIncomeServiceQueriesAsync.cs
+++ b/platform/tests/Platform.Tests/Insight/Income/WhenIncomeServiceQueriesAsync.cs
@@ -32,8 +32,8 @@ public class WhenIncomeServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<SchoolIncomeHistoryModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<SchoolIncomeHistoryModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -65,8 +65,8 @@ public class WhenIncomeServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<SchoolIncomeModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<SchoolIncomeModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = TestDatabase.GetDictionaryFromDynamicParameters(param, "URNS");
@@ -102,8 +102,8 @@ public class WhenIncomeServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<SchoolIncomeModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<SchoolIncomeModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = TestDatabase.GetDictionaryFromDynamicParameters(param, "CompanyNumber", "Phase");
@@ -142,8 +142,8 @@ public class WhenIncomeServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<SchoolIncomeModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<SchoolIncomeModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = TestDatabase.GetDictionaryFromDynamicParameters(param, "LaCode", "Phase");
@@ -178,8 +178,8 @@ public class WhenIncomeServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryFirstOrDefaultAsync<SchoolIncomeModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryFirstOrDefaultAsync<SchoolIncomeModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -211,8 +211,8 @@ public class WhenIncomeServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<TrustIncomeHistoryModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<TrustIncomeHistoryModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -244,8 +244,8 @@ public class WhenIncomeServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<TrustIncomeModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<TrustIncomeModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -274,8 +274,8 @@ public class WhenIncomeServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryFirstOrDefaultAsync<TrustIncomeModel>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryFirstOrDefaultAsync<TrustIncomeModel>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;

--- a/platform/tests/Platform.Tests/Insight/MetricRagRatings/WhenBudgetForecastServiceQueriesAsync.cs
+++ b/platform/tests/Platform.Tests/Insight/MetricRagRatings/WhenBudgetForecastServiceQueriesAsync.cs
@@ -24,7 +24,7 @@ public class WhenMetricRagRatingsServiceQueriesAsync
     {
         // arrange
         _connection
-            .Setup(c => c.QueryFirstAsync<string>("SELECT Value from Parameters where Name = 'CurrentYear'", null))
+            .Setup(c => c.QueryFirstAsync<string>("SELECT Value from Parameters where Name = 'CurrentYear'", null, It.IsAny<CancellationToken>()))
             .Verifiable();
 
         // act
@@ -76,12 +76,12 @@ public class WhenMetricRagRatingsServiceQueriesAsync
 
         const string year = "year";
         _connection
-            .Setup(c => c.QueryFirstAsync<string>("SELECT Value from Parameters where Name = 'CurrentYear'", null))
+            .Setup(c => c.QueryFirstAsync<string>("SELECT Value from Parameters where Name = 'CurrentYear'", null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(year);
 
         _connection
-            .Setup(c => c.QueryAsync<MetricRagRating>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<MetricRagRating>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = TestDatabase.GetDictionaryFromDynamicParameters(param, "RunType", "RunId", "URNS", "CompanyNumber", "LaCode", "Phase", "categories", "statuses");
@@ -160,8 +160,8 @@ public class WhenMetricRagRatingsServiceQueriesAsync
         var actualParam = new Dictionary<string, object>();
 
         _connection
-            .Setup(c => c.QueryAsync<MetricRagRating>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<MetricRagRating>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = TestDatabase.GetDictionaryFromDynamicParameters(param, "RunType", "RunId");

--- a/platform/tests/Platform.Tests/Insight/Schools/WhenSchoolsServiceQueriesAsync.cs
+++ b/platform/tests/Platform.Tests/Insight/Schools/WhenSchoolsServiceQueriesAsync.cs
@@ -32,8 +32,8 @@ public class WhenSchoolsServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<SchoolCharacteristic>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<SchoolCharacteristic>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;
@@ -62,8 +62,8 @@ public class WhenSchoolsServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryFirstOrDefaultAsync<SchoolCharacteristic>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryFirstOrDefaultAsync<SchoolCharacteristic>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;

--- a/platform/tests/Platform.Tests/Insight/Trusts/WhenTrustsServiceQueriesAsync.cs
+++ b/platform/tests/Platform.Tests/Insight/Trusts/WhenTrustsServiceQueriesAsync.cs
@@ -32,8 +32,8 @@ public class WhenTrustsServiceQueriesAsync
         object? actualParam = null;
 
         _connection
-            .Setup(c => c.QueryAsync<TrustCharacteristic>(It.IsAny<string>(), It.IsAny<object>()))
-            .Callback((string sql, object? param) =>
+            .Setup(c => c.QueryAsync<TrustCharacteristic>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Callback((string sql, object? param, CancellationToken _) =>
             {
                 actualSql = sql;
                 actualParam = param;


### PR DESCRIPTION
### Context
AB#242727 AB#237633

### Change proposed in this pull request
For the above endpoints only in the Insight function app, support the cancellation of the underlying SQL queries when the client aborts the request. This can be rolled out elsewhere when needed via consumption and propagation of the `CancellationToken` from Function, through Service to Query. To prevent excessive errors in the logs, the `TaskCanceledException` logs at `Information` level instead of `Error` via custom exception handling middleware that again could be rolled out everywhere (existing try/catches in functions will need to be removed). 

### Guidance to review 
To validate, use Swagger UI to test the above endpoints and close/refresh the page during execution (the 'Cancel' button in Swagger UI does not abort the request). Other clients such as Postman may support aborting the request in a better fashion.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

