### PR TITLE
Added 'chart title' to chart image downloads

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -92,14 +92,14 @@
       ></div>
       <button type="submit">Submit</button>
     </form>-->
-    <!--<div id="compare-your-trust" data-id="09617166"></div>-->
+    <div id="compare-your-trust" data-id="00000001"></div>
     <!--<div
       id="compare-your-costs"
       data-type="trust"
       data-id="02387916"
       data-phases='["Secondary","Primary","Post-16"]'
     ></div>-->
-    <div id="compare-your-costs" data-type="school" data-id="990095"></div>
+    <!--<div id="compare-your-costs" data-type="school" data-id="990095"></div>-->
     <!--<div id="historic-data" data-type="school" data-id="990095"></div>-->
     <!--<div id="historic-data-2" data-type="school" data-id="123456" data-phase="Primary" data-finance-type="Maintained"></div>-->
     <!--<div

--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -41,13 +41,13 @@
       data-value-field="supplyTeachingStaffCosts"
       data-value-unit="currency"
     ></div>-->
-    <!--<div
+    <div
       id="compare-your-census"
-      data-id="140565"
+      data-id="777054"
       data-type="school"
       data-academy-year="2021 / 2022"
       data-maintained-year="2020 - 2021"
-    ></div>-->
+    ></div>
     <!--<div
       id="vertical-chart-2-series"
       data-json='[{"group":"Year 7","pupilsOnRoll":14.2,"teacherCost":12.9,"id":0},{"group":"Year 8","pupilsOnRoll":16.3,"teacherCost":16.1,"id":1},{"group":"Year 9","pupilsOnRoll":14.1,"teacherCost":12.8,"id":2},{"group":"Year 10","pupilsOnRoll":12.9,"teacherCost":12.5,"id":3},{"group":"Year 11","pupilsOnRoll":15.2,"teacherCost":12.6,"id":4},{"group":"Year 12","pupilsOnRoll":14.2,"teacherCost":12.4,"id":5},{"group":"Year 13","pupilsOnRoll":14.1,"teacherCost":12.8,"id":6},{"group":"Intervention","teacherCost":3.2,"id":7},{"group":"Learning support","teacherCost":4,"id":8},{"group":"Dyslexia support","teacherCost":2.5,"id":9}]'
@@ -92,7 +92,7 @@
       ></div>
       <button type="submit">Submit</button>
     </form>-->
-    <div id="compare-your-trust" data-id="10817914"></div>
+    <!--<div id="compare-your-trust" data-id="10817914"></div>-->
     <!--<div
       id="compare-your-costs"
       data-type="trust"

--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -92,7 +92,7 @@
       ></div>
       <button type="submit">Submit</button>
     </form>-->
-    <div id="compare-your-trust" data-id="00000001"></div>
+    <div id="compare-your-trust" data-id="10817914"></div>
     <!--<div
       id="compare-your-costs"
       data-type="trust"

--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -99,15 +99,15 @@
       data-id="02387916"
       data-phases='["Secondary","Primary","Post-16"]'
     ></div>-->
-    <!--<div id="compare-your-costs" data-type="school" data-id="123456"></div>-->
+    <div id="compare-your-costs" data-type="school" data-id="990095"></div>
     <!--<div id="historic-data" data-type="school" data-id="990095"></div>-->
     <!--<div id="historic-data-2" data-type="school" data-id="123456" data-phase="Primary" data-finance-type="Maintained"></div>-->
-    <div
+    <!--<div
       id="compare-your-costs"
       data-type="local-authority"
       data-id="888"
       data-phases='["Primary"]'
-    ></div>
+    ></div>-->
     <!--<div id="budget-forecast-returns" data-id="01532445"></div>-->
     <!--<div id="historic-data" data-type="trust" data-id="10377760"></div>-->
     <!--<div id="find-organisation"

--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -41,13 +41,13 @@
       data-value-field="supplyTeachingStaffCosts"
       data-value-unit="currency"
     ></div>-->
-    <div
+    <!--<div
       id="compare-your-census"
       data-id="777054"
       data-type="school"
       data-academy-year="2021 / 2022"
       data-maintained-year="2020 - 2021"
-    ></div>
+    ></div>-->
     <!--<div
       id="vertical-chart-2-series"
       data-json='[{"group":"Year 7","pupilsOnRoll":14.2,"teacherCost":12.9,"id":0},{"group":"Year 8","pupilsOnRoll":16.3,"teacherCost":16.1,"id":1},{"group":"Year 9","pupilsOnRoll":14.1,"teacherCost":12.8,"id":2},{"group":"Year 10","pupilsOnRoll":12.9,"teacherCost":12.5,"id":3},{"group":"Year 11","pupilsOnRoll":15.2,"teacherCost":12.6,"id":4},{"group":"Year 12","pupilsOnRoll":14.2,"teacherCost":12.4,"id":5},{"group":"Year 13","pupilsOnRoll":14.1,"teacherCost":12.8,"id":6},{"group":"Intervention","teacherCost":3.2,"id":7},{"group":"Learning support","teacherCost":4,"id":8},{"group":"Dyslexia support","teacherCost":2.5,"id":9}]'
@@ -108,7 +108,7 @@
       data-id="888"
       data-phases='["Primary"]'
     ></div>-->
-    <!--<div id="budget-forecast-returns" data-id="01532445"></div>-->
+    <div id="budget-forecast-returns" data-id="00000001"></div>
     <!--<div id="historic-data" data-type="trust" data-id="10377760"></div>-->
     <!--<div id="find-organisation"
         data-company-number=""

