### PR TITLE
Replaced default Bson encoding for objects persisted to cache with Json

### DIFF
--- a/platform/src/abstractions/Platform.Cache/IDistributedCache.cs
+++ b/platform/src/abstractions/Platform.Cache/IDistributedCache.cs
@@ -15,18 +15,18 @@ public interface IDistributedCache
     ///     cref="IDatabase.StringSet(KeyValuePair&lt;RedisKey, RedisValue&gt;[], StackExchange.Redis.When, CommandFlags)" />
     Task<bool> SetStringsAsync(KeyValuePair<string, string>[] values, When when = When.Always);
 
-    Task<T?> GetAsync<T>(string key);
+    Task<T?> GetAsync<T>(string key, CacheValueEncoding cacheValueEncoding = CacheValueEncoding.Json);
 
-    Task<bool> SetAsync<T>(string key, T value, When when = When.Always);
+    Task<bool> SetAsync<T>(string key, T value, When when = When.Always, CacheValueEncoding cacheValueEncoding = CacheValueEncoding.Json);
 
-    Task<bool> SetAsync<T>(KeyValuePair<string, T>[] values, When when = When.Always);
+    Task<bool> SetAsync<T>(KeyValuePair<string, T>[] values, When when = When.Always, CacheValueEncoding cacheValueEncoding = CacheValueEncoding.Json);
 
     /// <inheritdoc cref="IDatabase.KeyDelete(RedisKey[], CommandFlags)" />
     Task<long> DeleteAsync(params string[] keys);
 
     Task DeleteAsync(string pattern);
 
-    Task<T> GetSetAsync<T>(string key, Func<Task<T>> getter);
+    Task<T> GetSetAsync<T>(string key, Func<Task<T>> getter, CacheValueEncoding cacheValueEncoding = CacheValueEncoding.Json);
 
     /// <inheritdoc cref="IServer.FlushDatabase(int, CommandFlags)" />
     Task FlushAsync();
@@ -48,4 +48,10 @@ public enum When
     ///     The operation should only occur when there is not an existing value.
     /// </summary>
     NotExists
+}
+
+public enum CacheValueEncoding
+{
+    Json,
+    Bson
 }

