### PR TITLE
Consume API and write transparency files to Data Sources page

### DIFF
--- a/web/src/Web.App/Controllers/DataSourceController.cs
+++ b/web/src/Web.App/Controllers/DataSourceController.cs
@@ -1,79 +1,54 @@
 ﻿using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
-using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Apis.Insight;
+using Web.App.Infrastructure.Extensions;
 using Web.App.Infrastructure.Storage;
 using Web.App.ViewModels;
+using File = Web.App.Domain.File;
 
 namespace Web.App.Controllers;
 
-
 [Controller]
 [Route("data-sources")]
-public class DataSourceController(ILogger<DataSourceController> logger, IDataSourceStorage storage)
+public class DataSourceController(ILogger<DataSourceController> logger, IDataSourceStorage storage, IFilesApi filesApi)
     : Controller
 {
-    private static readonly (string Description, string FileName)[] MaintainedSchools =
-        [
-            ("CFR 2022/23", "CFR_2022-23_Full_Data_Workbook.xlsx"),
-            ("CFR 2021/22", "CFR_2021-22_Full_Data_Workbook.xlsx"),
-            ("CFR 2020/21", "CFR_2020-21_Full_Data_Workbook.xlsx"),
-            ("CFR 2019/20", "CFR_2019-20_Full_Data_Workbook.xlsx"),
-            ("CFR 2018/19", "CFR_2018-19_Full_Data_Workbook.xlsx"),
-            ("CFR 2017/18", "CFR_2017-18_Full_Data_Workbook.xlsx"),
-            ("CFR 2016/17", "CFR_2016-17_Full_Data_Workbook.xlsx"),
-            ("CFR 2015/16", "CFR_2015-16_Full_Data_Workbook.xlsx"),
-            ("CFR 2014/15", "CFR_2014-15_Full_Data_Workbook.xlsx"),
-        ];
-    private static readonly (string Description, string FileName)[] Academies =
-        [
-            ("AAR 2022/23", "AAR_2022-23_download.xlsx"),
-            ("AAR 2021/22", "AAR_2021-22_download.xlsx"),
-            ("AAR 2020/21", "AAR_2020-21_download.xlsx"),
-            ("AAR 2019/20", "AAR_2019-20_download.xlsx"),
-            ("AAR 2018/19", "AAR_2018-19_download.xlsx"),
-            ("AAR 2017/18", "AAR_2017-18_download.xlsx"),
-            ("AAR 2016/17", "AAR_2016-17_download.xlsx"),
-            ("AAR 2015/16", "SFR32_2017_Main_Tables.xlsx"),
-            ("AAR 2014/15", "SFR27_2016_Main_Tables.xlsx"),
-        ];
-
     [HttpGet]
-    public IActionResult Index()
+    public async Task<IActionResult> Index()
     {
-        using (logger.BeginScope(new { }))
+        IEnumerable<DataSourceFileViewModel> academies = [];
+        IEnumerable<DataSourceFileViewModel> maintainedSchools = [];
+
+        try
         {
-            try
-            {
-                ViewData[ViewDataKeys.UseJsBackLink] = true;
+            ViewData[ViewDataKeys.UseJsBackLink] = true;
 
-                var sas = storage.GetAccessToken();
+            var sas = storage.GetAccessToken();
 
-                var academies = Academies.Select(x => BuildViewModel(x.Description, x.FileName, sas));
-                var maintainedSchools = MaintainedSchools.Select(x => BuildViewModel(x.Description, x.FileName, sas));
+            var aarFiles = await filesApi.GetAarTransparencyFiles().GetResultOrDefault<File[]>() ?? [];
+            academies = aarFiles
+                .OrderByDescending(x => x.Label)
+                .Select(x => BuildViewModel(x.Label, x.FileName, sas));
 
-                var vm = new DataSourceViewModel(academies, maintainedSchools);
-
-                return View(vm);
-            }
-            catch (Exception e)
-            {
-                logger.LogError(e, "An error occurred displaying data sources: {DisplayUrl}", Request.GetDisplayUrl());
-                return e is StatusCodeException s ? StatusCode((int)s.Status) : StatusCode(500);
-            }
+            var cfrFiles = await filesApi.GetCfrTransparencyFiles().GetResultOrDefault<File[]>() ?? [];
+            maintainedSchools = cfrFiles
+                .OrderByDescending(x => x.Label)
+                .Select(x => BuildViewModel(x.Label, x.FileName, sas));
         }
-    }
-
-    private static DataSourceFileViewModel BuildViewModel(string description, string fileName, SharedAccessTokenModel accessTokenModel)
-    {
-        return new DataSourceFileViewModel
+        catch (Exception e)
         {
-            DisplayText = description,
-            Link = BuildFileUri(accessTokenModel, fileName)
-        };
+            logger.LogError(e, "An error occurred displaying data sources: {DisplayUrl}", Request.GetDisplayUrl());
+        }
+
+        var vm = new DataSourceViewModel(academies, maintainedSchools);
+        return View(vm);
     }
 
