### PR TITLE
Expose endpoints for getting AAR and CFR files from database

### DIFF
--- a/core-infrastructure/src/db/Core.Database/Scripts/106-CreateFileTable.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/106-CreateFileTable.sql
@@ -1,0 +1,40 @@
+IF NOT EXISTS(SELECT *
+              FROM INFORMATION_SCHEMA.TABLES
+              WHERE table_name = 'File')
+    BEGIN
+        CREATE TABLE [dbo].[File]
+        (
+            Type      nvarchar(50)   NOT NULL,
+            Label     nvarchar(50)   NOT NULL,
+            FileName  nvarchar(255)  NOT NULL,
+            ValidFrom datetimeoffset NOT NULL DEFAULT GETUTCDATE(),
+            ValidTo   datetimeoffset NULL
+
+                CONSTRAINT PK_File PRIMARY KEY (Type, Label)
+        );
+
+        INSERT INTO [dbo].[File] (Type, Label, FileName)
+        VALUES ('transparency-cfr', 'CFR 2022/23', 'CFR_2022-23_Full_Data_Workbook.xlsx'),
+               ('transparency-cfr', 'CFR 2021/22', 'CFR_2021-22_Full_Data_Workbook.xlsx'),
+               ('transparency-cfr', 'CFR 2020/21', 'CFR_2020-21_Full_Data_Workbook.xlsx'),
+               ('transparency-cfr', 'CFR 2019/20', 'CFR_2019-20_Full_Data_Workbook.xlsx'),
+               ('transparency-cfr', 'CFR 2018/19', 'CFR_2018-19_Full_Data_Workbook.xlsx'),
+               ('transparency-cfr', 'CFR 2017/18', 'CFR_2017-18_Full_Data_Workbook.xlsx'),
+               ('transparency-cfr', 'CFR 2016/17', 'CFR_2016-17_Full_Data_Workbook.xlsx'),
+               ('transparency-cfr', 'CFR 2015/16', 'CFR_2015-16_Full_Data_Workbook.xlsx'),
+               ('transparency-cfr', 'CFR 2014/15', 'CFR_2014-15_Full_Data_Workbook.xlsx'),
+               ('transparency-aar', 'AAR 2022/23', 'AAR_2022-23_download.xlsx'),
+               ('transparency-aar', 'AAR 2021/22', 'AAR_2021-22_download.xlsx'),
+               ('transparency-aar', 'AAR 2020/21', 'AAR_2020-21_download.xlsx'),
+               ('transparency-aar', 'AAR 2019/20', 'AAR_2019-20_download.xlsx'),
+               ('transparency-aar', 'AAR 2018/19', 'AAR_2018-19_download.xlsx'),
+               ('transparency-aar', 'AAR 2017/18', 'AAR_2017-18_download.xlsx'),
+               ('transparency-aar', 'AAR 2016/17', 'AAR_2016-17_download.xlsx'),
+               ('transparency-aar', 'AAR 2015/16', 'SFR32_2017_Main_Tables.xlsx'),
+               ('transparency-aar', 'AAR 2014/15', 'SFR27_2016_Main_Tables.xlsx');
+
+        -- intentionally insert these files as available in the distant future
+        INSERT INTO [dbo].[File] (Type, Label, FileName, ValidFrom)
+        VALUES ('transparency-cfr', 'CFR 2023/24', 'CFR_2023-24_Full_Data_Workbook.xlsx', DATEADD(year, 1, GETUTCDATE())),
+               ('transparency-aar', 'AAR 2023/24', 'AAR_2023-24_download.xlsx', DATEADD(year, 1, GETUTCDATE()));
+    END;

