### PR TITLE
hotfix: adds missing dimensions to query builder for trust balance

### DIFF
--- a/platform/src/abstractions/Platform.Sql/QueryBuilders/BalanceQueries.cs
+++ b/platform/src/abstractions/Platform.Sql/QueryBuilders/BalanceQueries.cs
@@ -21,6 +21,9 @@ public class BalanceTrustDefaultCurrentQuery(string dimension) : PlatformQuery(G
         return dimension switch
         {
             Dimensions.Finance.Actuals => "SELECT * FROM VW_BalanceTrustDefaultCurrentActual /**where**/",
+            Dimensions.Finance.PerUnit => "SELECT * FROM VW_BalanceTrustDefaultCurrentPerUnit /**where**/",
+            Dimensions.Finance.PercentExpenditure => "SELECT * FROM VW_BalanceTrustDefaultCurrentPercentExpenditure /**where**/",
+            Dimensions.Finance.PercentIncome => "SELECT * FROM VW_BalanceTrustDefaultCurrentPercentIncome /**where**/",
             _ => throw new ArgumentOutOfRangeException(nameof(dimension), "Unknown dimension")
         };
     }

--- a/platform/src/abstractions/tests/Platform.Sql.Tests/Builders/BalanceQueryTests.cs
+++ b/platform/src/abstractions/tests/Platform.Sql.Tests/Builders/BalanceQueryTests.cs
@@ -48,6 +48,9 @@ public class BalanceTrustDefaultCurrentQueryTests
     public static TheoryData<string, string> Data => new()
     {
         { "Actuals", "SELECT * FROM VW_BalanceTrustDefaultCurrentActual " },
+        { "PerUnit", "SELECT * FROM VW_BalanceTrustDefaultCurrentPerUnit " },
+        { "PercentExpenditure", "SELECT * FROM VW_BalanceTrustDefaultCurrentPercentExpenditure " },
+        { "PercentIncome", "SELECT * FROM VW_BalanceTrustDefaultCurrentPercentIncome " },
     };
 
     private static BalanceTrustDefaultCurrentQuery Create(string dimension) => new(dimension);


### PR DESCRIPTION
### Context
AB#246336

### Change proposed in this pull request
Adds missing dimensions to trust balance query builder. SQL views where already present.

### Guidance to review 
Within trust benchmarking balance tab was failing to load additional dimensions.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

