### PR TITLE
build: add pytest-randomly

### DIFF
--- a/data-pipeline/poetry.lock
+++ b/data-pipeline/poetry.lock
@@ -2874,6 +2874,20 @@ pluggy = ">=1.5,<2.0"
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-randomly"
+version = "3.16.0"
+description = "Pytest plugin to randomly order tests and control random.seed."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pytest_randomly-3.16.0-py3-none-any.whl", hash = "sha256:8633d332635a1a0983d3bba19342196807f6afb17c3eef78e02c2f85dade45d6"},
+    {file = "pytest_randomly-3.16.0.tar.gz", hash = "sha256:11bf4d23a26484de7860d82f726c0629837cf4064b79157bd18ec9d41d7feb26"},
+]
+
+[package.dependencies]
+pytest = "*"
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -3882,4 +3896,4 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "23c8c71c0f5c842ef56409da21be798492294fef5b9126f255276cd331c2aaae"
+content-hash = "6957ce56545efc2949ee17fa44e3803eec4c981978175171457a2e5b8c02821c"

--- a/data-pipeline/pyproject.toml
+++ b/data-pipeline/pyproject.toml
@@ -31,6 +31,7 @@ httpx = "^0.27.0"
 isort = "^5.13.2"
 pre-commit = "^3.7.1"
 line-profiler = "^4.1.3"
+pytest-randomly = "^3.16.0"
 
 [tool.black]
 # https://github.com/psf/black


### PR DESCRIPTION
Make use of [`pytest-randomly`](https://pypi.org/project/pytest-randomly/) to randomise the test order, making sure there are no implicit dependencies between tests.