### PR TITLE
Renamed `PipelinePayload` types back to previous class names whilst persisting `kind` values

### DIFF
--- a/platform/src/abstractions/Platform.Domain/Messages/PipelinePayload.cs
+++ b/platform/src/abstractions/Platform.Domain/Messages/PipelinePayload.cs
@@ -2,29 +2,41 @@
 using JsonSubTypes;
 using Newtonsoft.Json;
 
+// ReSharper disable PropertyCanBeMadeInitOnly.Global
 // ReSharper disable UnusedAutoPropertyAccessor.Global
-
 namespace Platform.Domain.Messages;
 
 [ExcludeFromCodeCoverage]
-[JsonConverter(typeof(JsonSubtypes), "Kind")]
+[JsonConverter(typeof(JsonSubtypes), "_type")]
 public record PipelinePayload
 {
+    /// <summary>
+    ///     Used to discriminate type during deserialization (not used by data pipeline).
+    /// </summary>
+    [JsonProperty("_type")]
+    public virtual string? Type { get; }
+
+    /// <summary>
+    ///     Data pipeline has a dependency on <see cref="Pipeline.PayloadKind">specific values</see> for `kind`.
+    /// </summary>
     [JsonProperty(nameof(Kind))]
     public virtual string? Kind { get; }
 }
 
 [ExcludeFromCodeCoverage]
-public record ComparatorSetPayload : PipelinePayload
+public record ComparatorSetPipelinePayload : PipelinePayload
 {
-    public override string Kind => nameof(ComparatorSetPayload);
+    public override string Type => nameof(ComparatorSetPipelinePayload);
+    public override string Kind => Pipeline.PayloadKind.ComparatorSetPayload;
+
     public string[] Set { get; set; } = [];
 }
 
 [ExcludeFromCodeCoverage]
-public record CustomDataPayload : PipelinePayload
+public record CustomDataPipelinePayload : PipelinePayload
 {
-    public override string Kind => nameof(CustomDataPayload);
+    public override string Type => nameof(CustomDataPipelinePayload);
+    public override string Kind => Pipeline.PayloadKind.CustomDataPayload;
 
     public decimal? AdministrativeSuppliesNonEducationalCosts { get; set; }
     public decimal? CateringStaffCosts { get; set; }

--- a/platform/src/abstractions/Platform.Domain/Pipeline.cs
+++ b/platform/src/abstractions/Platform.Domain/Pipeline.cs
@@ -21,5 +21,12 @@ public static class Pipeline
         public const string Complete = "complete";
         public const string Pending = "pending";
         public const string Removed = "removed";
+        public const string Failed = "failed";
+    }
+
+    public static class PayloadKind
+    {
+        public const string ComparatorSetPayload = nameof(ComparatorSetPayload);
+        public const string CustomDataPayload = nameof(CustomDataPayload);
     }
 }

--- a/platform/src/apis/Platform.Api.Benchmark/ComparatorSets/ComparatorSetsFunctions.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/ComparatorSets/ComparatorSetsFunctions.cs
@@ -189,7 +189,7 @@ public class ComparatorSetsFunctions(IComparatorSetsService service, ILogger<Com
                         Type = Pipeline.JobType.ComparatorSet,
                         URN = comparatorSet.URN,
                         Year = int.Parse(year),
-                        Payload = new ComparatorSetPayload
+                        Payload = new ComparatorSetPipelinePayload
                         {
                             Set = comparatorSet.Set.ToArray()
                         }

--- a/platform/src/apis/Platform.Api.Benchmark/CustomData/CustomDataRequest.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/CustomData/CustomDataRequest.cs
@@ -56,7 +56,7 @@ public record CustomDataRequest
     public decimal? AuxiliaryStaffFTE { get; set; }
     public decimal? WorkforceHeadcount { get; set; }
 
-    public CustomDataPayload CreatePayload() => new()
+    public CustomDataPipelinePayload CreatePayload() => new()
     {
         AdministrativeSuppliesNonEducationalCosts = AdministrativeSuppliesNonEducationalCosts,
         CateringStaffCosts = CateringStaffCosts,

--- a/platform/tests/Platform.Benchmark.Tests/WhenFunctionReceivesCreateComparatorSetRequest.cs
+++ b/platform/tests/Platform.Benchmark.Tests/WhenFunctionReceivesCreateComparatorSetRequest.cs
@@ -95,8 +95,8 @@ public class WhenFunctionReceivesCreateComparatorSetRequest : ComparatorSetsFunc
         Assert.NotNull(actualMessage.RunId);
         Assert.Equal(year, actualMessage.Year);
         Assert.Equal(urn, actualMessage.URN);
-        Assert.Equal("ComparatorSetPayload", actualMessage.Payload?.Kind);
-        Assert.Equal(set, (actualMessage.Payload as ComparatorSetPayload)?.Set);
+        Assert.Equal("ComparatorSetPayload", actualMessage.Payload?.Kind); // `kind` expected by data pipeline
+        Assert.Equal(set, (actualMessage.Payload as ComparatorSetPipelinePayload)?.Set);
 
         Service.Verify(
             x => x.UpsertUserDefinedSchoolAsync(

--- a/platform/tests/Platform.Benchmark.Tests/WhenFunctionReceivesCreateCustomDataRequest.cs
+++ b/platform/tests/Platform.Benchmark.Tests/WhenFunctionReceivesCreateCustomDataRequest.cs
@@ -48,10 +48,10 @@ public class WhenFunctionReceivesCreateCustomDataRequest : FunctionsTestBase
         Assert.NotNull(actualMessage.RunId);
         Assert.Equal(year, actualMessage.Year);
         Assert.Equal(urn, actualMessage.URN);
-        Assert.Equal("CustomDataPayload", actualMessage.Payload?.Kind);
+        Assert.Equal("CustomDataPayload", actualMessage.Payload?.Kind); // `kind` expected by data pipeline
         Assert.Equal(
             model.AdministrativeSuppliesNonEducationalCosts,
-            (actualMessage.Payload as CustomDataPayload)?.AdministrativeSuppliesNonEducationalCosts);
+            (actualMessage.Payload as CustomDataPipelinePayload)?.AdministrativeSuppliesNonEducationalCosts);
 
         _service.Verify(x => x.UpsertCustomDataAsync(It.IsAny<CustomDataSchool>()), Times.Once());
         _service.Verify(x => x.InsertNewAndDeactivateExistingUserDataAsync(It.IsAny<CustomDataUserData>()), Times.Once());


### PR DESCRIPTION
### Context
[AB#246377](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/246377) [AB#242105](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/242105) #1793

### Change proposed in this pull request
Follow-up change from linked PR to rename classes back as they were, whilst keeping the `kind` values expected by the data pipeline. This is done by using an alternative field for subtype discrimination during deserialization. Validated via unit tests.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [ ] ~~You have tested by running locally~~
- [ ] ~~You have reviewed with UX/Design~~

