### PR TITLE
Removed `identifier` dependency when submitting and polling on status of custom school data

### DIFF
--- a/platform/src/apis/Platform.Api.Benchmark/CustomData/CustomDataFunctions.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/CustomData/CustomDataFunctions.cs
@@ -34,18 +34,10 @@ public class CustomDataFunctions(ILogger<CustomDataFunctions> logger, ICustomDat
 
         using (logger.BeginScope(new Dictionary<string, object>
                {
-                   {
-                       "Application", Constants.ApplicationName
-                   },
-                   {
-                       "CorrelationID", correlationId
-                   },
-                   {
-                       "URN", urn
-                   },
-                   {
-                       "Identifier", identifier
-                   }
+                   { "Application", Constants.ApplicationName },
+                   { "CorrelationID", correlationId },
+                   { "URN", urn },
+                   { "Identifier", identifier }
                }))
         {
             try
@@ -66,43 +58,33 @@ public class CustomDataFunctions(ILogger<CustomDataFunctions> logger, ICustomDat
     [Function(nameof(CreateSchoolCustomDataAsync))]
     [OpenApiOperation(nameof(CreateSchoolCustomDataAsync), "Custom Data")]
     [OpenApiParameter("urn", Type = typeof(string), Required = true)]
-    [OpenApiParameter("identifier", Type = typeof(string), Required = true)]
     [OpenApiSecurityHeader]
     [OpenApiRequestBody("application/json", typeof(CustomDataRequest), Description = "The user defined set of schools object")]
     [OpenApiResponseWithoutBody(HttpStatusCode.Accepted)]
     [OpenApiResponseWithoutBody(HttpStatusCode.BadRequest)]
     [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
     public async Task<MultiResponse> CreateSchoolCustomDataAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, "put", Route = "custom-data/school/{urn}/{identifier}")] HttpRequestData req,
-        string urn,
-        string identifier)
+        [HttpTrigger(AuthorizationLevel.Admin, "post", Route = "custom-data/school/{urn}")] HttpRequestData req,
+        string urn)
     {
         var correlationId = req.GetCorrelationId();
         var response = new MultiResponse();
 
         using (logger.BeginScope(new Dictionary<string, object>
                {
-                   {
-                       "Application", Constants.ApplicationName
-                   },
-                   {
-                       "CorrelationID", correlationId
-                   },
-                   {
-                       "URN", urn
-                   },
-                   {
-                       "Identifier", identifier
-                   }
+                   { "Application", Constants.ApplicationName },
+                   { "CorrelationID", correlationId },
+                   { "URN", urn }
                }))
         {
             try
             {
                 var body = await req.ReadAsJsonAsync<CustomDataRequest>();
+                var identifier = Guid.NewGuid().ToString();
                 var data = body.CreateData(identifier, urn);
 
                 await service.UpsertCustomDataAsync(data);
-                await service.UpsertUserDataAsync(CustomDataUserData.School(identifier, body.UserId, urn));
+                await service.InsertNewAndDeactivateExistingUserDataAsync(CustomDataUserData.School(identifier, body.UserId, urn));
 
                 var year = await service.CurrentYearAsync();
 
@@ -146,18 +128,10 @@ public class CustomDataFunctions(ILogger<CustomDataFunctions> logger, ICustomDat
 
         using (logger.BeginScope(new Dictionary<string, object>
                {
-                   {
-                       "Application", Constants.ApplicationName
-                   },
-                   {
-                       "CorrelationID", correlationId
-                   },
-                   {
-                       "URN", urn
-                   },
-                   {
-                       "Identifier", identifier
-                   }
+                   { "Application", Constants.ApplicationName },
+                   { "CorrelationID", correlationId },
+                   { "URN", urn },
+                   { "Identifier", identifier }
                }))
         {
             try

--- a/platform/src/apis/Platform.Api.Benchmark/CustomData/CustomDataService.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/CustomData/CustomDataService.cs
@@ -1,9 +1,8 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Dapper;
 using Dapper.Contrib.Extensions;
-using Platform.Functions.Extensions;
+using Platform.Domain;
 using Platform.Sql;
 
 namespace Platform.Api.Benchmark.CustomData;
@@ -12,29 +11,25 @@ public interface ICustomDataService
 {
     Task UpsertCustomDataAsync(CustomDataSchool data);
     Task<CustomDataSchool?> CustomDataSchoolAsync(string urn, string identifier);
-    Task UpsertUserDataAsync(CustomDataUserData userData);
+    Task InsertNewAndDeactivateExistingUserDataAsync(CustomDataUserData userData);
     Task<string> CurrentYearAsync();
     Task DeleteSchoolAsync(CustomDataSchool data);
 }
 
 [ExcludeFromCodeCoverage]
-public class CustomDataService : ICustomDataService
+public class CustomDataService(IDatabaseFactory dbFactory) : ICustomDataService
 {
-    private readonly IDatabaseFactory _dbFactory;
-
-    public CustomDataService(IDatabaseFactory dbFactory)
-    {
-        _dbFactory = dbFactory;
-    }
-
-
     public async Task UpsertCustomDataAsync(CustomDataSchool data)
     {
         const string sql = "SELECT * from CustomDataSchool where URN = @URN AND Id = @Id ";
 
-        var parameters = new { data.URN, data.Id };
+        var parameters = new
+        {
+            data.URN,
+            data.Id
+        };
 
-        using var conn = await _dbFactory.GetConnection();
+        using var conn = await dbFactory.GetConnection();
         var existing = await conn.QueryFirstOrDefaultAsync<CustomDataSchool>(sql, parameters);
 
         using var transaction = conn.BeginTransaction();
@@ -54,49 +49,52 @@ public class CustomDataService : ICustomDataService
     public async Task<CustomDataSchool?> CustomDataSchoolAsync(string urn, string identifier)
     {
         const string sql = "SELECT * from CustomDataSchool where URN = @URN AND Id = @Id";
-        var parameters = new { URN = urn, Id = identifier };
+        var parameters = new
+        {
+            URN = urn,
+            Id = identifier
+        };
 
-        using var conn = await _dbFactory.GetConnection();
+        using var conn = await dbFactory.GetConnection();
         return await conn.QueryFirstOrDefaultAsync<CustomDataSchool>(sql, parameters);
     }
 
-    public async Task UpsertUserDataAsync(CustomDataUserData userData)
+    public async Task InsertNewAndDeactivateExistingUserDataAsync(CustomDataUserData userData)
     {
-        const string sql = "SELECT * from UserData where Id = @Id";
+        const string sql = "UPDATE UserData SET Active = 0 where OrganisationId = @OrganisationId AND OrganisationType = @OrganisationType AND Type = @Type AND UserId = @UserId";
 
-        var parameters = new { userData.Id };
+        var parameters = new
+        {
+            userData.OrganisationId,
+            userData.OrganisationType,
+            userData.Type,
+            userData.UserId
+        };
 
-        using var conn = await _dbFactory.GetConnection();
-        var existing = await conn.QueryFirstOrDefaultAsync<CustomDataUserData>(sql, parameters);
-
+        using var conn = await dbFactory.GetConnection();
         using var transaction = conn.BeginTransaction();
-        if (existing != null)
-        {
-            existing.Expiry = userData.Expiry;
-            existing.Status = userData.Status;
-            await conn.UpdateAsync(existing, transaction);
-        }
-        else
-        {
-            await conn.InsertAsync(userData, transaction);
-        }
-
+        await conn.ExecuteAsync(sql, parameters, transaction);
+        await conn.InsertAsync(userData, transaction);
         transaction.Commit();
     }
 
     public async Task<string> CurrentYearAsync()
     {
         const string sql = "SELECT Value from Parameters where Name = 'CurrentYear'";
-        using var conn = await _dbFactory.GetConnection();
+        using var conn = await dbFactory.GetConnection();
         return await conn.QueryFirstAsync<string>(sql);
     }
 
     public async Task DeleteSchoolAsync(CustomDataSchool data)
     {
-        const string sql = "UPDATE UserData SET Status = 'removed' where Id = @Id";
-        var parameters = new { data.Id };
+        const string sql = "UPDATE UserData SET Status = @Removed, Active = 0 where Id = @Id";
+        var parameters = new
+        {
+            data.Id,
+            Pipeline.JobStatus.Removed
+        };
 
-        using var connection = await _dbFactory.GetConnection();
+        using var connection = await dbFactory.GetConnection();
         using var transaction = connection.BeginTransaction();
 
         await connection.DeleteAsync(data, transaction);

--- a/platform/src/apis/Platform.Api.Benchmark/CustomData/CustomDataUserData.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/CustomData/CustomDataUserData.cs
@@ -1,14 +1,18 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using Dapper.Contrib.Extensions;
+using Platform.Domain;
 
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable PropertyCanBeMadeInitOnly.Global
+// ReSharper disable UnusedAutoPropertyAccessor.Global
 namespace Platform.Api.Benchmark.CustomData;
 
 [ExcludeFromCodeCoverage]
 [Table("UserData")]
 public record CustomDataUserData
 {
-    [ExplicitKey] public string? Id { get; set; }
+    [ExplicitKey] public string? Id { get; set; } = Guid.NewGuid().ToString();
     public string? UserId { get; set; }
     public string? Type { get; set; }
 
@@ -17,19 +21,17 @@ public record CustomDataUserData
     public string? OrganisationId { get; set; }
     public DateTimeOffset Expiry { get; set; }
     public string? Status { get; set; }
+    public bool Active { get; set; }
 
-
-    public static CustomDataUserData School(string? id, string? userId, string? urn)
+    public static CustomDataUserData School(string? id, string? userId, string? urn) => new()
     {
-        return new CustomDataUserData
-        {
-            Id = id,
-            UserId = userId,
-            Type = "custom-data",
-            OrganisationType = "school",
-            OrganisationId = urn,
-            Expiry = DateTimeOffset.Now.AddDays(30),
-            Status = "pending"
-        };
-    }
+        Id = id,
+        UserId = userId,
+        Type = Pipeline.JobType.CustomData,
+        OrganisationType = "school",
+        OrganisationId = urn,
+        Expiry = DateTimeOffset.Now.AddDays(30),
+        Status = Pipeline.JobStatus.Pending,
+        Active = true
+    };
 }

--- a/platform/tests/Platform.ApiTests/Features/BenchmarkCustomData.feature
+++ b/platform/tests/Platform.ApiTests/Features/BenchmarkCustomData.feature
@@ -1,28 +1,29 @@
 ﻿Feature: Benchmark Custom Data Endpoint Testing
-    
+
     Scenario: Getting custom data successfully
         Given I have a valid custom data get request for school id '990000' containing:
           | Key                                       | Value  |
           | AdministrativeSuppliesNonEducationalCosts | 123.00 |
         When I submit the custom data request
-        Then the custom data response should contain:
+        Then new user data should be created for school id '990000'
+        And the custom data response should contain:
           | Key                                       | Value  |
           | AdministrativeSuppliesNonEducationalCosts | 123.00 |
-          
+
     Scenario: Setting custom data successfully
-        Given I have a valid custom data put request for school id '990000' containing:
+        Given I have a valid custom data post request for school id '990000' containing:
           | Key                                       | Value  |
           | AdministrativeSuppliesNonEducationalCosts | 123.00 |
         When I submit the custom data request
-        Then the custom data response should return accepted
-        
+        Then new user data should be created for school id '990000'
+
     Scenario: Deleting custom data successfully
         Given I have a valid custom data delete request for school id '990000' containing:
           | Key                                       | Value  |
           | AdministrativeSuppliesNonEducationalCosts | 123.00 |
         When I submit the custom data request
         Then the custom data response should return ok
-        
+
     Scenario: Deleting custom data unsuccessfully
         Given I have an invalid custom data delete request for school id '990000'
         When I submit the custom data request

--- a/platform/tests/Platform.ApiTests/Steps/BenchmarkComparatorSetSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/BenchmarkComparatorSetSteps.cs
@@ -11,6 +11,7 @@ using Platform.Json;
 namespace Platform.ApiTests.Steps;
 
 [Binding]
+[Scope(Feature = "Benchmark Comparator set Endpoint Testing")]
 public class BenchmarkComparatorSetSteps(BenchmarkApiDriver api)
 {
     private const string DefaultComparatorSetKey = "default-comparator-set";
@@ -399,7 +400,7 @@ public class BenchmarkComparatorSetSteps(BenchmarkApiDriver api)
     {
         api.CreateRequest(UserDefinedDataKey, new HttpRequestMessage
         {
-            RequestUri = new Uri($"/api/user-data?userId={_userGuid}&organisationId={identifier}&organisationType={type}&status=complete", UriKind.Relative),
+            RequestUri = new Uri($"/api/user-data?userId={_userGuid}&organisationId={identifier}&organisationType={type}&status=complete&type=comparator-set", UriKind.Relative),
             Method = HttpMethod.Get
         });
     }

--- a/platform/tests/Platform.ApiTests/Steps/BenchmarkCustomDataSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/BenchmarkCustomDataSteps.cs
@@ -2,37 +2,57 @@
 using System.Text;
 using FluentAssertions;
 using Platform.Api.Benchmark.CustomData;
+using Platform.Api.Benchmark.UserData;
 using Platform.ApiTests.Drivers;
 using Platform.Json;
 using Xunit;
+
 namespace Platform.ApiTests.Steps;
 
 [Binding]
+[Scope(Feature = "Benchmark Custom Data Endpoint Testing")]
 public class BenchmarkCustomDataSteps(BenchmarkApiDriver api)
 {
     private const string CustomDataKey = "custom-data";
+    private const string UserDefinedDataKey = "user-defined-data";
     private readonly string _userGuid = Guid.NewGuid().ToString();
 
     [Given("I have a valid custom data get request for school id '(.*)' containing:")]
     public async Task GivenIHaveAValidCustomDataGetRequestForSchoolIdContaining(string urn, DataTable table)
     {
-        var identifier = PutCustomDataRequest(urn, table);
+        PostCustomDataRequest(urn, table);
         await WhenISubmitTheCustomDataRequest();
-        GetCustomDataRequest(urn, identifier);
+
+        GetUserDefinedCustomDataRequest(urn);
     }
 
-    [Given("I have a valid custom data put request for school id '(.*)' containing:")]
-    public void GivenIHaveAValidCustomDataPutRequestForSchoolIdContaining(string urn, DataTable table)
+    [Given("I have a valid custom data post request for school id '(.*)' containing:")]
+    public async Task GivenIHaveAValidCustomDataPostRequestForSchoolIdContaining(string urn, DataTable table)
     {
-        PutCustomDataRequest(urn, table);
+        PostCustomDataRequest(urn, table);
+        await WhenISubmitTheCustomDataRequest();
+
+        GetUserDefinedCustomDataRequest(urn);
     }
 
     [Given("I have a valid custom data delete request for school id '(.*)' containing:")]
     public async Task GivenIHaveAValidCustomDataDeleteRequestForSchoolIdContaining(string urn, DataTable table)
     {
-        var identifier = PutCustomDataRequest(urn, table);
+        PostCustomDataRequest(urn, table);
         await WhenISubmitTheCustomDataRequest();
-        DeleteCustomDataRequest(urn, identifier);
+
+        GetUserDefinedCustomDataRequest(urn);
+        await api.Send();
+
+        var response = api[UserDefinedDataKey].Response;
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsByteArrayAsync();
+        var result = content.FromJson<UserData[]>();
+        result.Should().NotBeNull().And.HaveCount(1);
+
+        DeleteCustomDataRequest(urn, result.Select(r => new Guid(r.Id!)).FirstOrDefault());
     }
 
     [Given("I have an invalid custom data delete request for school id '(.*)'")]
@@ -44,6 +64,21 @@ public class BenchmarkCustomDataSteps(BenchmarkApiDriver api)
     [When("I submit the custom data request")]
     public async Task WhenISubmitTheCustomDataRequest()
     {
+        await api.Send();
+    }
+
+    [Then("new user data should be created for school id '(.*)'")]
+    public async Task ThenNewUserDataShouldBeCreatedForSchoolId(string urn)
+    {
+        var response = api[UserDefinedDataKey].Response;
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsByteArrayAsync();
+        var result = content.FromJson<UserData[]>();
+
+        GetCustomDataRequest(urn, new Guid(result.First().Id!));
+
         await api.Send();
     }
 
@@ -90,19 +125,16 @@ public class BenchmarkCustomDataSteps(BenchmarkApiDriver api)
         });
     }
 
-    private Guid PutCustomDataRequest(string urn, DataTable table)
+    private void PostCustomDataRequest(string urn, DataTable table)
     {
-        var identifier = Guid.NewGuid();
         var json = GetJsonFromTable(table);
 
         api.CreateRequest(CustomDataKey, new HttpRequestMessage
         {
-            RequestUri = new Uri($"/api/custom-data/school/{urn}/{identifier}", UriKind.Relative),
-            Method = HttpMethod.Put,
+            RequestUri = new Uri($"/api/custom-data/school/{urn}", UriKind.Relative),
+            Method = HttpMethod.Post,
             Content = new StringContent(json, Encoding.UTF8, "application/json")
         });
-
-        return identifier;
     }
 
     private void DeleteCustomDataRequest(string urn, Guid identifier)
@@ -118,9 +150,7 @@ public class BenchmarkCustomDataSteps(BenchmarkApiDriver api)
     {
         var content = new Dictionary<string, object>
         {
-            {
-                "UserId", _userGuid
-            }
+            { "UserId", _userGuid }
         };
         foreach (var row in table.Rows)
         {
@@ -130,5 +160,14 @@ public class BenchmarkCustomDataSteps(BenchmarkApiDriver api)
         }
 
         return content.ToJson();
+    }
+
+    private void GetUserDefinedCustomDataRequest(string urn)
+    {
+        api.CreateRequest(UserDefinedDataKey, new HttpRequestMessage
+        {
+            RequestUri = new Uri($"/api/user-data?userId={_userGuid}&organisationId={urn}&organisationType=school&type=custom-data", UriKind.Relative),
+            Method = HttpMethod.Get
+        });
     }
 }

--- a/platform/tests/Platform.ApiTests/Steps/BenchmarkUserDataSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/BenchmarkUserDataSteps.cs
@@ -5,6 +5,7 @@ using Platform.Api.Benchmark.UserData;
 using Platform.ApiTests.Drivers;
 using Platform.Json;
 using Xunit;
+
 namespace Platform.ApiTests.Steps;
 
 [Binding]
@@ -50,7 +51,7 @@ public class BenchmarkUserDataSteps(BenchmarkApiDriver api)
     {
         api.CreateRequest(UserDataKey, new HttpRequestMessage
         {
-            RequestUri = new Uri($"/api/user-data?userId={_userGuid}&organisationId={urn}&organisationType=school&id={identifier}", UriKind.Relative),
+            RequestUri = new Uri($"/api/user-data?userId={_userGuid}&organisationId={urn}&organisationType=school&id={identifier}&type=custom-data", UriKind.Relative),
             Method = HttpMethod.Get
         });
     }
@@ -74,9 +75,7 @@ public class BenchmarkUserDataSteps(BenchmarkApiDriver api)
     {
         var content = new Dictionary<string, object>
         {
-            {
-                "UserId", _userGuid
-            }
+            { "UserId", _userGuid }
         };
         foreach (var row in table.Rows)
         {

--- a/platform/tests/Platform.Benchmark.Tests/WhenFunctionReceivesCreateCustomDataRequest.cs
+++ b/platform/tests/Platform.Benchmark.Tests/WhenFunctionReceivesCreateCustomDataRequest.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using AutoFixture;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Platform.Api.Benchmark.ComparatorSets;
+using Platform.Api.Benchmark.CustomData;
+using Platform.Domain;
+using Platform.Domain.Messages;
+using Platform.Json;
+using Platform.Test;
+using Xunit;
+
+namespace Platform.Benchmark.Tests;
+
+public class WhenFunctionReceivesCreateCustomDataRequest : FunctionsTestBase
+{
+    private readonly Fixture _fixture = new();
+    private readonly CustomDataFunctions _functions;
+    private readonly Mock<ICustomDataService> _service = new();
+
+    public WhenFunctionReceivesCreateCustomDataRequest()
+    {
+        _functions = new CustomDataFunctions(new NullLogger<CustomDataFunctions>(), _service.Object);
+    }
+
+    [Fact]
+    public async Task CreateUserDefinedShouldCreateSuccessfully()
+    {
+        var model = _fixture.Create<CustomDataRequest>();
+        _service.Setup(d => d.UpsertCustomDataAsync(It.IsAny<CustomDataSchool>()));
+
+        const int year = 2024;
+        _service
+            .Setup(d => d.CurrentYearAsync())
+            .ReturnsAsync(year.ToString());
+
+        const string urn = "123321";
+        var response = await _functions.CreateSchoolCustomDataAsync(CreateHttpRequestDataWithBody(model), urn);
+
+        Assert.NotNull(response);
+        Assert.NotNull(response.HttpResponse);
+        Assert.Equal(HttpStatusCode.Accepted, response.HttpResponse.StatusCode);
+
+        Assert.NotEmpty(response.Messages);
+        var actualMessage = response.Messages.First().FromJson<PipelineStartCustom>();
+        Assert.Equal(Pipeline.JobType.CustomData, actualMessage.Type);
+        Assert.Equal(Pipeline.RunType.Custom, actualMessage.RunType);
+        Assert.NotNull(actualMessage.RunId);
+        Assert.Equal(year, actualMessage.Year);
+        Assert.Equal(urn, actualMessage.URN);
+        Assert.Equal("CustomDataPipelinePayload", actualMessage.Payload?.Kind);
+        Assert.Equal(
+            model.AdministrativeSuppliesNonEducationalCosts,
+            (actualMessage.Payload as CustomDataPipelinePayload)?.AdministrativeSuppliesNonEducationalCosts);
+
+        _service.Verify(x => x.UpsertCustomDataAsync(It.IsAny<CustomDataSchool>()), Times.Once());
+        _service.Verify(x => x.InsertNewAndDeactivateExistingUserDataAsync(It.IsAny<CustomDataUserData>()), Times.Once());
+    }
+
+    [Fact]
+    public async Task CreateUserDefinedShouldBe500OnError()
+    {
+        var set = new[] { "1", "2" };
+
+        var model = _fixture.Build<ComparatorSetUserDefinedRequest>()
+            .With(x => x.Set, set)
+            .Create();
+
+        _service
+            .Setup(d => d.UpsertCustomDataAsync(It.IsAny<CustomDataSchool>()))
+            .Throws(new Exception());
+
+        var response = await _functions.CreateSchoolCustomDataAsync(CreateHttpRequestDataWithBody(model), "123321");
+
+        Assert.NotNull(response);
+        Assert.NotNull(response.HttpResponse);
+        Assert.Equal(HttpStatusCode.InternalServerError, response.HttpResponse.StatusCode);
+    }
+}

--- a/web/src/Web.App/Controllers/Api/UserDataProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/UserDataProxyController.cs
@@ -71,21 +71,21 @@ public class UserDataProxyController(ILogger<UserDataProxyController> logger, IU
     }
 
     [HttpGet]
-    [Route("school/custom-data/{urn}/{identifier}")]
+    [Route("school/custom-data/{urn}")]
     [Produces("application/json")]
     [ProducesResponseType<UserData>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> SchoolCustomDataUserData(string urn, string identifier)
+    public async Task<IActionResult> SchoolCustomDataUserData(string urn)
     {
         using (logger.BeginScope(new
         {
-            identifier
+            urn
         }))
         {
             try
             {
-                var userData = await userDataService.GetCustomDataAsync(User, identifier, urn);
+                var userData = await userDataService.GetCustomDataActiveAsync(User, urn);
                 if (userData == null)
                 {
                     return new NotFoundResult();
@@ -95,7 +95,7 @@ public class UserDataProxyController(ILogger<UserDataProxyController> logger, IU
             }
             catch (Exception e)
             {
-                logger.LogError(e, "An error getting school custom data user data {Id} for {User}", identifier, User.UserGuid());
+                logger.LogError(e, "An error getting school custom data user data for {User}", User.UserGuid());
                 return StatusCode(500);
             }
         }

--- a/web/src/Web.App/Controllers/SchoolCensusController.cs
+++ b/web/src/Web.App/Controllers/SchoolCensusController.cs
@@ -11,6 +11,7 @@ using Web.App.Infrastructure.Apis.Insight;
 using Web.App.Infrastructure.Extensions;
 using Web.App.Services;
 using Web.App.ViewModels;
+
 namespace Web.App.Controllers;
 
 [Controller]
@@ -66,19 +67,8 @@ public class SchoolCensusController(
         {
             try
             {
-                var userData = await UserData(urn);
-                var customDataId = userData.CustomData;
-                if (string.IsNullOrEmpty(customDataId))
-                {
-                    return RedirectToAction("Index", "School", new
-                    {
-                        urn
-                    });
-                }
-
-                //TODO: Remove duplicate call for user data
-                var userCustomData = await userDataService.GetCustomDataAsync(User, customDataId, urn);
-                if (userCustomData?.Status != "complete")
+                var userCustomData = await userDataService.GetCustomDataActiveAsync(User, urn);
+                if (userCustomData?.Status != Pipeline.JobStatus.Complete)
                 {
                     return RedirectToAction("Index", "School", new
                     {
@@ -89,7 +79,7 @@ public class SchoolCensusController(
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.SchoolCustomisedDataCensus(urn);
 
                 var school = await School(urn);
-                var viewModel = new SchoolCensusViewModel(school, customDataId: customDataId);
+                var viewModel = new SchoolCensusViewModel(school, customDataId: userCustomData.Id);
 
                 return View(viewModel);
             }

--- a/web/src/Web.App/Controllers/SchoolComparisonController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparisonController.cs
@@ -11,6 +11,7 @@ using Web.App.Infrastructure.Apis.Insight;
 using Web.App.Infrastructure.Extensions;
 using Web.App.Services;
 using Web.App.ViewModels;
+
 namespace Web.App.Controllers;
 
 [Controller]
@@ -66,19 +67,8 @@ public class SchoolComparisonController(
         {
             try
             {
-                var userData = await userDataService.GetSchoolDataAsync(User, urn);
-                var customDataId = userData.CustomData;
-                if (string.IsNullOrEmpty(customDataId))
-                {
-                    return RedirectToAction("Index", "School", new
-                    {
-                        urn
-                    });
-                }
-
-                //TODO: Remove duplicate call for user data
-                var userCustomData = await userDataService.GetCustomDataAsync(User, customDataId, urn);
-                if (userCustomData?.Status != "complete")
+                var userCustomData = await userDataService.GetCustomDataActiveAsync(User, urn);
+                if (userCustomData?.Status != Pipeline.JobStatus.Complete)
                 {
                     return RedirectToAction("Index", "School", new
                     {
@@ -90,7 +80,7 @@ public class SchoolComparisonController(
 
                 var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
 
-                var viewModel = new SchoolComparisonViewModel(school, customDataId: customDataId);
+                var viewModel = new SchoolComparisonViewModel(school, customDataId: userCustomData.Id);
 
                 return View(viewModel);
             }

--- a/web/src/Web.App/Controllers/SchoolController.cs
+++ b/web/src/Web.App/Controllers/SchoolController.cs
@@ -11,6 +11,7 @@ using Web.App.Infrastructure.Extensions;
 using Web.App.Services;
 using Web.App.TagHelpers;
 using Web.App.ViewModels;
+
 namespace Web.App.Controllers;
 
 [Controller]
@@ -165,19 +166,16 @@ public class SchoolController(
         {
             try
             {
-                var userData = await userDataService.GetSchoolDataAsync(User, urn);
-                var customDataId = userData.CustomData;
-                if (string.IsNullOrEmpty(customDataId))
+                var userCustomData = await userDataService.GetCustomDataActiveAsync(User, urn);
+                if (userCustomData?.Status == Pipeline.JobStatus.Pending)
                 {
-                    return RedirectToAction("Index", "School", new
+                    return RedirectToAction("Submitted", "SchoolCustomDataChange", new
                     {
                         urn
                     });
                 }
 
-                //TODO: Remove duplicate call for user data
-                var userCustomData = await userDataService.GetCustomDataAsync(User, customDataId, urn);
-                if (userCustomData?.Status != "complete")
+                if (userCustomData?.Status != Pipeline.JobStatus.Complete)
                 {
                     return RedirectToAction("Index", "School", new
                     {

--- a/web/src/Web.App/Controllers/SchoolSpendingComparisonController.cs
+++ b/web/src/Web.App/Controllers/SchoolSpendingComparisonController.cs
@@ -35,18 +35,8 @@ public class SchoolSpendingComparisonController(
         {
             try
             {
-                var userData = await userDataService.GetSchoolDataAsync(User, urn);
-                var customDataId = userData.CustomData;
-                if (string.IsNullOrEmpty(customDataId))
-                {
-                    return RedirectToAction("Index", "School", new
-                    {
-                        urn
-                    });
-                }
-
-                var userCustomData = await userDataService.GetCustomDataAsync(User, customDataId, urn);
-                if (userCustomData?.Status != "complete")
+                var userCustomData = await userDataService.GetCustomDataActiveAsync(User, urn);
+                if (userCustomData?.Status != Pipeline.JobStatus.Complete)
                 {
                     return RedirectToAction("Index", "School", new
                     {
@@ -58,7 +48,7 @@ public class SchoolSpendingComparisonController(
 
                 var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
                 var originalRating = await metricRagRatingApi.GetDefaultAsync(new ApiQuery().AddIfNotNull("urns", urn)).GetResultOrThrow<RagRating[]>();
-                var customRating = await metricRagRatingApi.CustomAsync(customDataId).GetResultOrThrow<RagRating[]>();
+                var customRating = await metricRagRatingApi.CustomAsync(userCustomData.Id!).GetResultOrThrow<RagRating[]>();
 
                 var viewModel = new SchoolSpendingComparisonViewModel(school, originalRating, customRating);
 

--- a/web/src/Web.App/Controllers/SchoolSpendingController.cs
+++ b/web/src/Web.App/Controllers/SchoolSpendingController.cs
@@ -10,6 +10,7 @@ using Web.App.Infrastructure.Apis.Insight;
 using Web.App.Infrastructure.Extensions;
 using Web.App.Services;
 using Web.App.ViewModels;
+
 namespace Web.App.Controllers;
 
 [Controller]
@@ -95,9 +96,8 @@ public class SchoolSpendingController(
         {
             try
             {
-                var userData = await userDataService.GetSchoolDataAsync(User, urn);
-                var customDataId = userData.CustomData;
-                if (string.IsNullOrEmpty(customDataId))
+                var userCustomData = await userDataService.GetCustomDataActiveAsync(User, urn);
+                if (userCustomData?.Status != Pipeline.JobStatus.Complete)
                 {
                     return RedirectToAction("Index", "School", new
                     {
@@ -105,16 +105,7 @@ public class SchoolSpendingController(
                     });
                 }
 
-                var userCustomData = await userDataService.GetCustomDataAsync(User, customDataId, urn);
-                if (userCustomData?.Status != "complete")
-                {
-                    return RedirectToAction("Index", "School", new
-                    {
-                        urn
-                    });
-                }
-
-
+                var customDataId = userCustomData.Id!;
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.SchoolCustomisedDataSpending(urn);
 
                 var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();

--- a/web/src/Web.App/Domain/Pipeline.cs
+++ b/web/src/Web.App/Domain/Pipeline.cs
@@ -1,0 +1,24 @@
+﻿namespace Web.App.Domain;
+
+public static class Pipeline
+{
+    public static class RunType
+    {
+        public const string Default = "default";
+        public const string Custom = "custom";
+    }
+
+    public static class JobType
+    {
+        public const string Default = "default";
+        public const string ComparatorSet = "comparator-set";
+        public const string CustomData = "custom-data";
+    }
+
+    public static class JobStatus
+    {
+        public const string Complete = "complete";
+        public const string Pending = "pending";
+        public const string Removed = "removed";
+    }
+}

--- a/web/src/Web.App/Infrastructure/Apis/ApiRequests/PostCustomDataRequest.cs
+++ b/web/src/Web.App/Infrastructure/Apis/ApiRequests/PostCustomDataRequest.cs
@@ -1,8 +1,7 @@
 ﻿namespace Web.App.Infrastructure.Apis;
 
-public record PutCustomDataRequest
+public record PostCustomDataRequest
 {
-    public Guid Identifier { get; set; } = Guid.NewGuid();
     public string? UserId { get; set; }
     public decimal? AdministrativeSuppliesNonEducationalCosts { get; set; }
     public decimal? CateringStaffCosts { get; set; }
@@ -51,4 +50,4 @@ public record PutCustomDataRequest
     public decimal? NonClassroomSupportStaffFTE { get; set; }
     public decimal? AuxiliaryStaffFTE { get; set; }
     public decimal? WorkforceHeadcount { get; set; }
-};
+}

--- a/web/src/Web.App/Infrastructure/Apis/Benchmark/Api.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Benchmark/Api.cs
@@ -22,7 +22,7 @@ public static class Api
 
     public static class CustomData
     {
-        public static string School(string urn, string identifier) => $"api/custom-data/school/{urn}/{identifier}";
+        public static string School(string urn, string? identifier = null) => $"api/custom-data/school/{urn}/{identifier}";
     }
 
     public static class FinancialPlan

--- a/web/src/Web.App/Infrastructure/Apis/Benchmark/CustomDataApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Benchmark/CustomDataApi.cs
@@ -6,12 +6,12 @@ public class CustomDataApi(HttpClient httpClient, string? key = default) : ApiBa
 
     public async Task<ApiResult> RemoveSchoolAsync(string urn, string identifier) => await DeleteAsync(Api.CustomData.School(urn, identifier));
 
-    public async Task<ApiResult> UpsertSchoolAsync(string urn, PutCustomDataRequest request) => await PutAsync(Api.CustomData.School(urn, request.Identifier.ToString()), new JsonContent(request));
+    public async Task<ApiResult> UpsertSchoolAsync(string urn, PostCustomDataRequest request) => await PostAsync(Api.CustomData.School(urn), new JsonContent(request));
 }
 
 public interface ICustomDataApi
 {
     Task<ApiResult> GetSchoolAsync(string urn, string identifier);
     Task<ApiResult> RemoveSchoolAsync(string urn, string identifier);
-    Task<ApiResult> UpsertSchoolAsync(string urn, PutCustomDataRequest request);
+    Task<ApiResult> UpsertSchoolAsync(string urn, PostCustomDataRequest request);
 }

--- a/web/src/Web.App/Services/CustomDataService.cs
+++ b/web/src/Web.App/Services/CustomDataService.cs
@@ -5,6 +5,7 @@ using Web.App.Infrastructure.Apis.Benchmark;
 using Web.App.Infrastructure.Apis.Insight;
 using Web.App.Infrastructure.Extensions;
 using Web.App.ViewModels;
+
 namespace Web.App.Services;
 
 public interface ICustomDataService
@@ -102,14 +103,14 @@ public class CustomDataService(
             return null;
         }
 
-        var parsed = customDataSchool.Data.FromJson<PutCustomDataRequest>();
+        var parsed = customDataSchool.Data.FromJson<PostCustomDataRequest>();
         return parsed == null ? null : CreateCustomData(parsed);
     }
 
     public async Task RemoveCustomData(string urn, string identifier) =>
         await customDataApi.RemoveSchoolAsync(urn, identifier).EnsureSuccess();
 
-    private static PutCustomDataRequest CreateRequest(CustomData data) => new()
+    private static PostCustomDataRequest CreateRequest(CustomData data) => new()
     {
         AdministrativeSuppliesNonEducationalCosts = data.AdministrativeSuppliesNonEducationalCosts,
         CateringStaffCosts = data.CateringStaffCosts,
@@ -160,7 +161,7 @@ public class CustomDataService(
         WorkforceHeadcount = data.WorkforceHeadcount
     };
 
-    private static CustomData CreateCustomData(PutCustomDataRequest data) => new()
+    private static CustomData CreateCustomData(PostCustomDataRequest data) => new()
     {
         AdministrativeSuppliesNonEducationalCosts = data.AdministrativeSuppliesNonEducationalCosts,
         CateringStaffCosts = data.CateringStaffCosts,

--- a/web/src/Web.App/ViewModels/SchoolCustomDataSubmittedViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolCustomDataSubmittedViewModel.cs
@@ -1,11 +1,9 @@
 ﻿using Web.App.Domain;
-using Web.App.Infrastructure.Apis;
 
 namespace Web.App.ViewModels;
 
-public class SchoolCustomDataSubmittedViewModel(School school, string customData)
+public class SchoolCustomDataSubmittedViewModel(School school)
 {
     public string? Urn => school.URN;
     public string? Name => school.SchoolName;
-    public string Identifier => customData;
 }

--- a/web/src/Web.App/Views/SchoolComparatorsCreateBy/Submitted.cshtml
+++ b/web/src/Web.App/Views/SchoolComparatorsCreateBy/Submitted.cshtml
@@ -1,4 +1,5 @@
-﻿@using Web.App.TagHelpers
+﻿@using Web.App.Domain
+@using Web.App.TagHelpers
 @model Web.App.ViewModels.SchoolComparatorsSubmittedViewModel
 @{
     ViewData[ViewDataKeys.Title] = Model.IsEdit
@@ -39,9 +40,9 @@
                 .then(response => response.json())
                 .then(json => {
                     if (json) {
-                        if (json.status === "complete") {
+                        if (json.status === "@Pipeline.JobStatus.Complete") {
                             done = true;
-                        } else if (json.status !== "pending") {
+                        } else if (json.status !== "@Pipeline.JobStatus.Pending") {
                             throw new Error("Unexpected response returned from API call");
                         }
                     }

--- a/web/src/Web.App/Views/SchoolCustomDataChange/Submitted.cshtml
+++ b/web/src/Web.App/Views/SchoolCustomDataChange/Submitted.cshtml
@@ -1,4 +1,5 @@
-﻿@using Web.App.TagHelpers
+﻿@using Web.App.Domain
+@using Web.App.TagHelpers
 @model Web.App.ViewModels.SchoolCustomDataSubmittedViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.SchoolChangeDataSubmit;
@@ -20,6 +21,7 @@
         // todo: refactor entire view its own partial/component for re-use by other async processes such as custom data submission
         let done, failed = false;
         const interval = setInterval(statusCheck, 5000);
+
         function statusCheck() {
             if (done || failed) {
                 clearInterval(interval);
@@ -28,7 +30,7 @@
             }
 
             fetch(
-                "/api/user-data/school/custom-data/@Model.Urn/@Model.Identifier",
+                "/api/user-data/school/custom-data/@Model.Urn",
                 {
                     method: "GET",
                     credentials: "include"
@@ -36,9 +38,9 @@
                 .then(response => response.json())
                 .then(json => {
                     if (json) {
-                        if (json.status === "complete") {
+                        if (json.status === "@Pipeline.JobStatus.Complete") {
                             done = true;
-                        } else if (json.status !== "pending") {
+                        } else if (json.status !== "@Pipeline.JobStatus.Pending") {
                             throw new Error("Unexpected response returned from API call");
                         }
                     }

--- a/web/src/Web.App/Views/TrustComparatorsCreateBy/Submitted.cshtml
+++ b/web/src/Web.App/Views/TrustComparatorsCreateBy/Submitted.cshtml
@@ -1,4 +1,5 @@
-﻿@using Web.App.TagHelpers
+﻿@using Web.App.Domain
+@using Web.App.TagHelpers
 @model Web.App.ViewModels.TrustComparatorsSubmittedViewModel
 @{
     ViewData[ViewDataKeys.Title] = Model.IsEdit
@@ -39,9 +40,9 @@
                 .then(response => response.json())
                 .then(json => {
                     if (json) {
-                        if (json.status === "complete") {
+                        if (json.status === "@Pipeline.JobStatus.Complete") {
                             done = true;
-                        } else if (json.status !== "pending") {
+                        } else if (json.status !== "@Pipeline.JobStatus.Pending") {
                             throw new Error("Unexpected response returned from API call");
                         }
                     }

--- a/web/tests/Web.E2ETests/Features/School/CreateCustomData.feature
+++ b/web/tests/Web.E2ETests/Features/School/CreateCustomData.feature
@@ -1,0 +1,25 @@
+Feature: School create custom data
+
+    Background:
+        Given I am on create custom data page for school with URN '990234'
+        And I have signed in with organisation '01: FBIT TEST - Community School (Open)'
+
+    Scenario: Can view create custom data page
+        When I click start now
+        Then the change financial data page is displayed
+
+    Scenario: Can submit custom data
+        When I click start now
+        And I supply the following financial data:
+          | Cost                                      | Value |
+          | Administrative supplies (non-educational) | 5000  |
+        And I click continue
+        And I supply the following non-financial data:
+          | Item                                    | Value |
+          | Number of pupils (full time equivalent) | 100   |
+        And I click continue
+        And I supply the following workforce data:
+          | Item                                    | Value |
+          | School workforce (full time equivalent) | 20    |
+        And I save the custom data
+        Then the submitted page is displayed

--- a/web/tests/Web.E2ETests/Features/School/SchoolHome.feature
+++ b/web/tests/Web.E2ETests/Features/School/SchoolHome.feature
@@ -53,10 +53,10 @@
     Scenario: Top priority categories have the correct RAG commentary
         Given I am on school homepage for school with urn '777042'
         Then the RAG commentary for each priority category is
-          | Name                                | Commentary                                                                               |
-          | Teaching and Teaching support staff | High priority Spends £6,315 per pupil — Spending is higher than 99% of similar schools.  |
+          | Name                                | Commentary                                                                              |
+          | Teaching and Teaching support staff | High priority Spends £6,315 per pupil — Spending is higher than 99% of similar schools. |
           | Non-educational support staff       | High priority Spends £845 per pupil — Spending is higher than 95.7% of similar schools. |
-          | Administrative supplies             | High priority Spends £429 per pupil — Spending is higher than 99% of similar schools.    |
+          | Administrative supplies             | High priority Spends £429 per pupil — Spending is higher than 99% of similar schools.   |
 
     Scenario: RAG guidance is displayed
         Given I am on school homepage for school with urn '777042'

--- a/web/tests/Web.E2ETests/Pages/School/CustomData/ChangeFinancialDataPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/CustomData/ChangeFinancialDataPage.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Playwright;
+
+namespace Web.E2ETests.Pages.School.CustomData;
+
+public class ChangeFinancialDataPage(IPage page)
+{
+    private ILocator PageH1Heading => page.Locator(Selectors.H1,
+        new PageLocatorOptions
+        {
+            HasText = "Change financial data"
+        });
+
+    private ILocator ContinueButton => page.Locator(Selectors.GovButton,
+        new PageLocatorOptions
+        {
+            HasText = "Continue"
+        });
+    private ILocator Accordion => page.Locator("#accordion-financial-data");
+    private ILocator CustomDataField(string category) => page.Locator($".table-custom-data > tbody > tr:has-text('{category}') > td input");
+
+    public async Task IsDisplayed()
+    {
+        await PageH1Heading.ShouldBeVisible();
+        await Accordion.ShouldBeVisible();
+    }
+
+    public async Task TypeIntoCustomDataFieldForCost(string category, string text)
+    {
+        await CustomDataField(category).ClearAsync();
+        await CustomDataField(category).PressSequentially(text);
+    }
+
+    public async Task<ChangeNonFinancialDataPage> ClickContinue()
+    {
+        await ContinueButton.ClickAsync();
+        return new ChangeNonFinancialDataPage(page);
+    }
+}

--- a/web/tests/Web.E2ETests/Pages/School/CustomData/ChangeNonFinancialDataPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/CustomData/ChangeNonFinancialDataPage.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Playwright;
+
+namespace Web.E2ETests.Pages.School.CustomData;
+
+public class ChangeNonFinancialDataPage(IPage page)
+{
+    private ILocator PageH1Heading => page.Locator(Selectors.H1,
+        new PageLocatorOptions
+        {
+            HasText = "Change non-financial data"
+        });
+
+    private ILocator ContinueButton => page.Locator(Selectors.GovButton,
+        new PageLocatorOptions
+        {
+            HasText = "Continue"
+        });
+    private ILocator Warning => page.Locator(".govuk-warning-text");
+    private ILocator CustomDataField(string item) => page.Locator($".table-custom-data > tbody > tr:has-text('{item}') > td input");
+
+    public async Task IsDisplayed()
+    {
+        await PageH1Heading.ShouldBeVisible();
+        await Warning.ShouldBeVisible();
+    }
+
+    public async Task TypeIntoCustomDataFieldForItem(string item, string text)
+    {
+        await CustomDataField(item).ClearAsync();
+        await CustomDataField(item).PressSequentially(text);
+    }
+
+    public async Task<ChangeWorkforceDataPage> ClickContinue()
+    {
+        await ContinueButton.ClickAsync();
+        return new ChangeWorkforceDataPage(page);
+    }
+}

--- a/web/tests/Web.E2ETests/Pages/School/CustomData/ChangeWorkforceDataPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/CustomData/ChangeWorkforceDataPage.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Playwright;
+
+namespace Web.E2ETests.Pages.School.CustomData;
+
+public class ChangeWorkforceDataPage(IPage page)
+{
+    private ILocator PageH1Heading => page.Locator(Selectors.H1,
+        new PageLocatorOptions
+        {
+            HasText = "Change workforce data"
+        });
+
+    private ILocator SaveChangesButton => page.Locator(Selectors.GovButton,
+        new PageLocatorOptions
+        {
+            HasText = "Save changes to data"
+        });
+    private ILocator CustomDataField(string item) => page.Locator($".table-custom-data > tbody > tr:has-text('{item}') > td input");
+
+    public async Task IsDisplayed()
+    {
+        await PageH1Heading.ShouldBeVisible();
+    }
+
+    public async Task TypeIntoCustomDataFieldForItem(string item, string text)
+    {
+        await CustomDataField(item).ClearAsync();
+        await CustomDataField(item).PressSequentially(text);
+    }
+
+    public async Task<CreateCustomDataSubmittedPage> ClickSaveChangesButton()
+    {
+        await SaveChangesButton.ClickAsync();
+        return new CreateCustomDataSubmittedPage(page);
+    }
+}

--- a/web/tests/Web.E2ETests/Pages/School/CustomData/CreateCustomDataPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/CustomData/CreateCustomDataPage.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Playwright;
+
+namespace Web.E2ETests.Pages.School.CustomData;
+
+public class CreateCustomDataPage(IPage page)
+{
+    private ILocator PageH1Heading => page.Locator(Selectors.H1,
+        new PageLocatorOptions
+        {
+            HasText = "Change data used to compare this school"
+        });
+
+    private ILocator StartNowButton => page.Locator(Selectors.GovButton,
+        new PageLocatorOptions
+        {
+            HasText = "Start now"
+        });
+
+    public async Task IsDisplayed()
+    {
+        await PageH1Heading.ShouldBeVisible();
+    }
+
+    public async Task<ChangeFinancialDataPage> ClickStartNow()
+    {
+        await StartNowButton.ClickAsync();
+        return new ChangeFinancialDataPage(page);
+    }
+}

--- a/web/tests/Web.E2ETests/Pages/School/CustomData/CreateCustomDataSubmittedPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/CustomData/CreateCustomDataSubmittedPage.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Playwright;
+
+namespace Web.E2ETests.Pages.School.CustomData;
+
+public class CreateCustomDataSubmittedPage(IPage page)
+{
+    private ILocator PageH1Heading => page.Locator(Selectors.H1,
+        new PageLocatorOptions
+        {
+            HasText = "Generating custom data"
+        });
+
+    public async Task IsDisplayed()
+    {
+        await PageH1Heading.ShouldBeVisible();
+    }
+}

--- a/web/tests/Web.E2ETests/Pages/School/HomePage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/HomePage.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Playwright;
 using Xunit;
+
 namespace Web.E2ETests.Pages.School;
 
 public class HomePage(IPage page)
@@ -56,7 +57,12 @@ public class HomePage(IPage page)
     private ILocator CookieBanner => page.Locator(Selectors.CookieBanner);
     private ILocator RagGuidance => page.Locator("#rag-guidance");
 
-    public async Task IsDisplayed(bool isPartYear = false, string? trustName = null, bool isUserDefinedComparator = false, bool isMissingRags = false)
+    public async Task IsDisplayed(
+        bool isPartYear = false,
+        string? trustName = null,
+        bool isUserDefinedComparator = false,
+        bool isMissingRags = false,
+        bool isCustomData = false)
     {
         await PageH1Heading.ShouldBeVisible();
         //await Breadcrumbs.ShouldBeVisible();

--- a/web/tests/Web.E2ETests/Steps/School/CreateCustomDataSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/CreateCustomDataSteps.cs
@@ -1,0 +1,106 @@
+using Web.E2ETests.Drivers;
+using Web.E2ETests.Pages.School.CustomData;
+using Xunit;
+
+namespace Web.E2ETests.Steps.School;
+
+[Binding]
+[Scope(Feature = "School create custom data")]
+public class CreateCustomDataSteps(PageDriver driver)
+{
+    private ChangeFinancialDataPage? _changeFinancialDataPage;
+    private ChangeNonFinancialDataPage? _changeNonFinancialDataPage;
+    private ChangeWorkforceDataPage? _changeWorkforceDataPage;
+    private CreateCustomDataPage? _createCustomDataPage;
+    private CreateCustomDataSubmittedPage? _createCustomDataSubmittedPage;
+
+    [Given("I am on create custom data page for school with URN '(.*)'")]
+    public async Task GivenIAmOnCreateCustomDataPageForSchoolWithURN(string urn)
+    {
+        var url = CreateCustomDataUrl(urn);
+        var page = await driver.Current;
+        await page.GotoAndWaitForLoadAsync(url);
+
+        _createCustomDataPage = new CreateCustomDataPage(page);
+        await _createCustomDataPage.IsDisplayed();
+    }
+
+    [When("I click start now")]
+    public async Task WhenIClickStartNow()
+    {
+        Assert.NotNull(_createCustomDataPage);
+        _changeFinancialDataPage = await _createCustomDataPage.ClickStartNow();
+    }
+
+    [When("I supply the following financial data:")]
+    public async Task WhenISupplyTheFollowingFinancialData(Table table)
+    {
+        Assert.NotNull(_changeFinancialDataPage);
+
+        var rags = table.Rows.ToDictionary(row => row["Cost"], row => row["Value"]);
+        foreach (var row in rags)
+        {
+            await _changeFinancialDataPage.TypeIntoCustomDataFieldForCost(row.Key, row.Value);
+        }
+    }
+
+    [When("I supply the following non-financial data:")]
+    public async Task WhenISupplyTheFollowingNonFinancialData(Table table)
+    {
+        Assert.NotNull(_changeNonFinancialDataPage);
+
+        var rags = table.Rows.ToDictionary(row => row["Item"], row => row["Value"]);
+        foreach (var row in rags)
+        {
+            await _changeNonFinancialDataPage.TypeIntoCustomDataFieldForItem(row.Key, row.Value);
+        }
+    }
+
+    [When("I supply the following workforce data:")]
+    public async Task WhenISupplyTheFollowingWorkforceData(Table table)
+    {
+        Assert.NotNull(_changeWorkforceDataPage);
+
+        var rags = table.Rows.ToDictionary(row => row["Item"], row => row["Value"]);
+        foreach (var row in rags)
+        {
+            await _changeWorkforceDataPage.TypeIntoCustomDataFieldForItem(row.Key, row.Value);
+        }
+    }
+
+    [When("I click continue")]
+    public async Task WhenIClickContinue()
+    {
+        if (_changeNonFinancialDataPage != null)
+        {
+            _changeWorkforceDataPage = await _changeNonFinancialDataPage.ClickContinue();
+            return;
+        }
+
+        Assert.NotNull(_changeFinancialDataPage);
+        _changeNonFinancialDataPage = await _changeFinancialDataPage.ClickContinue();
+    }
+
+    [When("I save the custom data")]
+    public async Task WhenISaveTheCustomData()
+    {
+        Assert.NotNull(_changeWorkforceDataPage);
+        _createCustomDataSubmittedPage = await _changeWorkforceDataPage.ClickSaveChangesButton();
+    }
+
+    [Then("the change financial data page is displayed")]
+    public async Task ThenTheChangeFinancialDataPageIsDisplayed()
+    {
+        Assert.NotNull(_changeFinancialDataPage);
+        await _changeFinancialDataPage.IsDisplayed();
+    }
+
+    [Then("the submitted page is displayed")]
+    public async Task ThenTheSubmittedPageIsDisplayed()
+    {
+        Assert.NotNull(_createCustomDataSubmittedPage);
+        await _createCustomDataSubmittedPage.IsDisplayed();
+    }
+
+    private static string CreateCustomDataUrl(string urn) => $"{TestConfiguration.ServiceUrl}/school/{urn}/custom-data";
+}

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -10,6 +10,7 @@ using Web.App.Infrastructure.Apis.Establishment;
 using Web.App.Infrastructure.Apis.Insight;
 using Web.App.Infrastructure.Storage;
 using Xunit.Abstractions;
+
 namespace Web.Integration.Tests;
 
 public class SchoolBenchmarkingWebAppClient : BenchmarkingWebAppClient
@@ -73,18 +74,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
 
     private void EnableFeatures(params string[] ignoreFeatures)
     {
-        var features = new[]
-        {
-            FeatureFlags.CurriculumFinancialPlanning,
-            FeatureFlags.CustomData,
-            FeatureFlags.UserDefinedComparators,
-            FeatureFlags.TrustComparison,
-            FeatureFlags.Trusts,
-            FeatureFlags.LocalAuthorities,
-            FeatureFlags.ForecastRisk,
-            FeatureFlags.FinancialBenchmarkingInsightsSummary,
-            FeatureFlags.HistoricalTrends
-        };
+        var features = new[] { FeatureFlags.CurriculumFinancialPlanning, FeatureFlags.CustomData, FeatureFlags.UserDefinedComparators, FeatureFlags.TrustComparison, FeatureFlags.Trusts, FeatureFlags.LocalAuthorities, FeatureFlags.ForecastRisk, FeatureFlags.FinancialBenchmarkingInsightsSummary, FeatureFlags.HistoricalTrends };
 
         foreach (var feature in features.Where(x => !ignoreFeatures.Contains(x)))
         {
@@ -390,7 +380,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     public BenchmarkingWebAppClient SetUpCustomData(CustomDataSchool? customData = null)
     {
         CustomDataApi.Reset();
-        CustomDataApi.Setup(api => api.UpsertSchoolAsync(It.IsAny<string>(), It.IsAny<PutCustomDataRequest>())).ReturnsAsync(ApiResult.Ok());
+        CustomDataApi.Setup(api => api.UpsertSchoolAsync(It.IsAny<string>(), It.IsAny<PostCustomDataRequest>())).ReturnsAsync(ApiResult.Ok());
         CustomDataApi.Setup(api => api.GetSchoolAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(ApiResult.Ok(customData));
         CustomDataApi.Setup(api => api.RemoveSchoolAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(ApiResult.Ok());
         return this;

--- a/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataFinancialData.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataFinancialData.cs
@@ -6,6 +6,7 @@ using Web.App.Extensions;
 using Web.App.Infrastructure.Apis;
 using Web.App.ViewModels;
 using Xunit;
+
 namespace Web.Integration.Tests.Pages.Schools.CustomData;
 
 public class WhenViewingCustomDataFinancialData : PageBase<SchoolBenchmarkingWebAppClient>
@@ -41,111 +42,41 @@ public class WhenViewingCustomDataFinancialData : PageBase<SchoolBenchmarkingWeb
 
         _formValues = new Dictionary<string, decimal?>
         {
-            {
-                nameof(FinancialDataCustomDataViewModel.AdministrativeSuppliesNonEducationalCosts), _customExpenditure.AdministrativeSuppliesNonEducationalCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.CateringStaffCosts), _customExpenditure.CateringStaffCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.CateringSuppliesCosts), _customExpenditure.CateringSuppliesCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.ExaminationFeesCosts), _customExpenditure.ExaminationFeesCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.LearningResourcesNonIctCosts), _customExpenditure.LearningResourcesNonIctCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.LearningResourcesIctCosts), _customExpenditure.LearningResourcesIctCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.AdministrativeClericalStaffCosts), _customExpenditure.AdministrativeClericalStaffCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.AuditorsCosts), _customExpenditure.AuditorsCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.OtherStaffCosts), _customExpenditure.OtherStaffCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.ProfessionalServicesNonCurriculumCosts), _customExpenditure.ProfessionalServicesNonCurriculumCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.CleaningCaretakingCosts), _customExpenditure.CleaningCaretakingCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.MaintenancePremisesCosts), _customExpenditure.MaintenancePremisesCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.OtherOccupationCosts), _customExpenditure.OtherOccupationCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.PremisesStaffCosts), _customExpenditure.PremisesStaffCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.AgencySupplyTeachingStaffCosts), _customExpenditure.AgencySupplyTeachingStaffCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.EducationSupportStaffCosts), _customExpenditure.EducationSupportStaffCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.EducationalConsultancyCosts), _customExpenditure.EducationalConsultancyCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.SupplyTeachingStaffCosts), _customExpenditure.SupplyTeachingStaffCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.TeachingStaffCosts), _customExpenditure.TeachingStaffCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.EnergyCosts), _customExpenditure.EnergyCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.WaterSewerageCosts), _customExpenditure.WaterSewerageCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.DirectRevenueFinancingCosts), _customExpenditure.DirectRevenueFinancingCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.GroundsMaintenanceCosts), _customExpenditure.GroundsMaintenanceCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.IndirectEmployeeExpenses), _customExpenditure.IndirectEmployeeExpenses
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.InterestChargesLoanBank), _customExpenditure.InterestChargesLoanBank
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.OtherInsurancePremiumsCosts), _customExpenditure.OtherInsurancePremiumsCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.PrivateFinanceInitiativeCharges), _customExpenditure.PrivateFinanceInitiativeCharges
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.RentRatesCosts), _customExpenditure.RentRatesCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.SpecialFacilitiesCosts), _customExpenditure.SpecialFacilitiesCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.StaffDevelopmentTrainingCosts), _customExpenditure.StaffDevelopmentTrainingCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.StaffRelatedInsuranceCosts), _customExpenditure.StaffRelatedInsuranceCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.SupplyTeacherInsurableCosts), _customExpenditure.SupplyTeacherInsurableCosts
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.TotalIncome), _customIncome.TotalIncome
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.TotalExpenditure), _customExpenditure.TotalExpenditure
-            },
-            {
-                nameof(FinancialDataCustomDataViewModel.RevenueReserve), _balance.RevenueReserve
-            }
+            { nameof(FinancialDataCustomDataViewModel.AdministrativeSuppliesNonEducationalCosts), _customExpenditure.AdministrativeSuppliesNonEducationalCosts },
+            { nameof(FinancialDataCustomDataViewModel.CateringStaffCosts), _customExpenditure.CateringStaffCosts },
+            { nameof(FinancialDataCustomDataViewModel.CateringSuppliesCosts), _customExpenditure.CateringSuppliesCosts },
+            { nameof(FinancialDataCustomDataViewModel.ExaminationFeesCosts), _customExpenditure.ExaminationFeesCosts },
+            { nameof(FinancialDataCustomDataViewModel.LearningResourcesNonIctCosts), _customExpenditure.LearningResourcesNonIctCosts },
+            { nameof(FinancialDataCustomDataViewModel.LearningResourcesIctCosts), _customExpenditure.LearningResourcesIctCosts },
+            { nameof(FinancialDataCustomDataViewModel.AdministrativeClericalStaffCosts), _customExpenditure.AdministrativeClericalStaffCosts },
+            { nameof(FinancialDataCustomDataViewModel.AuditorsCosts), _customExpenditure.AuditorsCosts },
+            { nameof(FinancialDataCustomDataViewModel.OtherStaffCosts), _customExpenditure.OtherStaffCosts },
+            { nameof(FinancialDataCustomDataViewModel.ProfessionalServicesNonCurriculumCosts), _customExpenditure.ProfessionalServicesNonCurriculumCosts },
+            { nameof(FinancialDataCustomDataViewModel.CleaningCaretakingCosts), _customExpenditure.CleaningCaretakingCosts },
+            { nameof(FinancialDataCustomDataViewModel.MaintenancePremisesCosts), _customExpenditure.MaintenancePremisesCosts },
+            { nameof(FinancialDataCustomDataViewModel.OtherOccupationCosts), _customExpenditure.OtherOccupationCosts },
+            { nameof(FinancialDataCustomDataViewModel.PremisesStaffCosts), _customExpenditure.PremisesStaffCosts },
+            { nameof(FinancialDataCustomDataViewModel.AgencySupplyTeachingStaffCosts), _customExpenditure.AgencySupplyTeachingStaffCosts },
+            { nameof(FinancialDataCustomDataViewModel.EducationSupportStaffCosts), _customExpenditure.EducationSupportStaffCosts },
+            { nameof(FinancialDataCustomDataViewModel.EducationalConsultancyCosts), _customExpenditure.EducationalConsultancyCosts },
+            { nameof(FinancialDataCustomDataViewModel.SupplyTeachingStaffCosts), _customExpenditure.SupplyTeachingStaffCosts },
+            { nameof(FinancialDataCustomDataViewModel.TeachingStaffCosts), _customExpenditure.TeachingStaffCosts },
+            { nameof(FinancialDataCustomDataViewModel.EnergyCosts), _customExpenditure.EnergyCosts },
+            { nameof(FinancialDataCustomDataViewModel.WaterSewerageCosts), _customExpenditure.WaterSewerageCosts },
+            { nameof(FinancialDataCustomDataViewModel.DirectRevenueFinancingCosts), _customExpenditure.DirectRevenueFinancingCosts },
+            { nameof(FinancialDataCustomDataViewModel.GroundsMaintenanceCosts), _customExpenditure.GroundsMaintenanceCosts },
+            { nameof(FinancialDataCustomDataViewModel.IndirectEmployeeExpenses), _customExpenditure.IndirectEmployeeExpenses },
+            { nameof(FinancialDataCustomDataViewModel.InterestChargesLoanBank), _customExpenditure.InterestChargesLoanBank },
+            { nameof(FinancialDataCustomDataViewModel.OtherInsurancePremiumsCosts), _customExpenditure.OtherInsurancePremiumsCosts },
+            { nameof(FinancialDataCustomDataViewModel.PrivateFinanceInitiativeCharges), _customExpenditure.PrivateFinanceInitiativeCharges },
+            { nameof(FinancialDataCustomDataViewModel.RentRatesCosts), _customExpenditure.RentRatesCosts },
+            { nameof(FinancialDataCustomDataViewModel.SpecialFacilitiesCosts), _customExpenditure.SpecialFacilitiesCosts },
+            { nameof(FinancialDataCustomDataViewModel.StaffDevelopmentTrainingCosts), _customExpenditure.StaffDevelopmentTrainingCosts },
+            { nameof(FinancialDataCustomDataViewModel.StaffRelatedInsuranceCosts), _customExpenditure.StaffRelatedInsuranceCosts },
+            { nameof(FinancialDataCustomDataViewModel.SupplyTeacherInsurableCosts), _customExpenditure.SupplyTeacherInsurableCosts },
+            { nameof(FinancialDataCustomDataViewModel.TotalIncome), _customIncome.TotalIncome },
+            { nameof(FinancialDataCustomDataViewModel.TotalExpenditure), _customExpenditure.TotalExpenditure },
+            { nameof(FinancialDataCustomDataViewModel.RevenueReserve), _balance.RevenueReserve }
         };
     }
 
@@ -407,7 +338,7 @@ public class WhenViewingCustomDataFinancialData : PageBase<SchoolBenchmarkingWeb
         return (doc, school);
     }
 
-    private async Task<(IHtmlDocument page, School school, PutCustomDataRequest customData)> SetupNavigateInitPageWithUserData()
+    private async Task<(IHtmlDocument page, School school, PostCustomDataRequest customData)> SetupNavigateInitPageWithUserData()
     {
         var (client, school) = SetupClient();
 
@@ -416,7 +347,7 @@ public class WhenViewingCustomDataFinancialData : PageBase<SchoolBenchmarkingWeb
             .Create();
         client.SetupUserData([userData]);
 
-        var customData = Fixture.Build<PutCustomDataRequest>().Create();
+        var customData = Fixture.Build<PostCustomDataRequest>().Create();
         var customDataSchool = new CustomDataSchool
         {
             Data = customData.ToJson()

--- a/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataWorkforceData.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataWorkforceData.cs
@@ -4,6 +4,7 @@ using AutoFixture;
 using Web.App.Domain;
 using Web.App.ViewModels;
 using Xunit;
+
 namespace Web.Integration.Tests.Pages.Schools.CustomData;
 
 public class WhenViewingCustomDataWorkforceData : PageBase<SchoolBenchmarkingWebAppClient>
@@ -41,30 +42,14 @@ public class WhenViewingCustomDataWorkforceData : PageBase<SchoolBenchmarkingWeb
 
         _formValues = new Dictionary<string, decimal?>
         {
-            {
-                nameof(WorkforceDataCustomDataViewModel.WorkforceFte), customCensus.Workforce
-            },
-            {
-                nameof(WorkforceDataCustomDataViewModel.TeachersFte), customCensus.Teachers
-            },
-            {
-                nameof(WorkforceDataCustomDataViewModel.QualifiedTeacherPercent), customCensus.PercentTeacherWithQualifiedStatus
-            },
-            {
-                nameof(WorkforceDataCustomDataViewModel.SeniorLeadershipFte), customCensus.SeniorLeadership
-            },
-            {
-                nameof(WorkforceDataCustomDataViewModel.TeachingAssistantsFte), customCensus.TeachingAssistant
-            },
-            {
-                nameof(WorkforceDataCustomDataViewModel.NonClassroomSupportStaffFte), customCensus.NonClassroomSupportStaff
-            },
-            {
-                nameof(WorkforceDataCustomDataViewModel.AuxiliaryStaffFte), customCensus.AuxiliaryStaff
-            },
-            {
-                nameof(WorkforceDataCustomDataViewModel.WorkforceHeadcount), customCensus.WorkforceHeadcount
-            }
+            { nameof(WorkforceDataCustomDataViewModel.WorkforceFte), customCensus.Workforce },
+            { nameof(WorkforceDataCustomDataViewModel.TeachersFte), customCensus.Teachers },
+            { nameof(WorkforceDataCustomDataViewModel.QualifiedTeacherPercent), customCensus.PercentTeacherWithQualifiedStatus },
+            { nameof(WorkforceDataCustomDataViewModel.SeniorLeadershipFte), customCensus.SeniorLeadership },
+            { nameof(WorkforceDataCustomDataViewModel.TeachingAssistantsFte), customCensus.TeachingAssistant },
+            { nameof(WorkforceDataCustomDataViewModel.NonClassroomSupportStaffFte), customCensus.NonClassroomSupportStaff },
+            { nameof(WorkforceDataCustomDataViewModel.AuxiliaryStaffFte), customCensus.AuxiliaryStaff },
+            { nameof(WorkforceDataCustomDataViewModel.WorkforceHeadcount), customCensus.WorkforceHeadcount }
         };
     }
 
@@ -89,7 +74,7 @@ public class WhenViewingCustomDataWorkforceData : PageBase<SchoolBenchmarkingWeb
             f.SetFormValues(_formValues.ToDictionary(k => k.Key, v => v.Value?.ToString() ?? string.Empty));
         });
 
-        DocumentAssert.AssertPageUrl(page, Paths.SchoolCustomDataSubmit(school.URN).ToAbsolute());
+        DocumentAssert.AssertPageUrl(page, Paths.SchoolCustomDataSubmitted(school.URN).ToAbsolute());
     }
 
     [Fact]
@@ -102,7 +87,7 @@ public class WhenViewingCustomDataWorkforceData : PageBase<SchoolBenchmarkingWeb
 
         page = await Client.SubmitForm(page.Forms[0], action);
 
-        DocumentAssert.AssertPageUrl(page, Paths.SchoolCustomDataSubmit(school.URN).ToAbsolute());
+        DocumentAssert.AssertPageUrl(page, Paths.SchoolCustomDataSubmitted(school.URN).ToAbsolute());
     }
 
     [Fact]

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -77,6 +77,7 @@ public static class Paths
     public static string SchoolCustomDataRevert(string? urn) => $"/school/{urn}/custom-data/revert";
     public static string SchoolCustomDataWorkforceData(string? urn) => $"/school/{urn}/custom-data/workforce";
     public static string SchoolCustomDataSubmit(string? urn) => $"/school/{urn}/custom-data/submit";
+    public static string SchoolCustomDataSubmitted(string? urn) => $"/school/{urn}/custom-data/submitted";
     public static string SchoolComparators(string? urn) => $"/school/{urn}/comparators";
     public static string SchoolComparatorsCreate(string? urn) => $"/school/{urn}/comparators/create";
     public static string SchoolComparatorsCreateBy(string? urn) => $"/school/{urn}/comparators/create/by";


### PR DESCRIPTION
### Context
[AB#244072](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/244072) [AB#242105](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/242105)

### Change proposed in this pull request
- When submitting new/updating existing custom School data, set all matching existing `UserData` rows as `Active = 0` (via earlier modified `POST` Benchmark API endpoint)
- Do not rely on `UserData` identifier when polling for submission status - just check the `Active = 1` row for that user/organisation/type combination (via earlier modified `GET` Benchmark API endpoint)
- If page refreshed during polling stage, do not return to beginning of custom data journey, rather keep polling
- If the user leaves the page after a submission and elects to 'view custom data' when the job is still `pending` then the 'spinner' page should be shown again, rather than a redirect back to self
- E2E tests for Custom Data journey (up to submission page due to otherwise potentially lengthy waits on date pipeline)

### Guidance to review 
Running through the Custom Data journey locally should behave the same after this change as before. The `custom-data` pipeline run may take a long time to complete, so the 'spinner' will poll for a significant period. 

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~



