### PR TITLE
fix: use outer join for census data

### DIFF
--- a/data-pipeline/tests/unit/pre_processing/test_census.py
+++ b/data-pipeline/tests/unit/pre_processing/test_census.py
@@ -1,4 +1,8 @@
+import io
+
 import pandas as pd
+
+from pipeline.pre_processing import prepare_census_data
 
 
 def test_census_data_has_correct_output_columns(prepared_census_data: pd.DataFrame):
@@ -46,3 +50,90 @@ def test_total_nursery_computed_correctly(prepared_census_data: pd.DataFrame):
 
 def test_total_sixth_form_computed_correctly(prepared_census_data: pd.DataFrame):
     assert prepared_census_data.loc[100150]["TotalPupilsSixthForm"] == 40
+
+
+def test_census_data_pupil_merge(
+    workforce_census_data: pd.DataFrame,
+    pupil_census_data: pd.DataFrame,
+):
+    """
+    Missing rows from the pupil-census data should not result in
+    missing rows from the final, merged dataset.
+    """
+    pupil_census_data = pupil_census_data[pupil_census_data["URN"] != 100153]
+    pupil_csv = io.StringIO(pupil_census_data.to_csv())
+
+    output = io.BytesIO()
+    writer = pd.ExcelWriter(output)
+    workforce_census_data.to_excel(
+        writer, startrow=5, sheet_name="Schools 2022", index=False
+    )
+    writer.close()
+    output.seek(0)
+    workforce_xlsx = output
+
+    census = prepare_census_data(workforce_xlsx, pupil_csv)
+
+    assert sorted(list(pupil_census_data["URN"])) == [100150, 100152]
+    assert sorted(list(workforce_census_data["URN"])) == [100150, 100152, 100153]
+    assert sorted(list(census.index)) == [100150, 100152, 100153]
+
+
+def test_census_data_workforce_merge(
+    workforce_census_data: pd.DataFrame,
+    pupil_census_data: pd.DataFrame,
+):
+    """
+    Missing rows from the workforce-census data should not result in
+    missing rows from the final, merged dataset.
+    """
+    pupil_csv = io.StringIO(pupil_census_data.to_csv())
+
+    output = io.BytesIO()
+    writer = pd.ExcelWriter(output)
+    workforce_census_data = workforce_census_data[
+        workforce_census_data["URN"] != 100153
+    ]
+    workforce_census_data.to_excel(
+        writer, startrow=5, sheet_name="Schools 2022", index=False
+    )
+    writer.close()
+    output.seek(0)
+    workforce_xlsx = output
+
+    census = prepare_census_data(workforce_xlsx, pupil_csv)
+
+    assert sorted(list(pupil_census_data["URN"])) == [100150, 100152, 100153]
+    assert sorted(list(workforce_census_data["URN"])) == [100150, 100152]
+    assert sorted(list(census.index)) == [100150, 100152, 100153]
+
+
+def test_census_data_merge(
+    workforce_census_data: pd.DataFrame,
+    pupil_census_data: pd.DataFrame,
+):
+    """
+    Missing rows from the either census data should not result in
+    missing rows from the final, merged dataset.
+    """
+    pupil_census_data = pupil_census_data[pupil_census_data["URN"] != 100153]
+    pupil_csv = io.StringIO(pupil_census_data.to_csv())
+
+    output = io.BytesIO()
+    writer = pd.ExcelWriter(output)
+    workforce_census_data = workforce_census_data[
+        workforce_census_data["URN"] != 100152
+    ]
+    workforce_census_data.to_excel(
+        writer, startrow=5, sheet_name="Schools 2022", index=False
+    )
+    writer.close()
+    output.seek(0)
+    workforce_xlsx = output
+
+    census = prepare_census_data(workforce_xlsx, pupil_csv)
+
+    print(census)
+    assert sorted(list(pupil_census_data["URN"])) == [100150, 100152]
+    assert sorted(list(workforce_census_data["URN"])) == [100150, 100153]
+    assert sorted(list(census.index)) == [100150, 100152, 100153]


### PR DESCRIPTION
### Context

Previously, the "census" dataset was missing orgs. present in the pupil data when those orgs. were missing from the workforce data.

[AB#241759](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/241759)  
[AB#243030](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/243030)

### Change proposed in this pull request

- update the `inner` merge to an `outer`
- add tests to validate that missing rows from either or both data sets retain the rows in the merged output

### Guidance to review 

Because workforce is joined onto pupils, depending on which is missing data, the resulting index might be `URN` or not, hence the `reset_index().set_index()` addition.

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~You have reviewed with UX/Design~

