### PR TITLE
chore: bump `front-end` to `1.1.28`

### DIFF
--- a/web/src/Web.App/package-lock.json
+++ b/web/src/Web.App/package-lock.json
@@ -1474,9 +1474,9 @@
       }
     },
     "node_modules/front-end": {
-      "version": "1.1.27",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-1.1.27.tgz",
-      "integrity": "sha1-1wkY4+eQIWUb8jUZcdHp2MOc+Y8=",
+      "version": "1.1.28",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-1.1.28.tgz",
+      "integrity": "sha1-fNqaNHRzvlACmM/DTBg6E6GrwKE=",
       "dependencies": {
         "accessible-autocomplete": "^3.0.0",
         "classnames": "^2.5.1",


### PR DESCRIPTION
### Context
[AB#235748](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/235748)

following #1776 bump front end package required

### Change proposed in this pull request
bump `front-end` to `1.1.28`

### Guidance to review 
n/a

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