-    private static Uri BuildFileUri(SharedAccessTokenModel accessTokenModel, string fileName)
+    private static DataSourceFileViewModel BuildViewModel(string? description, string? fileName, SharedAccessTokenModel accessTokenModel) => new()
     {
-        return new Uri($"{accessTokenModel.ContainerUri}/{fileName}{accessTokenModel.SasToken}");
-    }
+        DisplayText = description,
+        Link = string.IsNullOrWhiteSpace(fileName) ? null : BuildFileUri(accessTokenModel, fileName)
+    };
+
+    private static Uri BuildFileUri(SharedAccessTokenModel accessTokenModel, string fileName) => new($"{accessTokenModel.ContainerUri}/{fileName}{accessTokenModel.SasToken}");
 }

--- a/web/src/Web.App/Domain/Insight/Files.cs
+++ b/web/src/Web.App/Domain/Insight/Files.cs
@@ -1,0 +1,7 @@
+﻿namespace Web.App.Domain;
+
+public record File
+{
+    public string? Label { get; set; }
+    public string? FileName { get; set; }
+}

--- a/web/src/Web.App/Extensions/ServiceCollectionExtensions.cs
+++ b/web/src/Web.App/Extensions/ServiceCollectionExtensions.cs
@@ -5,14 +5,12 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
-using Web.App.Domain;
 using Web.App.Identity;
 using Web.App.Identity.Models;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.Benchmark;
 using Web.App.Infrastructure.Apis.Establishment;
 using Web.App.Infrastructure.Apis.Insight;
-using Web.App.Infrastructure.Extensions;
 using Web.App.Infrastructure.Storage;
 using Web.App.Services;
 
@@ -78,6 +76,7 @@ public static class ServiceCollectionExtensions
         services.AddHttpClient<ITrustInsightApi, TrustInsightApi>().Configure<TrustInsightApi>(section);
         services.AddHttpClient<IBudgetForecastApi, BudgetForecastApi>().Configure<BudgetForecastApi>(section);
         services.AddHttpClient<IHealthApi, HealthApi>().Configure<HealthApi>(section);
+        services.AddHttpClient<IFilesApi, FilesApi>().Configure<FilesApi>(section);
 
         return services;
     }

--- a/web/src/Web.App/Infrastructure/Apis/Insight/Api.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Insight/Api.cs
@@ -38,6 +38,12 @@ public static class Api
         public static string TrustHistory(string? companyNo) => $"api/expenditure/trust/{companyNo}/history";
     }
 