--- a/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
@@ -57,6 +57,7 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
   const {
     barCategoryGap,
     chartName,
+    chartTitle,
     data,
     grid,
     hideXAxis,
@@ -99,7 +100,7 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
   const rechartsRef = useRef<CategoricalChartWrapper>(null);
   const downloadPng = useDownloadPngImage({
     ref: rechartsRef,
-    fileName: `${chartName}.png`,
+    fileName: `${chartName.replace(/\s/g, "-")}.png`,
     onImageLoading,
     elementSelector: ({ container }) => container,
     filter: (node) => {
@@ -108,6 +109,7 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
         node.classList?.contains(classname)
       );
     },
+    title: chartTitle,
   });
 
   useImperativeHandle(ref, () => ({
@@ -248,7 +250,7 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
       />
       <div style={{ height: 22 * filteredData.length + 75 }}>
         <div
-          aria-label={chartName}
+          aria-label={chartTitle ?? chartName}
           className="govuk-body-s govuk-!-font-size-14 full-height-width"
           role="img"
         >

--- a/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
@@ -56,7 +56,6 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
 ) {
   const {
     barCategoryGap,
-    chartName,
     chartTitle,
     data,
     grid,
@@ -100,7 +99,6 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
   const rechartsRef = useRef<CategoricalChartWrapper>(null);
   const downloadPng = useDownloadPngImage({
     ref: rechartsRef,
-    fileName: `${chartName.replace(/\s/g, "-")}.png`,
     onImageLoading,
     elementSelector: ({ container }) => container,
     filter: (node) => {
@@ -250,7 +248,7 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
       />
       <div style={{ height: 22 * filteredData.length + 75 }}>
         <div
-          aria-label={chartTitle ?? chartName}
+          aria-label={chartTitle}
           className="govuk-body-s govuk-!-font-size-14 full-height-width"
           role="img"
         >

--- a/front-end-components/src/components/charts/line-chart/component.tsx
+++ b/front-end-components/src/components/charts/line-chart/component.tsx
@@ -30,7 +30,7 @@ import { LineChartDot } from "../line-chart-dot";
 
 function LineChartInner<TData extends ChartDataSeries>(
   {
-    chartName,
+    chartTitle,
     className,
     curveType,
     data,
@@ -62,9 +62,9 @@ function LineChartInner<TData extends ChartDataSeries>(
   const rechartsRef = useRef<CategoricalChartWrapper>(null);
   const downloadPng = useDownloadPngImage({
     ref: rechartsRef,
-    fileName: `${chartName}.png`,
     onImageLoading,
     elementSelector: ({ container }) => container,
+    title: chartTitle,
   });
 
   useImperativeHandle(ref, () => ({
@@ -193,7 +193,7 @@ function LineChartInner<TData extends ChartDataSeries>(
   return (
     // a11y: https://github.com/recharts/recharts/issues/3816
     <div
-      aria-label={chartName}
+      aria-label={chartTitle}
       className="govuk-body-s govuk-!-font-size-14 full-height-width"
       role="img"
     >

--- a/front-end-components/src/components/charts/stat/component.tsx
+++ b/front-end-components/src/components/charts/stat/component.tsx
@@ -4,7 +4,7 @@ import classNames from "classnames";
 
 export function Stat<TData extends ChartDataSeries>(props: StatProps<TData>) {
   const {
-    chartName,
+    chartTitle,
     className,
     compactValue,
     label,
@@ -18,7 +18,7 @@ export function Stat<TData extends ChartDataSeries>(props: StatProps<TData>) {
   return (
     <div
       className={classNames(className, "chart-stat-wrapper")}
-      aria-label={chartName}
+      aria-label={chartTitle}
       role="note"
     >
       <div className="chart-stat-label">

--- a/front-end-components/src/components/charts/stat/types.tsx
+++ b/front-end-components/src/components/charts/stat/types.tsx
@@ -4,7 +4,7 @@ import { ChartDataSeries, ChartProps, ChartSeriesValue } from "src/components";
 export interface StatProps<TData extends ChartDataSeries>
   extends Pick<
     ChartProps<TData>,
-    "chartName" | "valueFormatter" | "valueUnit"
+    "chartTitle" | "valueFormatter" | "valueUnit"
   > {
   className?: string;
   compactValue?: boolean;

--- a/front-end-components/src/components/charts/types.tsx
+++ b/front-end-components/src/components/charts/types.tsx
@@ -16,6 +16,7 @@ export interface ChartProps<TData extends ChartDataSeries>
   extends ValueFormatterProps {
   barCategoryGap?: string | number;
   chartName: string;
+  chartTitle?: string;
   className?: string;
   data: TData[];
   grid?: boolean;

--- a/front-end-components/src/components/charts/types.tsx
+++ b/front-end-components/src/components/charts/types.tsx
@@ -15,8 +15,7 @@ import { CartesianTickItem } from "recharts/types/util/types";
 export interface ChartProps<TData extends ChartDataSeries>
   extends ValueFormatterProps {
   barCategoryGap?: string | number;
-  chartName: string;
-  chartTitle?: string;
+  chartTitle: string;
   className?: string;
   data: TData[];
   grid?: boolean;

--- a/front-end-components/src/components/charts/vertical-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/vertical-bar-chart/component.tsx
@@ -38,7 +38,7 @@ function VerticalBarChartInner<TData extends ChartDataSeries>(
 ) {
   const {
     barCategoryGap,
-    chartName,
+    chartTitle,
     data,
     grid,
     hideXAxis,
@@ -60,9 +60,9 @@ function VerticalBarChartInner<TData extends ChartDataSeries>(
   const rechartsRef = useRef<CategoricalChartWrapper>(null);
   const downloadPng = useDownloadPngImage({
     ref: rechartsRef,
-    fileName: `${chartName}.png`,
     onImageLoading,
     elementSelector: ({ container }) => container,
+    title: chartTitle,
   });
 
   useImperativeHandle(ref, () => ({
@@ -129,7 +129,7 @@ function VerticalBarChartInner<TData extends ChartDataSeries>(
   return (
     // a11y: https://github.com/recharts/recharts/issues/3816
     <div
-      aria-label={chartName}
+      aria-label={chartTitle}
       className="govuk-body-s govuk-!-font-size-14 full-height-width"
       role="img"
     >

--- a/front-end-components/src/composed/accordion-section/composed.tsx
+++ b/front-end-components/src/composed/accordion-section/composed.tsx
@@ -1,11 +1,11 @@
-import { AccordionSectionProps } from "src/views/compare-your-costs/partials/accordion-sections/types";
+import { AccordionSectionProps } from "./types";
 import { useHash } from "src/hooks/useHash";
 import classNames from "classnames";
 import {
   SchoolChartData,
   TrustChartData,
 } from "src/components/charts/table-chart";
-import { Section } from "..";
+import { DimensionedChart } from "../dimensioned-chart";
 
 export function AccordionSection<
   TData extends SchoolChartData | TrustChartData,
@@ -36,7 +36,7 @@ export function AccordionSection<
         aria-labelledby={`accordion-heading-${index}`}
         role="region"
       >
-        <Section {...rest} />
+        <DimensionedChart {...rest} />
       </div>
     </div>
   );

--- a/front-end-components/src/composed/accordion-section/index.tsx
+++ b/front-end-components/src/composed/accordion-section/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/composed/accordion-section/types";
+export * from "src/composed/accordion-section/composed";

--- a/front-end-components/src/composed/accordion-section/types.tsx
+++ b/front-end-components/src/composed/accordion-section/types.tsx
@@ -1,0 +1,12 @@
+import {
+  SchoolChartData,
+  TrustChartData,
+} from "src/components/charts/table-chart";
+import { DimensionedChartProps } from "../dimensioned-chart";
+
+export type AccordionSectionProps<
+  TData extends SchoolChartData | TrustChartData,
+> = Omit<DimensionedChartProps<TData>, "dimensions" | "topLevel"> & {
+  index: number;
+  title: string;
+};

--- a/front-end-components/src/composed/comparison-chart-summary/composed.tsx
+++ b/front-end-components/src/composed/comparison-chart-summary/composed.tsx
@@ -68,7 +68,7 @@ export function ComparisonChartSummary<TData extends ChartDataSeries>(
         </div>
         <div className="chart-stat-summary">
           <ResolvedStat
-            chartName="This school spends"
+            chartTitle="This school spends"
             className="chart-stat-highlight"
             data={data}
             displayIndex={highlightedItemIndex}
@@ -80,7 +80,7 @@ export function ComparisonChartSummary<TData extends ChartDataSeries>(
             valueUnit="currency"
           />
           <Stat
-            chartName="Similar schools spend"
+            chartTitle="Similar schools spend"
             label="Similar schools spend"
             suffix={suffix && `${suffix}, on average`}
             value={chartStats.average}
@@ -89,7 +89,7 @@ export function ComparisonChartSummary<TData extends ChartDataSeries>(
           />
           {!isNaN(chartStats.difference) && (
             <Stat
-              chartName="This school spends"
+              chartTitle="This school spends"
               label="This school spends"
               suffix={
                 <span>

--- a/front-end-components/src/composed/comparison-chart-summary/types.tsx
+++ b/front-end-components/src/composed/comparison-chart-summary/types.tsx
@@ -7,7 +7,7 @@ import {
 export type ComparisonChartSummaryComposedProps<TData extends ChartDataSeries> =
   Pick<
     ChartProps<TData>,
-    "chartName" | "data" | "keyField" | "valueUnit" | "suffix"
+    "chartTitle" | "data" | "keyField" | "valueUnit" | "suffix"
   > & {
     highlightedItemKey?: string;
     sortDirection: ChartSortDirection;

--- a/front-end-components/src/composed/dimensioned-chart/composed.tsx
+++ b/front-end-components/src/composed/dimensioned-chart/composed.tsx
@@ -7,9 +7,11 @@ import {
   SchoolChartData,
   TrustChartData,
 } from "src/components/charts/table-chart";
-import { SectionProps } from "./types";
+import { DimensionedChartProps } from "./types";
 
-export function Section<TData extends SchoolChartData | TrustChartData>({
+export function DimensionedChart<
+  TData extends SchoolChartData | TrustChartData,
+>({
   charts,
   dimension,
   dimensions,
@@ -17,7 +19,7 @@ export function Section<TData extends SchoolChartData | TrustChartData>({
   hasNoData,
   options,
   topLevel,
-}: SectionProps<TData>) {
+}: DimensionedChartProps<TData>) {
   const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
     event
   ) => {

--- a/front-end-components/src/composed/dimensioned-chart/composed.tsx
+++ b/front-end-components/src/composed/dimensioned-chart/composed.tsx
@@ -35,8 +35,12 @@ export function DimensionedChart<
       message="There isn't enough information available to create a set of similar schools."
     />
   ) : (
-    charts.map(({ data, selector, title }, i) => {
-      const chartName = title.toLowerCase().replace(/\W/g, " ").trim();
+    charts.map(({ data, selector, title, ...chart }, i) => {
+      const chartName = title
+        .toLowerCase()
+        .replace(/\W/g, " ")
+        .replace(/\s{2,}/g, " ")
+        .trim();
       const chartId = chartName.replace(/\s/g, "-");
 
       return (
@@ -55,7 +59,7 @@ export function DimensionedChart<
             {(i === 0 || selector) &&
               (options ?? (
                 <ChartDimensions
-                  dimensions={dimensions || CostCategories}
+                  dimensions={chart.dimensions || dimensions || CostCategories}
                   elementId={chartId}
                   handleChange={handleSelectChange}
                   value={dimension.value}

--- a/front-end-components/src/composed/dimensioned-chart/composed.tsx
+++ b/front-end-components/src/composed/dimensioned-chart/composed.tsx
@@ -36,17 +36,16 @@ export function DimensionedChart<
     />
   ) : (
     charts.map(({ data, selector, title, ...chart }, i) => {
-      const chartName = title
+      const chartId = title
         .toLowerCase()
         .replace(/\W/g, " ")
         .replace(/\s{2,}/g, " ")
-        .trim();
-      const chartId = chartName.replace(/\s/g, "-");
+        .trim()
+        .replace(/\s/g, "-");
 
       return (
         <ChartDimensionContext.Provider key={chartId} value={dimension}>
           <HorizontalBarChartWrapper
-            chartName={chartName}
             chartTitle={title}
             data={data}
             trust={trust}

--- a/front-end-components/src/composed/dimensioned-chart/composed.tsx
+++ b/front-end-components/src/composed/dimensioned-chart/composed.tsx
@@ -19,6 +19,7 @@ export function DimensionedChart<
   hasNoData,
   options,
   topLevel,
+  trust,
 }: DimensionedChartProps<TData>) {
   const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
     event
@@ -34,7 +35,7 @@ export function DimensionedChart<
       message="There isn't enough information available to create a set of similar schools."
     />
   ) : (
-    charts.map(({ title, data }, i) => {
+    charts.map(({ data, selector, title }, i) => {
       const chartName = title.toLowerCase().replace(/\W/g, " ").trim();
       const chartId = chartName.replace(/\s/g, "-");
 
@@ -44,13 +45,14 @@ export function DimensionedChart<
             chartName={chartName}
             chartTitle={title}
             data={data}
+            trust={trust}
           >
             {topLevel ? (
               <h2 className="govuk-heading-m">{title}</h2>
             ) : (
               <h3 className="govuk-heading-s">{title}</h3>
             )}
-            {i === 0 &&
+            {(i === 0 || selector) &&
               (options ?? (
                 <ChartDimensions
                   dimensions={dimensions || CostCategories}

--- a/front-end-components/src/composed/dimensioned-chart/index.tsx
+++ b/front-end-components/src/composed/dimensioned-chart/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/composed/dimensioned-chart/types";
+export * from "src/composed/dimensioned-chart/composed";

--- a/front-end-components/src/composed/dimensioned-chart/types.tsx
+++ b/front-end-components/src/composed/dimensioned-chart/types.tsx
@@ -6,16 +6,23 @@ import {
 } from "src/components/charts/table-chart";
 import { HorizontalBarChartWrapperProps } from "src/composed/horizontal-bar-chart-wrapper";
 
+type DimensionedChart<TData extends SchoolChartData | TrustChartData> = Pick<
+  HorizontalBarChartWrapperProps<TData>,
+  "data"
+> & {
+  selector?: boolean;
+  title: string;
+};
+
 export type DimensionedChartProps<
   TData extends SchoolChartData | TrustChartData,
 > = {
-  charts: (Pick<HorizontalBarChartWrapperProps<TData>, "data"> & {
-    title: string;
-  })[];
+  charts: DimensionedChart<TData>[];
   dimension: Dimension;
   dimensions?: Dimension[];
   handleDimensionChange?: (dimension: string) => void;
-  hasNoData: boolean;
+  hasNoData?: boolean;
   options?: ReactNode;
   topLevel?: boolean;
+  trust?: boolean;
 };

--- a/front-end-components/src/composed/dimensioned-chart/types.tsx
+++ b/front-end-components/src/composed/dimensioned-chart/types.tsx
@@ -12,6 +12,7 @@ type DimensionedChart<TData extends SchoolChartData | TrustChartData> = Pick<
 > & {
   selector?: boolean;
   title: string;
+  dimensions?: Dimension[];
 };
 
 export type DimensionedChartProps<

--- a/front-end-components/src/composed/dimensioned-chart/types.tsx
+++ b/front-end-components/src/composed/dimensioned-chart/types.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from "react";
+import { Dimension } from "src/components";
+import {
+  SchoolChartData,
+  TrustChartData,
+} from "src/components/charts/table-chart";
+import { HorizontalBarChartWrapperProps } from "src/composed/horizontal-bar-chart-wrapper";
+
+export type DimensionedChartProps<
+  TData extends SchoolChartData | TrustChartData,
+> = {
+  charts: (Pick<HorizontalBarChartWrapperProps<TData>, "data"> & {
+    title: string;
+  })[];
+  dimension: Dimension;
+  dimensions?: Dimension[];
+  handleDimensionChange?: (dimension: string) => void;
+  hasNoData: boolean;
+  options?: ReactNode;
+  topLevel?: boolean;
+};

--- a/front-end-components/src/composed/historic-chart-2-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-2-composed/component.tsx
@@ -105,7 +105,7 @@ export function HistoricChart2<TData extends HistoryBase>({
           <div className="govuk-grid-column-three-quarters">
             <div style={{ height: 200 }}>
               <LineChart
-                chartName={chartName}
+                chartTitle={chartName}
                 className="historic-chart-2"
                 data={mergedData}
                 grid
@@ -147,7 +147,7 @@ export function HistoricChart2<TData extends HistoryBase>({
           </div>
           <aside className="govuk-grid-column-one-quarter">
             <ResolvedStat
-              chartName={`Most recent ${chartName.toLowerCase()}`}
+              chartTitle={`Most recent ${chartName.toLowerCase()}`}
               className="chart-stat-line-chart"
               compactValue
               data={data.school || []}

--- a/front-end-components/src/composed/historic-chart-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/component.tsx
@@ -33,7 +33,7 @@ export function HistoricChart<TData extends ChartDataSeries>({
           <div className="govuk-grid-column-three-quarters">
             <div style={{ height: 200 }}>
               <LineChart
-                chartName={chartName}
+                chartTitle={chartName}
                 data={data}
                 grid
                 highlightActive
@@ -59,7 +59,7 @@ export function HistoricChart<TData extends ChartDataSeries>({
           </div>
           <aside className="govuk-grid-column-one-quarter">
             <ResolvedStat
-              chartName={`Most recent ${chartName.toLowerCase()}`}
+              chartTitle={`Most recent ${chartName.toLowerCase()}`}
               className="chart-stat-line-chart"
               compactValue
               data={data}

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -37,7 +37,8 @@ import { SchoolExpenditure } from "src/services";
 export function HorizontalBarChartWrapper<
   TData extends SchoolChartData | TrustChartData,
 >(props: HorizontalBarChartWrapperProps<TData>) {
-  const { chartName, children, data, sort, trust, valueUnit } = props;
+  const { chartName, chartTitle, children, data, sort, trust, valueUnit } =
+    props;
   const { chartMode } = useChartModeContext();
   const dimension = useContext(ChartDimensionContext);
   const selectedEstabishment = useContext(SelectedEstablishmentContext);
@@ -171,8 +172,11 @@ export function HorizontalBarChartWrapper<
               data-custom-event-id="save-chart-as-image"
               data-custom-event-chart-name={chartName}
             >
-              Save <span className="govuk-visually-hidden">{chartName}</span> as
-              image
+              Save{" "}
+              <span className="govuk-visually-hidden">
+                {chartTitle ?? chartName}
+              </span>{" "}
+              as image
             </button>
           </div>
         )}
@@ -185,6 +189,7 @@ export function HorizontalBarChartWrapper<
                 <HorizontalBarChart
                   barCategoryGap={3}
                   chartName={chartName}
+                  chartTitle={chartTitle}
                   data={sortedDataPoints}
                   highlightActive
                   highlightedItemKeys={

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -37,8 +37,7 @@ import { SchoolExpenditure } from "src/services";
 export function HorizontalBarChartWrapper<
   TData extends SchoolChartData | TrustChartData,
 >(props: HorizontalBarChartWrapperProps<TData>) {
-  const { chartName, chartTitle, children, data, sort, trust, valueUnit } =
-    props;
+  const { chartTitle, children, data, sort, trust, valueUnit } = props;
   const { chartMode } = useChartModeContext();
   const dimension = useContext(ChartDimensionContext);
   const selectedEstabishment = useContext(SelectedEstablishmentContext);
@@ -170,12 +169,9 @@ export function HorizontalBarChartWrapper<
               disabled={imageLoading || !hasData}
               aria-disabled={imageLoading || !hasData}
               data-custom-event-id="save-chart-as-image"
-              data-custom-event-chart-name={chartName}
+              data-custom-event-chart-name={chartTitle}
             >
-              Save{" "}
-              <span className="govuk-visually-hidden">
-                {chartTitle ?? chartName}
-              </span>{" "}
+              Save <span className="govuk-visually-hidden">{chartTitle}</span>{" "}
               as image
             </button>
           </div>
@@ -188,7 +184,6 @@ export function HorizontalBarChartWrapper<
               {chartMode == ChartModeChart && (
                 <HorizontalBarChart
                   barCategoryGap={3}
-                  chartName={chartName}
                   chartTitle={chartTitle}
                   data={sortedDataPoints}
                   highlightActive

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/types.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/types.tsx
@@ -6,7 +6,7 @@ import {
 
 export type HorizontalBarChartWrapperProps<
   TData extends SchoolChartData | TrustChartData,
-> = Pick<ChartProps<TData>, "chartName" | "valueUnit"> & {
+> = Pick<ChartProps<TData>, "chartName" | "chartTitle" | "valueUnit"> & {
   children?: React.ReactNode[] | React.ReactNode;
   data: HorizontalBarChartWrapperPropsData<TData>;
   sort?: ChartDataSeriesSortMode<TData>;

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/types.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/types.tsx
@@ -6,7 +6,7 @@ import {
 
 export type HorizontalBarChartWrapperProps<
   TData extends SchoolChartData | TrustChartData,
-> = Pick<ChartProps<TData>, "chartName" | "chartTitle" | "valueUnit"> & {
+> = Pick<ChartProps<TData>, "chartTitle" | "valueUnit"> & {
   children?: React.ReactNode[] | React.ReactNode;
   data: HorizontalBarChartWrapperPropsData<TData>;
   sort?: ChartDataSeriesSortMode<TData>;

--- a/front-end-components/src/hooks/useDownloadImage.ts
+++ b/front-end-components/src/hooks/useDownloadImage.ts
@@ -4,7 +4,7 @@ import { ImageOptions, ImageService } from "src/services";
 
 type DownloadPngImageOptions<T> = {
   ref?: React.RefObject<T>;
-  fileName: string;
+  fileName?: string;
   onImageLoading?: (loading: boolean) => void;
   elementSelector: (ref: T) => HTMLElement | undefined;
   title?: string;
@@ -14,12 +14,23 @@ const imageTitleHeight = 50;
 
 export function useDownloadPngImage<T>({
   ref,
-  fileName,
+  fileName: fileNameProp,
   onImageLoading,
   elementSelector,
   filter,
   title,
 }: DownloadPngImageOptions<T>) {
+  const fileName = title
+    ? `${title
+        .toLowerCase()
+        .replace(/\W/g, " ")
+        .replace(/\s{2,}/g, " ")
+        .trim()
+        .replace(/\s/g, "-")}.png`
+    : fileNameProp
+      ? fileNameProp
+      : "download.png";
+
   const downloadPng = useCallback(async () => {
     if (!ref?.current) {
       return;

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -236,7 +236,7 @@ const HorizontalChart1Series = ({
       <div className="govuk-grid-column-two-thirds" style={{ height: 800 }}>
         <HorizontalBarChart
           barCategoryGap={2}
-          chartName="School workforce (Full Time Equivalent)"
+          chartTitle="School workforce (Full Time Equivalent)"
           data={sortedData}
           highlightActive
           highlightedItemKeys={
@@ -373,7 +373,7 @@ const HorizontalChartTrustFinancial = ({
       <div className="govuk-grid-column-two-thirds" style={{ height }}>
         <HorizontalBarChart
           barCategoryGap={2}
-          chartName="School workforce (Full Time Equivalent)"
+          chartTitle="School workforce (Full Time Equivalent)"
           data={sortedData}
           highlightActive
           highlightedItemKeys={
@@ -479,7 +479,7 @@ const VerticalChart2Series = ({
       </button>
       <div className="govuk-grid-column-two-thirds" style={{ height: 400 }}>
         <VerticalBarChart
-          chartName="Percentage of pupils on roll and teacher cost"
+          chartTitle="Percentage of pupils on roll and teacher cost"
           data={data}
           grid
           highlightActive
@@ -551,7 +551,7 @@ if (verticalChart3SeriesElement) {
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-two-thirds" style={{ height: 400 }}>
             <VerticalBarChart
-              chartName="Percentage of pupils on roll and teacher cost"
+              chartTitle="Percentage of pupils on roll and teacher cost"
               data={data}
               grid
               highlightActive
@@ -613,7 +613,7 @@ const LineChart1Series = ({
           style={{ height: 400 }}
         >
           <LineChart
-            chartName="In-year balance"
+            chartTitle="In-year balance"
             data={data}
             grid
             highlightActive
@@ -643,7 +643,7 @@ const LineChart1Series = ({
         </div>
         <aside className="govuk-grid-column-one-quarter desktop">
           <ResolvedStat
-            chartName="Most recent in-year balance"
+            chartTitle="Most recent in-year balance"
             className="chart-stat-line-chart"
             compactValue
             data={data}
@@ -707,7 +707,7 @@ const LineChart2Series = ({
       </button>
       <div className="govuk-grid-column-two-thirds" style={{ height: 400 }}>
         <LineChart
-          chartName="In-year balance"
+          chartTitle="In-year balance"
           data={data}
           grid
           highlightActive
@@ -785,7 +785,7 @@ if (spendingAndCostsComposedElements) {
       root.render(
         <React.StrictMode>
           <ComparisonChartSummary
-            chartName="Percentage of pupils on roll and teacher cost"
+            chartTitle="Percentage of pupils on roll and teacher cost"
             data={data}
             chartStats={statData}
             highlightedItemKey={highlight}

--- a/front-end-components/src/services/image-service.ts
+++ b/front-end-components/src/services/image-service.ts
@@ -1,0 +1,80 @@
+import { applyStyle } from "html-to-image/lib/apply-style";
+import { cloneNode } from "html-to-image/lib/clone-node";
+import { embedImages } from "html-to-image/lib/embed-images";
+import { embedWebFonts } from "html-to-image/lib/embed-webfonts";
+import {
+  getImageSize,
+  getPixelRatio,
+  createImage,
+  canvasToBlob,
+  nodeToDataURL,
+  checkCanvasDimensions,
+} from "html-to-image/lib/util";
+import { Options } from "html-to-image/lib/types";
+
+export type ImageOptions = Options & {
+  onCloned?: (node: HTMLElement) => void;
+};
+
+// below merged in from https://github.com/bubkoo/html-to-image/blob/master/src/index.ts
+// with the addition of the onCloned() callback as added to the extended `Options` object
+export class ImageService {
+  static async toSvg<T extends HTMLElement>(
+    node: T,
+    options: ImageOptions = {}
+  ): Promise<string> {
+    const { width, height } = getImageSize(node, options);
+    const clonedNode = (await cloneNode(node, options, true)) as HTMLElement;
+    if (options.onCloned) {
+      options.onCloned(clonedNode);
+    }
+
+    await embedWebFonts(clonedNode, options);
+    await embedImages(clonedNode, options);
+    applyStyle(clonedNode, options);
+    const datauri = await nodeToDataURL(clonedNode, width, height);
+    return datauri;
+  }
+
+  static async toCanvas<T extends HTMLElement>(
+    node: T,
+    options: ImageOptions = {}
+  ): Promise<HTMLCanvasElement> {
+    const { width, height } = getImageSize(node, options);
+    const svg = await ImageService.toSvg(node, options);
+    const img = await createImage(svg);
+
+    const canvas = document.createElement("canvas");
+    const context = canvas.getContext("2d")!;
+    const ratio = options.pixelRatio || getPixelRatio();
+    const canvasWidth = options.canvasWidth || width;
+    const canvasHeight = options.canvasHeight || height;
+
+    canvas.width = canvasWidth * ratio;
+    canvas.height = canvasHeight * ratio;
+
+    if (!options.skipAutoScale) {
+      checkCanvasDimensions(canvas);
+    }
+    canvas.style.width = `${canvasWidth}`;
+    canvas.style.height = `${canvasHeight}`;
+
+    if (options.backgroundColor) {
+      context.fillStyle = options.backgroundColor;
+      context.fillRect(0, 0, canvas.width, canvas.height);
+    }
+
+    context.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+    return canvas;
+  }
+
+  static async toBlob<T extends HTMLElement>(
+    node: T,
+    options: ImageOptions = {}
+  ): Promise<Blob | null> {
+    const canvas = await ImageService.toCanvas(node, options);
+    const blob = await canvasToBlob(canvas);
+    return blob;
+  }
+}

--- a/front-end-components/src/services/index.tsx
+++ b/front-end-components/src/services/index.tsx
@@ -5,3 +5,4 @@ export * from "src/services/balance-api";
 export * from "src/services/expenditure-api";
 export * from "src/services/types";
 export * from "src/services/history-service";
+export * from "src/services/image-service";

--- a/front-end-components/src/views/budget-forecast-returns/partials/bfr-chart.tsx
+++ b/front-end-components/src/views/budget-forecast-returns/partials/bfr-chart.tsx
@@ -12,7 +12,7 @@ export const BfrChart = forwardRef<ChartHandler, BfrChartProps>(
       <div className="govuk-grid-column-full" style={{ height: 400 }}>
         {data.length > 0 ? (
           <LineChart
-            chartName="Year-end revenue reserves"
+            chartTitle="Year-end revenue reserves"
             data={data}
             grid
             highlightActive

--- a/front-end-components/src/views/compare-your-census/partials/auxiliary-staff.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/auxiliary-staff.tsx
@@ -5,22 +5,12 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import {
-  ChartDimensions,
-  PupilsPerStaffRole,
-  CensusCategories,
-} from "src/components";
-import {
-  ChartDimensionContext,
-  PhaseContext,
-  CustomDataContext,
-} from "src/contexts";
+import { PupilsPerStaffRole, CensusCategories } from "src/components";
+import { PhaseContext, CustomDataContext } from "src/contexts";
 import { AuxiliaryStaffData } from "src/views/compare-your-census/partials";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { Census, CensusApi } from "src/services";
+import { DimensionedChart } from "src/composed/dimensioned-chart";
 
 export const AuxiliaryStaff: React.FC<{ type: string; id: string }> = ({
   type,
@@ -70,31 +60,21 @@ export const AuxiliaryStaff: React.FC<{ type: string; id: string }> = ({
       };
     }, [dimension, data]);
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      CensusCategories.find((x) => x.value === event.target.value) ??
-      PupilsPerStaffRole;
+      CensusCategories.find((x) => x.value === value) ?? PupilsPerStaffRole;
     setDimension(dimension);
   };
 
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <HorizontalBarChartWrapper
-        data={chartData}
-        chartName="auxiliary staff (full time equivalent)"
-      >
-        <h2 className="govuk-heading-m">
-          Auxiliary staff (Full Time Equivalent)
-        </h2>
-        <ChartDimensions
-          dimensions={CensusCategories}
-          handleChange={handleSelectChange}
-          elementId="auxiliary-staff"
-          value={dimension.value}
-        />
-      </HorizontalBarChartWrapper>
-    </ChartDimensionContext.Provider>
+    <DimensionedChart
+      charts={[
+        { data: chartData, title: "Auxiliary staff (Full Time Equivalent)" },
+      ]}
+      dimension={dimension}
+      dimensions={CensusCategories}
+      handleDimensionChange={handleDimensionChange}
+      topLevel
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-census/partials/headcount.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/headcount.tsx
@@ -6,23 +6,16 @@ import React, {
   useState,
 } from "react";
 import {
-  ChartDimensions,
   HeadcountPerFTE,
   PercentageOfWorkforce,
   PupilsPerStaffRole,
   CensusCategories,
 } from "src/components";
-import {
-  ChartDimensionContext,
-  PhaseContext,
-  CustomDataContext,
-} from "src/contexts";
+import { PhaseContext, CustomDataContext } from "src/contexts";
 import { HeadcountData } from "src/views/compare-your-census/partials";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { Census, CensusApi } from "src/services";
+import { DimensionedChart } from "src/composed/dimensioned-chart";
 
 export const Headcount: React.FC<{ type: string; id: string }> = ({
   type,
@@ -72,32 +65,22 @@ export const Headcount: React.FC<{ type: string; id: string }> = ({
       };
     }, [dimension, data]);
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      CensusCategories.find((x) => x.value === event.target.value) ??
-      PupilsPerStaffRole;
+      CensusCategories.find((x) => x.value === value) ?? PupilsPerStaffRole;
     setDimension(dimension);
   };
 
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <HorizontalBarChartWrapper
-        data={chartData}
-        chartName="school workforce (headcount)"
-      >
-        <h2 className="govuk-heading-m">School workforce (Headcount)</h2>
-        <ChartDimensions
-          dimensions={CensusCategories.filter(
-            (category) =>
-              category !== HeadcountPerFTE && category !== PercentageOfWorkforce
-          )}
-          handleChange={handleSelectChange}
-          elementId="headcount"
-          value={dimension.value}
-        />
-      </HorizontalBarChartWrapper>
-    </ChartDimensionContext.Provider>
+    <DimensionedChart
+      charts={[{ data: chartData, title: "School workforce (Headcount)" }]}
+      dimension={dimension}
+      dimensions={CensusCategories.filter(
+        (category) =>
+          category !== HeadcountPerFTE && category !== PercentageOfWorkforce
+      )}
+      handleDimensionChange={handleDimensionChange}
+      topLevel
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-census/partials/non-classroom-support.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/non-classroom-support.tsx
@@ -5,22 +5,12 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import {
-  ChartDimensions,
-  PupilsPerStaffRole,
-  CensusCategories,
-} from "src/components";
-import {
-  ChartDimensionContext,
-  PhaseContext,
-  CustomDataContext,
-} from "src/contexts";
+import { PupilsPerStaffRole, CensusCategories } from "src/components";
+import { PhaseContext, CustomDataContext } from "src/contexts";
 import { NonClassroomSupportData } from "src/views/compare-your-census/partials";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { Census, CensusApi } from "src/services";
+import { DimensionedChart } from "src/composed/dimensioned-chart";
 
 export const NonClassroomSupport: React.FC<{ type: string; id: string }> = ({
   type,
@@ -70,32 +60,25 @@ export const NonClassroomSupport: React.FC<{ type: string; id: string }> = ({
       };
     }, [dimension, data]);
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      CensusCategories.find((x) => x.value === event.target.value) ??
-      PupilsPerStaffRole;
+      CensusCategories.find((x) => x.value === value) ?? PupilsPerStaffRole;
     setDimension(dimension);
   };
 
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <HorizontalBarChartWrapper
-        data={chartData}
-        chartName="non-classroom support staff - excluding auxiliary staff (full time equivalent)"
-      >
-        <h2 className="govuk-heading-m">
-          Non-classroom support staff - excluding auxiliary staff (Full Time
-          Equivalent)
-        </h2>
-        <ChartDimensions
-          dimensions={CensusCategories}
-          handleChange={handleSelectChange}
-          elementId="nonclassroom-support"
-          value={dimension.value}
-        />
-      </HorizontalBarChartWrapper>
-    </ChartDimensionContext.Provider>
+    <DimensionedChart
+      charts={[
+        {
+          data: chartData,
+          title:
+            "Non-classroom support staff - excluding auxiliary staff (Full Time Equivalent)",
+        },
+      ]}
+      dimension={dimension}
+      dimensions={CensusCategories}
+      handleDimensionChange={handleDimensionChange}
+      topLevel
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-census/partials/school-workforce.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/school-workforce.tsx
@@ -6,22 +6,15 @@ import React, {
   useState,
 } from "react";
 import {
-  ChartDimensions,
   PercentageOfWorkforce,
   PupilsPerStaffRole,
   CensusCategories,
 } from "src/components";
-import {
-  ChartDimensionContext,
-  PhaseContext,
-  CustomDataContext,
-} from "src/contexts";
+import { PhaseContext, CustomDataContext } from "src/contexts";
 import { SchoolCensusData } from "src/views/compare-your-census/partials";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { Census, CensusApi } from "src/services";
+import { DimensionedChart } from "src/composed/dimensioned-chart";
 
 export const SchoolWorkforce: React.FC<{ type: string; id: string }> = ({
   type,
@@ -71,33 +64,23 @@ export const SchoolWorkforce: React.FC<{ type: string; id: string }> = ({
       };
     }, [dimension, data]);
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      CensusCategories.find((x) => x.value === event.target.value) ??
-      PupilsPerStaffRole;
+      CensusCategories.find((x) => x.value === value) ?? PupilsPerStaffRole;
     setDimension(dimension);
   };
 
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <HorizontalBarChartWrapper
-        data={chartData}
-        chartName="school workforce (full time equivalent)"
-      >
-        <h2 className="govuk-heading-m">
-          School workforce (Full Time Equivalent)
-        </h2>
-        <ChartDimensions
-          dimensions={CensusCategories.filter(
-            (category) => category !== PercentageOfWorkforce
-          )}
-          handleChange={handleSelectChange}
-          elementId="school-workforce"
-          value={dimension.value}
-        />
-      </HorizontalBarChartWrapper>
-    </ChartDimensionContext.Provider>
+    <DimensionedChart
+      charts={[
+        { data: chartData, title: "School workforce (Full Time Equivalent)" },
+      ]}
+      dimension={dimension}
+      dimensions={CensusCategories.filter(
+        (category) => category !== PercentageOfWorkforce
+      )}
+      handleDimensionChange={handleDimensionChange}
+      topLevel
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-census/partials/senior-leadership.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/senior-leadership.tsx
@@ -5,22 +5,12 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import {
-  ChartDimensions,
-  PupilsPerStaffRole,
-  CensusCategories,
-} from "src/components";
-import {
-  ChartDimensionContext,
-  PhaseContext,
-  CustomDataContext,
-} from "src/contexts";
+import { PupilsPerStaffRole, CensusCategories } from "src/components";
+import { PhaseContext, CustomDataContext } from "src/contexts";
 import { SeniorLeadershipData } from "src/views/compare-your-census/partials";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { Census, CensusApi } from "src/services";
+import { DimensionedChart } from "src/composed/dimensioned-chart";
 
 export const SeniorLeadership: React.FC<{ type: string; id: string }> = ({
   type,
@@ -70,31 +60,21 @@ export const SeniorLeadership: React.FC<{ type: string; id: string }> = ({
       };
     }, [dimension, data]);
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      CensusCategories.find((x) => x.value === event.target.value) ??
-      PupilsPerStaffRole;
+      CensusCategories.find((x) => x.value === value) ?? PupilsPerStaffRole;
     setDimension(dimension);
   };
 
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <HorizontalBarChartWrapper
-        data={chartData}
-        chartName="senior leadership (full time equivalent)"
-      >
-        <h2 className="govuk-heading-m">
-          Senior Leadership (Full Time Equivalent)
-        </h2>
-        <ChartDimensions
-          dimensions={CensusCategories}
-          handleChange={handleSelectChange}
-          elementId="senior-leadership"
-          value={dimension.value}
-        />
-      </HorizontalBarChartWrapper>
-    </ChartDimensionContext.Provider>
+    <DimensionedChart
+      charts={[
+        { data: chartData, title: "Senior Leadership (Full Time Equivalent)" },
+      ]}
+      dimension={dimension}
+      dimensions={CensusCategories}
+      handleDimensionChange={handleDimensionChange}
+      topLevel
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-census/partials/teaching-assistants.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/teaching-assistants.tsx
@@ -5,22 +5,12 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import {
-  ChartDimensions,
-  PupilsPerStaffRole,
-  CensusCategories,
-} from "src/components";
-import {
-  ChartDimensionContext,
-  PhaseContext,
-  CustomDataContext,
-} from "src/contexts";
+import { PupilsPerStaffRole, CensusCategories } from "src/components";
+import { PhaseContext, CustomDataContext } from "src/contexts";
 import { TeachingAssistantsData } from "src/views/compare-your-census/partials";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { Census, CensusApi } from "src/services";
+import { DimensionedChart } from "src/composed/dimensioned-chart";
 
 export const TeachingAssistants: React.FC<{ type: string; id: string }> = ({
   type,
@@ -70,31 +60,24 @@ export const TeachingAssistants: React.FC<{ type: string; id: string }> = ({
       };
     }, [dimension, data]);
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      CensusCategories.find((x) => x.value === event.target.value) ??
-      PupilsPerStaffRole;
+      CensusCategories.find((x) => x.value === value) ?? PupilsPerStaffRole;
     setDimension(dimension);
   };
 
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <HorizontalBarChartWrapper
-        data={chartData}
-        chartName="teaching assistants (full time equivalent)"
-      >
-        <h2 className="govuk-heading-m">
-          Teaching Assistants (Full Time Equivalent)
-        </h2>
-        <ChartDimensions
-          dimensions={CensusCategories}
-          handleChange={handleSelectChange}
-          elementId="teaching-assistants"
-          value={dimension.value}
-        />
-      </HorizontalBarChartWrapper>
-    </ChartDimensionContext.Provider>
+    <DimensionedChart
+      charts={[
+        {
+          data: chartData,
+          title: "Teaching Assistants (Full Time Equivalent)",
+        },
+      ]}
+      dimension={dimension}
+      dimensions={CensusCategories}
+      handleDimensionChange={handleDimensionChange}
+      topLevel
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-census/partials/total-teachers-qualified.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/total-teachers-qualified.tsx
@@ -65,15 +65,16 @@ export const TotalTeachersQualified: React.FC<{ type: string; id: string }> = ({
       };
     }, [data]);
 
+  const title = "Teachers with qualified teacher status (percentage)";
+
   return (
     <ChartDimensionContext.Provider value={Percent}>
       <HorizontalBarChartWrapper
         data={chartData}
         chartName="teachers with qualified teacher status (%)"
+        chartTitle={title}
       >
-        <h2 className="govuk-heading-m">
-          Teachers with qualified teacher status (percentage)
-        </h2>
+        <h2 className="govuk-heading-m">{title}</h2>
       </HorizontalBarChartWrapper>
     </ChartDimensionContext.Provider>
   );

--- a/front-end-components/src/views/compare-your-census/partials/total-teachers-qualified.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/total-teachers-qualified.tsx
@@ -69,11 +69,7 @@ export const TotalTeachersQualified: React.FC<{ type: string; id: string }> = ({
 
   return (
     <ChartDimensionContext.Provider value={Percent}>
-      <HorizontalBarChartWrapper
-        data={chartData}
-        chartName="teachers with qualified teacher status (%)"
-        chartTitle={title}
-      >
+      <HorizontalBarChartWrapper data={chartData} chartTitle={title}>
         <h2 className="govuk-heading-m">{title}</h2>
       </HorizontalBarChartWrapper>
     </ChartDimensionContext.Provider>

--- a/front-end-components/src/views/compare-your-census/partials/total-teachers.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/total-teachers.tsx
@@ -5,22 +5,12 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import {
-  ChartDimensions,
-  PupilsPerStaffRole,
-  CensusCategories,
-} from "src/components";
-import {
-  ChartDimensionContext,
-  PhaseContext,
-  CustomDataContext,
-} from "src/contexts";
+import { PupilsPerStaffRole, CensusCategories } from "src/components";
+import { PhaseContext, CustomDataContext } from "src/contexts";
 import { TotalTeachersData } from "src/views/compare-your-census/partials";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { Census, CensusApi } from "src/services";
+import { DimensionedChart } from "src/composed/dimensioned-chart";
 
 export const TotalTeachers: React.FC<{ type: string; id: string }> = ({
   type,
@@ -70,31 +60,24 @@ export const TotalTeachers: React.FC<{ type: string; id: string }> = ({
       };
     }, [dimension, data]);
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      CensusCategories.find((x) => x.value === event.target.value) ??
-      PupilsPerStaffRole;
+      CensusCategories.find((x) => x.value === value) ?? PupilsPerStaffRole;
     setDimension(dimension);
   };
 
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <HorizontalBarChartWrapper
-        data={chartData}
-        chartName="total number of teachers (full time equivalent)"
-      >
-        <h2 className="govuk-heading-m">
-          Total number of teachers (Full Time Equivalent)
-        </h2>
-        <ChartDimensions
-          dimensions={CensusCategories}
-          handleChange={handleSelectChange}
-          elementId="total-teachers"
-          value={dimension.value}
-        />
-      </HorizontalBarChartWrapper>
-    </ChartDimensionContext.Provider>
+    <DimensionedChart
+      charts={[
+        {
+          data: chartData,
+          title: "Total number of teachers (Full Time Equivalent)",
+        },
+      ]}
+      dimension={dimension}
+      dimensions={CensusCategories}
+      handleDimensionChange={handleDimensionChange}
+      topLevel
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/accordion-section.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/accordion-section.tsx
@@ -1,0 +1,43 @@
+import { AccordionSectionProps } from "src/views/compare-your-costs/partials/accordion-sections/types";
+import { useHash } from "src/hooks/useHash";
+import classNames from "classnames";
+import {
+  SchoolChartData,
+  TrustChartData,
+} from "src/components/charts/table-chart";
+import { Section } from "..";
+
+export function AccordionSection<
+  TData extends SchoolChartData | TrustChartData,
+>({ index, title, ...rest }: AccordionSectionProps<TData>) {
+  const elementId = title.toLowerCase().replace(/\W/g, "-");
+  const [hash] = useHash();
+
+  return (
+    <div
+      className={classNames("govuk-accordion__section", {
+        "govuk-accordion__section--expanded": hash === `#${elementId}`,
+      })}
+      id={elementId}
+    >
+      <div className="govuk-accordion__section-header">
+        <h2 className="govuk-accordion__section-heading">
+          <span
+            className="govuk-accordion__section-button"
+            id={`accordion-heading-${index}`}
+          >
+            {title}
+          </span>
+        </h2>
+      </div>
+      <div
+        id={`accordion-content-${index}`}
+        className="govuk-accordion__section-content"
+        aria-labelledby={`accordion-heading-${index}`}
+        role="region"
+      >
+        <Section {...rest} />
+      </div>
+    </div>
+  );
+}

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/administrative-supplies.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/administrative-supplies.tsx
@@ -16,7 +16,7 @@ import {
   ExpenditureApi,
   AdministrativeSuppliesExpenditure,
 } from "src/services";
-import { AccordionSection } from "./accordion-section";
+import { AccordionSection } from "src/composed/accordion-section";
 
 export const AdministrativeSupplies: React.FC<CompareYourCostsProps> = ({
   type,

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/administrative-supplies.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/administrative-supplies.tsx
@@ -9,27 +9,14 @@ import {
   AdministrativeSuppliesData,
   CompareYourCostsProps,
 } from "src/views/compare-your-costs/partials/accordion-sections/types";
-import {
-  CostCategories,
-  PoundsPerPupil,
-  ChartDimensions,
-} from "src/components";
-import {
-  ChartDimensionContext,
-  PhaseContext,
-  CustomDataContext,
-} from "src/contexts";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
-import { useHash } from "src/hooks/useHash";
-import classNames from "classnames";
+import { CostCategories, PoundsPerPupil } from "src/components";
+import { PhaseContext, CustomDataContext } from "src/contexts";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import {
   ExpenditureApi,
   AdministrativeSuppliesExpenditure,
 } from "src/services";
-import { ErrorBanner } from "src/components/error-banner";
+import { AccordionSection } from "./accordion-section";
 
 export const AdministrativeSupplies: React.FC<CompareYourCostsProps> = ({
   type,
@@ -59,12 +46,9 @@ export const AdministrativeSupplies: React.FC<CompareYourCostsProps> = ({
     });
   }, [getData]);
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      CostCategories.find((x) => x.value === event.target.value) ??
-      PoundsPerPupil;
+      CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);
   };
 
@@ -90,60 +74,19 @@ export const AdministrativeSupplies: React.FC<CompareYourCostsProps> = ({
       };
     }, [data, dimension]);
 
-  const elementId = "administrative-supplies";
-  const [hash] = useHash();
-
-  const hasNoData = data?.length === 0;
-
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <div
-        className={classNames("govuk-accordion__section", {
-          "govuk-accordion__section--expanded": hash === `#${elementId}`,
-        })}
-        id={elementId}
-      >
-        <div className="govuk-accordion__section-header">
-          <h2 className="govuk-accordion__section-heading">
-            <span
-              className="govuk-accordion__section-button"
-              id="accordion-heading-7"
-            >
-              Administrative supplies
-            </span>
-          </h2>
-        </div>
-        <div
-          id="accordion-content-7"
-          className="govuk-accordion__section-content"
-          aria-labelledby="accordion-heading-7"
-          role="region"
-        >
-          {hasNoData ? (
-            <ErrorBanner
-              isRendered={hasNoData}
-              message="There isn't enough information available to create a set of similar schools."
-            />
-          ) : (
-            <>
-              <HorizontalBarChartWrapper
-                data={administrativeSuppliesBarData}
-                chartName="administrative supplies (non-eductional)"
-              >
-                <h3 className="govuk-heading-s">
-                  Administrative supplies (Non-educational)
-                </h3>
-                <ChartDimensions
-                  dimensions={CostCategories}
-                  handleChange={handleSelectChange}
-                  elementId="administrative-supplies-non-eductional"
-                  value={dimension.value}
-                />
-              </HorizontalBarChartWrapper>
-            </>
-          )}
-        </div>
-      </div>
-    </ChartDimensionContext.Provider>
+    <AccordionSection
+      charts={[
+        {
+          data: administrativeSuppliesBarData,
+          title: "Administrative supplies (Non-educational)",
+        },
+      ]}
+      dimension={dimension}
+      handleDimensionChange={handleDimensionChange}
+      hasNoData={data?.length === 0}
+      index={7}
+      title="Administrative supplies"
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
@@ -14,24 +14,15 @@ import {
   PoundsPerPupil,
   ChartDimensions,
 } from "src/components";
-import {
-  ChartDimensionContext,
-  CustomDataContext,
-  PhaseContext,
-} from "src/contexts";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
-import { useHash } from "src/hooks/useHash";
-import classNames from "classnames";
+import { CustomDataContext, PhaseContext } from "src/contexts";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import {
   ExpenditureApi,
   CateringStaffServicesExpenditure,
   TotalCateringCostsField,
 } from "src/services";
 import { TotalCateringCostsType } from "src/components/total-catering-costs-type";
-import { ErrorBanner } from "src/components/error-banner";
+import { AccordionSection } from "./accordion-section";
 
 export const CateringStaffServices: React.FC<CompareYourCostsProps> = ({
   type,
@@ -126,80 +117,44 @@ export const CateringStaffServices: React.FC<CompareYourCostsProps> = ({
       };
     }, [data, tableHeadings]);
 
-  const elementId = "catering-staff-and-supplies";
-  const [hash] = useHash();
-
-  const hasNoData = data?.length === 0;
-
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <div
-        className={classNames("govuk-accordion__section", {
-          "govuk-accordion__section--expanded": hash === `#${elementId}`,
-        })}
-        id={elementId}
-      >
-        <div className="govuk-accordion__section-header">
-          <h2 className="govuk-accordion__section-heading">
-            <span
-              className="govuk-accordion__section-button"
-              id="accordion-heading-8"
-            >
-              Catering staff and services
-            </span>
-          </h2>
-        </div>
-        <div
-          id="accordion-content-8"
-          className="govuk-accordion__section-content"
-          aria-labelledby="accordion-heading-8"
-          role="region"
-        >
-          {hasNoData ? (
-            <ErrorBanner
-              isRendered={hasNoData}
-              message="There isn't enough information available to create a set of similar schools."
+    <AccordionSection
+      charts={[
+        {
+          data: totalCateringBarData,
+          title: `Total catering costs (${totalCateringCostsField === "totalGrossCateringCosts" ? "gross" : "net"})`,
+        },
+        {
+          data: cateringStaffBarData,
+          title: "Catering staff costs",
+        },
+        {
+          data: cateringSuppliesBarData,
+          title: "Catering supplies costs",
+        },
+      ]}
+      dimension={dimension}
+      hasNoData={data?.length === 0}
+      index={8}
+      options={
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-one-half">
+            <ChartDimensions
+              dimensions={CostCategories}
+              handleChange={handleSelectChange}
+              elementId="total-catering-costs"
+              value={dimension.value}
             />
-          ) : (
-            <>
-              <HorizontalBarChartWrapper
-                data={totalCateringBarData}
-                chartName="total catering costs"
-              >
-                <h3 className="govuk-heading-s">Total catering costs</h3>
-                <div className="govuk-grid-row">
-                  <div className="govuk-grid-column-one-half">
-                    <ChartDimensions
-                      dimensions={CostCategories}
-                      handleChange={handleSelectChange}
-                      elementId="total-catering-costs"
-                      value={dimension.value}
-                    />
-                  </div>
-                  <div className="govuk-grid-column-one-half">
-                    <TotalCateringCostsType
-                      field={totalCateringCostsField}
-                      onChange={setTotalCateringCostsField}
-                    />
-                  </div>
-                </div>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={cateringStaffBarData}
-                chartName="catering staff costs"
-              >
-                <h3 className="govuk-heading-s">Catering staff costs</h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={cateringSuppliesBarData}
-                chartName="catering supplies costs"
-              >
-                <h3 className="govuk-heading-s">Catering supplies costs</h3>
-              </HorizontalBarChartWrapper>
-            </>
-          )}
+          </div>
+          <div className="govuk-grid-column-one-half">
+            <TotalCateringCostsType
+              field={totalCateringCostsField}
+              onChange={setTotalCateringCostsField}
+            />
+          </div>
         </div>
-      </div>
-    </ChartDimensionContext.Provider>
+      }
+      title="Catering staff and supplies"
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
@@ -22,7 +22,7 @@ import {
   TotalCateringCostsField,
 } from "src/services";
 import { TotalCateringCostsType } from "src/components/total-catering-costs-type";
-import { AccordionSection } from "./accordion-section";
+import { AccordionSection } from "src/composed/accordion-section";
 
 export const CateringStaffServices: React.FC<CompareYourCostsProps> = ({
   type,

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-ict.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-ict.tsx
@@ -13,7 +13,7 @@ import { CostCategories, PoundsPerPupil } from "src/components";
 import { PhaseContext, CustomDataContext } from "src/contexts";
 import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, EducationalIctExpenditure } from "src/services";
-import { AccordionSection } from "./accordion-section";
+import { AccordionSection } from "src/composed/accordion-section";
 
 export const EducationalIct: React.FC<CompareYourCostsProps> = ({
   type,

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-ict.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-ict.tsx
@@ -9,24 +9,11 @@ import {
   CompareYourCostsProps,
   EducationalIctData,
 } from "src/views/compare-your-costs/partials/accordion-sections/types";
-import {
-  CostCategories,
-  PoundsPerPupil,
-  ChartDimensions,
-} from "src/components";
-import {
-  ChartDimensionContext,
-  PhaseContext,
-  CustomDataContext,
-} from "src/contexts";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
-import { useHash } from "src/hooks/useHash";
-import classNames from "classnames";
+import { CostCategories, PoundsPerPupil } from "src/components";
+import { PhaseContext, CustomDataContext } from "src/contexts";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, EducationalIctExpenditure } from "src/services";
-import { ErrorBanner } from "src/components/error-banner";
+import { AccordionSection } from "./accordion-section";
 
 export const EducationalIct: React.FC<CompareYourCostsProps> = ({
   type,
@@ -54,12 +41,9 @@ export const EducationalIct: React.FC<CompareYourCostsProps> = ({
     });
   }, [getData]);
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      CostCategories.find((x) => x.value === event.target.value) ??
-      PoundsPerPupil;
+      CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);
   };
 
@@ -85,60 +69,19 @@ export const EducationalIct: React.FC<CompareYourCostsProps> = ({
       };
     }, [dimension, data]);
 
-  const elementId = "educational-ict";
-  const [hash] = useHash();
-
-  const hasNoData = data?.length === 0;
-
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <div
-        className={classNames("govuk-accordion__section", {
-          "govuk-accordion__section--expanded": hash === `#${elementId}`,
-        })}
-        id={elementId}
-      >
-        <div className="govuk-accordion__section-header">
-          <h2 className="govuk-accordion__section-heading">
-            <span
-              className="govuk-accordion__section-button"
-              id="accordion-heading-4"
-            >
-              Educational ICT
-            </span>
-          </h2>
-        </div>
-        <div
-          id="accordion-content-4"
-          className="govuk-accordion__section-content"
-          aria-labelledby="accordion-heading-4"
-          role="region"
-        >
-          {hasNoData ? (
-            <ErrorBanner
-              isRendered={hasNoData}
-              message="There isn't enough information available to create a set of similar schools."
-            />
-          ) : (
-            <>
-              <HorizontalBarChartWrapper
-                data={learningResourcesBarData}
-                chartName="eductional learning resources costs"
-              >
-                <h3 className="govuk-heading-s">
-                  Educational learning resources costs
-                </h3>
-                <ChartDimensions
-                  dimensions={CostCategories}
-                  handleChange={handleSelectChange}
-                  elementId="eductional-learning-resources-costs"
-                  value={dimension.value}
-                />
-              </HorizontalBarChartWrapper>
-            </>
-          )}
-        </div>
-      </div>
-    </ChartDimensionContext.Provider>
+    <AccordionSection
+      charts={[
+        {
+          data: learningResourcesBarData,
+          title: "Educational learning resources costs",
+        },
+      ]}
+      dimension={dimension}
+      handleDimensionChange={handleDimensionChange}
+      hasNoData={data?.length === 0}
+      index={4}
+      title="Educational ICT"
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-supplies.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-supplies.tsx
@@ -9,24 +9,11 @@ import {
   CompareYourCostsProps,
   EducationalSuppliesData,
 } from "src/views/compare-your-costs/partials/accordion-sections/types";
-import {
-  CostCategories,
-  PoundsPerPupil,
-  ChartDimensions,
-} from "src/components";
-import {
-  ChartDimensionContext,
-  CustomDataContext,
-  PhaseContext,
-} from "src/contexts";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
-import { useHash } from "src/hooks/useHash";
-import classNames from "classnames";
+import { CostCategories, PoundsPerPupil } from "src/components";
+import { CustomDataContext, PhaseContext } from "src/contexts";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, EducationalSuppliesExpenditure } from "src/services";
-import { ErrorBanner } from "src/components/error-banner";
+import { AccordionSection } from "./accordion-section";
 
 export const EducationalSupplies: React.FC<CompareYourCostsProps> = ({
   type,
@@ -65,12 +52,9 @@ export const EducationalSupplies: React.FC<CompareYourCostsProps> = ({
     [dimension]
   );
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      CostCategories.find((x) => x.value === event.target.value) ??
-      PoundsPerPupil;
+      CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);
   };
 
@@ -116,74 +100,27 @@ export const EducationalSupplies: React.FC<CompareYourCostsProps> = ({
       };
     }, [data, tableHeadings]);
 
-  const elementId = "educational-supplies";
-  const [hash] = useHash();
-
-  const hasNoData = data?.length === 0;
-
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <div
-        className={classNames("govuk-accordion__section", {
-          "govuk-accordion__section--expanded": hash === `#${elementId}`,
-        })}
-        id={elementId}
-      >
-        <div className="govuk-accordion__section-header">
-          <h2 className="govuk-accordion__section-heading">
-            <span
-              className="govuk-accordion__section-button"
-              id="accordion-heading-3"
-            >
-              Educational supplies
-            </span>
-          </h2>
-        </div>
-        <div
-          id="accordion-content-3"
-          className="govuk-accordion__section-content"
-          aria-labelledby="accordion-heading-3"
-          role="region"
-        >
-          {hasNoData ? (
-            <ErrorBanner
-              isRendered={hasNoData}
-              message="There isn't enough information available to create a set of similar schools."
-            />
-          ) : (
-            <>
-              <HorizontalBarChartWrapper
-                data={totalEducationalSuppliesBarData}
-                chartName="total educational supplies costs"
-              >
-                <h3 className="govuk-heading-s">
-                  Total educational supplies costs
-                </h3>
-                <ChartDimensions
-                  dimensions={CostCategories}
-                  handleChange={handleSelectChange}
-                  elementId="total-educational-supplies-costs"
-                  value={dimension.value}
-                />
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={examinationFeesBarData}
-                chartName="examination fees costs"
-              >
-                <h3 className="govuk-heading-s">Examination fees costs</h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={learningResourcesBarData}
-                chartName="learning resource (not ICT equipment) costs"
-              >
-                <h3 className="govuk-heading-s">
-                  Learning resources (not ICT equipment) costs
-                </h3>
-              </HorizontalBarChartWrapper>
-            </>
-          )}
-        </div>
-      </div>
-    </ChartDimensionContext.Provider>
+    <AccordionSection
+      charts={[
+        {
+          data: totalEducationalSuppliesBarData,
+          title: "Total educational supplies costs",
+        },
+        {
+          data: examinationFeesBarData,
+          title: "Examination fees costs",
+        },
+        {
+          data: learningResourcesBarData,
+          title: "Learning resources (not ICT equipment) costs",
+        },
+      ]}
+      dimension={dimension}
+      handleDimensionChange={handleDimensionChange}
+      hasNoData={data?.length === 0}
+      index={3}
+      title="Educational supplies"
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-supplies.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-supplies.tsx
@@ -13,7 +13,7 @@ import { CostCategories, PoundsPerPupil } from "src/components";
 import { CustomDataContext, PhaseContext } from "src/contexts";
 import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, EducationalSuppliesExpenditure } from "src/services";
-import { AccordionSection } from "./accordion-section";
+import { AccordionSection } from "src/composed/accordion-section";
 
 export const EducationalSupplies: React.FC<CompareYourCostsProps> = ({
   type,

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/index.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/index.tsx
@@ -8,3 +8,4 @@ export * from "src/views/compare-your-costs/partials/accordion-sections/educatio
 export * from "src/views/compare-your-costs/partials/accordion-sections/educational-ict";
 export * from "src/views/compare-your-costs/partials/accordion-sections/catering-staff-services";
 export * from "src/views/compare-your-costs/partials/accordion-sections/administrative-supplies";
+export * from "src/views/compare-your-costs/partials/accordion-sections/accordion-section";

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/index.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/index.tsx
@@ -8,4 +8,3 @@ export * from "src/views/compare-your-costs/partials/accordion-sections/educatio
 export * from "src/views/compare-your-costs/partials/accordion-sections/educational-ict";
 export * from "src/views/compare-your-costs/partials/accordion-sections/catering-staff-services";
 export * from "src/views/compare-your-costs/partials/accordion-sections/administrative-supplies";
-export * from "src/views/compare-your-costs/partials/accordion-sections/accordion-section";

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/non-educational-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/non-educational-support-staff.tsx
@@ -9,27 +9,14 @@ import {
   CompareYourCostsProps,
   NonEducationalSupportStaffData,
 } from "src/views/compare-your-costs/partials/accordion-sections/types";
-import {
-  CostCategories,
-  PoundsPerPupil,
-  ChartDimensions,
-} from "src/components";
-import {
-  ChartDimensionContext,
-  PhaseContext,
-  CustomDataContext,
-} from "src/contexts";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
-import classNames from "classnames";
-import { useHash } from "src/hooks/useHash";
+import { CostCategories, PoundsPerPupil } from "src/components";
+import { PhaseContext, CustomDataContext } from "src/contexts";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import {
   ExpenditureApi,
   NonEducationalSupportStaffExpenditure,
 } from "src/services";
-import { ErrorBanner } from "src/components/error-banner";
+import { AccordionSection } from "./accordion-section";
 
 export const NonEducationalSupportStaff: React.FC<CompareYourCostsProps> = ({
   type,
@@ -70,12 +57,9 @@ export const NonEducationalSupportStaff: React.FC<CompareYourCostsProps> = ({
     [dimension]
   );
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      CostCategories.find((x) => x.value === event.target.value) ??
-      PoundsPerPupil;
+      CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);
   };
 
@@ -149,88 +133,35 @@ export const NonEducationalSupportStaff: React.FC<CompareYourCostsProps> = ({
       };
     }, [data, tableHeadings]);
 
-  const elementId = "non-educational-support-staff-and-services";
-  const [hash] = useHash();
-
-  const hasNoData = data?.length === 0;
-
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <div
-        className={classNames("govuk-accordion__section", {
-          "govuk-accordion__section--expanded": hash === `#${elementId}`,
-        })}
-        id={elementId}
-      >
-        <div className="govuk-accordion__section-header">
-          <h2 className="govuk-accordion__section-heading">
-            <span
-              className="govuk-accordion__section-button"
-              id="accordion-heading-2"
-            >
-              Non-educational support staff
-            </span>
-          </h2>
-        </div>
-        <div
-          id="accordion-content-2"
-          className="govuk-accordion__section-content"
-          aria-labelledby="accordion-2"
-          role="region"
-        >
-          {hasNoData ? (
-            <ErrorBanner
-              isRendered={hasNoData}
-              message="There isn't enough information available to create a set of similar schools."
-            />
-          ) : (
-            <>
-              <HorizontalBarChartWrapper
-                data={totalNonEducationalBarData}
-                chartName="total non-educational support staff costs"
-              >
-                <h3 className="govuk-heading-s">
-                  Total non-educational support staff costs
-                </h3>
-                <ChartDimensions
-                  dimensions={CostCategories}
-                  handleChange={handleSelectChange}
-                  elementId="total-non-educational-support-staff-costs"
-                  value={dimension.value}
-                />
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={administrativeClericalBarData}
-                chartName="administrative and clerical staff costs"
-              >
-                <h3 className="govuk-heading-s">
-                  Administrative and clerical staff costs
-                </h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={auditorsCostsBarData}
-                chartName="auditors costs"
-              >
-                <h3 className="govuk-heading-s">Auditors costs</h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={otherStaffCostsBarData}
-                chartName="other staff costs"
-              >
-                <h3 className="govuk-heading-s">Other staff costs</h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={professionalServicesBarData}
-                chartName="profession services (non-curriculum) costs"
-              >
-                <h3 className="govuk-heading-s">
-                  Professional services (non-curriculum) costs
-                </h3>
-              </HorizontalBarChartWrapper>
-            </>
-          )}
-        </div>
-      </div>
-    </ChartDimensionContext.Provider>
+    <AccordionSection
+      charts={[
+        {
+          data: totalNonEducationalBarData,
+          title: "Total non-educational support staff costs",
+        },
+        {
+          data: administrativeClericalBarData,
+          title: "Administrative and clerical staff costs",
+        },
+        {
+          data: auditorsCostsBarData,
+          title: "Auditors costs",
+        },
+        {
+          data: otherStaffCostsBarData,
+          title: "Other staff costs",
+        },
+        {
+          data: professionalServicesBarData,
+          title: "Professional services (non-curriculum) costs",
+        },
+      ]}
+      dimension={dimension}
+      handleDimensionChange={handleDimensionChange}
+      hasNoData={data?.length === 0}
+      index={2}
+      title="Non-educational support staff and services"
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/non-educational-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/non-educational-support-staff.tsx
@@ -16,7 +16,7 @@ import {
   ExpenditureApi,
   NonEducationalSupportStaffExpenditure,
 } from "src/services";
-import { AccordionSection } from "./accordion-section";
+import { AccordionSection } from "src/composed/accordion-section";
 
 export const NonEducationalSupportStaff: React.FC<CompareYourCostsProps> = ({
   type,

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/other-costs.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/other-costs.tsx
@@ -9,24 +9,11 @@ import {
   CompareYourCostsProps,
   OtherCostsData,
 } from "src/views/compare-your-costs/partials/accordion-sections/types";
-import {
-  CostCategories,
-  PoundsPerPupil,
-  ChartDimensions,
-} from "src/components";
-import {
-  ChartDimensionContext,
-  PhaseContext,
-  CustomDataContext,
-} from "src/contexts";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
-import { useHash } from "src/hooks/useHash";
-import classNames from "classnames";
+import { CostCategories, PoundsPerPupil } from "src/components";
+import { PhaseContext, CustomDataContext } from "src/contexts";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, OtherCostsDataExpenditure } from "src/services";
-import { ErrorBanner } from "src/components/error-banner";
+import { AccordionSection } from "./accordion-section";
 
 export const OtherCosts: React.FC<CompareYourCostsProps> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
@@ -62,12 +49,9 @@ export const OtherCosts: React.FC<CompareYourCostsProps> = ({ type, id }) => {
     [dimension]
   );
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      CostCategories.find((x) => x.value === event.target.value) ??
-      PoundsPerPupil;
+      CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);
   };
 
@@ -267,152 +251,62 @@ export const OtherCosts: React.FC<CompareYourCostsProps> = ({ type, id }) => {
       };
     }, [data, tableHeadings]);
 
-  const elementId = "other-costs";
-  const [hash] = useHash();
-
-  const hasNoData = data?.length === 0;
-
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <div
-        className={classNames("govuk-accordion__section", {
-          "govuk-accordion__section--expanded": hash === `#${elementId}`,
-        })}
-        id={elementId}
-      >
-        <div className="govuk-accordion__section-header">
-          <h2 className="govuk-accordion__section-heading">
-            <span
-              className="govuk-accordion__section-button"
-              id="accordion-heading-9"
-            >
-              Other costs
-            </span>
-          </h2>
-        </div>
-        <div
-          id="accordion-content-9"
-          className="govuk-accordion__section-content"
-          aria-labelledby="accordion-heading-9"
-          role="region"
-        >
-          {hasNoData ? (
-            <ErrorBanner
-              isRendered={hasNoData}
-              message="There isn't enough information available to create a set of similar schools."
-            />
-          ) : (
-            <>
-              <HorizontalBarChartWrapper
-                data={totalOtherCostsBarData}
-                chartName="total other costs"
-              >
-                <h3 className="govuk-heading-s">Total other costs</h3>
-                <ChartDimensions
-                  dimensions={CostCategories}
-                  handleChange={handleSelectChange}
-                  elementId="total-otehr-costs"
-                  value={dimension.value}
-                />
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={otherInsurancePremiumsCostsBarData}
-                chartName="other insurance premiums costs"
-              >
-                <h3 className="govuk-heading-s">
-                  Other insurance premiums costs
-                </h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={directRevenueFinancingCostsBarData}
-                chartName="direct revenue financing costs"
-              >
-                <h3 className="govuk-heading-s">
-                  Direct revenue financing costs
-                </h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={groundsMaintenanceCostsBarData}
-                chartName="ground maintenance costs"
-              >
-                <h3 className="govuk-heading-s">Ground maintenance costs</h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={indirectEmployeeExpensesBarData}
-                chartName="indirect employee expenses"
-              >
-                <h3 className="govuk-heading-s">Indirect employee expenses</h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={interestChargesLoanBankBarData}
-                chartName="interest charges for loan and bank"
-              >
-                <h3 className="govuk-heading-s">
-                  Interest charges for loan and bank
-                </h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={privateFinanceInitiativeChargesBarData}
-                chartName="PFI charges"
-              >
-                <h3 className="govuk-heading-s">PFI charges</h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={rentRatesCostsBarData}
-                chartName="rent and rates costs"
-              >
-                <h3 className="govuk-heading-s">Rent and rates costs</h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={specialFacilitiesCostsBarData}
-                chartName="special facilities costs"
-              >
-                <h3 className="govuk-heading-s">Special facilities costs</h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={staffDevelopmentTrainingCostsBarData}
-                chartName="staff development and training costs"
-              >
-                <h3 className="govuk-heading-s">
-                  Staff development and training costs
-                </h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={staffRelatedInsuranceCostsBarData}
-                chartName="staff-related insurance costs"
-              >
-                <h3 className="govuk-heading-s">
-                  Staff-related insurance costs
-                </h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={supplyTeacherInsurableCostsBarData}
-                chartName="supply teacher insurance costs"
-              >
-                <h3 className="govuk-heading-s">
-                  Supply teacher insurance costs
-                </h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={communityFocusedSchoolStaffBarData}
-                chartName="community focused school staff (maintained schools only)"
-              >
-                <h3 className="govuk-heading-s">
-                  Community focused school staff (maintained schools only)
-                </h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={communityFocusedSchoolCostsBarData}
-                chartName="community focused school costs (maintained schools only)"
-              >
-                <h3 className="govuk-heading-s">
-                  Community focused school costs (maintained schools only)
-                </h3>
-              </HorizontalBarChartWrapper>
-            </>
-          )}
-        </div>
-      </div>
-    </ChartDimensionContext.Provider>
+    <AccordionSection
+      charts={[
+        { data: totalOtherCostsBarData, title: "Total other costs" },
+        {
+          data: otherInsurancePremiumsCostsBarData,
+          title: "Other insurance premiums costs",
+        },
+        {
+          data: directRevenueFinancingCostsBarData,
+          title: "Direct revenue financing costs",
+        },
+        {
+          data: groundsMaintenanceCostsBarData,
+          title: "Ground maintenance costs",
+        },
+        {
+          data: indirectEmployeeExpensesBarData,
+          title: "Indirect employee expenses",
+        },
+        {
+          data: interestChargesLoanBankBarData,
+          title: "Interest charges for loan and bank",
+        },
+        { data: privateFinanceInitiativeChargesBarData, title: "PFI charges" },
+        { data: rentRatesCostsBarData, title: "Rent and rates costs" },
+        {
+          data: specialFacilitiesCostsBarData,
+          title: "Special facilities costs",
+        },
+        {
+          data: staffDevelopmentTrainingCostsBarData,
+          title: "Staff development and training costs",
+        },
+        {
+          data: staffRelatedInsuranceCostsBarData,
+          title: "Staff-related insurance costs",
+        },
+        {
+          data: supplyTeacherInsurableCostsBarData,
+          title: "Supply teacher insurance costs",
+        },
+        {
+          data: communityFocusedSchoolStaffBarData,
+          title: "Community focused school staff (maintained schools only)",
+        },
+        {
+          data: communityFocusedSchoolCostsBarData,
+          title: "Community focused school costs (maintained schools only)",
+        },
+      ]}
+      dimension={dimension}
+      handleDimensionChange={handleDimensionChange}
+      hasNoData={data?.length === 0}
+      index={9}
+      title="Other costs"
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/other-costs.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/other-costs.tsx
@@ -13,7 +13,7 @@ import { CostCategories, PoundsPerPupil } from "src/components";
 import { PhaseContext, CustomDataContext } from "src/contexts";
 import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, OtherCostsDataExpenditure } from "src/services";
-import { AccordionSection } from "./accordion-section";
+import { AccordionSection } from "src/composed/accordion-section";
 
 export const OtherCosts: React.FC<CompareYourCostsProps> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
@@ -13,7 +13,7 @@ import { PoundsPerMetreSq, PremisesCategories } from "src/components";
 import { PhaseContext, CustomDataContext } from "src/contexts";
 import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, PremisesStaffServicesExpenditure } from "src/services";
-import { AccordionSection } from "./accordion-section";
+import { AccordionSection } from "src/composed/accordion-section";
 
 export const PremisesStaffServices: React.FC<CompareYourCostsProps> = ({
   type,

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
@@ -9,24 +9,11 @@ import {
   CompareYourCostsProps,
   PremisesStaffServicesData,
 } from "src/views/compare-your-costs/partials/accordion-sections/types";
-import {
-  PoundsPerMetreSq,
-  PremisesCategories,
-  ChartDimensions,
-} from "src/components";
-import {
-  ChartDimensionContext,
-  PhaseContext,
-  CustomDataContext,
-} from "src/contexts";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
-import { useHash } from "src/hooks/useHash";
-import classNames from "classnames";
+import { PoundsPerMetreSq, PremisesCategories } from "src/components";
+import { PhaseContext, CustomDataContext } from "src/contexts";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, PremisesStaffServicesExpenditure } from "src/services";
-import { ErrorBanner } from "src/components/error-banner";
+import { AccordionSection } from "./accordion-section";
 
 export const PremisesStaffServices: React.FC<CompareYourCostsProps> = ({
   type,
@@ -65,12 +52,9 @@ export const PremisesStaffServices: React.FC<CompareYourCostsProps> = ({
     [dimension]
   );
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      PremisesCategories.find((x) => x.value === event.target.value) ??
-      PoundsPerMetreSq;
+      PremisesCategories.find((x) => x.value === value) ?? PoundsPerMetreSq;
     setDimension(dimension);
   };
 
@@ -144,88 +128,26 @@ export const PremisesStaffServices: React.FC<CompareYourCostsProps> = ({
       };
     }, [data, tableHeadings]);
 
-  const elementId = "premises-staff-and-services";
-  const [hash] = useHash();
-
-  const hasNoData = data?.length === 0;
-
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <div
-        className={classNames("govuk-accordion__section", {
-          "govuk-accordion__section--expanded": hash === `#${elementId}`,
-        })}
-        id={elementId}
-      >
-        <div className="govuk-accordion__section-header">
-          <h2 className="govuk-accordion__section-heading">
-            <span
-              className="govuk-accordion__section-button"
-              id="accordion-heading-5"
-            >
-              Premises staff and services
-            </span>
-          </h2>
-        </div>
-        <div
-          id="accordion-content-5"
-          className="govuk-accordion__section-content"
-          aria-labelledby="accordion-heading-5"
-          role="region"
-        >
-          {hasNoData ? (
-            <ErrorBanner
-              isRendered={hasNoData}
-              message="There isn't enough information available to create a set of similar schools."
-            />
-          ) : (
-            <>
-              <HorizontalBarChartWrapper
-                data={totalPremisesStaffServiceCostsBarData}
-                chartName="total premises staff and service costs"
-              >
-                <h3 className="govuk-heading-s">
-                  Total premises staff and service costs
-                </h3>
-                <ChartDimensions
-                  dimensions={PremisesCategories}
-                  handleChange={handleSelectChange}
-                  elementId="total-premises-staff-service-costs"
-                  value={dimension.value}
-                />
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={cleaningCaretakingBarData}
-                chartName="cleaning and caretaking costs"
-              >
-                <h3 className="govuk-heading-s">
-                  Cleaning and caretaking costs
-                </h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={maintenanceBarData}
-                chartName="maintenance of premises costs"
-              >
-                <h3 className="govuk-heading-s">
-                  Maintenance of premises costs
-                </h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={otherOccupationBarData}
-                chartName="other occupation costs"
-              >
-                <h3 className="govuk-heading-s">Other occupation costs</h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={premisesStaffBarData}
-                chartName="premises staff costs"
-              >
-                <h3 className="govuk-heading-s">Premises staff costs</h3>
-              </HorizontalBarChartWrapper>
-            </>
-          )}
-        </div>
-      </div>
-    </ChartDimensionContext.Provider>
+    <AccordionSection
+      charts={[
+        {
+          data: totalPremisesStaffServiceCostsBarData,
+          title: "Total premises staff and service costs",
+        },
+        {
+          data: cleaningCaretakingBarData,
+          title: "Cleaning and caretaking costs",
+        },
+        { data: maintenanceBarData, title: "Maintenance of premises costs" },
+        { data: otherOccupationBarData, title: "Other occupation costs" },
+        { data: premisesStaffBarData, title: "Premises staff costs" },
+      ]}
+      dimension={dimension}
+      handleDimensionChange={handleDimensionChange}
+      hasNoData={data?.length === 0}
+      index={5}
+      title="Premises staff and services"
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
@@ -134,6 +134,7 @@ export const PremisesStaffServices: React.FC<CompareYourCostsProps> = ({
         {
           data: totalPremisesStaffServiceCostsBarData,
           title: "Total premises staff and service costs",
+          dimensions: PremisesCategories,
         },
         {
           data: cleaningCaretakingBarData,

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/teaching-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/teaching-support-staff.tsx
@@ -9,24 +9,11 @@ import {
   CompareYourCostsProps,
   TeachingSupportStaffData,
 } from "src/views/compare-your-costs/partials/accordion-sections/types";
-import {
-  CostCategories,
-  PoundsPerPupil,
-  ChartDimensions,
-} from "src/components";
-import {
-  ChartDimensionContext,
-  PhaseContext,
-  CustomDataContext,
-} from "src/contexts";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
-import { useHash } from "src/hooks/useHash";
-import classNames from "classnames";
+import { CostCategories, PoundsPerPupil } from "src/components";
+import { PhaseContext, CustomDataContext } from "src/contexts";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, TeachingSupportStaffExpenditure } from "src/services";
-import { ErrorBanner } from "src/components/error-banner";
+import { AccordionSection } from "./accordion-section";
 
 export const TeachingSupportStaff: React.FC<CompareYourCostsProps> = ({
   type,
@@ -65,12 +52,9 @@ export const TeachingSupportStaff: React.FC<CompareYourCostsProps> = ({
     [dimension]
   );
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      CostCategories.find((x) => x.value === event.target.value) ??
-      PoundsPerPupil;
+      CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);
   };
 
@@ -158,96 +142,39 @@ export const TeachingSupportStaff: React.FC<CompareYourCostsProps> = ({
       };
     }, [data, tableHeadings]);
 
-  const elementId = "teaching-and-teaching-support-staff";
-  const [hash] = useHash();
-
-  const hasNoData = data?.length === 0;
-
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <div
-        className={classNames("govuk-accordion__section", {
-          "govuk-accordion__section--expanded": hash === `#${elementId}`,
-        })}
-        id={elementId}
-      >
-        <div className="govuk-accordion__section-header">
-          <h2 className="govuk-accordion__section-heading">
-            <span
-              className="govuk-accordion__section-button"
-              id="accordion-heading-1"
-            >
-              Teaching and teaching support staff
-            </span>
-          </h2>
-        </div>
-        <div
-          id="accordion-content-1"
-          className="govuk-accordion__section-content"
-          aria-labelledby="accordion-heading-1"
-          role="region"
-        >
-          {hasNoData ? (
-            <ErrorBanner
-              isRendered={hasNoData}
-              message="There isn't enough information available to create a set of similar schools."
-            />
-          ) : (
-            <>
-              <HorizontalBarChartWrapper
-                data={totalTeachingBarData}
-                chartName="total teaching and support staff cost"
-              >
-                <h3 className="govuk-heading-s">
-                  Total teaching and teaching support staff costs
-                </h3>
-                <ChartDimensions
-                  dimensions={CostCategories}
-                  handleChange={handleSelectChange}
-                  elementId="total-teaching-support-staff-cost"
-                  value={dimension.value}
-                />
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={teachingStaffBarData}
-                chartName="teaching staff costs"
-              >
-                <h3 className="govuk-heading-s">Teaching staff costs</h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={supplyTeachingBarData}
-                chartName="supply teaching staff costs"
-              >
-                <h3 className="govuk-heading-s">Supply teaching staff costs</h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={educationalConsultancyBarData}
-                chartName="educational consultancy costs"
-              >
-                <h3 className="govuk-heading-s">
-                  Educational consultancy costs
-                </h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={educationSupportStaffBarData}
-                chartName="educational support staff costs"
-              >
-                <h3 className="govuk-heading-s">
-                  Educational support staff costs
-                </h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={agencySupplyBarData}
-                chartName="agency supply teaching staff costs"
-              >
-                <h3 className="govuk-heading-s">
-                  Agency supply teaching staff costs
-                </h3>
-              </HorizontalBarChartWrapper>
-            </>
-          )}
-        </div>
-      </div>
-    </ChartDimensionContext.Provider>
+    <AccordionSection
+      charts={[
+        {
+          data: totalTeachingBarData,
+          title: "Total teaching and teaching support staff costs",
+        },
+        {
+          data: teachingStaffBarData,
+          title: "Teaching staff costs",
+        },
+        {
+          data: supplyTeachingBarData,
+          title: "Supply teaching staff costs",
+        },
+        {
+          data: educationalConsultancyBarData,
+          title: "Educational consultancy costs",
+        },
+        {
+          data: educationSupportStaffBarData,
+          title: "Educational support staff costs",
+        },
+        {
+          data: agencySupplyBarData,
+          title: "Agency supply teaching staff costs",
+        },
+      ]}
+      dimension={dimension}
+      handleDimensionChange={handleDimensionChange}
+      hasNoData={data?.length === 0}
+      index={1}
+      title="Teaching and teaching support staff"
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/teaching-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/teaching-support-staff.tsx
@@ -13,7 +13,7 @@ import { CostCategories, PoundsPerPupil } from "src/components";
 import { PhaseContext, CustomDataContext } from "src/contexts";
 import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, TeachingSupportStaffExpenditure } from "src/services";
-import { AccordionSection } from "./accordion-section";
+import { AccordionSection } from "src/composed/accordion-section";
 
 export const TeachingSupportStaff: React.FC<CompareYourCostsProps> = ({
   type,

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/types.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/types.tsx
@@ -1,3 +1,16 @@
+import {
+  SchoolChartData,
+  TrustChartData,
+} from "src/components/charts/table-chart";
+import { SectionProps } from "../types";
+
+export type AccordionSectionProps<
+  TData extends SchoolChartData | TrustChartData,
+> = Omit<SectionProps<TData>, "dimensions" | "topLevel"> & {
+  index: number;
+  title: string;
+};
+
 export type TeachingSupportStaffData = {
   urn: string;
   schoolType: string;

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/types.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/types.tsx
@@ -1,16 +1,3 @@
-import {
-  SchoolChartData,
-  TrustChartData,
-} from "src/components/charts/table-chart";
-import { SectionProps } from "../types";
-
-export type AccordionSectionProps<
-  TData extends SchoolChartData | TrustChartData,
-> = Omit<SectionProps<TData>, "dimensions" | "topLevel"> & {
-  index: number;
-  title: string;
-};
-
 export type TeachingSupportStaffData = {
   urn: string;
   schoolType: string;

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/utilities.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/utilities.tsx
@@ -9,24 +9,11 @@ import {
   CompareYourCostsProps,
   UtilitiesData,
 } from "src/views/compare-your-costs/partials/accordion-sections/types";
-import {
-  PoundsPerMetreSq,
-  PremisesCategories,
-  ChartDimensions,
-} from "src/components";
-import {
-  ChartDimensionContext,
-  PhaseContext,
-  CustomDataContext,
-} from "src/contexts";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
-import { useHash } from "src/hooks/useHash";
-import classNames from "classnames";
+import { PoundsPerMetreSq, PremisesCategories } from "src/components";
+import { PhaseContext, CustomDataContext } from "src/contexts";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, UtilitiesExpenditure } from "src/services";
-import { ErrorBanner } from "src/components/error-banner";
+import { AccordionSection } from "./accordion-section";
 
 export const Utilities: React.FC<CompareYourCostsProps> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerMetreSq);
@@ -62,12 +49,9 @@ export const Utilities: React.FC<CompareYourCostsProps> = ({ type, id }) => {
     [dimension]
   );
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      PremisesCategories.find((x) => x.value === event.target.value) ??
-      PoundsPerMetreSq;
+      PremisesCategories.find((x) => x.value === value) ?? PoundsPerMetreSq;
     setDimension(dimension);
   };
 
@@ -113,70 +97,24 @@ export const Utilities: React.FC<CompareYourCostsProps> = ({ type, id }) => {
       };
     }, [data, tableHeadings]);
 
-  const elementId = "utilities";
-  const [hash] = useHash();
-
-  const hasNoData = data?.length === 0;
-
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <div
-        className={classNames("govuk-accordion__section", {
-          "govuk-accordion__section--expanded": hash === `#${elementId}`,
-        })}
-        id={elementId}
-      >
-        <div className="govuk-accordion__section-header">
-          <h2 className="govuk-accordion__section-heading">
-            <span
-              className="govuk-accordion__section-button"
-              id="accordion-heading-6"
-            >
-              Utilities
-            </span>
-          </h2>
-        </div>
-        <div
-          id="accordion-content-6"
-          className="govuk-accordion__section-content"
-          aria-labelledby="accordion-heading-6"
-          role="region"
-        >
-          {hasNoData ? (
-            <ErrorBanner
-              isRendered={hasNoData}
-              message="There isn't enough information available to create a set of similar schools."
-            />
-          ) : (
-            <>
-              <HorizontalBarChartWrapper
-                data={totalUtilitiesCostsBarData}
-                chartName="total utilities costs"
-              >
-                <h3 className="govuk-heading-s">Total utilities costs</h3>
-                <ChartDimensions
-                  dimensions={PremisesCategories}
-                  handleChange={handleSelectChange}
-                  elementId="total-utilities-costs"
-                  value={dimension.value}
-                />
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={energyBarData}
-                chartName="energy costs"
-              >
-                <h3 className="govuk-heading-s">Energy costs</h3>
-              </HorizontalBarChartWrapper>
-              <HorizontalBarChartWrapper
-                data={waterSewerageBarData}
-                chartName="water and sewerage costs"
-              >
-                <h3 className="govuk-heading-s">Water and sewerage costs</h3>
-              </HorizontalBarChartWrapper>
-            </>
-          )}
-        </div>
-      </div>
-    </ChartDimensionContext.Provider>
+    <AccordionSection
+      charts={[
+        { data: totalUtilitiesCostsBarData, title: "Total utilities costs" },
+        {
+          data: energyBarData,
+          title: "Energy costs",
+        },
+        {
+          data: waterSewerageBarData,
+          title: "Water and sewerage costs",
+        },
+      ]}
+      dimension={dimension}
+      handleDimensionChange={handleDimensionChange}
+      hasNoData={data?.length === 0}
+      index={6}
+      title="Utilities"
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/utilities.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/utilities.tsx
@@ -13,7 +13,7 @@ import { PoundsPerMetreSq, PremisesCategories } from "src/components";
 import { PhaseContext, CustomDataContext } from "src/contexts";
 import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, UtilitiesExpenditure } from "src/services";
-import { AccordionSection } from "./accordion-section";
+import { AccordionSection } from "src/composed/accordion-section";
 
 export const Utilities: React.FC<CompareYourCostsProps> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerMetreSq);

--- a/front-end-components/src/views/compare-your-costs/partials/index.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/index.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react-refresh/only-export-components */
 export * from "src/views/compare-your-costs/partials/total-expenditure";
 export * from "src/views/compare-your-costs/partials/expenditure-accordion";
+export * from "src/views/compare-your-costs/partials/section";
 export * from "src/views/compare-your-costs/partials/types";

--- a/front-end-components/src/views/compare-your-costs/partials/index.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/index.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react-refresh/only-export-components */
 export * from "src/views/compare-your-costs/partials/total-expenditure";
 export * from "src/views/compare-your-costs/partials/expenditure-accordion";
-export * from "src/views/compare-your-costs/partials/section";
 export * from "src/views/compare-your-costs/partials/types";

--- a/front-end-components/src/views/compare-your-costs/partials/section.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/section.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { CostCategories, ChartDimensions } from "src/components";
+import { ChartDimensionContext } from "src/contexts";
+import { HorizontalBarChartWrapper } from "src/composed/horizontal-bar-chart-wrapper";
+import { ErrorBanner } from "src/components/error-banner";
+import {
+  SchoolChartData,
+  TrustChartData,
+} from "src/components/charts/table-chart";
+import { SectionProps } from "./types";
+
+export function Section<TData extends SchoolChartData | TrustChartData>({
+  charts,
+  dimension,
+  dimensions,
+  handleDimensionChange,
+  hasNoData,
+  options,
+  topLevel,
+}: SectionProps<TData>) {
+  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
+    event
+  ) => {
+    if (handleDimensionChange) {
+      handleDimensionChange(event.target.value);
+    }
+  };
+
+  return hasNoData ? (
+    <ErrorBanner
+      isRendered={hasNoData}
+      message="There isn't enough information available to create a set of similar schools."
+    />
+  ) : (
+    charts.map(({ title, data }, i) => {
+      const chartName = title.toLowerCase().replace(/\W/g, " ").trim();
+      const chartId = chartName.replace(/\s/g, "-");
+
+      return (
+        <ChartDimensionContext.Provider key={chartId} value={dimension}>
+          <HorizontalBarChartWrapper
+            chartName={chartName}
+            chartTitle={title}
+            data={data}
+          >
+            {topLevel ? (
+              <h2 className="govuk-heading-m">{title}</h2>
+            ) : (
+              <h3 className="govuk-heading-s">{title}</h3>
+            )}
+            {i === 0 &&
+              (options ?? (
+                <ChartDimensions
+                  dimensions={dimensions || CostCategories}
+                  elementId={chartId}
+                  handleChange={handleSelectChange}
+                  value={dimension.value}
+                />
+              ))}
+          </HorizontalBarChartWrapper>
+        </ChartDimensionContext.Provider>
+      );
+    })
+  );
+}

--- a/front-end-components/src/views/compare-your-costs/partials/total-expenditure.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/total-expenditure.tsx
@@ -5,10 +5,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import {
-  Section,
-  TotalExpenditureData,
-} from "src/views/compare-your-costs/partials";
+import { TotalExpenditureData } from "src/views/compare-your-costs/partials";
 import { CustomDataContext, PhaseContext } from "src/contexts";
 import {
   CostCategories,
@@ -18,6 +15,7 @@ import {
 import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, TotalExpenditureExpenditure } from "src/services";
 import { CompareYourCostsProps } from "./accordion-sections/types";
+import { DimensionedChart } from "src/composed/dimensioned-chart";
 
 export const TotalExpenditure: React.FC<CompareYourCostsProps> = ({
   type,
@@ -74,7 +72,7 @@ export const TotalExpenditure: React.FC<CompareYourCostsProps> = ({
   };
 
   return (
-    <Section
+    <DimensionedChart
       charts={[{ data: chartData, title: "Total expenditure" }]}
       dimension={dimension}
       dimensions={CostCategories.filter(function (category) {

--- a/front-end-components/src/views/compare-your-costs/partials/total-expenditure.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/total-expenditure.tsx
@@ -5,25 +5,19 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { TotalExpenditureData } from "src/views/compare-your-costs/partials";
 import {
-  ChartDimensionContext,
-  CustomDataContext,
-  PhaseContext,
-} from "src/contexts";
+  Section,
+  TotalExpenditureData,
+} from "src/views/compare-your-costs/partials";
+import { CustomDataContext, PhaseContext } from "src/contexts";
 import {
   CostCategories,
   PoundsPerPupil,
-  ChartDimensions,
   PercentageExpenditure,
 } from "src/components";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, TotalExpenditureExpenditure } from "src/services";
 import { CompareYourCostsProps } from "./accordion-sections/types";
-import { ErrorBanner } from "src/components/error-banner";
 
 export const TotalExpenditure: React.FC<CompareYourCostsProps> = ({
   type,
@@ -73,35 +67,22 @@ export const TotalExpenditure: React.FC<CompareYourCostsProps> = ({
       };
     }, [dimension, data]);
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      CostCategories.find((x) => x.value === event.target.value) ??
-      PoundsPerPupil;
+      CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);
   };
 
-  const hasNoData = data?.length === 0;
-
-  return hasNoData ? (
-    <ErrorBanner
-      isRendered={hasNoData}
-      message="There isn't enough information available to create a set of similar schools."
+  return (
+    <Section
+      charts={[{ data: chartData, title: "Total expenditure" }]}
+      dimension={dimension}
+      dimensions={CostCategories.filter(function (category) {
+        return category !== PercentageExpenditure;
+      })}
+      handleDimensionChange={handleDimensionChange}
+      hasNoData={data?.length === 0}
+      topLevel
     />
-  ) : (
-    <ChartDimensionContext.Provider value={dimension}>
-      <HorizontalBarChartWrapper data={chartData} chartName="total expenditure">
-        <h2 className="govuk-heading-m">Total expenditure</h2>
-        <ChartDimensions
-          dimensions={CostCategories.filter(function (category) {
-            return category !== PercentageExpenditure;
-          })}
-          handleChange={handleSelectChange}
-          elementId="total-expenditure"
-          value={dimension.value}
-        />
-      </HorizontalBarChartWrapper>
-    </ChartDimensionContext.Provider>
   );
 };

--- a/front-end-components/src/views/compare-your-costs/partials/types.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/types.tsx
@@ -1,23 +1,3 @@
-import { ReactNode } from "react";
-import { Dimension } from "src/components";
-import {
-  SchoolChartData,
-  TrustChartData,
-} from "src/components/charts/table-chart";
-import { HorizontalBarChartWrapperProps } from "src/composed/horizontal-bar-chart-wrapper";
-
-export type SectionProps<TData extends SchoolChartData | TrustChartData> = {
-  charts: (Pick<HorizontalBarChartWrapperProps<TData>, "data"> & {
-    title: string;
-  })[];
-  dimension: Dimension;
-  dimensions?: Dimension[];
-  handleDimensionChange?: (dimension: string) => void;
-  hasNoData: boolean;
-  options?: ReactNode;
-  topLevel?: boolean;
-};
-
 export type TotalExpenditureProps = {
   schools: TotalExpenditureData[];
 };

--- a/front-end-components/src/views/compare-your-costs/partials/types.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/types.tsx
@@ -1,3 +1,23 @@
+import { ReactNode } from "react";
+import { Dimension } from "src/components";
+import {
+  SchoolChartData,
+  TrustChartData,
+} from "src/components/charts/table-chart";
+import { HorizontalBarChartWrapperProps } from "src/composed/horizontal-bar-chart-wrapper";
+
+export type SectionProps<TData extends SchoolChartData | TrustChartData> = {
+  charts: (Pick<HorizontalBarChartWrapperProps<TData>, "data"> & {
+    title: string;
+  })[];
+  dimension: Dimension;
+  dimensions?: Dimension[];
+  handleDimensionChange?: (dimension: string) => void;
+  hasNoData: boolean;
+  options?: ReactNode;
+  topLevel?: boolean;
+};
+
 export type TotalExpenditureProps = {
   schools: TotalExpenditureData[];
 };

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/administrative-supplies.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/administrative-supplies.tsx
@@ -1,20 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { AdministrativeSuppliesData } from "src/views/compare-your-trust/partials/accordion-sections/types";
-import {
-  CostCategories,
-  PoundsPerPupil,
-  ChartDimensions,
-} from "src/components";
-import {
-  ChartDimensionContext,
-  useCentralServicesBreakdownContext,
-} from "src/contexts";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
-import { useHash } from "src/hooks/useHash";
-import classNames from "classnames";
+import { CostCategories, PoundsPerPupil } from "src/components";
+import { useCentralServicesBreakdownContext } from "src/contexts";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import {
   ExpenditureApi,
   AdministrativeSuppliesTrustExpenditure,
@@ -23,6 +11,7 @@ import {
   BreakdownExclude,
   BreakdownInclude,
 } from "src/components/central-services-breakdown";
+import { AccordionSection } from "src/composed/accordion-section";
 
 export const AdministrativeSupplies: React.FC<{
   id: string;
@@ -48,12 +37,9 @@ export const AdministrativeSupplies: React.FC<{
     });
   }, [getData]);
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      CostCategories.find((x) => x.value === event.target.value) ??
-      PoundsPerPupil;
+      CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);
   };
 
@@ -85,51 +71,19 @@ export const AdministrativeSupplies: React.FC<{
         tableHeadings,
       };
     }, [data, dimension, breakdown]);
-
-  const elementId = "administrative-supplies";
-  const [hash] = useHash();
-
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <div
-        className={classNames("govuk-accordion__section", {
-          "govuk-accordion__section--expanded": hash === `#${elementId}`,
-        })}
-        id={elementId}
-      >
-        <div className="govuk-accordion__section-header">
-          <h2 className="govuk-accordion__section-heading">
-            <span
-              className="govuk-accordion__section-button"
-              id="accordion-heading-7"
-            >
-              Administrative supplies
-            </span>
-          </h2>
-        </div>
-        <div
-          id="accordion-content-7"
-          className="govuk-accordion__section-content"
-          aria-labelledby="accordion-heading-7"
-          role="region"
-        >
-          <HorizontalBarChartWrapper
-            data={administrativeSuppliesBarData}
-            chartName="administrative supplies (non-eductional)"
-            trust
-          >
-            <h3 className="govuk-heading-s">
-              Administrative supplies (Non-educational)
-            </h3>
-            <ChartDimensions
-              dimensions={CostCategories}
-              handleChange={handleSelectChange}
-              elementId="administrative-supplies-non-eductional"
-              value={dimension.value}
-            />
-          </HorizontalBarChartWrapper>
-        </div>
-      </div>
-    </ChartDimensionContext.Provider>
+    <AccordionSection
+      charts={[
+        {
+          data: administrativeSuppliesBarData,
+          title: "Administrative supplies (Non-educational)",
+        },
+      ]}
+      dimension={dimension}
+      handleDimensionChange={handleDimensionChange}
+      hasNoData={data?.length === 0}
+      index={7}
+      title="Administrative supplies"
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/catering-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/catering-staff-services.tsx
@@ -5,16 +5,8 @@ import {
   PoundsPerPupil,
   ChartDimensions,
 } from "src/components";
-import {
-  ChartDimensionContext,
-  useCentralServicesBreakdownContext,
-} from "src/contexts";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
-import { useHash } from "src/hooks/useHash";
-import classNames from "classnames";
+import { useCentralServicesBreakdownContext } from "src/contexts";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import {
   ExpenditureApi,
   CateringStaffServicesTrustExpenditure,
@@ -25,6 +17,7 @@ import {
   BreakdownInclude,
 } from "src/components/central-services-breakdown";
 import { TotalCateringCostsType } from "src/components/total-catering-costs-type";
+import { AccordionSection } from "src/composed/accordion-section";
 
 export const CateringStaffServices: React.FC<{
   id: string;
@@ -135,72 +128,44 @@ export const CateringStaffServices: React.FC<{
       };
     }, [data, tableHeadings]);
 
-  const elementId = "catering-staff-and-supplies";
-  const [hash] = useHash();
-
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <div
-        className={classNames("govuk-accordion__section", {
-          "govuk-accordion__section--expanded": hash === `#${elementId}`,
-        })}
-        id={elementId}
-      >
-        <div className="govuk-accordion__section-header">
-          <h2 className="govuk-accordion__section-heading">
-            <span
-              className="govuk-accordion__section-button"
-              id="accordion-heading-8"
-            >
-              Catering staff and services
-            </span>
-          </h2>
+    <AccordionSection
+      charts={[
+        {
+          data: totalCateringBarData,
+          title: `Total catering costs (${totalCateringCostsField === "totalGrossCateringCosts" ? "gross" : "net"})`,
+        },
+        {
+          data: cateringStaffBarData,
+          title: "Catering staff costs",
+        },
+        {
+          data: cateringSuppliesBarData,
+          title: "Catering supplies costs",
+        },
+      ]}
+      dimension={dimension}
+      hasNoData={data?.length === 0}
+      index={8}
+      options={
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-one-half">
+            <ChartDimensions
+              dimensions={CostCategories}
+              handleChange={handleSelectChange}
+              elementId="total-catering-costs"
+              value={dimension.value}
+            />
+          </div>
+          <div className="govuk-grid-column-one-half">
+            <TotalCateringCostsType
+              field={totalCateringCostsField}
+              onChange={setTotalCateringCostsField}
+            />
+          </div>
         </div>
-        <div
-          id="accordion-content-8"
-          className="govuk-accordion__section-content"
-          aria-labelledby="accordion-heading-8"
-          role="region"
-        >
-          <HorizontalBarChartWrapper
-            data={totalCateringBarData}
-            chartName="total catering costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Total catering costs</h3>
-            <div className="govuk-grid-row">
-              <div className="govuk-grid-column-one-half">
-                <ChartDimensions
-                  dimensions={CostCategories}
-                  handleChange={handleSelectChange}
-                  elementId="total-catering-costs"
-                  value={dimension.value}
-                />
-              </div>
-              <div className="govuk-grid-column-one-half">
-                <TotalCateringCostsType
-                  field={totalCateringCostsField}
-                  onChange={setTotalCateringCostsField}
-                />
-              </div>
-            </div>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={cateringStaffBarData}
-            chartName="catering staff costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Catering staff costs</h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={cateringSuppliesBarData}
-            chartName="catering supplies costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Catering supplies costs</h3>
-          </HorizontalBarChartWrapper>
-        </div>
-      </div>
-    </ChartDimensionContext.Provider>
+      }
+      title="Catering staff and supplies"
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-ict.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-ict.tsx
@@ -1,25 +1,14 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { EducationalIctData } from "src/views/compare-your-trust/partials/accordion-sections/types";
-import {
-  CostCategories,
-  PoundsPerPupil,
-  ChartDimensions,
-} from "src/components";
-import {
-  ChartDimensionContext,
-  useCentralServicesBreakdownContext,
-} from "src/contexts";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
-import { useHash } from "src/hooks/useHash";
-import classNames from "classnames";
+import { CostCategories, PoundsPerPupil } from "src/components";
+import { useCentralServicesBreakdownContext } from "src/contexts";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, EducationalIctTrustExpenditure } from "src/services";
 import {
   BreakdownExclude,
   BreakdownInclude,
 } from "src/components/central-services-breakdown";
+import { AccordionSection } from "src/composed/accordion-section";
 
 export const EducationalIct: React.FC<{
   id: string;
@@ -43,12 +32,9 @@ export const EducationalIct: React.FC<{
     });
   }, [getData]);
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      CostCategories.find((x) => x.value === event.target.value) ??
-      PoundsPerPupil;
+      CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);
   };
 
@@ -78,50 +64,19 @@ export const EducationalIct: React.FC<{
       };
     }, [dimension, data, breakdown]);
 
-  const elementId = "educational-ict";
-  const [hash] = useHash();
-
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <div
-        className={classNames("govuk-accordion__section", {
-          "govuk-accordion__section--expanded": hash === `#${elementId}`,
-        })}
-        id={elementId}
-      >
-        <div className="govuk-accordion__section-header">
-          <h2 className="govuk-accordion__section-heading">
-            <span
-              className="govuk-accordion__section-button"
-              id="accordion-heading-4"
-            >
-              Educational ICT
-            </span>
-          </h2>
-        </div>
-        <div
-          id="accordion-content-4"
-          className="govuk-accordion__section-content"
-          aria-labelledby="accordion-heading-4"
-          role="region"
-        >
-          <HorizontalBarChartWrapper
-            data={learningResourcesBarData}
-            chartName="eductional learning resources costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">
-              Educational learning resources costs
-            </h3>
-            <ChartDimensions
-              dimensions={CostCategories}
-              handleChange={handleSelectChange}
-              elementId="eductional-learning-resources-costs"
-              value={dimension.value}
-            />
-          </HorizontalBarChartWrapper>
-        </div>
-      </div>
-    </ChartDimensionContext.Provider>
+    <AccordionSection
+      charts={[
+        {
+          data: learningResourcesBarData,
+          title: "Educational learning resources costs",
+        },
+      ]}
+      dimension={dimension}
+      handleDimensionChange={handleDimensionChange}
+      hasNoData={data?.length === 0}
+      index={4}
+      title="Educational ICT"
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-supplies.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-supplies.tsx
@@ -1,20 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { EducationalSuppliesData } from "src/views/compare-your-trust/partials/accordion-sections/types";
-import {
-  CostCategories,
-  PoundsPerPupil,
-  ChartDimensions,
-} from "src/components";
-import {
-  ChartDimensionContext,
-  useCentralServicesBreakdownContext,
-} from "src/contexts";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
-import { useHash } from "src/hooks/useHash";
-import classNames from "classnames";
+import { CostCategories, PoundsPerPupil } from "src/components";
+import { useCentralServicesBreakdownContext } from "src/contexts";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import {
   ExpenditureApi,
   EducationalSuppliesTrustExpenditure,
@@ -23,6 +11,7 @@ import {
   BreakdownExclude,
   BreakdownInclude,
 } from "src/components/central-services-breakdown";
+import { AccordionSection } from "src/composed/accordion-section";
 
 export const EducationalSupplies: React.FC<{
   id: string;
@@ -59,12 +48,9 @@ export const EducationalSupplies: React.FC<{
     return headings;
   }, [dimension, breakdown]);
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      CostCategories.find((x) => x.value === event.target.value) ??
-      PoundsPerPupil;
+      CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);
   };
 
@@ -122,66 +108,27 @@ export const EducationalSupplies: React.FC<{
       };
     }, [data, tableHeadings]);
 
-  const elementId = "educational-supplies";
-  const [hash] = useHash();
-
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <div
-        className={classNames("govuk-accordion__section", {
-          "govuk-accordion__section--expanded": hash === `#${elementId}`,
-        })}
-        id={elementId}
-      >
-        <div className="govuk-accordion__section-header">
-          <h2 className="govuk-accordion__section-heading">
-            <span
-              className="govuk-accordion__section-button"
-              id="accordion-heading-3"
-            >
-              Educational supplies
-            </span>
-          </h2>
-        </div>
-        <div
-          id="accordion-content-3"
-          className="govuk-accordion__section-content"
-          aria-labelledby="accordion-heading-3"
-          role="region"
-        >
-          <HorizontalBarChartWrapper
-            data={totalEducationalSuppliesBarData}
-            chartName="total educational supplies costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">
-              Total educational supplies costs
-            </h3>
-            <ChartDimensions
-              dimensions={CostCategories}
-              handleChange={handleSelectChange}
-              elementId="total-educational-supplies-costs"
-              value={dimension.value}
-            />
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={examinationFeesBarData}
-            chartName="examination fees costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Examination fees costs</h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={learningResourcesBarData}
-            chartName="learning resource (not ICT equipment) costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">
-              Learning resources (not ICT equipment) costs
-            </h3>
-          </HorizontalBarChartWrapper>
-        </div>
-      </div>
-    </ChartDimensionContext.Provider>
+    <AccordionSection
+      charts={[
+        {
+          data: totalEducationalSuppliesBarData,
+          title: "Total educational supplies costs",
+        },
+        {
+          data: examinationFeesBarData,
+          title: "Examination fees costs",
+        },
+        {
+          data: learningResourcesBarData,
+          title: "Learning resources (not ICT equipment) costs",
+        },
+      ]}
+      dimension={dimension}
+      handleDimensionChange={handleDimensionChange}
+      hasNoData={data?.length === 0}
+      index={3}
+      title="Educational supplies"
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/non-educational-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/non-educational-support-staff.tsx
@@ -1,20 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { NonEducationalSupportStaffData } from "src/views/compare-your-trust/partials/accordion-sections/types";
-import {
-  CostCategories,
-  PoundsPerPupil,
-  ChartDimensions,
-} from "src/components";
-import {
-  ChartDimensionContext,
-  useCentralServicesBreakdownContext,
-} from "src/contexts";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
-import classNames from "classnames";
-import { useHash } from "src/hooks/useHash";
+import { CostCategories, PoundsPerPupil } from "src/components";
+import { useCentralServicesBreakdownContext } from "src/contexts";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import {
   ExpenditureApi,
   NonEducationalSupportStaffTrustExpenditure,
@@ -23,6 +11,7 @@ import {
   BreakdownExclude,
   BreakdownInclude,
 } from "src/components/central-services-breakdown";
+import { AccordionSection } from "src/composed/accordion-section";
 
 export const NonEducationalSupportStaff: React.FC<{
   id: string;
@@ -59,12 +48,9 @@ export const NonEducationalSupportStaff: React.FC<{
     return headings;
   }, [dimension, breakdown]);
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      CostCategories.find((x) => x.value === event.target.value) ??
-      PoundsPerPupil;
+      CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);
   };
 
@@ -164,82 +150,35 @@ export const NonEducationalSupportStaff: React.FC<{
       };
     }, [data, tableHeadings]);
 
-  const elementId = "non-educational-support-staff-and-services";
-  const [hash] = useHash();
-
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <div
-        className={classNames("govuk-accordion__section", {
-          "govuk-accordion__section--expanded": hash === `#${elementId}`,
-        })}
-        id={elementId}
-      >
-        <div className="govuk-accordion__section-header">
-          <h2 className="govuk-accordion__section-heading">
-            <span
-              className="govuk-accordion__section-button"
-              id="accordion-heading-2"
-            >
-              Non-educational support staff
-            </span>
-          </h2>
-        </div>
-        <div
-          id="accordion-content-2"
-          className="govuk-accordion__section-content"
-          aria-labelledby="accordion-2"
-          role="region"
-        >
-          <HorizontalBarChartWrapper
-            data={totalNonEducationalBarData}
-            chartName="total non-educational support staff costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">
-              Total non-educational support staff costs
-            </h3>
-            <ChartDimensions
-              dimensions={CostCategories}
-              handleChange={handleSelectChange}
-              elementId="total-non-educational-support-staff-costs"
-              value={dimension.value}
-            />
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={administrativeClericalBarData}
-            chartName="administrative and clerical staff costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">
-              Administrative and clerical staff costs
-            </h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={auditorsCostsBarData}
-            chartName="auditors costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Auditors costs</h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={otherStaffCostsBarData}
-            chartName="other staff costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Other staff costs</h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={professionalServicesBarData}
-            chartName="profession services (non-curriculum) costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">
-              Professional services (non-curriculum) costs
-            </h3>
-          </HorizontalBarChartWrapper>
-        </div>
-      </div>
-    </ChartDimensionContext.Provider>
+    <AccordionSection
+      charts={[
+        {
+          data: totalNonEducationalBarData,
+          title: "Total non-educational support staff costs",
+        },
+        {
+          data: administrativeClericalBarData,
+          title: "Administrative and clerical staff costs",
+        },
+        {
+          data: auditorsCostsBarData,
+          title: "Auditors costs",
+        },
+        {
+          data: otherStaffCostsBarData,
+          title: "Other staff costs",
+        },
+        {
+          data: professionalServicesBarData,
+          title: "Professional services (non-curriculum) costs",
+        },
+      ]}
+      dimension={dimension}
+      handleDimensionChange={handleDimensionChange}
+      hasNoData={data?.length === 0}
+      index={2}
+      title="Non-educational support staff and services"
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/other-costs.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/other-costs.tsx
@@ -1,25 +1,14 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { OtherCostsData } from "src/views/compare-your-trust/partials/accordion-sections/types";
-import {
-  CostCategories,
-  PoundsPerPupil,
-  ChartDimensions,
-} from "src/components";
-import {
-  ChartDimensionContext,
-  useCentralServicesBreakdownContext,
-} from "src/contexts";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
-import { useHash } from "src/hooks/useHash";
-import classNames from "classnames";
+import { CostCategories, PoundsPerPupil } from "src/components";
+import { useCentralServicesBreakdownContext } from "src/contexts";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, OtherCostsDataTrustExpenditure } from "src/services";
 import {
   BreakdownExclude,
   BreakdownInclude,
 } from "src/components/central-services-breakdown";
+import { AccordionSection } from "src/composed/accordion-section";
 
 export const OtherCosts: React.FC<{
   id: string;
@@ -54,12 +43,9 @@ export const OtherCosts: React.FC<{
     return headings;
   }, [dimension, breakdown]);
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      CostCategories.find((x) => x.value === event.target.value) ??
-      PoundsPerPupil;
+      CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);
   };
 
@@ -280,129 +266,54 @@ export const OtherCosts: React.FC<{
       };
     }, [data, tableHeadings]);
 
-  const elementId = "other-costs";
-  const [hash] = useHash();
-
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <div
-        className={classNames("govuk-accordion__section", {
-          "govuk-accordion__section--expanded": hash === `#${elementId}`,
-        })}
-        id={elementId}
-      >
-        <div className="govuk-accordion__section-header">
-          <h2 className="govuk-accordion__section-heading">
-            <span
-              className="govuk-accordion__section-button"
-              id="accordion-heading-9"
-            >
-              Other costs
-            </span>
-          </h2>
-        </div>
-        <div
-          id="accordion-content-9"
-          className="govuk-accordion__section-content"
-          aria-labelledby="accordion-heading-9"
-          role="region"
-        >
-          <HorizontalBarChartWrapper
-            data={totalOtherCostsBarData}
-            chartName="total other costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Total other costs</h3>
-            <ChartDimensions
-              dimensions={CostCategories}
-              handleChange={handleSelectChange}
-              elementId="total-otehr-costs"
-              value={dimension.value}
-            />
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={otherInsurancePremiumsCostsBarData}
-            chartName="other insurance premiums costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Other insurance premiums costs</h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={directRevenueFinancingCostsBarData}
-            chartName="direct revenue financing costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Direct revenue financing costs</h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={groundsMaintenanceCostsBarData}
-            chartName="ground maintenance costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Ground maintenance costs</h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={indirectEmployeeExpensesBarData}
-            chartName="indirect employee expenses"
-            trust
-          >
-            <h3 className="govuk-heading-s">Indirect employee expenses</h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={interestChargesLoanBankBarData}
-            chartName="interest charges for loan and bank"
-            trust
-          >
-            <h3 className="govuk-heading-s">
-              Interest charges for loan and bank
-            </h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={privateFinanceInitiativeChargesBarData}
-            chartName="PFI charges"
-            trust
-          >
-            <h3 className="govuk-heading-s">PFI charges</h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={rentRatesCostsBarData}
-            chartName="rent and rates costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Rent and rates costs</h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={specialFacilitiesCostsBarData}
-            chartName="special facilities costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Special facilities costs</h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={staffDevelopmentTrainingCostsBarData}
-            chartName="staff development and training costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">
-              Staff development and training costs
-            </h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={staffRelatedInsuranceCostsBarData}
-            chartName="staff-related insurance costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Staff-related insurance costs</h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={supplyTeacherInsurableCostsBarData}
-            chartName="supply teacher insurance costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Supply teacher insurance costs</h3>
-          </HorizontalBarChartWrapper>
-        </div>
-      </div>
-    </ChartDimensionContext.Provider>
+    <AccordionSection
+      charts={[
+        { data: totalOtherCostsBarData, title: "Total other costs" },
+        {
+          data: otherInsurancePremiumsCostsBarData,
+          title: "Other insurance premiums costs",
+        },
+        {
+          data: directRevenueFinancingCostsBarData,
+          title: "Direct revenue financing costs",
+        },
+        {
+          data: groundsMaintenanceCostsBarData,
+          title: "Ground maintenance costs",
+        },
+        {
+          data: indirectEmployeeExpensesBarData,
+          title: "Indirect employee expenses",
+        },
+        {
+          data: interestChargesLoanBankBarData,
+          title: "Interest charges for loan and bank",
+        },
+        { data: privateFinanceInitiativeChargesBarData, title: "PFI charges" },
+        { data: rentRatesCostsBarData, title: "Rent and rates costs" },
+        {
+          data: specialFacilitiesCostsBarData,
+          title: "Special facilities costs",
+        },
+        {
+          data: staffDevelopmentTrainingCostsBarData,
+          title: "Staff development and training costs",
+        },
+        {
+          data: staffRelatedInsuranceCostsBarData,
+          title: "Staff-related insurance costs",
+        },
+        {
+          data: supplyTeacherInsurableCostsBarData,
+          title: "Supply teacher insurance costs",
+        },
+      ]}
+      dimension={dimension}
+      handleDimensionChange={handleDimensionChange}
+      hasNoData={data?.length === 0}
+      index={9}
+      title="Other costs"
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/premises-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/premises-staff-services.tsx
@@ -1,20 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { PremisesStaffServicesData } from "src/views/compare-your-trust/partials/accordion-sections/types";
-import {
-  PoundsPerMetreSq,
-  PremisesCategories,
-  ChartDimensions,
-} from "src/components";
-import {
-  ChartDimensionContext,
-  useCentralServicesBreakdownContext,
-} from "src/contexts";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
-import { useHash } from "src/hooks/useHash";
-import classNames from "classnames";
+import { PoundsPerMetreSq, PremisesCategories } from "src/components";
+import { useCentralServicesBreakdownContext } from "src/contexts";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import {
   ExpenditureApi,
   PremisesStaffServicesTrustExpenditure,
@@ -23,6 +11,7 @@ import {
   BreakdownExclude,
   BreakdownInclude,
 } from "src/components/central-services-breakdown";
+import { AccordionSection } from "src/composed/accordion-section";
 
 export const PremisesStaffServices: React.FC<{
   id: string;
@@ -59,12 +48,9 @@ export const PremisesStaffServices: React.FC<{
     return headings;
   }, [dimension, breakdown]);
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      PremisesCategories.find((x) => x.value === event.target.value) ??
-      PoundsPerMetreSq;
+      PremisesCategories.find((x) => x.value === value) ?? PoundsPerMetreSq;
     setDimension(dimension);
   };
 
@@ -159,78 +145,26 @@ export const PremisesStaffServices: React.FC<{
       };
     }, [data, tableHeadings]);
 
-  const elementId = "premises-staff-and-services";
-  const [hash] = useHash();
-
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <div
-        className={classNames("govuk-accordion__section", {
-          "govuk-accordion__section--expanded": hash === `#${elementId}`,
-        })}
-        id={elementId}
-      >
-        <div className="govuk-accordion__section-header">
-          <h2 className="govuk-accordion__section-heading">
-            <span
-              className="govuk-accordion__section-button"
-              id="accordion-heading-5"
-            >
-              Premises staff and services
-            </span>
-          </h2>
-        </div>
-        <div
-          id="accordion-content-5"
-          className="govuk-accordion__section-content"
-          aria-labelledby="accordion-heading-5"
-          role="region"
-        >
-          <HorizontalBarChartWrapper
-            data={totalPremisesStaffServiceCostsBarData}
-            chartName="total premises staff and service costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">
-              Total premises staff and service costs
-            </h3>
-            <ChartDimensions
-              dimensions={PremisesCategories}
-              handleChange={handleSelectChange}
-              elementId="total-premises-staff-service-costs"
-              value={dimension.value}
-            />
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={cleaningCaretakingBarData}
-            chartName="cleaning and caretaking costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Cleaning and caretaking costs</h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={maintenanceBarData}
-            chartName="maintenance of premises costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Maintenance of premises costs</h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={otherOccupationBarData}
-            chartName="other occupation costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Other occupation costs</h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={premisesStaffBarData}
-            chartName="premises staff costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Premises staff costs</h3>
-          </HorizontalBarChartWrapper>
-        </div>
-      </div>
-    </ChartDimensionContext.Provider>
+    <AccordionSection
+      charts={[
+        {
+          data: totalPremisesStaffServiceCostsBarData,
+          title: "Total premises staff and service costs",
+        },
+        {
+          data: cleaningCaretakingBarData,
+          title: "Cleaning and caretaking costs",
+        },
+        { data: maintenanceBarData, title: "Maintenance of premises costs" },
+        { data: otherOccupationBarData, title: "Other occupation costs" },
+        { data: premisesStaffBarData, title: "Premises staff costs" },
+      ]}
+      dimension={dimension}
+      handleDimensionChange={handleDimensionChange}
+      hasNoData={data?.length === 0}
+      index={5}
+      title="Premises staff and services"
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/teaching-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/teaching-support-staff.tsx
@@ -1,20 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { TeachingSupportStaffData } from "src/views/compare-your-trust/partials/accordion-sections/types";
-import {
-  CostCategories,
-  PoundsPerPupil,
-  ChartDimensions,
-} from "src/components";
-import {
-  ChartDimensionContext,
-  useCentralServicesBreakdownContext,
-} from "src/contexts";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
-import { useHash } from "src/hooks/useHash";
-import classNames from "classnames";
+import { CostCategories, PoundsPerPupil } from "src/components";
+import { useCentralServicesBreakdownContext } from "src/contexts";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import {
   ExpenditureApi,
   TeachingSupportStaffTrustExpenditure,
@@ -23,6 +11,7 @@ import {
   BreakdownExclude,
   BreakdownInclude,
 } from "src/components/central-services-breakdown";
+import { AccordionSection } from "src/composed/accordion-section";
 
 export const TeachingSupportStaff: React.FC<{ id: string }> = ({ id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
@@ -57,12 +46,9 @@ export const TeachingSupportStaff: React.FC<{ id: string }> = ({ id }) => {
     return headings;
   }, [dimension, breakdown]);
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      CostCategories.find((x) => x.value === event.target.value) ??
-      PoundsPerPupil;
+      CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);
   };
 
@@ -176,87 +162,40 @@ export const TeachingSupportStaff: React.FC<{ id: string }> = ({ id }) => {
       };
     }, [data, tableHeadings]);
 
-  const elementId = "teaching-and-teaching-support-staff";
-  const [hash] = useHash();
-
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <div
-        className={classNames("govuk-accordion__section", {
-          "govuk-accordion__section--expanded": hash === `#${elementId}`,
-        })}
-        id={elementId}
-      >
-        <div className="govuk-accordion__section-header">
-          <h2 className="govuk-accordion__section-heading">
-            <span
-              className="govuk-accordion__section-button"
-              id="accordion-heading-1"
-            >
-              Teaching and teaching support staff
-            </span>
-          </h2>
-        </div>
-        <div
-          id="accordion-content-1"
-          className="govuk-accordion__section-content"
-          aria-labelledby="accordion-heading-1"
-          role="region"
-        >
-          <HorizontalBarChartWrapper
-            data={totalTeachingBarData}
-            chartName="total teaching and support staff cost"
-            trust
-          >
-            <h3 className="govuk-heading-s">
-              Total teaching and teaching support staff costs
-            </h3>
-            <ChartDimensions
-              dimensions={CostCategories}
-              handleChange={handleSelectChange}
-              elementId="total-teaching-support-staff-cost"
-              value={dimension.value}
-            />
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={teachingStaffBarData}
-            chartName="teaching staff costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Teaching staff costs</h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={supplyTeachingBarData}
-            chartName="supply teaching staff costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Supply teaching staff costs</h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={educationalConsultancyBarData}
-            chartName="educational consultancy costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Educational consultancy costs</h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={educationSupportStaffBarData}
-            chartName="educational support staff costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Educational support staff costs</h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={agencySupplyBarData}
-            chartName="agency supply teaching staff costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">
-              Agency supply teaching staff costs
-            </h3>
-          </HorizontalBarChartWrapper>
-        </div>
-      </div>
-    </ChartDimensionContext.Provider>
+    <AccordionSection
+      charts={[
+        {
+          data: totalTeachingBarData,
+          title: "Total teaching and teaching support staff costs",
+        },
+        {
+          data: teachingStaffBarData,
+          title: "Teaching staff costs",
+        },
+        {
+          data: supplyTeachingBarData,
+          title: "Supply teaching staff costs",
+        },
+        {
+          data: educationalConsultancyBarData,
+          title: "Educational consultancy costs",
+        },
+        {
+          data: educationSupportStaffBarData,
+          title: "Educational support staff costs",
+        },
+        {
+          data: agencySupplyBarData,
+          title: "Agency supply teaching staff costs",
+        },
+      ]}
+      dimension={dimension}
+      handleDimensionChange={handleDimensionChange}
+      hasNoData={data?.length === 0}
+      index={1}
+      title="Teaching and teaching support staff"
+      trust
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/utilities.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/utilities.tsx
@@ -1,25 +1,14 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { UtilitiesData } from "src/views/compare-your-trust/partials/accordion-sections/types";
-import {
-  PoundsPerMetreSq,
-  PremisesCategories,
-  ChartDimensions,
-} from "src/components";
-import {
-  ChartDimensionContext,
-  useCentralServicesBreakdownContext,
-} from "src/contexts";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
-import { useHash } from "src/hooks/useHash";
-import classNames from "classnames";
+import { PoundsPerMetreSq, PremisesCategories } from "src/components";
+import { useCentralServicesBreakdownContext } from "src/contexts";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, UtilitiesTrustExpenditure } from "src/services";
 import {
   BreakdownExclude,
   BreakdownInclude,
 } from "src/components/central-services-breakdown";
+import { AccordionSection } from "src/composed/accordion-section";
 
 export const Utilities: React.FC<{
   id: string;
@@ -54,12 +43,9 @@ export const Utilities: React.FC<{
     return headings;
   }, [dimension, breakdown]);
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      PremisesCategories.find((x) => x.value === event.target.value) ??
-      PoundsPerMetreSq;
+      PremisesCategories.find((x) => x.value === value) ?? PoundsPerMetreSq;
     setDimension(dimension);
   };
 
@@ -117,62 +103,24 @@ export const Utilities: React.FC<{
       };
     }, [data, tableHeadings]);
 
-  const elementId = "utilities";
-  const [hash] = useHash();
-
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <div
-        className={classNames("govuk-accordion__section", {
-          "govuk-accordion__section--expanded": hash === `#${elementId}`,
-        })}
-        id={elementId}
-      >
-        <div className="govuk-accordion__section-header">
-          <h2 className="govuk-accordion__section-heading">
-            <span
-              className="govuk-accordion__section-button"
-              id="accordion-heading-6"
-            >
-              Utilities
-            </span>
-          </h2>
-        </div>
-        <div
-          id="accordion-content-6"
-          className="govuk-accordion__section-content"
-          aria-labelledby="accordion-heading-6"
-          role="region"
-        >
-          <HorizontalBarChartWrapper
-            data={totalUtilitiesCostsBarData}
-            chartName="total utilities costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Total utilities costs</h3>
-            <ChartDimensions
-              dimensions={PremisesCategories}
-              handleChange={handleSelectChange}
-              elementId="total-utilities-costs"
-              value={dimension.value}
-            />
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={energyBarData}
-            chartName="energy costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Energy costs</h3>
-          </HorizontalBarChartWrapper>
-          <HorizontalBarChartWrapper
-            data={waterSewerageBarData}
-            chartName="water and sewerage costs"
-            trust
-          >
-            <h3 className="govuk-heading-s">Water and sewerage costs</h3>
-          </HorizontalBarChartWrapper>
-        </div>
-      </div>
-    </ChartDimensionContext.Provider>
+    <AccordionSection
+      charts={[
+        { data: totalUtilitiesCostsBarData, title: "Total utilities costs" },
+        {
+          data: energyBarData,
+          title: "Energy costs",
+        },
+        {
+          data: waterSewerageBarData,
+          title: "Water and sewerage costs",
+        },
+      ]}
+      dimension={dimension}
+      handleDimensionChange={handleDimensionChange}
+      hasNoData={data?.length === 0}
+      index={6}
+      title="Utilities"
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-trust/partials/balance.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/balance.tsx
@@ -1,16 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { BalanceData } from "src/views/compare-your-trust/partials";
-import { ChartDimensionContext } from "src/contexts";
-import {
-  CostCategories,
-  PoundsPerPupil,
-  ChartDimensions,
-} from "src/components";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
+import { CostCategories, PoundsPerPupil } from "src/components";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { BalanceApi, TrustBalance } from "src/services";
+import { DimensionedChart } from "src/composed/dimensioned-chart";
 
 export const Balance: React.FC<{
   id: string;
@@ -75,43 +68,27 @@ export const Balance: React.FC<{
       };
     }, [dimension, data]);
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      CostCategories.find((x) => x.value === event.target.value) ??
-      PoundsPerPupil;
+      CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);
   };
 
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <HorizontalBarChartWrapper
-        data={inYearBalanceChartData}
-        chartName="in year balance"
-        trust
-      >
-        <h2 className="govuk-heading-m">In-year balance</h2>
-        <ChartDimensions
-          dimensions={CostCategories}
-          handleChange={handleSelectChange}
-          elementId="in-year-balance"
-          value={dimension.value}
-        />
-      </HorizontalBarChartWrapper>
-      <HorizontalBarChartWrapper
-        data={revenueReserveChartData}
-        chartName="revenue reserve"
-        trust
-      >
-        <h2 className="govuk-heading-m">Revenue reserve</h2>
-        <ChartDimensions
-          dimensions={CostCategories}
-          handleChange={handleSelectChange}
-          elementId="in-year-balance"
-          value={dimension.value}
-        />
-      </HorizontalBarChartWrapper>
-    </ChartDimensionContext.Provider>
+    <DimensionedChart
+      charts={[
+        { data: inYearBalanceChartData, title: "In-year balance" },
+        {
+          data: revenueReserveChartData,
+          title: "Revenue reserve",
+          selector: true,
+        },
+      ]}
+      dimension={dimension}
+      dimensions={CostCategories}
+      handleDimensionChange={handleDimensionChange}
+      topLevel
+      trust
+    />
   );
 };

--- a/front-end-components/src/views/compare-your-trust/partials/total-expenditure.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/total-expenditure.tsx
@@ -1,24 +1,18 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { TotalExpenditureData } from "src/views/compare-your-trust/partials";
-import {
-  ChartDimensionContext,
-  useCentralServicesBreakdownContext,
-} from "src/contexts";
+import { useCentralServicesBreakdownContext } from "src/contexts";
 import {
   CostCategories,
   PoundsPerPupil,
-  ChartDimensions,
   PercentageExpenditure,
 } from "src/components";
-import {
-  HorizontalBarChartWrapper,
-  HorizontalBarChartWrapperData,
-} from "src/composed/horizontal-bar-chart-wrapper";
+import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, TotalExpenditureTrustExpenditure } from "src/services";
 import {
   BreakdownExclude,
   BreakdownInclude,
 } from "src/components/central-services-breakdown";
+import { DimensionedChart } from "src/composed/dimensioned-chart";
 
 export const TotalExpenditure: React.FC<{
   id: string;
@@ -68,32 +62,22 @@ export const TotalExpenditure: React.FC<{
       };
     }, [dimension, data, breakdown]);
 
-  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const handleDimensionChange = (value: string) => {
     const dimension =
-      CostCategories.find((x) => x.value === event.target.value) ??
-      PoundsPerPupil;
+      CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);
   };
 
   return (
-    <ChartDimensionContext.Provider value={dimension}>
-      <HorizontalBarChartWrapper
-        data={chartData}
-        chartName="total expenditure"
-        trust
-      >
-        <h2 className="govuk-heading-m">Total expenditure</h2>
-        <ChartDimensions
-          dimensions={CostCategories.filter(function (category) {
-            return category !== PercentageExpenditure;
-          })}
-          handleChange={handleSelectChange}
-          elementId="total-expenditure"
-          value={dimension.value}
-        />
-      </HorizontalBarChartWrapper>
-    </ChartDimensionContext.Provider>
+    <DimensionedChart
+      charts={[{ data: chartData, title: "Total expenditure" }]}
+      dimension={dimension}
+      dimensions={CostCategories.filter(function (category) {
+        return category !== PercentageExpenditure;
+      })}
+      handleDimensionChange={handleDimensionChange}
+      topLevel
+      trust
+    />
   );
 };

--- a/front-end-components/src/views/deployment-plan/view.tsx
+++ b/front-end-components/src/views/deployment-plan/view.tsx
@@ -10,7 +10,7 @@ export const DeploymentPlan: React.FC<DeploymentPlanViewProps> = (props) => {
   return (
     <div style={{ height: 500 }}>
       <VerticalBarChart
-        chartName="Percentage of pupils on roll and teacher cost"
+        chartTitle="Percentage of pupils on roll and teacher cost"
         data={data}
         grid
         keyField="id"

--- a/web/tests/Web.E2ETests/Features/LocalAuthority/BenchmarkCensus.feature
+++ b/web/tests/Web.E2ETests/Features/LocalAuthority/BenchmarkCensus.feature
@@ -4,7 +4,6 @@
         Given I am on the service home
         And I am not logged in
 
-    @ignore
     Scenario: Download school workforce chart
         Given I am on census page for local authority with code '201'
         When I click on save as image for 'school workforce'

--- a/web/tests/Web.E2ETests/Features/LocalAuthority/CompareYourCosts.feature
+++ b/web/tests/Web.E2ETests/Features/LocalAuthority/CompareYourCosts.feature
@@ -1,6 +1,5 @@
 Feature: Local Authority compare your costs
 
-    @ignore
     Scenario: Download total expenditure chart
         Given I am on compare your costs page for local authority with code '201'
         When I click on save as image for 'total expenditure'

--- a/web/tests/Web.E2ETests/Features/School/BenchmarkCensus.feature
+++ b/web/tests/Web.E2ETests/Features/School/BenchmarkCensus.feature
@@ -4,7 +4,6 @@
         Given I am on the service home
         And I am not logged in
 
-    @ignore
     Scenario: Download school workforce chart
         Given I am on census page for school with URN '777042'
         When I click on save as image for 'school workforce'

--- a/web/tests/Web.E2ETests/Features/School/CompareYourCosts.feature
+++ b/web/tests/Web.E2ETests/Features/School/CompareYourCosts.feature
@@ -1,6 +1,5 @@
 Feature: School compare your costs
 
-    @ignore
     Scenario: Download total expenditure chart
         Given I am on compare your costs page for school with URN '777042'
         When I click on save as image for 'total expenditure'

--- a/web/tests/Web.E2ETests/Features/Trust/BenchmarkCensus.feature
+++ b/web/tests/Web.E2ETests/Features/Trust/BenchmarkCensus.feature
@@ -4,7 +4,6 @@
         Given I am on the service home
         And I am not logged in
 
-    @ignore
     Scenario: Download school workforce chart
         Given I am on census page for trust with company number '8104190'
         When I click on save as image for 'school workforce'

--- a/web/tests/Web.E2ETests/Features/Trust/CompareYourCosts.feature
+++ b/web/tests/Web.E2ETests/Features/Trust/CompareYourCosts.feature
@@ -1,6 +1,5 @@
 Feature: Trust compare your costs
 
-    @ignore
     Scenario: Download total expenditure chart
         Given I am on compare your costs page for trust with company number '10074054'
         When I click on save as image for 'total expenditure'

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -66,17 +66,17 @@ public static class Selectors
     public const string TotalExpenditureDimension = "#total-expenditure-dimension";
     public const string TotalExpenditureChart = "//*[@aria-label='Total expenditure']";
 
-    public const string PremisesDimension = "#total-premises-staff-service-costs-dimension";
+    public const string PremisesDimension = "#total-premises-staff-and-service-costs-dimension";
 
-    public const string SchoolWorkforceDimension = "#school-workforce-dimension";
+    public const string SchoolWorkforceDimension = "#school-workforce-full-time-equivalent-dimension";
     public const string SchoolWorkforceSaveAsImage = "xpath=//*[@id='compare-your-census']/div[2]/div[2]/button";
 
-    public const string TotalNumberOfTeacherDimension = "#total-teachers-dimension";
-    public const string SeniorLeadershipDimension = "#senior-leadership-dimension";
-    public const string TeachingAssistantDimension = "#teaching-assistants-dimension";
-    public const string NonClassRoomSupportStaffDimension = "#nonclassroom-support-dimension";
-    public const string AuxiliaryStaffDimension = "#auxiliary-staff-dimension";
-    public const string SchoolWorkforceHeadcountDimension = "#headcount-dimension";
+    public const string TotalNumberOfTeacherDimension = "#total-number-of-teachers-full-time-equivalent-dimension";
+    public const string SeniorLeadershipDimension = "#senior-leadership-full-time-equivalent-dimension";
+    public const string TeachingAssistantDimension = "#teaching-assistants-full-time-equivalent-dimension";
+    public const string NonClassRoomSupportStaffDimension = "#non-classroom-support-staff-excluding-auxiliary-staff-full-time-equivalent-dimension";
+    public const string AuxiliaryStaffDimension = "#auxiliary-staff-full-time-equivalent-dimension";
+    public const string SchoolWorkforceHeadcountDimension = "#school-workforce-headcount-dimension";
     public const string SchoolGiasPageLink = "a[data-id='gias-school-details']";
 
     public const string SchoolDetailsEmailAddress = ".govuk-summary-list__key:has-text('Contact email') + .govuk-summary-list__value";

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -64,7 +64,7 @@ public static class Selectors
 
     public const string TotalExpenditureSaveAsImage = "xpath=//*[@id='compare-your-costs']/div[2]/div[2]/button";
     public const string TotalExpenditureDimension = "#total-expenditure-dimension";
-    public const string TotalExpenditureChart = "//*[@aria-label='total expenditure']";
+    public const string TotalExpenditureChart = "//*[@aria-label='Total expenditure']";
 
     public const string PremisesDimension = "#total-premises-staff-service-costs-dimension";
 

--- a/web/tests/Web.E2ETests/Steps/LocalAuthority/BenchmarkCensusSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/LocalAuthority/BenchmarkCensusSteps.cs
@@ -3,6 +3,7 @@ using Web.E2ETests.Drivers;
 using Web.E2ETests.Pages.LocalAuthority;
 using Xunit;
 using HomePage = Web.E2ETests.Pages.School.HomePage;
+
 namespace Web.E2ETests.Steps.LocalAuthority;
 
 [Binding]
@@ -147,7 +148,7 @@ public class BenchmarkCensusSteps(PageDriver driver)
         Assert.NotNull(_download);
         var downloadedFileName = ChartNameFromFriendlyName(chartName) switch
         {
-            CensusChartNames.SchoolWorkforce => "school workforce (full time equivalent)",
+            CensusChartNames.SchoolWorkforce => "school-workforce-full-time-equivalent",
             _ => throw new ArgumentOutOfRangeException(nameof(chartName))
         };
 

--- a/web/tests/Web.E2ETests/Steps/LocalAuthority/CompareYourCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/LocalAuthority/CompareYourCostsSteps.cs
@@ -3,6 +3,7 @@ using Web.E2ETests.Drivers;
 using Web.E2ETests.Pages.LocalAuthority;
 using Xunit;
 using HomePage = Web.E2ETests.Pages.School.HomePage;
+
 namespace Web.E2ETests.Steps.LocalAuthority;
 
 [Binding]
@@ -237,7 +238,7 @@ public class CompareYourCostsSteps(PageDriver driver)
         Assert.NotNull(_download);
         var downloadedFileName = ChartNameFromFriendlyName(chartName) switch
         {
-            ComparisonChartNames.TotalExpenditure => "total expenditure",
+            ComparisonChartNames.TotalExpenditure => "total-expenditure",
             _ => throw new ArgumentOutOfRangeException(nameof(chartName))
         };
 

--- a/web/tests/Web.E2ETests/Steps/School/BenchmarkCensusSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/BenchmarkCensusSteps.cs
@@ -153,7 +153,7 @@ public class BenchmarkCensusSteps(PageDriver driver)
         Assert.NotNull(_download);
         var downloadedFileName = ChartNameFromFriendlyName(chartName) switch
         {
-            CensusChartNames.SchoolWorkforce => "school workforce (full time equivalent)",
+            CensusChartNames.SchoolWorkforce => "school-workforce-full-time-equivalent",
             _ => throw new ArgumentOutOfRangeException(nameof(chartName))
         };
 

--- a/web/tests/Web.E2ETests/Steps/School/CompareYourCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/CompareYourCostsSteps.cs
@@ -327,7 +327,7 @@ public class CompareYourCostsSteps(PageDriver driver)
         Assert.NotNull(_download);
         var downloadedFileName = ChartNameFromFriendlyName(chartName) switch
         {
-            ComparisonChartNames.TotalExpenditure => "total expenditure",
+            ComparisonChartNames.TotalExpenditure => "total-expenditure",
             _ => throw new ArgumentOutOfRangeException(nameof(chartName))
         };
 

--- a/web/tests/Web.E2ETests/Steps/Trust/BenchmarkCensusSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/Trust/BenchmarkCensusSteps.cs
@@ -147,7 +147,7 @@ public class BenchmarkCensusSteps(PageDriver driver)
         Assert.NotNull(_download);
         var downloadedFileName = ChartNameFromFriendlyName(chartName) switch
         {
-            CensusChartNames.SchoolWorkforce => "school workforce (full time equivalent)",
+            CensusChartNames.SchoolWorkforce => "school-workforce-full-time-equivalent",
             _ => throw new ArgumentOutOfRangeException(nameof(chartName))
         };
 

--- a/web/tests/Web.E2ETests/Steps/Trust/CompareYourCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/Trust/CompareYourCostsSteps.cs
@@ -238,7 +238,7 @@ public class CompareYourCostsSteps(PageDriver driver)
         Assert.NotNull(_download);
         var downloadedFileName = ChartNameFromFriendlyName(chartName) switch
         {
-            ComparisonChartNames.TotalExpenditure => "total expenditure",
+            ComparisonChartNames.TotalExpenditure => "total-expenditure",
             _ => throw new ArgumentOutOfRangeException(nameof(chartName))
         };
 


### PR DESCRIPTION
### Context
[AB#246167](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/246167) [AB#244563](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/244563) [AB#242104](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/242104)

### Change proposed in this pull request
- School compare your costs page
- School compare workforce page
- Trust compare your costs page
- Trust compare workforce page
- LA compare your costs page
- LA compare workforce page
- Trust BFR
- This included refactoring accordion partials to extract common and repeated functionality

### Guidance to review 
Build and copy `front-end-components` to `Web` and then view one of the pages above. Downloading chart image should include the chart title.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