--- a/core-infrastructure/src/db/Core.Database/Views/015-Files.sql
+++ b/core-infrastructure/src/db/Core.Database/Views/015-Files.sql
@@ -1,0 +1,21 @@
+DROP VIEW IF EXISTS VW_TransparencyFilesAar
+GO
+
+CREATE VIEW VW_TransparencyFilesAar AS
+SELECT [Label], [FileName]
+FROM [dbo].[File]
+WHERE [Type] = 'transparency-aar'
+  AND [ValidFrom] < GETUTCDATE()
+  AND ([ValidTo] IS NULL OR [ValidTo] > GETUTCDATE())
+GO
+
+DROP VIEW IF EXISTS VW_TransparencyFilesCfr
+GO
+
+CREATE VIEW VW_TransparencyFilesCfr AS
+SELECT [Label], [FileName]
+FROM [dbo].[File]
+WHERE [Type] = 'transparency-cfr'
+  AND [ValidFrom] < GETUTCDATE()
+  AND ([ValidTo] IS NULL OR [ValidTo] > GETUTCDATE())
+GO

--- a/platform/src/apis/Platform.Api.Insight/Configuration/Services.cs
+++ b/platform/src/apis/Platform.Api.Insight/Configuration/Services.cs
@@ -13,6 +13,7 @@ using Platform.Api.Insight.Features.Census.Validators;
 using Platform.Api.Insight.Features.Expenditure.Parameters;
 using Platform.Api.Insight.Features.Expenditure.Services;
 using Platform.Api.Insight.Features.Expenditure.Validators;
+using Platform.Api.Insight.Features.Files.Services;
 using Platform.Api.Insight.Features.Income.Parameters;
 using Platform.Api.Insight.Features.Income.Services;
 using Platform.Api.Insight.Features.Income.Validators;
@@ -50,7 +51,8 @@ internal static class Services
             .AddSingleton<ITrustsService, TrustsService>()
             .AddSingleton<IExpenditureService, ExpenditureService>()
             .AddSingleton<IIncomeService, IncomeService>()
-            .AddSingleton<IBudgetForecastService, BudgetForecastService>();
+            .AddSingleton<IBudgetForecastService, BudgetForecastService>()
+            .AddSingleton<IFilesService, FilesService>();
 
         serviceCollection
             .AddTransient<IValidator<ExpenditureParameters>, ExpenditureParametersValidator>()

--- a/platform/src/apis/Platform.Api.Insight/Constants.cs
+++ b/platform/src/apis/Platform.Api.Insight/Constants.cs
@@ -15,5 +15,6 @@ public static class Constants
         public const string Expenditure = "Expenditure";
         public const string Years = "Years";
         public const string HealthCheck = "Health Check";
+        public const string Files = "Files";
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Files/GetAarTransparencyFilesFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Files/GetAarTransparencyFilesFunction.cs
@@ -1,0 +1,26 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Platform.Api.Insight.Features.Files.Responses;
+using Platform.Api.Insight.Features.Files.Services;
+using Platform.Functions;
+using Platform.Functions.Extensions;
+using Platform.Functions.OpenApi;
+
+namespace Platform.Api.Insight.Features.Files;
+
+public class GetAarTransparencyFilesFunction(IFilesService service)
+{
+    [Function(nameof(GetAarTransparencyFilesFunction))]
+    [OpenApiSecurityHeader]
+    [OpenApiOperation(nameof(GetAarTransparencyFilesFunction), Constants.Features.Files)]
+    [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(FileResponse[]))]
+    public async Task<HttpResponseData> RunAsync(
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.TransparencyAar)] HttpRequestData req)
+    {
+        var result = await service.GetAarTransparencyFiles();
+        return await req.CreateJsonResponseAsync(result.MapToApiResponse());
+    }
+}

--- a/platform/src/apis/Platform.Api.Insight/Features/Files/GetCfrTransparencyFilesFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Files/GetCfrTransparencyFilesFunction.cs
@@ -1,0 +1,26 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Platform.Api.Insight.Features.Files.Responses;
+using Platform.Api.Insight.Features.Files.Services;
+using Platform.Functions;
+using Platform.Functions.Extensions;
+using Platform.Functions.OpenApi;
+
+namespace Platform.Api.Insight.Features.Files;
+
+public class GetCfrTransparencyFilesFunction(IFilesService service)
+{
+    [Function(nameof(GetCfrTransparencyFilesFunction))]
+    [OpenApiSecurityHeader]
+    [OpenApiOperation(nameof(GetCfrTransparencyFilesFunction), Constants.Features.Files)]
+    [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(FileResponse[]))]
+    public async Task<HttpResponseData> RunAsync(
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.TransparencyCfr)] HttpRequestData req)
+    {
+        var result = await service.GetCfrTransparencyFiles();
+        return await req.CreateJsonResponseAsync(result.MapToApiResponse());
+    }
+}

