### PR TITLE
feat: suppress negative and zero values for spending priorities page

### DIFF
--- a/data-pipeline/src/pipeline/rag.py
+++ b/data-pipeline/src/pipeline/rag.py
@@ -116,7 +116,7 @@ def category_stats(urn, category_name, data, ofsted_rating, rag_mapping, close_c
     key = "outstanding" if ofsted_rating.lower() == "outstanding" else "other"
     key += "_10" if close_count > 10 else ""
 
-    series = data[category_name]
+    series = _get_series_for_category(data, category_name, urn)
     value = series.loc[urn]
 
     percentile = find_percentile(series, value)
@@ -316,3 +316,19 @@ def compute_user_defined_rag(
                     exc_info=error,
                 )
                 return
+            
+def _get_series_for_category(data: pd.DataFrame, category: str, urn: int) -> pd.Series:
+    """
+    Filters the comparator set data for the specified category, retaining only 
+    positive values or the value for the specified org. (identified by URN).
+
+    This ensures that only positive expenditure values are considered for 
+    rag calculations.
+
+    :param data: A DataFrame containing comparator data for RAG calculations.
+    :param category: The category column to filter on
+    :param urn: The URN of the org. whose value should always be included.
+    :return: A Series containing the filtered values
+    """
+
+    return data.loc[(data[category] > 0) | (data.index == urn), category]

--- a/data-pipeline/tests/unit/rag/test_rag.py
+++ b/data-pipeline/tests/unit/rag/test_rag.py
@@ -149,11 +149,10 @@ def test_category_stats(
     value, data, diff_median, percent_diff, percentile, decile, expected_rag
 ):
     category = "Teaching and Teaching support staff_Sub Cat"
-    data = {
-        category: pd.Series(
-            data, index=[item for item in range(100000, 100000 + len(data))]
-        )
-    }
+    data = pd.DataFrame(
+        {category: data},
+        index=[item for item in range(100000, 100000 + len(data))],
+    )
 
     expected = {
         "URN": 100000,

--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -390,3 +390,19 @@ hr.govuk-section-break--print {
     opacity: 0;
   }
 }
+
+.app-resources {
+  margin-top: govuk-spacing(6);
+  
+  @include govuk-media-query('tablet') {
+    margin-top: 0;
+  }
+}
+
+.app-resources-warning-spacing {
+  padding-top: 0;
+
+  @include govuk-media-query('tablet') {
+    padding-top: govuk-spacing(2);
+  }
+}

--- a/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
@@ -12,6 +12,12 @@
     {
         var category = costs[i];
 
+        var data = category.Values.Select(x => new { urn = x.Key, amount = x.Value.Value }).ToArray();
+
+        var filteredData = data.Where(x => x.urn == Model.Urn || x.amount > 0).ToArray();
+
+        var hasNegativeOrZeroValues = data.Length > filteredData.Length;
+        
         var categoryHeading = category.Rating.Category == Category.NonEducationalSupportStaff
             ? "Non-educational support staff"
             : category.Rating.Category;
@@ -43,17 +49,31 @@
                     </p>
                 </div>
             </div>
+
             <div class="govuk-grid-row govuk-!-margin-bottom-4">
                 <div class="govuk-grid-column-two-thirds">
+
+                    @if (hasNegativeOrZeroValues)
+                    {
+                    <div class="govuk-warning-text">
+                        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                        <strong class="govuk-warning-text__text">
+                            <span class="govuk-visually-hidden">Warning</span>
+                            Only displaying schools with expenditure.
+                        </strong>
+                    </div>
+                    }
+
                     <div class="govuk-!-margin-bottom-2 composed-container"
                          data-spending-and-costs-composed
-                         data-json="@category.Values.Select(x => new { urn = x.Key, amount = x.Value.Value }).ToArray().ToJson(Formatting.None)"
+                         data-json="@filteredData.ToJson(Formatting.None)"
                          data-highlight="@Model.Urn"
                          data-suffix="@category.Rating.Unit"
                          data-sort-direction="asc"
                          data-stats="@SchoolSpendingViewModel.Stats(category.Rating).ToJson(Formatting.None)"
                          data-has-incomplete-data="@Model.HasIncompleteData">
                     </div>
+
                     <p class="govuk-body category-commentary">
                         <a href="@categoryUri#@category.Rating.CostCategoryAnchorId" class="govuk-link govuk-link--no-visited-state">View all @category.Rating.Category?.ToLower(true) costs</a>@(category.SubCategories.Any() ? ". " : string.Empty)
                         @if (category.SubCategories.Any())
@@ -70,6 +90,7 @@
                                 {
                                     subCategory = $"{(category.SubCategories.Length > 1 ? "and " : string.Empty)} {subCategory}.";
                                 }
+
                                 <span>@subCategory</span>
                             }
                         }
@@ -78,7 +99,7 @@
                 <div class="govuk-grid-column-one-third">
                     @if (category.CanShowCommercialResources)
                     {
-                        <div class="govuk-!-margin-top-6">
+                        <div class="app-resources @(hasNegativeOrZeroValues ? "app-resources-warning-spacing" : "")">
                             <h4 class="govuk-heading-s">
                                 Find ways to spend less
                             </h4>


### PR DESCRIPTION
### Context
[AB#235748](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/235748) - [AB#243322](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/243322) & [AB#244430](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/244430)

### Change proposed in this pull request

filter non selected schools in the comparator set when they have negative or zero values for each cost category for the spending priorites page (default and custom data) so they are not included in the charts.
display a warning for each chart when values are suppressed.

when calculating the values for the rag rating for each category in the data pipeline exclude other schools in the comparator set when they have negative or zero values so the calculations match the schools displayed on the graphs on the spending priorities page

add two new app css classes for the commercial resources container to both fix an existing issue with margin that is only required when viewing on smaller screen after the grid row collapses and to add padding to align the text when the warning is adjacent.

### Guidance to review 
Check implementation for the logic in web and data pipeline and how this is displayed at various browser sizes.


### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