+    public static class Files
+    {
+        public static string TransparencyAar => "api/files/transparency/aar";
+        public static string TransparencyCfr => "api/files/transparency/cfr";
+    }
+
     public static class Income
     {
         public static string School(string? urn) => $"api/income/school/{urn}";

--- a/web/src/Web.App/Infrastructure/Apis/Insight/FilesApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Insight/FilesApi.cs
@@ -1,0 +1,13 @@
+﻿namespace Web.App.Infrastructure.Apis.Insight;
+
+public interface IFilesApi
+{
+    Task<ApiResult> GetAarTransparencyFiles();
+    Task<ApiResult> GetCfrTransparencyFiles();
+}
+
+public class FilesApi(HttpClient httpClient, string? key = default) : ApiBase(httpClient, key), IFilesApi
+{
+    public async Task<ApiResult> GetAarTransparencyFiles() => await GetAsync(Api.Files.TransparencyAar);
+    public async Task<ApiResult> GetCfrTransparencyFiles() => await GetAsync(Api.Files.TransparencyCfr);
+}

--- a/web/src/Web.App/ViewModels/DataSourceViewModel.cs
+++ b/web/src/Web.App/ViewModels/DataSourceViewModel.cs
@@ -6,6 +6,7 @@ public record DataSourceViewModel(
 {
     public IEnumerable<DataSourceFileViewModel> Academies { get; set; } = Academies;
     public IEnumerable<DataSourceFileViewModel> MaintainedSchools { get; set; } = MaintainedSchools;
+    public bool MissingFiles => !Academies.Any() || !MaintainedSchools.Any();
 }
 
 public record DataSourceFileViewModel

--- a/web/src/Web.App/Views/DataSource/_DataSources.cshtml
+++ b/web/src/Web.App/Views/DataSource/_DataSources.cshtml
@@ -1,10 +1,12 @@
 ﻿@using Web.App.Extensions
+@model Web.App.ViewModels.DataSourceViewModel
 <h2 class="govuk-heading-l">Data Sources</h2>
 
 <h3 class="govuk-heading-m">Types of schools you can get data for</h3>
 
 <p class="govuk-body">
-    The data on the site is for maintained schools and academies in England. It's based on schools' Consistent Financial Reporting (CFR) returns and academies' accounts returns (AAR).
+    The data on the site is for maintained schools and academies in England. It's based on schools' Consistent Financial
+    Reporting (CFR) returns and academies' accounts returns (AAR).
 </p>
 
 <p class="govuk-body">
@@ -14,38 +16,52 @@
 <h3 class="govuk-heading-m">Financial returns</h3>
 
 <p class="govuk-body">
-    This data is based on schools' Consistent Financial Reporting (CFR) returns for Local Authority (LA) maintained schools and academies' accounts returns (AARs).
+    This data is based on schools' Consistent Financial Reporting (CFR) returns for Local Authority (LA) maintained
+    schools and academies' accounts returns (AARs).
 </p>
 
-<section id="data-sources-cfr">
-    <h4 class="govuk-heading-s">LA Maintained Schools</h4>
-    <ul class="govuk-list">
-        @foreach (var dataSourceFile in Model.MaintainedSchools)
-        {
-            <li>
-                <a target="_blank" rel="external noopener noreferrer" class="govuk-link" href=@dataSourceFile.Link>
-                @dataSourceFile.DisplayText
-                <span class="govuk-visually-hidden"> link will open an Excel spreadsheet</span>
-            </a>
-            </li>
-        }
-    </ul>
-</section>
+@if (Model.MissingFiles)
+{
+    <p class="govuk-body">
+        Transparency files are unavailable for download at this time. Please try again later.
+    </p>
+}
 
-<section id="data-sources-aar">
-    <h4 class="govuk-heading-s">Academies</h4>
-    <ul class="govuk-list">
-        @foreach (var dataSourceFile in Model.Academies)
-        {
-            <li>
-                <a target="_blank" rel="external noopener noreferrer" class="govuk-link" href=@dataSourceFile.Link>
-                @dataSourceFile.DisplayText
-                <span class="govuk-visually-hidden"> link will open an Excel spreadsheet</span>
-            </a>
-            </li>
-        }
-    </ul>
-</section>
+@if (Model.MaintainedSchools.Any())
+{
+    <section id="data-sources-cfr">
+        <h4 class="govuk-heading-s">LA Maintained Schools</h4>
+        <ul class="govuk-list">
+            @foreach (var dataSourceFile in Model.MaintainedSchools)
+            {
+                <li>
+                    <a target="_blank" rel="external noopener noreferrer" class="govuk-link" href=@dataSourceFile.Link>
+                        @dataSourceFile.DisplayText
+                        <span class="govuk-visually-hidden"> link will open an Excel spreadsheet</span>
+                    </a>
+                </li>
+            }
+        </ul>
+    </section>
+}
+
+@if (Model.Academies.Any())
+{
+    <section id="data-sources-aar">
+        <h4 class="govuk-heading-s">Academies</h4>
+        <ul class="govuk-list">
+            @foreach (var dataSourceFile in Model.Academies)
+            {
+                <li>
+                    <a target="_blank" rel="external noopener noreferrer" class="govuk-link" href=@dataSourceFile.Link>
+                        @dataSourceFile.DisplayText
+                        <span class="govuk-visually-hidden"> link will open an Excel spreadsheet</span>
+                    </a>
+                </li>
+            }
+        </ul>
+    </section>
+}
 
 <h3 class="govuk-heading-m">Performance tables</h3>
 

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -10,6 +10,7 @@ using Web.App.Infrastructure.Apis.Establishment;
 using Web.App.Infrastructure.Apis.Insight;
 using Web.App.Infrastructure.Storage;
 using Xunit.Abstractions;
+using File = Web.App.Domain.File;
 
 namespace Web.Integration.Tests;
 
@@ -45,6 +46,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     public Mock<IHttpContextAccessor> HttpContextAccessor { get; } = new();
     public Mock<IDataSourceStorage> DataSourceStorage { get; } = new();
     public Mock<IFeatureManager> FeatureManager { get; } = new();
+    public Mock<IFilesApi> FilesApi { get; } = new();
 
 
     protected override void Configure(IServiceCollection services)
@@ -68,6 +70,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         services.AddSingleton(HttpContextAccessor.Object);
         services.AddSingleton(DataSourceStorage.Object);
         services.AddSingleton(FeatureManager.Object);
+        services.AddSingleton(FilesApi.Object);
 
         EnableFeatures();
     }
@@ -109,6 +112,14 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         DataSourceStorage.Reset();
         DataSourceStorage.Setup(storage => storage.GetAccessToken()).Returns(sharedAccessTokenModel);
 
+        return this;
+    }
+
+    public BenchmarkingWebAppClient SetupFiles(File[]? aarFiles = null, File[]? cfrFiles = null)
+    {
+        FilesApi.Reset();
+        FilesApi.Setup(api => api.GetAarTransparencyFiles()).ReturnsAsync(ApiResult.Ok(aarFiles));
+        FilesApi.Setup(api => api.GetCfrTransparencyFiles()).ReturnsAsync(ApiResult.Ok(cfrFiles));
         return this;
     }
 