--- a/platform/src/apis/Platform.Api.Insight/Features/Files/Mapper.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Files/Mapper.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Platform.Api.Insight.Features.Files.Models;
+using Platform.Api.Insight.Features.Files.Responses;
+
+namespace Platform.Api.Insight.Features.Files;
+
+[ExcludeFromCodeCoverage]
+public static class Mapper
+{
+    public static IEnumerable<FileResponse> MapToApiResponse(this IEnumerable<FileModel> models) => models.Select(MapToApiResponse);
+
+    private static FileResponse MapToApiResponse(this FileModel model)
+    {
+        if (model == null)
+        {
+            throw new ArgumentNullException(nameof(model), "Model cannot be null.");
+        }
+
+        return new FileResponse
+        {
+            Label = model.Label,
+            FileName = model.FileName
+        };
+    }
+}

--- a/platform/src/apis/Platform.Api.Insight/Features/Files/Models/FileModel.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Files/Models/FileModel.cs
@@ -1,0 +1,12 @@
+﻿using System.Diagnostics.CodeAnalysis;
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+// ReSharper disable ClassNeverInstantiated.Global
+
+namespace Platform.Api.Insight.Features.Files.Models;
+
+[ExcludeFromCodeCoverage]
+public record FileModel
+{
+    public string? Label { get; set; }
+    public string? FileName { get; set; }
+}

--- a/platform/src/apis/Platform.Api.Insight/Features/Files/Responses/FileResponse.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Files/Responses/FileResponse.cs
@@ -1,0 +1,11 @@
+﻿using System.Diagnostics.CodeAnalysis;
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+
+namespace Platform.Api.Insight.Features.Files.Responses;
+
+[ExcludeFromCodeCoverage]
+public record FileResponse
+{
+    public string? Label { get; set; }
+    public string? FileName { get; set; }
+}

--- a/platform/src/apis/Platform.Api.Insight/Features/Files/Routes.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Files/Routes.cs
@@ -1,0 +1,7 @@
+﻿namespace Platform.Api.Insight.Features.Files;
+
+public static class Routes
+{
+    public const string TransparencyAar = "files/transparency/aar";
+    public const string TransparencyCfr = "files/transparency/cfr";
+}

--- a/platform/src/apis/Platform.Api.Insight/Features/Files/Services/FilesService.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Files/Services/FilesService.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Platform.Api.Insight.Features.Files.Models;
+using Platform.Sql;
+
+namespace Platform.Api.Insight.Features.Files.Services;
+
+public interface IFilesService
+{
+    Task<IEnumerable<FileModel>> GetAarTransparencyFiles();
+    Task<IEnumerable<FileModel>> GetCfrTransparencyFiles();
+}
+
+[ExcludeFromCodeCoverage]
+public class FilesService(IDatabaseFactory dbFactory) : IFilesService
+{
+    public Task<IEnumerable<FileModel>> GetAarTransparencyFiles() => GetTransparencyFiles("VW_TransparencyFilesAar");
+
+    public Task<IEnumerable<FileModel>> GetCfrTransparencyFiles() => GetTransparencyFiles("VW_TransparencyFilesCfr");
+
+    private async Task<IEnumerable<FileModel>> GetTransparencyFiles(string view)
+    {
+        var sql = $"SELECT [Label], [FileName] from {view} ORDER BY [Label]";
+        using var conn = await dbFactory.GetConnection();
+        return await conn.QueryAsync<FileModel>(sql);
+    }
+}

