### PR TITLE
Revert pipeline message payload `kind` from earlier commit 

### DIFF
--- a/platform/src/abstractions/Platform.Domain/Messages/PipelinePayload.cs
+++ b/platform/src/abstractions/Platform.Domain/Messages/PipelinePayload.cs
@@ -15,16 +15,16 @@ public record PipelinePayload
 }
 
 [ExcludeFromCodeCoverage]
-public record ComparatorSetPipelinePayload : PipelinePayload
+public record ComparatorSetPayload : PipelinePayload
 {
-    public override string Kind => nameof(ComparatorSetPipelinePayload);
+    public override string Kind => nameof(ComparatorSetPayload);
     public string[] Set { get; set; } = [];
 }
 
 [ExcludeFromCodeCoverage]
-public record CustomDataPipelinePayload : PipelinePayload
+public record CustomDataPayload : PipelinePayload
 {
-    public override string Kind => nameof(CustomDataPipelinePayload);
+    public override string Kind => nameof(CustomDataPayload);
 
     public decimal? AdministrativeSuppliesNonEducationalCosts { get; set; }
     public decimal? CateringStaffCosts { get; set; }

--- a/platform/src/apis/Platform.Api.Benchmark/ComparatorSets/ComparatorSetsFunctions.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/ComparatorSets/ComparatorSetsFunctions.cs
@@ -189,7 +189,7 @@ public class ComparatorSetsFunctions(IComparatorSetsService service, ILogger<Com
                         Type = Pipeline.JobType.ComparatorSet,
                         URN = comparatorSet.URN,
                         Year = int.Parse(year),
-                        Payload = new ComparatorSetPipelinePayload
+                        Payload = new ComparatorSetPayload
                         {
                             Set = comparatorSet.Set.ToArray()
                         }

--- a/platform/src/apis/Platform.Api.Benchmark/CustomData/CustomDataRequest.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/CustomData/CustomDataRequest.cs
@@ -56,7 +56,7 @@ public record CustomDataRequest
     public decimal? AuxiliaryStaffFTE { get; set; }
     public decimal? WorkforceHeadcount { get; set; }
 
-    public CustomDataPipelinePayload CreatePayload() => new()
+    public CustomDataPayload CreatePayload() => new()
     {
         AdministrativeSuppliesNonEducationalCosts = AdministrativeSuppliesNonEducationalCosts,
         CateringStaffCosts = CateringStaffCosts,

--- a/platform/tests/Platform.Benchmark.Tests/WhenFunctionReceivesCreateComparatorSetRequest.cs
+++ b/platform/tests/Platform.Benchmark.Tests/WhenFunctionReceivesCreateComparatorSetRequest.cs
@@ -95,8 +95,8 @@ public class WhenFunctionReceivesCreateComparatorSetRequest : ComparatorSetsFunc
         Assert.NotNull(actualMessage.RunId);
         Assert.Equal(year, actualMessage.Year);
         Assert.Equal(urn, actualMessage.URN);
-        Assert.Equal("ComparatorSetPipelinePayload", actualMessage.Payload?.Kind);
-        Assert.Equal(set, (actualMessage.Payload as ComparatorSetPipelinePayload)?.Set);
+        Assert.Equal("ComparatorSetPayload", actualMessage.Payload?.Kind);
+        Assert.Equal(set, (actualMessage.Payload as ComparatorSetPayload)?.Set);
 
         Service.Verify(
             x => x.UpsertUserDefinedSchoolAsync(

--- a/platform/tests/Platform.Benchmark.Tests/WhenFunctionReceivesCreateCustomDataRequest.cs
+++ b/platform/tests/Platform.Benchmark.Tests/WhenFunctionReceivesCreateCustomDataRequest.cs
@@ -48,10 +48,10 @@ public class WhenFunctionReceivesCreateCustomDataRequest : FunctionsTestBase
         Assert.NotNull(actualMessage.RunId);
         Assert.Equal(year, actualMessage.Year);
         Assert.Equal(urn, actualMessage.URN);
-        Assert.Equal("CustomDataPipelinePayload", actualMessage.Payload?.Kind);
+        Assert.Equal("CustomDataPayload", actualMessage.Payload?.Kind);
         Assert.Equal(
             model.AdministrativeSuppliesNonEducationalCosts,
-            (actualMessage.Payload as CustomDataPipelinePayload)?.AdministrativeSuppliesNonEducationalCosts);
+            (actualMessage.Payload as CustomDataPayload)?.AdministrativeSuppliesNonEducationalCosts);
 
         _service.Verify(x => x.UpsertCustomDataAsync(It.IsAny<CustomDataSchool>()), Times.Once());
         _service.Verify(x => x.InsertNewAndDeactivateExistingUserDataAsync(It.IsAny<CustomDataUserData>()), Times.Once());


### PR DESCRIPTION
### Context
[AB#246377](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/246377) [AB#242105](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/242105)

### Change proposed in this pull request
Partially reverts change from 1303232a16a1b790512be150d7c3795e51ea0ce0 that sent unexpected `kind` value to Orchestrator and ultimately data pipeline.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