--- a/web/tests/Web.Integration.Tests/Pages/WhenViewingDataSources.cs
+++ b/web/tests/Web.Integration.Tests/Pages/WhenViewingDataSources.cs
@@ -1,4 +1,5 @@
 ﻿using Xunit;
+using File = Web.App.Domain.File;
 
 namespace Web.Integration.Tests.Pages;
 
@@ -7,33 +8,206 @@ public class WhenViewingDataSources(SchoolBenchmarkingWebAppClient client) : Pag
     [Fact]
     public async Task CanDisplay()
     {
+        var cfrFiles = new File[]
+        {
+            new()
+            {
+                Label = "CFR 2022/23",
+                FileName = "CFR_2022-23_Full_Data_Workbook.xlsx"
+            },
+            new()
+            {
+                Label = "CFR 2021/22",
+                FileName = "CFR_2021-22_Full_Data_Workbook.xlsx"
+            },
+            new()
+            {
+                Label = "CFR 2020/21",
+                FileName = "CFR_2020-21_Full_Data_Workbook.xlsx"
+            },
+            new()
+            {
+                Label = "CFR 2019/20",
+                FileName = "CFR_2019-20_Full_Data_Workbook.xlsx"
+            },
+            new()
+            {
+                Label = "CFR 2018/19",
+                FileName = "CFR_2018-19_Full_Data_Workbook.xlsx"
+            },
+            new()
+            {
+                Label = "CFR 2017/18",
+                FileName = "CFR_2017-18_Full_Data_Workbook.xlsx"
+            },
+            new()
+            {
+                Label = "CFR 2016/17",
+                FileName = "CFR_2016-17_Full_Data_Workbook.xlsx"
+            },
+            new()
+            {
+                Label = "CFR 2015/16",
+                FileName = "CFR_2015-16_Full_Data_Workbook.xlsx"
+            },
+            new()
+            {
+                Label = "CFR 2014/15",
+                FileName = "CFR_2014-15_Full_Data_Workbook.xlsx"
+            }
+        };
+
         var expectedMaintainedSchools = new[]
         {
-            new { DisplayText = "CFR 2022/23", Link = "https://teststorageaccount.net/testcontainer/CFR_2022-23_Full_Data_Workbook.xlsx" },
-            new { DisplayText = "CFR 2021/22", Link = "https://teststorageaccount.net/testcontainer/CFR_2021-22_Full_Data_Workbook.xlsx" },
-            new { DisplayText = "CFR 2020/21", Link = "https://teststorageaccount.net/testcontainer/CFR_2020-21_Full_Data_Workbook.xlsx" },
-            new { DisplayText = "CFR 2019/20", Link = "https://teststorageaccount.net/testcontainer/CFR_2019-20_Full_Data_Workbook.xlsx" },
-            new { DisplayText = "CFR 2018/19", Link = "https://teststorageaccount.net/testcontainer/CFR_2018-19_Full_Data_Workbook.xlsx" },
-            new { DisplayText = "CFR 2017/18", Link = "https://teststorageaccount.net/testcontainer/CFR_2017-18_Full_Data_Workbook.xlsx" },
-            new { DisplayText = "CFR 2016/17", Link = "https://teststorageaccount.net/testcontainer/CFR_2016-17_Full_Data_Workbook.xlsx" },
-            new { DisplayText = "CFR 2015/16", Link = "https://teststorageaccount.net/testcontainer/CFR_2015-16_Full_Data_Workbook.xlsx" },
-            new { DisplayText = "CFR 2014/15", Link = "https://teststorageaccount.net/testcontainer/CFR_2014-15_Full_Data_Workbook.xlsx" },
+            new
+            {
+                DisplayText = "CFR 2022/23",
+                Link = "https://teststorageaccount.net/testcontainer/CFR_2022-23_Full_Data_Workbook.xlsx"
+            },
+            new
+            {
+                DisplayText = "CFR 2021/22",
+                Link = "https://teststorageaccount.net/testcontainer/CFR_2021-22_Full_Data_Workbook.xlsx"
+            },
+            new
+            {
+                DisplayText = "CFR 2020/21",
+                Link = "https://teststorageaccount.net/testcontainer/CFR_2020-21_Full_Data_Workbook.xlsx"
+            },
+            new
+            {
+                DisplayText = "CFR 2019/20",
+                Link = "https://teststorageaccount.net/testcontainer/CFR_2019-20_Full_Data_Workbook.xlsx"
+            },
+            new
+            {
+                DisplayText = "CFR 2018/19",
+                Link = "https://teststorageaccount.net/testcontainer/CFR_2018-19_Full_Data_Workbook.xlsx"
+            },
+            new
+            {
+                DisplayText = "CFR 2017/18",
+                Link = "https://teststorageaccount.net/testcontainer/CFR_2017-18_Full_Data_Workbook.xlsx"
+            },
+            new
+            {
+                DisplayText = "CFR 2016/17",
+                Link = "https://teststorageaccount.net/testcontainer/CFR_2016-17_Full_Data_Workbook.xlsx"
+            },
+            new
+            {
+                DisplayText = "CFR 2015/16",
+                Link = "https://teststorageaccount.net/testcontainer/CFR_2015-16_Full_Data_Workbook.xlsx"
+            },
+            new
+            {
+                DisplayText = "CFR 2014/15",
+                Link = "https://teststorageaccount.net/testcontainer/CFR_2014-15_Full_Data_Workbook.xlsx"
+            }
+        };
+
+        var aarFiles = new File[]
+        {
+            new()
+            {
+                Label = "AAR 2022/23",
+                FileName = "AAR_2022-23_download.xlsx"
+            },
+            new()
+            {
+                Label = "AAR 2021/22",
+                FileName = "AAR_2021-22_download.xlsx"
+            },
+            new()
+            {
+                Label = "AAR 2020/21",
+                FileName = "AAR_2020-21_download.xlsx"
+            },
+            new()
+            {
+                Label = "AAR 2019/20",
+                FileName = "AAR_2019-20_download.xlsx"
+            },
+            new()
+            {
+                Label = "AAR 2018/19",
+                FileName = "AAR_2018-19_download.xlsx"
+            },
+            new()
+            {
+                Label = "AAR 2017/18",
+                FileName = "AAR_2017-18_download.xlsx"
+            },
+            new()
+            {
+                Label = "AAR 2016/17",
+                FileName = "AAR_2016-17_download.xlsx"
+            },
+            new()
+            {
+                Label = "AAR 2015/16",
+                FileName = "SFR32_2017_Main_Tables.xlsx"
+            },
+            new()
+            {
+                Label = "AAR 2014/15",
+                FileName = "SFR27_2016_Main_Tables.xlsx"
+            }
         };
 
         var expectedAcademies = new[]
         {
-            new { DisplayText = "AAR 2022/23", Link = "https://teststorageaccount.net/testcontainer/AAR_2022-23_download.xlsx" },
-            new { DisplayText = "AAR 2021/22", Link = "https://teststorageaccount.net/testcontainer/AAR_2021-22_download.xlsx" },
-            new { DisplayText = "AAR 2020/21", Link = "https://teststorageaccount.net/testcontainer/AAR_2020-21_download.xlsx" },
-            new { DisplayText = "AAR 2019/20", Link = "https://teststorageaccount.net/testcontainer/AAR_2019-20_download.xlsx" },
-            new { DisplayText = "AAR 2018/19", Link = "https://teststorageaccount.net/testcontainer/AAR_2018-19_download.xlsx" },
-            new { DisplayText = "AAR 2017/18", Link = "https://teststorageaccount.net/testcontainer/AAR_2017-18_download.xlsx" },
-            new { DisplayText = "AAR 2016/17", Link = "https://teststorageaccount.net/testcontainer/AAR_2016-17_download.xlsx" },
-            new { DisplayText = "AAR 2015/16", Link = "https://teststorageaccount.net/testcontainer/SFR32_2017_Main_Tables.xlsx" },
-            new { DisplayText = "AAR 2014/15", Link = "https://teststorageaccount.net/testcontainer/SFR27_2016_Main_Tables.xlsx" },
+            new
+            {
+                DisplayText = "AAR 2022/23",
+                Link = "https://teststorageaccount.net/testcontainer/AAR_2022-23_download.xlsx"
+            },
+            new
+            {
+                DisplayText = "AAR 2021/22",
+                Link = "https://teststorageaccount.net/testcontainer/AAR_2021-22_download.xlsx"
+            },
+            new
+            {
+                DisplayText = "AAR 2020/21",
+                Link = "https://teststorageaccount.net/testcontainer/AAR_2020-21_download.xlsx"
+            },
+            new
+            {
+                DisplayText = "AAR 2019/20",
+                Link = "https://teststorageaccount.net/testcontainer/AAR_2019-20_download.xlsx"
+            },
+            new
+            {
+                DisplayText = "AAR 2018/19",
+                Link = "https://teststorageaccount.net/testcontainer/AAR_2018-19_download.xlsx"
+            },
+            new
+            {
+                DisplayText = "AAR 2017/18",
+                Link = "https://teststorageaccount.net/testcontainer/AAR_2017-18_download.xlsx"
+            },
+            new
+            {
+                DisplayText = "AAR 2016/17",
+                Link = "https://teststorageaccount.net/testcontainer/AAR_2016-17_download.xlsx"
+            },
+            new
+            {
+                DisplayText = "AAR 2015/16",
+                Link = "https://teststorageaccount.net/testcontainer/SFR32_2017_Main_Tables.xlsx"
+            },
+            new
+            {
+                DisplayText = "AAR 2014/15",
+                Link = "https://teststorageaccount.net/testcontainer/SFR27_2016_Main_Tables.xlsx"
+            }
         };
 
-        var page = await Client.SetupStorage().Navigate(Paths.DataSources);
+        var page = await Client
+            .SetupStorage()
+            .SetupFiles(aarFiles, cfrFiles)
+            .Navigate(Paths.DataSources);
 
         var laHeading = page.QuerySelectorAll("h4.govuk-heading-s")
             .FirstOrDefault(h => h.TextContent.Contains("LA Maintained Schools"));
@@ -45,7 +219,7 @@ public class WhenViewingDataSources(SchoolBenchmarkingWebAppClient client) : Pag
         var laReturns = laList.QuerySelectorAll("li > a.govuk-link");
         Assert.NotNull(laReturns);
 
-        for (int i = 0; i < laReturns.Length; i++)
+        for (var i = 0; i < laReturns.Length; i++)
         {
             var link = laReturns[i];
             Assert.Contains(expectedMaintainedSchools[i].DisplayText, link.TextContent);
@@ -62,7 +236,7 @@ public class WhenViewingDataSources(SchoolBenchmarkingWebAppClient client) : Pag
         var academiesReturns = academiesList.QuerySelectorAll("li > a.govuk-link");
         Assert.NotNull(academiesReturns);
 
-        for (int i = 0; i < academiesReturns.Length; i++)
+        for (var i = 0; i < academiesReturns.Length; i++)
         {
             var link = academiesReturns[i];
             Assert.Contains(expectedAcademies[i].DisplayText, link.TextContent);


### PR DESCRIPTION
### Context
[AB#246012](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/246012) [AB#244563](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/244563)

### Change proposed in this pull request
Display list of downloadable transparency files from blob storage based on response from API call instead of hard-coded in application.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

