### PR TITLE
Replaced `recharts-to-png` with `html-to-image`

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -99,14 +99,15 @@
       data-id="02387916"
       data-phases='["Secondary","Primary","Post-16"]'
     ></div>-->
-    <!--<div id="compare-your-costs" data-type="school" data-id="143996"></div>-->
+    <!--<div id="compare-your-costs" data-type="school" data-id="123456"></div>-->
     <!--<div id="historic-data" data-type="school" data-id="990095"></div>-->
-    <div id="historic-data-2" data-type="school" data-id="123456" data-phase="Primary" data-finance-type="Maintained"></div>
-    <!--<div
+    <!--<div id="historic-data-2" data-type="school" data-id="123456" data-phase="Primary" data-finance-type="Maintained"></div>-->
+    <div
       id="compare-your-costs"
       data-type="local-authority"
-      data-id="383"
-    ></div>-->
+      data-id="888"
+      data-phases='["Primary"]'
+    ></div>
     <!--<div id="budget-forecast-returns" data-id="01532445"></div>-->
     <!--<div id="historic-data" data-type="trust" data-id="10377760"></div>-->
     <!--<div id="find-organisation"

--- a/front-end-components/package-lock.json
+++ b/front-end-components/package-lock.json
@@ -13,11 +13,11 @@
         "date-fns": "^4.1.0",
         "file-saver": "^2.0.5",
         "govuk-frontend": "^5.6.0",
+        "html-to-image": "^1.11.11",
         "punycode": "^2.3.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "recharts": "^2.12.4",
-        "recharts-to-png": "^2.3.1",
         "stats-lite": "^2.2.0",
         "usehooks-ts": "^3.1.0",
         "uuid": "^11.0.2"
@@ -4248,14 +4248,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "node_modules/base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -4549,14 +4541,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/css-line-break": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
-      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-      "dependencies": {
-        "utrie": "^1.0.2"
       }
     },
     "node_modules/css.escape": {
@@ -5674,17 +5658,10 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
-    "node_modules/html2canvas": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
-      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-      "dependencies": {
-        "css-line-break": "^2.1.0",
-        "text-segmentation": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
+    "node_modules/html-to-image": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
+      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA=="
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -8308,24 +8285,6 @@
         "decimal.js-light": "^2.4.1"
       }
     },
-    "node_modules/recharts-to-png": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/recharts-to-png/-/recharts-to-png-2.4.0.tgz",
-      "integrity": "sha512-2enABoIsBrI+8NrdFzQCuS/6pIUQVDy9KOPP8VeKN0szLNix5nzfwtyopdTDo6fSKtjojbsQpQ6AN/s5bfJkWg==",
-      "dependencies": {
-        "html2canvas": "^1.2.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.3",
-        "react-dom": ">=16.8.3",
-        "recharts": ">=2.9.0"
-      },
-      "peerDependenciesMeta": {
-        "recharts": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/recharts/node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -8880,14 +8839,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/text-segmentation": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
-      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-      "dependencies": {
-        "utrie": "^1.0.2"
-      }
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -9146,14 +9097,6 @@
       },
       "peerDependencies": {
         "react": "^16.8.0  || ^17 || ^18"
-      }
-    },
-    "node_modules/utrie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
-      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-      "dependencies": {
-        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/front-end-components/package.json
+++ b/front-end-components/package.json
@@ -22,11 +22,11 @@
     "date-fns": "^4.1.0",
     "file-saver": "^2.0.5",
     "govuk-frontend": "^5.6.0",
+    "html-to-image": "^1.11.11",
     "punycode": "^2.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "recharts": "^2.12.4",
-    "recharts-to-png": "^2.3.1",
     "stats-lite": "^2.2.0",
     "usehooks-ts": "^3.1.0",
     "uuid": "^11.0.2"

--- a/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   useImperativeHandle,
   useMemo,
+  useRef,
   useState,
   useContext,
 } from "react";
