### PR TITLE
Added 'save as image' component to work with elements outside the React context

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -108,7 +108,7 @@
       data-id="888"
       data-phases='["Primary"]'
     ></div>-->
-    <div id="budget-forecast-returns" data-id="00000001"></div>
+    <!--<div id="budget-forecast-returns" data-id="00000001"></div>-->
     <!--<div id="historic-data" data-type="trust" data-id="10377760"></div>-->
     <!--<div id="find-organisation"
         data-company-number=""
@@ -121,6 +121,10 @@
         data-trust-input=""
         data-urn=""
       >-->
+    <div data-share-content-by-element-id data-element-id="test-element-id" data-title="Test title"></div>
+    <svg id="test-element-id" height="100" width="100" xmlns="http://www.w3.org/2000/svg">
+      <circle r="45" cx="50" cy="50" fill="red" />
+    </svg>
     <script type="module" src="/src/main.tsx"></script>
     <script
       type="module"

--- a/front-end-components/package-lock.json
+++ b/front-end-components/package-lock.json
@@ -9147,9 +9147,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.7.tgz",
-      "integrity": "sha512-RDt8r/7qx9940f8FcOIAH9PTViRrghKaK2K1jY3RaAURrEUbm9Du1mJ72G+jlhtG3WwodnfzY8ORQZbBavZEAQ==",
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.11.tgz",
+      "integrity": "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.24.2",