--- a/platform/tests/Platform.ApiTests/Features/InsightFiles.feature
+++ b/platform/tests/Platform.ApiTests/Features/InsightFiles.feature
@@ -1,0 +1,31 @@
+﻿Feature: Insights files endpoints
+
+    Scenario: Sending a valid AAR transparency files request
+        Given an AAR transparency files request
+        When I submit the insights files request
+        Then the result should be ok and contain:
+          | Label       | FileName                    |
+          | AAR 2014/15 | SFR27_2016_Main_Tables.xlsx |
+          | AAR 2015/16 | SFR32_2017_Main_Tables.xlsx |
+          | AAR 2016/17 | AAR_2016-17_download.xlsx   |
+          | AAR 2017/18 | AAR_2017-18_download.xlsx   |
+          | AAR 2018/19 | AAR_2018-19_download.xlsx   |
+          | AAR 2019/20 | AAR_2019-20_download.xlsx   |
+          | AAR 2020/21 | AAR_2020-21_download.xlsx   |
+          | AAR 2021/22 | AAR_2021-22_download.xlsx   |
+          | AAR 2022/23 | AAR_2022-23_download.xlsx   |
+
+    Scenario: Sending a valid CFR transparency files request
+        Given an CFR transparency files request
+        When I submit the insights files request
+        Then the result should be ok and contain:
+          | Label       | FileName                            |
+          | CFR 2014/15 | CFR_2014-15_Full_Data_Workbook.xlsx |
+          | CFR 2015/16 | CFR_2015-16_Full_Data_Workbook.xlsx |
+          | CFR 2016/17 | CFR_2016-17_Full_Data_Workbook.xlsx |
+          | CFR 2017/18 | CFR_2017-18_Full_Data_Workbook.xlsx |
+          | CFR 2018/19 | CFR_2018-19_Full_Data_Workbook.xlsx |
+          | CFR 2019/20 | CFR_2019-20_Full_Data_Workbook.xlsx |
+          | CFR 2020/21 | CFR_2020-21_Full_Data_Workbook.xlsx |
+          | CFR 2021/22 | CFR_2021-22_Full_Data_Workbook.xlsx |
+          | CFR 2022/23 | CFR_2022-23_Full_Data_Workbook.xlsx |

--- a/platform/tests/Platform.ApiTests/Steps/InsightFilesSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/InsightFilesSteps.cs
@@ -1,0 +1,53 @@
+﻿using System.Net;
+using FluentAssertions;
+using Platform.Api.Insight.Features.Files.Responses;
+using Platform.ApiTests.Drivers;
+using Platform.Json;
+
+namespace Platform.ApiTests.Steps;
+
+[Binding]
+[Scope(Feature = "Insights files endpoints")]
+public class InsightFilesSteps(InsightApiDriver api)
+{
+    private const string FilesKey = "files";
+
+    [Given("an AAR transparency files request")]
+    public void GivenAnAarTransparencyFilesRequest()
+    {
+        api.CreateRequest(FilesKey, new HttpRequestMessage
+        {
+            RequestUri = new Uri("/api/files/transparency/aar", UriKind.Relative),
+            Method = HttpMethod.Get
+        });
+    }
+
+    [Given("an CFR transparency files request")]
+    public void GivenAnCfrTransparencyFilesRequest()
+    {
+        api.CreateRequest(FilesKey, new HttpRequestMessage
+        {
+            RequestUri = new Uri("/api/files/transparency/cfr", UriKind.Relative),
+            Method = HttpMethod.Get
+        });
+    }
+
+    [When("I submit the insights files request")]
+    public async Task WhenISubmitTheInsightsFilesRequest()
+    {
+        await api.Send();
+    }
+
+    [Then("the result should be ok and contain:")]
+    public async Task ThenTheResultShouldBeOkAndContain(DataTable table)
+    {
+        var response = api[FilesKey].Response;
+
+        response.Should().NotBeNull();
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsByteArrayAsync();
+        var result = content.FromJson<FileResponse[]>();
+        table.CompareToSet(result);
+    }
+}

