### PR TITLE
Added mising prop to `trust` cost comparison charts, post refactor

### DIFF
--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/administrative-supplies.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/administrative-supplies.tsx
@@ -84,6 +84,7 @@ export const AdministrativeSupplies: React.FC<{
       hasNoData={data?.length === 0}
       index={7}
       title="Administrative supplies"
+      trust
     />
   );
 };

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/catering-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/catering-staff-services.tsx
@@ -166,6 +166,7 @@ export const CateringStaffServices: React.FC<{
         </div>
       }
       title="Catering staff and supplies"
+      trust
     />
   );
 };

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-ict.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-ict.tsx
@@ -77,6 +77,7 @@ export const EducationalIct: React.FC<{
       hasNoData={data?.length === 0}
       index={4}
       title="Educational ICT"
+      trust
     />
   );
 };

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-supplies.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-supplies.tsx
@@ -129,6 +129,7 @@ export const EducationalSupplies: React.FC<{
       hasNoData={data?.length === 0}
       index={3}
       title="Educational supplies"
+      trust
     />
   );
 };

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/non-educational-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/non-educational-support-staff.tsx
@@ -179,6 +179,7 @@ export const NonEducationalSupportStaff: React.FC<{
       hasNoData={data?.length === 0}
       index={2}
       title="Non-educational support staff and services"
+      trust
     />
   );
 };

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/other-costs.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/other-costs.tsx
@@ -314,6 +314,7 @@ export const OtherCosts: React.FC<{
       hasNoData={data?.length === 0}
       index={9}
       title="Other costs"
+      trust
     />
   );
 };

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/premises-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/premises-staff-services.tsx
@@ -165,6 +165,7 @@ export const PremisesStaffServices: React.FC<{
       hasNoData={data?.length === 0}
       index={5}
       title="Premises staff and services"
+      trust
     />
   );
 };

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/utilities.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/utilities.tsx
@@ -121,6 +121,7 @@ export const Utilities: React.FC<{
       hasNoData={data?.length === 0}
       index={6}
       title="Utilities"
+      trust
     />
   );
 };


### PR DESCRIPTION
### Context
[AB#246167](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/246167) [AB#244563](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/244563) #1786

### Change proposed in this pull request
Added missing prop from the earlier refactor. Identified via failing a11y test. `front-end` will need to be bumped after this is merged.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