--- a/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
@@ -100,7 +100,7 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
   const downloadPng = useDownloadPngImage({
     ref: rechartsRef,
     onImageLoading,
-    elementSelector: ({ container }) => container,
+    elementSelector: (ref) => ref?.container,
     filter: (node) => {
       const exclusionClasses = ["recharts-tooltip-wrapper"];
       return !exclusionClasses.some((classname) =>

--- a/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
@@ -108,6 +108,7 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
       );
     },
     title: chartTitle,
+    showTitle: true,
   });
 
   useImperativeHandle(ref, () => ({

--- a/front-end-components/src/components/charts/line-chart/component.tsx
+++ b/front-end-components/src/components/charts/line-chart/component.tsx
@@ -65,6 +65,7 @@ function LineChartInner<TData extends ChartDataSeries>(
     onImageLoading,
     elementSelector: ({ container }) => container,
     title: chartTitle,
+    showTitle: true,
   });
 
   useImperativeHandle(ref, () => ({

--- a/front-end-components/src/components/charts/line-chart/component.tsx
+++ b/front-end-components/src/components/charts/line-chart/component.tsx
@@ -63,7 +63,7 @@ function LineChartInner<TData extends ChartDataSeries>(
   const downloadPng = useDownloadPngImage({
     ref: rechartsRef,
     onImageLoading,
-    elementSelector: ({ container }) => container,
+    elementSelector: (ref) => ref?.container,
     title: chartTitle,
     showTitle: true,
   });

--- a/front-end-components/src/components/charts/vertical-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/vertical-bar-chart/component.tsx
@@ -63,6 +63,7 @@ function VerticalBarChartInner<TData extends ChartDataSeries>(
     onImageLoading,
     elementSelector: ({ container }) => container,
     title: chartTitle,
+    showTitle: true,
   });
 
   useImperativeHandle(ref, () => ({

--- a/front-end-components/src/components/charts/vertical-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/vertical-bar-chart/component.tsx
@@ -61,7 +61,7 @@ function VerticalBarChartInner<TData extends ChartDataSeries>(
   const downloadPng = useDownloadPngImage({
     ref: rechartsRef,
     onImageLoading,
-    elementSelector: ({ container }) => container,
+    elementSelector: (ref) => ref?.container,
     title: chartTitle,
     showTitle: true,
   });

--- a/front-end-components/src/components/share-content-by-element/component.tsx
+++ b/front-end-components/src/components/share-content-by-element/component.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from "react";
+import { ShareContentByElementProps } from "./types";
+import { useDownloadPngImage } from "src/hooks/useDownloadImage";
+import { ShareContent } from "../share-content";
+
+export const ShareContentByElement: React.FC<ShareContentByElementProps> = ({
+  disabled,
+  elementSelector,
+  title,
+  showTitle,
+  ...props
+}) => {
+  const [imageLoading, setImageLoading] = useState<boolean>();
+  const downloadPng = useDownloadPngImage({
+    ref: nullRef,
+    elementSelector,
+    onImageLoading: setImageLoading,
+    title,
+    showTitle,
+  });
+
+  return (
+    <ShareContent
+      disabled={imageLoading || disabled}
+      onSaveClick={async () => await downloadPng()}
+      title={title}
+      {...props}
+    />
+  );
+};
+
+const nullRef: React.RefObject<HTMLElement> = {
+  current: (<div />) as unknown as HTMLElement,
+};

--- a/front-end-components/src/components/share-content-by-element/component.tsx
+++ b/front-end-components/src/components/share-content-by-element/component.tsx
@@ -12,7 +12,6 @@ export const ShareContentByElement: React.FC<ShareContentByElementProps> = ({
 }) => {
   const [imageLoading, setImageLoading] = useState<boolean>();
   const downloadPng = useDownloadPngImage({
-    ref: nullRef,
     elementSelector,
     onImageLoading: setImageLoading,
     title,
@@ -27,8 +26,4 @@ export const ShareContentByElement: React.FC<ShareContentByElementProps> = ({
       {...props}
     />
   );
-};
-
-const nullRef: React.RefObject<HTMLElement> = {
-  current: (<div />) as unknown as HTMLElement,
 };

--- a/front-end-components/src/components/share-content-by-element/index.tsx
+++ b/front-end-components/src/components/share-content-by-element/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/components/share-content-by-element/types";
+export * from "src/components/share-content-by-element/component";

--- a/front-end-components/src/components/share-content-by-element/types.tsx
+++ b/front-end-components/src/components/share-content-by-element/types.tsx
@@ -1,0 +1,8 @@
+import { ShareContentProps } from "../share-content/types";
+
+export type ShareContentByElementProps = Omit<
+  ShareContentProps,
+  "onSaveClick"
+> & {
+  elementSelector: () => HTMLElement | undefined;
+};

--- a/front-end-components/src/components/share-content/component.tsx
+++ b/front-end-components/src/components/share-content/component.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import "src/components/share-content/styles.css";
+import { ShareContentProps } from "./types";
+
+export const ShareContent: React.FC<ShareContentProps> = ({
+  disabled,
+  onSaveClick,
+  saveEventId,
+  title,
+}) => {
+  return (
+    <div>
+      <button
+        className="govuk-button govuk-button--secondary"
+        data-module="govuk-button"
+        data-prevent-double-click="true"
+        onClick={onSaveClick}
+        disabled={disabled}
+        aria-disabled={disabled}
+        data-custom-event-id={saveEventId}
+        data-custom-event-chart-name={saveEventId && title}
+      >
+        Save <span className="govuk-visually-hidden">{title}</span> as image
+      </button>
+    </div>
+  );
+};

--- a/front-end-components/src/components/share-content/index.tsx
+++ b/front-end-components/src/components/share-content/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/components/share-content/types";
+export * from "src/components/share-content/component";

--- a/front-end-components/src/components/share-content/types.tsx
+++ b/front-end-components/src/components/share-content/types.tsx
@@ -1,0 +1,8 @@
+import { MouseEventHandler } from "react";
+
+export type ShareContentProps = {
+  disabled?: boolean;
+  onSaveClick?: MouseEventHandler<HTMLButtonElement> | undefined;
+  saveEventId?: string;
+  title: string;
+};

--- a/front-end-components/src/components/share-content/types.tsx
+++ b/front-end-components/src/components/share-content/types.tsx
@@ -1,8 +1,11 @@
 import { MouseEventHandler } from "react";
+import { DownloadPngImageOptions } from "src/hooks/useDownloadImage";
 
-export type ShareContentProps = {
+export type ShareContentProps = Pick<
+  DownloadPngImageOptions<HTMLElement>,
+  "showTitle" | "title"
+> & {
   disabled?: boolean;
   onSaveClick?: MouseEventHandler<HTMLButtonElement> | undefined;
   saveEventId?: string;
-  title: string;
 };

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -33,6 +33,7 @@ import {
   ValueType,
 } from "recharts/types/component/DefaultTooltipContent";
 import { SchoolExpenditure } from "src/services";
+import { ShareContent } from "src/components/share-content";
 
 export function HorizontalBarChartWrapper<
   TData extends SchoolChartData | TrustChartData,
@@ -161,19 +162,12 @@ export function HorizontalBarChartWrapper<
         <div className="govuk-grid-column-two-thirds">{children}</div>
         {chartMode == ChartModeChart && (
           <div className="govuk-grid-column-one-third">
-            <button
-              className="govuk-button govuk-button--secondary"
-              data-module="govuk-button"
-              data-prevent-double-click="true"
-              onClick={() => chartRef.current?.download()}
+            <ShareContent
               disabled={imageLoading || !hasData}
-              aria-disabled={imageLoading || !hasData}
-              data-custom-event-id="save-chart-as-image"
-              data-custom-event-chart-name={chartTitle}
-            >
-              Save <span className="govuk-visually-hidden">{chartTitle}</span>{" "}
-              as image
-            </button>
+              onSaveClick={() => chartRef.current?.download()}
+              saveEventId="save-chart-as-image"
+              title={chartTitle}
+            />
           </div>
         )}
       </div>

--- a/front-end-components/src/constants.tsx
+++ b/front-end-components/src/constants.tsx
@@ -19,3 +19,4 @@ export const SchoolSuggesterId = "school-suggester";
 export const LaSuggesterId = "la-suggester";
 export const TrustSuggesterId = "trust-suggester";
 export const BudgetForecastReturnsElementId = "budget-forecast-returns";
+export const ShareContentByElementIdDataAttr = "share-content-by-element-id";

--- a/front-end-components/src/hooks/useDownloadImage.ts
+++ b/front-end-components/src/hooks/useDownloadImage.ts
@@ -2,22 +2,24 @@ import saveAs from "file-saver";
 import { useCallback } from "react";
 import { ImageOptions, ImageService } from "src/services";
 
-type DownloadPngImageOptions<T> = {
-  ref?: React.RefObject<T>;
+export type DownloadPngImageOptions<T> = {
+  elementSelector: (ref: T) => HTMLElement | undefined;
   fileName?: string;
   onImageLoading?: (loading: boolean) => void;
-  elementSelector: (ref: T) => HTMLElement | undefined;
+  ref?: React.RefObject<T>;
+  showTitle?: boolean;
   title?: string;
 } & Pick<ImageOptions, "filter">;
 
 const imageTitleHeight = 50;
 
 export function useDownloadPngImage<T>({
-  ref,
   fileName: fileNameProp,
-  onImageLoading,
   elementSelector,
   filter,
+  onImageLoading,
+  showTitle,
+  ref,
   title,
 }: DownloadPngImageOptions<T>) {
   const fileName = title
@@ -47,7 +49,7 @@ export function useDownloadPngImage<T>({
     // cloned for the purpose of generating the image (so as to not affect the original DOM,
     // but still be able to apply styles and fonts as resolved from class names).
     let onCloned: (node: HTMLElement) => void | undefined;
-    if (title) {
+    if (title && showTitle) {
       height += imageTitleHeight;
       onCloned = (node) => {
         const child = document.createElement("h2");
@@ -98,7 +100,15 @@ export function useDownloadPngImage<T>({
     } else {
       await download();
     }
-  }, [ref, fileName, onImageLoading, elementSelector, filter, title]);
+  }, [
+    elementSelector,
+    fileName,
+    filter,
+    onImageLoading,
+    ref,
+    showTitle,
+    title,
+  ]);
 
   return downloadPng;
 }

--- a/front-end-components/src/hooks/useDownloadImage.ts
+++ b/front-end-components/src/hooks/useDownloadImage.ts
@@ -3,7 +3,7 @@ import { useCallback } from "react";
 import { ImageOptions, ImageService } from "src/services";
 
 export type DownloadPngImageOptions<T> = {
-  elementSelector: (ref: T) => HTMLElement | undefined;
+  elementSelector: (ref?: T) => HTMLElement | undefined;
   fileName?: string;
   onImageLoading?: (loading: boolean) => void;
   ref?: React.RefObject<T>;
@@ -34,11 +34,7 @@ export function useDownloadPngImage<T>({
       : "download.png";
 
   const downloadPng = useCallback(async () => {
-    if (!ref?.current) {
-      return;
-    }
-
-    const element = elementSelector(ref.current);
+    const element = elementSelector(ref?.current || undefined);
     if (!element) {
       return;
     }

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -31,6 +31,7 @@ import {
   CompareTrustElementId,
   LineChart2SeriesElementId,
   BudgetForecastReturnsElementId,
+  ShareContentByElementIdDataAttr,
 } from "src/constants";
 import { HorizontalBarChart } from "./components/charts/horizontal-bar-chart";
 import { VerticalBarChart } from "./components/charts/vertical-bar-chart";
@@ -58,6 +59,7 @@ import TrustInput from "./views/find-organisation/partials/trust-input";
 import { TrustDataTooltip } from "./components/charts/trust-data-tooltip";
 import { TrustChartData } from "./components/charts/table-chart";
 import { BudgetForecastReturns } from "./views/budget-forecast-returns";
+import { ShareContentByElement } from "./components/share-content-by-element";
 
 const historicDataElement = document.getElementById(HistoricDataElementId);
 if (historicDataElement) {
@@ -861,4 +863,31 @@ if (budgetForecastReturnsElement) {
       </React.StrictMode>
     );
   }
+}
+
+const shareContentByElementIdElements = document.querySelectorAll<HTMLElement>(
+  `[data-${ShareContentByElementIdDataAttr}]`
+);
+
+if (shareContentByElementIdElements) {
+  shareContentByElementIdElements.forEach((element) => {
+    const { elementId, showTitle, title } = element.dataset;
+    if (elementId && title) {
+      const el = document.getElementById(elementId);
+      if (el) {
+        const root = ReactDOM.createRoot(element);
+        root.render(
+          <React.StrictMode>
+            <ShareContentByElement
+              elementSelector={() =>
+                document.getElementById(elementId) ?? undefined
+              }
+              showTitle={showTitle === "true"}
+              title={title}
+            />
+          </React.StrictMode>
+        );
+      }
+    }
+  });
 }

--- a/front-end-components/src/views/budget-forecast-returns/partials/year-end.tsx
+++ b/front-end-components/src/views/budget-forecast-returns/partials/year-end.tsx
@@ -16,6 +16,7 @@ import {
 } from "src/components";
 import { BfrChart } from "./bfr-chart";
 import { BfrTable } from "./bfr-table";
+import { ShareContent } from "src/components/share-content";
 
 export const YearEnd: React.FC<{
   id: string;
@@ -92,21 +93,12 @@ export const YearEnd: React.FC<{
       </div>
       <div className="govuk-grid-column-one-half">
         <div>
-          <button
-            className="govuk-button govuk-button--secondary"
-            data-module="govuk-button"
+          <ShareContent
             disabled={imageLoading || !hasData}
-            aria-disabled={imageLoading || !hasData}
-            onClick={() => chartRef?.current?.download()}
-            data-custom-event-id="save-chart-as-image"
-            data-custom-event-chart-name={chartName.toLowerCase()}
-          >
-            Save{" "}
-            <span className="govuk-visually-hidden">
-              {chartName.toLowerCase()}
-            </span>{" "}
-            as image
-          </button>
+            onSaveClick={() => chartRef.current?.download()}
+            saveEventId="save-chart-as-image"
+            title={chartName}
+          />
         </div>
         <div>
           <ChartDimensions


### PR DESCRIPTION
### Context
AB#246601 AB#244349 #1790 

### Change proposed in this pull request
- Refactored 'save as image' button into `<ShareContent />` component
- Added `<ShareContentByElement />` component for use with any HTMLElement
- Added default implementation to be to select by any element ID, which may be outside the React context
- Made `ref` prop optional in `DownloadPngImageOptions`
- Updated `vite` to version without reported vulnerability

### Guidance to review 
Sample usage of new component available in `vite` dev server. Existing consumers of refactored button should work as per before this change.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