--- a/platform/tests/Platform.Insight.Tests/Files/GetAarTransparencyFilesFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Files/GetAarTransparencyFilesFunctionTests.cs
@@ -1,0 +1,46 @@
+using System.Net;
+using AutoFixture;
+using Moq;
+using Platform.Api.Insight.Features.Files;
+using Platform.Api.Insight.Features.Files.Models;
+using Platform.Api.Insight.Features.Files.Responses;
+using Platform.Api.Insight.Features.Files.Services;
+using Platform.Functions;
+using Platform.Test;
+using Platform.Test.Extensions;
+using Xunit;
+
+namespace Platform.Insight.Tests.Files;
+
+public class GetAarTransparencyFilesFunctionTests : FunctionsTestBase
+{
+    private readonly Fixture _fixture;
+    private readonly GetAarTransparencyFilesFunction _function;
+    private readonly Mock<IFilesService> _service;
+
+    public GetAarTransparencyFilesFunctionTests()
+    {
+        _service = new Mock<IFilesService>();
+        _fixture = new Fixture();
+        _function = new GetAarTransparencyFilesFunction(_service.Object);
+    }
+
+    [Fact]
+    public async Task ShouldReturn200OnValidRequest()
+    {
+        var models = _fixture.CreateMany<FileModel>();
+
+        _service
+            .Setup(d => d.GetAarTransparencyFiles())
+            .ReturnsAsync(models);
+
+        var result = await _function.RunAsync(CreateHttpRequestData());
+
+        Assert.NotNull(result);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal(ContentType.ApplicationJson, result.ContentType());
+
+        var body = await result.ReadAsJsonAsync<FileResponse[]>();
+        Assert.NotNull(body);
+    }
+}

--- a/platform/tests/Platform.Insight.Tests/Files/GetCfrTransparencyFilesFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Files/GetCfrTransparencyFilesFunctionTests.cs
@@ -1,0 +1,46 @@
+using System.Net;
+using AutoFixture;
+using Moq;
+using Platform.Api.Insight.Features.Files;
+using Platform.Api.Insight.Features.Files.Models;
+using Platform.Api.Insight.Features.Files.Responses;
+using Platform.Api.Insight.Features.Files.Services;
+using Platform.Functions;
+using Platform.Test;
+using Platform.Test.Extensions;
+using Xunit;
+
+namespace Platform.Insight.Tests.Files;
+
+public class GetCfrTransparencyFilesFunctionTests : FunctionsTestBase
+{
+    private readonly Fixture _fixture;
+    private readonly GetCfrTransparencyFilesFunction _function;
+    private readonly Mock<IFilesService> _service;
+
+    public GetCfrTransparencyFilesFunctionTests()
+    {
+        _service = new Mock<IFilesService>();
+        _fixture = new Fixture();
+        _function = new GetCfrTransparencyFilesFunction(_service.Object);
+    }
+
+    [Fact]
+    public async Task ShouldReturn200OnValidRequest()
+    {
+        var models = _fixture.CreateMany<FileModel>();
+
+        _service
+            .Setup(d => d.GetCfrTransparencyFiles())
+            .ReturnsAsync(models);
+
+        var result = await _function.RunAsync(CreateHttpRequestData());
+
+        Assert.NotNull(result);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal(ContentType.ApplicationJson, result.ContentType());
+
+        var body = await result.ReadAsJsonAsync<FileResponse[]>();
+        Assert.NotNull(body);
+    }
+}


### PR DESCRIPTION
### Context
[AB#244999](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/244999) [AB#244563](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/244563)

### Change proposed in this pull request
- New table and view for system files, with initial seeding
- API for getting CFR and AAR files from the database
- Unit and API tests

### Guidance to review 
Run the migrations against a local database and then run the Insight API pointing to that database. The URLs `http://localhost:7071/api/files/transparency/aar` and `http://localhost:7071/api/files/transparency/cfr` may then be used to get each set of transparency files.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