--- a/platform/src/abstractions/tests/Platform.Cache.Tests/Cache/WhenRedisDistributedCacheGetsObject.cs
+++ b/platform/src/abstractions/tests/Platform.Cache.Tests/Cache/WhenRedisDistributedCacheGetsObject.cs
@@ -9,10 +9,21 @@ public class WhenRedisDistributedCacheGetsObject(ITestOutputHelper testOutputHel
 {
     public static TheoryData<ShouldReturnExpectedValueFromCacheTestData> ShouldReturnObjectFromStringTestDataItems =>
     [
-        new("key", "IQAAAANEYXRhABYAAAACVmFsdWUABgAAAHZhbHVlAAAA", new TestObject("value")),
-        new("key", "FgAAAAJWYWx1ZQAGAAAAdmFsdWUAAA==", null),
-        new("key", "not base64", null),
-        new("key", "bm90IGJzb24=", null)
+        new("key", "IQAAAANEYXRhABYAAAACVmFsdWUABgAAAHZhbHVlAAAA", new TestObject("value"), CacheValueEncoding.Bson),
+        new("key", "FgAAAAJWYWx1ZQAGAAAAdmFsdWUAAA==", null, CacheValueEncoding.Bson),
+        new("key", "not base64", null, CacheValueEncoding.Bson),
+        new("key", "bm90IGJzb24=", null, CacheValueEncoding.Bson),
+        new("key", "{\"Data\":{\"Value\":\"value\"}}", new TestObject("value"), CacheValueEncoding.Json),
+        new("key", "not json", null, CacheValueEncoding.Json),
+        new("key", "{}", null, CacheValueEncoding.Json)
+    ];
+
+    public static TheoryData<ShouldReturnExpectedNumericValueFromCacheTestData> ShouldReturnNumericObjectFromStringTestDataItems =>
+    [
+        new("key", "HwAAAANEYXRhABQAAAABVmFsdWUAlRcvtGWH9D8AAA==", new TestNumericObject(1.28305597671849m), CacheValueEncoding.Bson), // decimal precision lost when parsing via Bson reader
+        new("key", "HwAAAANEYXRhABQAAAABVmFsdWUAjxcvtGWH9D8AAA==", new TestNumericObject(1.28305597671849m), CacheValueEncoding.Bson),
+        new("key", "{\"Data\":{\"Value\":1.2830559767184912978}}", new TestNumericObject(1.2830559767184912978m), CacheValueEncoding.Json),
+        new("key", "{\"Data\":{\"Value\":1.28305597671849}}", new TestNumericObject(1.28305597671849m), CacheValueEncoding.Json)
     ];
 
     [Theory]
@@ -21,10 +32,25 @@ public class WhenRedisDistributedCacheGetsObject(ITestOutputHelper testOutputHel
     {
         Database
             .Setup(d => d.StringGetAsync(input.Key, CommandFlags.None))
-            .ReturnsAsync(input.Bson)
+            .ReturnsAsync(input.Encoded)
             .Verifiable(Times.Once);
 
-        var actual = await Cache.GetAsync<TestObject>(input.Key);
+        var actual = await Cache.GetAsync<TestObject>(input.Key, input.CacheValueEncoding);
+
+        Database.Verify();
+        Assert.Equal(input.ExpectedValue, actual);
+    }
+
+    [Theory]
+    [MemberData(nameof(ShouldReturnNumericObjectFromStringTestDataItems), MemberType = typeof(WhenRedisDistributedCacheGetsObject))]
+    public async Task ShouldReturnExpectedNumericValueFromCache(ShouldReturnExpectedNumericValueFromCacheTestData input)
+    {
+        Database
+            .Setup(d => d.StringGetAsync(input.Key, CommandFlags.None))
+            .ReturnsAsync(input.Encoded)
+            .Verifiable(Times.Once);
+
+        var actual = await Cache.GetAsync<TestNumericObject>(input.Key, input.CacheValueEncoding);
 
         Database.Verify();
         Assert.Equal(input.ExpectedValue, actual);
@@ -45,7 +71,11 @@ public class WhenRedisDistributedCacheGetsObject(ITestOutputHelper testOutputHel
         Assert.NotNull(actual);
     }
 
-    public record ShouldReturnExpectedValueFromCacheTestData(string Key, string Bson, TestObject? ExpectedValue);
+    public record ShouldReturnExpectedValueFromCacheTestData(string Key, string Encoded, TestObject? ExpectedValue, CacheValueEncoding CacheValueEncoding);
+
+    public record ShouldReturnExpectedNumericValueFromCacheTestData(string Key, string Encoded, TestNumericObject? ExpectedValue, CacheValueEncoding CacheValueEncoding);
 
     public record TestObject(string Value);
+
+    public record TestNumericObject(decimal Value);
 }

--- a/platform/src/abstractions/tests/Platform.Cache.Tests/Cache/WhenRedisDistributedCacheSetsObject.cs
+++ b/platform/src/abstractions/tests/Platform.Cache.Tests/Cache/WhenRedisDistributedCacheSetsObject.cs
@@ -9,21 +9,57 @@ public class WhenRedisDistributedCacheSetsObject(ITestOutputHelper testOutputHel
 {
     public static TheoryData<ShouldSetValueInCacheTestData> ShouldReturnObjectFromStringTestDataItems =>
     [
-        new("key", new TestObject("value"), "IQAAAANEYXRhABYAAAACVmFsdWUABgAAAHZhbHVlAAAA")
+        new("key", new TestObject("value"), "IQAAAANEYXRhABYAAAACVmFsdWUABgAAAHZhbHVlAAAA", CacheValueEncoding.Bson),
+        new("key", new TestObject("value"), "{\"Data\":{\"Value\":\"value\"}}", CacheValueEncoding.Json)
+    ];
+
+    public static TheoryData<ShouldSetNumericValueInCacheTestData> ShouldReturnNumericObjectFromStringTestDataItems =>
+    [
+        new("key", new TestNumericObject(1.2830559767184912978m), "HwAAAANEYXRhABQAAAABVmFsdWUAlRcvtGWH9D8AAA==", CacheValueEncoding.Bson),
+        new("key", new TestNumericObject(1.28305597671849m), "HwAAAANEYXRhABQAAAABVmFsdWUAjxcvtGWH9D8AAA==", CacheValueEncoding.Bson),
+        new("key", new TestNumericObject(1.2830559767184912978m), "{\"Data\":{\"Value\":1.2830559767184912978}}", CacheValueEncoding.Json),
+        new("key", new TestNumericObject(1.28305597671849m), "{\"Data\":{\"Value\":1.28305597671849}}", CacheValueEncoding.Json)
     ];
 
     [Theory]
     [MemberData(nameof(ShouldReturnObjectFromStringTestDataItems), MemberType = typeof(WhenRedisDistributedCacheSetsObject))]
     public async Task ShouldReturnExpectedValueFromCache(ShouldSetValueInCacheTestData input)
     {
+        var actualEncoded = string.Empty;
         Database
-            .Setup(d => d.StringSetAsync(input.Key, input.ExpectedBson, null, false, StackExchange.Redis.When.Always, CommandFlags.None))
+            .Setup(d => d.StringSetAsync(input.Key, It.IsAny<RedisValue>(), null, false, StackExchange.Redis.When.Always, CommandFlags.None))
             .ReturnsAsync(true)
+            .Callback<RedisKey, RedisValue, TimeSpan?, bool, StackExchange.Redis.When, CommandFlags>((_, value, _, _, _, _) =>
+            {
+                actualEncoded = value;
+            })
             .Verifiable(Times.Once);
 
-        var actual = await Cache.SetAsync(input.Key, input.Value);
+        var actual = await Cache.SetAsync(input.Key, input.Value, When.Always, input.CacheValueEncoding);
 
         Database.Verify();
+        Assert.Equal(input.ExpectedEncoded, actualEncoded);
+        Assert.True(actual);
+    }
+
+    [Theory]
+    [MemberData(nameof(ShouldReturnNumericObjectFromStringTestDataItems), MemberType = typeof(WhenRedisDistributedCacheSetsObject))]
+    public async Task ShouldReturnExpectedNumericValueFromCache(ShouldSetNumericValueInCacheTestData input)
+    {
+        var actualEncoded = string.Empty;
+        Database
+            .Setup(d => d.StringSetAsync(input.Key, It.IsAny<RedisValue>(), null, false, StackExchange.Redis.When.Always, CommandFlags.None))
+            .ReturnsAsync(true)
+            .Callback<RedisKey, RedisValue, TimeSpan?, bool, StackExchange.Redis.When, CommandFlags>((_, value, _, _, _, _) =>
+            {
+                actualEncoded = value;
+            })
+            .Verifiable(Times.Once);
+
+        var actual = await Cache.SetAsync(input.Key, input.Value, When.Always, input.CacheValueEncoding);
+
+        Database.Verify();
+        Assert.Equal(input.ExpectedEncoded, actualEncoded);
         Assert.True(actual);
     }
 
@@ -43,7 +79,11 @@ public class WhenRedisDistributedCacheSetsObject(ITestOutputHelper testOutputHel
         Assert.NotNull(actual);
     }
 
-    public record ShouldSetValueInCacheTestData(string Key, TestObject Value, string ExpectedBson);
+    public record ShouldSetValueInCacheTestData(string Key, TestObject Value, string ExpectedEncoded, CacheValueEncoding CacheValueEncoding);
+
+    public record ShouldSetNumericValueInCacheTestData(string Key, TestNumericObject Value, string ExpectedEncoded, CacheValueEncoding CacheValueEncoding);
 
     public record TestObject(string Value);
+
+    public record TestNumericObject(decimal Value);
 }


### PR DESCRIPTION
### Context
[AB#244049](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/244049) [AB#237633](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/237633)

### Change proposed in this pull request
This is mostly to get around [deserialization issue with decimal precision](https://github.com/JamesNK/Newtonsoft.Json/issues/2551), but also for reported [performance boost](https://github.com/JamesNK/Newtonsoft.Json.Bson/issues/30).

### Guidance to review 
Repeatedly running API tests after flushing cache initially should always return consistent results. This was failing with BSON encoding. 

> **NOTE:** Future work will flush the cache automatically before running the API tests from a pipeline build

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