@@ -38,6 +39,7 @@ import {
 import { CategoricalChartState } from "recharts/types/chart/types";
 import classNames from "classnames";
 import {
+  CategoricalChartWrapper,
   ChartDataSeries,
   ChartHandler,
   ChartSeriesConfigItem,
@@ -94,9 +96,18 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
     );
   }, [data, suppressNegativeOrZero, dataPointKey, keyField, selectedSchool]);
 
-  const { downloadPng, ref: rechartsRef } = useDownloadPngImage({
+  const rechartsRef = useRef<CategoricalChartWrapper>(null);
+  const downloadPng = useDownloadPngImage({
+    ref: rechartsRef,
     fileName: `${chartName}.png`,
     onImageLoading,
+    elementSelector: ({ container }) => container,
+    filter: (node) => {
+      const exclusionClasses = ["recharts-tooltip-wrapper"];
+      return !exclusionClasses.some((classname) =>
+        node.classList?.contains(classname)
+      );
+    },
   });
 
   useImperativeHandle(ref, () => ({
@@ -253,7 +264,10 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
                 left: hasSomeNegativeValues ? margin + 48 : margin,
               }}
               onMouseMove={handleBarChartMouseMove}
-              ref={rechartsRef}
+              ref={
+                // https://github.com/recharts/recharts/issues/2665
+                rechartsRef as never
+              }
               className="recharts-wrapper-horizontal-bar-chart"
             >
               {grid && <CartesianGrid />}

--- a/front-end-components/src/components/charts/line-chart/component.tsx
+++ b/front-end-components/src/components/charts/line-chart/component.tsx
@@ -5,6 +5,7 @@ import {
   forwardRef,
   useImperativeHandle,
   useMemo,
+  useRef,
 } from "react";
 import { LineChartProps } from "src/components/charts/line-chart";
 import {
@@ -18,7 +19,11 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { ChartDataSeries, ChartHandler } from "src/components";
+import {
+  CategoricalChartWrapper,
+  ChartDataSeries,
+  ChartHandler,
+} from "src/components";
 import classNames from "classnames";
 import { useDownloadPngImage } from "src/hooks/useDownloadImage";
 import { LineChartDot } from "../line-chart-dot";
@@ -54,9 +59,12 @@ function LineChartInner<TData extends ChartDataSeries>(
   }: LineChartProps<TData>,
   ref: ForwardedRef<ChartHandler>
 ) {
-  const { downloadPng, ref: rechartsRef } = useDownloadPngImage({
+  const rechartsRef = useRef<CategoricalChartWrapper>(null);
+  const downloadPng = useDownloadPngImage({
+    ref: rechartsRef,
     fileName: `${chartName}.png`,
     onImageLoading,
+    elementSelector: ({ container }) => container,
   });
 
   useImperativeHandle(ref, () => ({
@@ -200,7 +208,10 @@ function LineChartInner<TData extends ChartDataSeries>(
               margin + (seriesLabel ? 10 : 0) + (multiLineAxisLabel ? 10 : 0),
             left: margin,
           }}
-          ref={rechartsRef}
+          ref={
+            // https://github.com/recharts/recharts/issues/2665
+            rechartsRef as never
+          }
           className={classNames("recharts-wrapper-line-chart", className)}
         >
           {grid && <CartesianGrid vertical={false} />}

--- a/front-end-components/src/components/charts/types.tsx
+++ b/front-end-components/src/components/charts/types.tsx
@@ -1,4 +1,5 @@
-import { Ref, SVGProps } from "react";
+import { PureComponent, Ref, SVGProps } from "react";
+import { CategoricalChartState } from "recharts/types/chart/types";
 import {
   HorizontalAlignmentType,
   IconType,
@@ -98,3 +99,12 @@ export type ValueFormatterType = (
 ) => string;
 
 export type SpecialItemFlag = "partYear";
+
+export type CategoricalChartWrapper = PureComponent<
+  unknown,
+  CategoricalChartState
+> & {
+  container?: HTMLElement;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handleItemMouseEnter: (el: any) => void;
+};

--- a/front-end-components/src/components/charts/vertical-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/vertical-bar-chart/component.tsx
@@ -5,6 +5,7 @@ import {
   forwardRef,
   useImperativeHandle,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { VerticalBarChartProps } from "src/components/charts/vertical-bar-chart";
@@ -23,7 +24,12 @@ import {
 } from "recharts";
 import { CategoricalChartState } from "recharts/types/chart/types";
 import classNames from "classnames";
-import { ChartDataSeries, ChartHandler, TickProps } from "src/components";
+import {
+  CategoricalChartWrapper,
+  ChartDataSeries,
+  ChartHandler,
+  TickProps,
+} from "src/components";
 import { useDownloadPngImage } from "src/hooks/useDownloadImage";
 
 function VerticalBarChartInner<TData extends ChartDataSeries>(
@@ -51,9 +57,12 @@ function VerticalBarChartInner<TData extends ChartDataSeries>(
     valueUnit,
   } = props;
 
-  const { downloadPng, ref: rechartsRef } = useDownloadPngImage({
+  const rechartsRef = useRef<CategoricalChartWrapper>(null);
+  const downloadPng = useDownloadPngImage({
+    ref: rechartsRef,
     fileName: `${chartName}.png`,
     onImageLoading,
+    elementSelector: ({ container }) => container,
   });
 
   useImperativeHandle(ref, () => ({
@@ -137,7 +146,10 @@ function VerticalBarChartInner<TData extends ChartDataSeries>(
             left: margin,
           }}
           onMouseMove={handleBarChartMouseMove}
-          ref={rechartsRef}
+          ref={
+            // https://github.com/recharts/recharts/issues/2665
+            rechartsRef as never
+          }
           className="recharts-wrapper-vertical-bar-chart"
         >
           {grid && (

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -153,6 +153,8 @@ export function HorizontalBarChartWrapper<
     setTickFocused(Object.assign(tickFocused, { [key]: focused }));
   };
 
+  const hasData = sortedDataPoints.length > 0;
+
   return (
     <>
       <div className="govuk-grid-row">
@@ -164,8 +166,8 @@ export function HorizontalBarChartWrapper<
               data-module="govuk-button"
               data-prevent-double-click="true"
               onClick={() => chartRef.current?.download()}
-              disabled={imageLoading}
-              aria-disabled={imageLoading}
+              disabled={imageLoading || !hasData}
+              aria-disabled={imageLoading || !hasData}
               data-custom-event-id="save-chart-as-image"
               data-custom-event-chart-name={chartName}
             >
@@ -177,7 +179,7 @@ export function HorizontalBarChartWrapper<
       </div>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-full">
-          {sortedDataPoints.length > 0 ? (
+          {hasData ? (
             <>
               {chartMode == ChartModeChart && (
                 <HorizontalBarChart

--- a/front-end-components/src/views/budget-forecast-returns/partials/year-end.tsx
+++ b/front-end-components/src/views/budget-forecast-returns/partials/year-end.tsx
@@ -83,6 +83,7 @@ export const YearEnd: React.FC<{
   };
 
   const chartName = "Year-end revenue reserves";
+  const hasData = chartData.length > 0;
 
   return (
     <div className="govuk-grid-row govuk-!-margin-top-5">
@@ -94,8 +95,8 @@ export const YearEnd: React.FC<{
           <button
             className="govuk-button govuk-button--secondary"
             data-module="govuk-button"
-            disabled={imageLoading}
-            aria-disabled={imageLoading}
+            disabled={imageLoading || !hasData}
+            aria-disabled={imageLoading || !hasData}
             onClick={() => chartRef?.current?.download()}
             data-custom-event-id="save-chart-as-image"
             data-custom-event-chart-name={chartName.toLowerCase()}


### PR DESCRIPTION
### Context
[AB#245969](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/245969) [AB#245362](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/245362) [AB#216495](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/216495)

### Change proposed in this pull request
Switched above named npm packages

### Guidance to review 
Build and copy build from `front-end-components` to `Web` after `npm i`. View a page with charts and click <kbd>Save as image</kbd> for functionally the same behaviour as per previous implementation.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

