### PR TITLE
fix: permit RAG for custom-data

### DIFF
--- a/data-pipeline/src/pipeline/pre_processing.py
+++ b/data-pipeline/src/pipeline/pre_processing.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 from warnings import simplefilter
 
@@ -1456,6 +1455,10 @@ def update_custom_data(
     (less the "Financial Position" as this is non-numeric) will be set
     to zero, again for that row only.
 
+    It is assumed that the updated custom-data constitutes a full year
+    of financial information and as a result, `Partial Years Present`
+    will _always_ be set to _false_ for the row in question.
+
     Note: only a subset of the custom fields may be present in the
     inbound message; only a subset of mapped columns may be present in
     the existing data. Equally, the data will only be updated if the
@@ -1545,6 +1548,8 @@ def update_custom_data(
     existing_data.loc[target_urn] = _post_process_custom(
         target_data=existing_data.loc[[target_urn]]
     ).loc[target_urn]
+
+    existing_data.loc[target_urn, "Partial Years Present"] = False
 
     return existing_data
 

--- a/data-pipeline/tests/unit/pre_processing/test_custom_data.py
+++ b/data-pipeline/tests/unit/pre_processing/test_custom_data.py
@@ -126,6 +126,7 @@ _default_existing_data = {
     "NonClassroomSupportStaffFTE": [0.0, 0.0, 0.0, 0.0],
     "Total Number of Auxiliary Staff (Full-Time Equivalent)": [0.0, 0.0, 0.0, 0.0],
     "Total School Workforce (Headcount)": [0.0, 0.0, 0.0, 0.0],
+    "Partial Years Present": [True, True, True, True],
 }
 
 
@@ -170,7 +171,11 @@ def test_update_custom_data():
                 ]
             ),
         ].items()
-        if column != "Catering staff and supplies_Net Costs"
+        if column
+        not in (
+            "Catering staff and supplies_Net Costs",
+            "Partial Years Present",
+        )
         and not column.endswith(
             (
                 "_Total",
@@ -264,3 +269,19 @@ def test_update_custom_data_missing_target():
     )
 
     assert 4 not in result.index
+
+
+def test_custom_data_part_year():
+    """
+    `Partial Years Present` will be set to `False` for the URN in
+    question.
+    """
+    df = pd.DataFrame(_default_existing_data, index=[0, 1, 2, 3])
+
+    result = update_custom_data(
+        existing_data=df,
+        custom_data=_default_custom_data,
+        target_urn=1,
+    )
+
+    assert list(result["Partial Years Present"]) == [True, False, True, True]


### PR DESCRIPTION
### Context

A "custom-data" job allows users to submit a new set of financial data.

Currently, rows where `Partial Years Present` is `True` are skipped, even if the job is processing custom-data.

[AB#241954](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/241954)  

### Change proposed in this pull request

As we're considering a custom-data job to represent a full-year's financial data, update the custom-data being processed accordingly and continue as normal.

### Guidance to review 

WIP: adding tests.

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~You have reviewed with UX/Design~

