### PR TITLE
Added 'Save all chart images' button to School and Trust cost comparison pages 

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -121,9 +121,19 @@
         data-trust-input=""
         data-urn=""
       >-->
-    <div data-share-content-by-element-id data-element-id="test-element-id" data-title="Test title"></div>
+    <!-- <div data-share-content-by-element-id data-element-id="test-element-id" data-title="Test title"></div>
     <svg id="test-element-id" height="100" width="100" xmlns="http://www.w3.org/2000/svg">
       <circle r="45" cx="50" cy="50" fill="red" />
+    </svg> -->
+    <div data-share-content-by-element-class-name data-element-class-name="test-element-class" data-label="Save all" data-element-title-attr="aria-label"></div>
+    <svg class="test-element-class" aria-label="Red" height="100" width="100" xmlns="http://www.w3.org/2000/svg">
+      <circle r="45" cx="50" cy="50" fill="red" />
+    </svg>
+    <svg class="test-element-class" aria-label="Green" height="100" width="100" xmlns="http://www.w3.org/2000/svg">
+      <circle r="45" cx="50" cy="50" fill="green" />
+    </svg>
+    <svg class="test-element-class" height="100" width="100" xmlns="http://www.w3.org/2000/svg">
+      <circle r="45" cx="50" cy="50" fill="blue" />
     </svg>
     <script type="module" src="/src/main.tsx"></script>
     <script

--- a/front-end-components/package-lock.json
+++ b/front-end-components/package-lock.json
@@ -14,6 +14,7 @@
         "file-saver": "^2.0.5",
         "govuk-frontend": "^5.6.0",
         "html-to-image": "^1.11.11",
+        "jszip": "^3.10.1",
         "punycode": "^2.3.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -4508,6 +4509,11 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -5720,6 +5726,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -5787,8 +5798,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internmap": {
       "version": "2.0.3",
@@ -5893,6 +5903,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -6984,6 +6999,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7022,6 +7048,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lines-and-columns": {
@@ -7449,6 +7483,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -8097,6 +8136,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -8253,6 +8297,20 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/recharts": {
@@ -8549,6 +8607,11 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -8583,6 +8646,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -8690,6 +8758,14 @@
       },
       "engines": {
         "node": ">=2.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-format": {
@@ -9098,6 +9174,11 @@
       "peerDependencies": {
         "react": "^16.8.0  || ^17 || ^18"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
       "version": "11.0.3",

--- a/front-end-components/package.json
+++ b/front-end-components/package.json
@@ -23,6 +23,7 @@
     "file-saver": "^2.0.5",
     "govuk-frontend": "^5.6.0",
     "html-to-image": "^1.11.11",
+    "jszip": "^3.10.1",
     "punycode": "^2.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/front-end-components/src/components/chart-mode/component.tsx
+++ b/front-end-components/src/components/chart-mode/component.tsx
@@ -15,7 +15,7 @@ export const ChartMode: React.FC<ChartModeProps> = (props) => {
           <h2 className="govuk-fieldset__heading">View as</h2>
         </legend>
         <div
-          className="govuk-radios govuk-radios--small govuk-radios--inline"
+          className="govuk-radios govuk-radios--small govuk-radios--inline chart-mode-radios"
           data-module="govuk-radios"
         >
           <div className="govuk-radios__item">

--- a/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
@@ -280,6 +280,7 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
                     key={seriesName as string}
                     dataKey={seriesName as string}
                     stackId={config?.stackId}
+                    isAnimationActive={false}
                   >
                     {filteredData.map((entry, dataIndex) =>
                       renderCell(entry, dataIndex, seriesIndex, config)

--- a/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
@@ -250,7 +250,7 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
       <div style={{ height: 22 * filteredData.length + 75 }}>
         <div
           aria-label={chartTitle}
-          className="govuk-body-s govuk-!-font-size-14 full-height-width"
+          className="govuk-body-s govuk-!-font-size-14 full-height-width chart-wrapper"
           role="img"
         >
           <ResponsiveContainer>

--- a/front-end-components/src/components/charts/line-chart/component.tsx
+++ b/front-end-components/src/components/charts/line-chart/component.tsx
@@ -187,6 +187,7 @@ function LineChartInner<TData extends ChartDataSeries>(
             true
           )
         }
+        isAnimationActive={false}
       ></Line>
     );
   };

--- a/front-end-components/src/components/charts/line-chart/component.tsx
+++ b/front-end-components/src/components/charts/line-chart/component.tsx
@@ -195,7 +195,7 @@ function LineChartInner<TData extends ChartDataSeries>(
     // a11y: https://github.com/recharts/recharts/issues/3816
     <div
       aria-label={chartTitle}
-      className="govuk-body-s govuk-!-font-size-14 full-height-width"
+      className="govuk-body-s govuk-!-font-size-14 full-height-width chart-wrapper"
       role="img"
     >
       <ResponsiveContainer>

--- a/front-end-components/src/components/charts/vertical-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/vertical-bar-chart/component.tsx
@@ -176,7 +176,11 @@ function VerticalBarChartInner<TData extends ChartDataSeries>(
             />
           )}
           {visibleSeriesNames.map((seriesName, seriesIndex) => (
-            <Bar key={seriesName as string} dataKey={seriesName as string}>
+            <Bar
+              key={seriesName as string}
+              dataKey={seriesName as string}
+              isAnimationActive={false}
+            >
               {data.map((entry, dataIndex) =>
                 renderCell(entry, dataIndex, seriesName, seriesIndex)
               )}

--- a/front-end-components/src/components/charts/vertical-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/vertical-bar-chart/component.tsx
@@ -131,7 +131,7 @@ function VerticalBarChartInner<TData extends ChartDataSeries>(
     // a11y: https://github.com/recharts/recharts/issues/3816
     <div
       aria-label={chartTitle}
-      className="govuk-body-s govuk-!-font-size-14 full-height-width"
+      className="govuk-body-s govuk-!-font-size-14 full-height-width chart-wrapper"
       role="img"
     >
       <ResponsiveContainer>

--- a/front-end-components/src/components/progress/component.tsx
+++ b/front-end-components/src/components/progress/component.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import "src/components/progress/styles.css";
+import { ProgressProps } from ".";
+import classNames from "classnames";
+
+// inspired by https://medium.com/@pppped/how-to-code-a-responsive-circular-percentage-chart-with-svg-and-css-3632f8cd7705
+export const Progress: React.FC<ProgressProps> = ({
+  className,
+  percentage,
+  ...props
+}) => {
+  return (
+    <svg
+      viewBox="0 0 40 40"
+      className={classNames("progress-wrapper", className)}
+      {...props}
+    >
+      <path
+        className="progress-circle"
+        d="M20 4.0845
+      a 15.9155 15.9155 0 0 1 0 31.831
+      a 15.9155 15.9155 0 0 1 0 -31.831"
+        strokeDasharray={`${percentage}, 100`}
+      />
+    </svg>
+  );
+};

--- a/front-end-components/src/components/progress/index.tsx
+++ b/front-end-components/src/components/progress/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/components/progress/component";
+export * from "src/components/progress/types";

--- a/front-end-components/src/components/progress/styles.css
+++ b/front-end-components/src/components/progress/styles.css
@@ -1,0 +1,24 @@
+.progress-wrapper {
+    display: block;
+    max-width: 80%;
+    max-height: 250px;
+}
+
+.progress-wrapper.progress-left {
+    float: left;
+    margin-right: 10px;
+}
+
+.progress-wrapper .progress-circle {
+    stroke: #005EA5;
+    fill: none;
+    stroke-width: 6;
+    stroke-linecap: round;
+    animation: progress 1s ease-out forwards;
+}
+
+@keyframes progress {
+    0% {
+        stroke-dasharray: 0 100;
+    }
+}

--- a/front-end-components/src/components/progress/types.tsx
+++ b/front-end-components/src/components/progress/types.tsx
@@ -1,0 +1,8 @@
+import { SVGProps } from "react";
+
+export type ProgressProps = Pick<
+  SVGProps<SVGSVGElement>,
+  "width" | "height" | "className"
+> & {
+  percentage: number;
+};

--- a/front-end-components/src/components/share-content-by-elements/component.tsx
+++ b/front-end-components/src/components/share-content-by-elements/component.tsx
@@ -10,6 +10,7 @@ export const ShareContentByElements: React.FC<ShareContentByElementsProps> = ({
   showProgress,
   showTitles,
   label,
+  onClick,
   ...props
 }) => {
   const [imagesLoading, setImagesLoading] = useState<boolean>();
@@ -31,7 +32,13 @@ export const ShareContentByElements: React.FC<ShareContentByElementsProps> = ({
   return (
     <ShareContent
       disabled={imagesLoading || disabled}
-      onSaveClick={async () => await downloadPngs()}
+      onSaveClick={async () => {
+        if (onClick) {
+          await onClick();
+        }
+
+        await downloadPngs();
+      }}
       {...props}
     >
       <>

--- a/front-end-components/src/components/share-content-by-elements/component.tsx
+++ b/front-end-components/src/components/share-content-by-elements/component.tsx
@@ -1,22 +1,32 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { ShareContentByElementsProps } from "./types";
 import { useDownloadPngImages } from "src/hooks/useDownloadImage";
 import { ShareContent } from "../share-content";
+import { Progress } from "../progress";
 
 export const ShareContentByElements: React.FC<ShareContentByElementsProps> = ({
   disabled,
   elementsSelector,
+  showProgress,
   showTitles,
   label,
   ...props
 }) => {
   const [imagesLoading, setImagesLoading] = useState<boolean>();
+  const [progress, setProgress] = useState<number>();
 
   const downloadPngs = useDownloadPngImages({
     elementsSelector,
     onImagesLoading: setImagesLoading,
+    onProgress: setProgress,
     showTitles,
   });
+
+  useEffect(() => {
+    if (!imagesLoading) {
+      setProgress(undefined);
+    }
+  }, [imagesLoading]);
 
   return (
     <ShareContent
@@ -24,7 +34,17 @@ export const ShareContentByElements: React.FC<ShareContentByElementsProps> = ({
       onSaveClick={async () => await downloadPngs()}
       {...props}
     >
-      {label}
+      <>
+        {showProgress && progress && (
+          <Progress
+            className="progress-left"
+            percentage={progress}
+            width={18}
+            height={18}
+          />
+        )}
+        {label}
+      </>
     </ShareContent>
   );
 };

--- a/front-end-components/src/components/share-content-by-elements/component.tsx
+++ b/front-end-components/src/components/share-content-by-elements/component.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from "react";
+import { ShareContentByElementsProps } from "./types";
+import { useDownloadPngImages } from "src/hooks/useDownloadImage";
+import { ShareContent } from "../share-content";
+
+export const ShareContentByElements: React.FC<ShareContentByElementsProps> = ({
+  disabled,
+  elementsSelector,
+  showTitles,
+  label,
+  ...props
+}) => {
+  const [imagesLoading, setImagesLoading] = useState<boolean>();
+
+  const downloadPngs = useDownloadPngImages({
+    elementsSelector,
+    onImagesLoading: setImagesLoading,
+    showTitles,
+  });
+
+  return (
+    <ShareContent
+      disabled={imagesLoading || disabled}
+      onSaveClick={async () => await downloadPngs()}
+      {...props}
+    >
+      {label}
+    </ShareContent>
+  );
+};

--- a/front-end-components/src/components/share-content-by-elements/index.tsx
+++ b/front-end-components/src/components/share-content-by-elements/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/components/share-content-by-elements/types";
+export * from "src/components/share-content-by-elements/component";

--- a/front-end-components/src/components/share-content-by-elements/types.tsx
+++ b/front-end-components/src/components/share-content-by-elements/types.tsx
@@ -11,5 +11,6 @@ export type ShareContentByElementsProps = Omit<
 > & {
   elementsSelector: () => ElementAndTitle[];
   label: string;
+  showProgress?: boolean;
   showTitles?: boolean;
 };

--- a/front-end-components/src/components/share-content-by-elements/types.tsx
+++ b/front-end-components/src/components/share-content-by-elements/types.tsx
@@ -1,0 +1,15 @@
+import { ShareContentByElementProps } from "../share-content-by-element";
+
+type ElementAndTitle = {
+  element: HTMLElement;
+  title?: string;
+};
+
+export type ShareContentByElementsProps = Omit<
+  ShareContentByElementProps,
+  "elementSelector" | "title" | "showTitle"
+> & {
+  elementsSelector: () => ElementAndTitle[];
+  label: string;
+  showTitles?: boolean;
+};

--- a/front-end-components/src/components/share-content-by-elements/types.tsx
+++ b/front-end-components/src/components/share-content-by-elements/types.tsx
@@ -11,6 +11,7 @@ export type ShareContentByElementsProps = Omit<
 > & {
   elementsSelector: () => ElementAndTitle[];
   label: string;
+  onClick: () => Promise<void>;
   showProgress?: boolean;
   showTitles?: boolean;
 };

--- a/front-end-components/src/components/share-content/component.tsx
+++ b/front-end-components/src/components/share-content/component.tsx
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { PropsWithChildren } from "react";
 import "src/components/share-content/styles.css";
 import { ShareContentProps } from "./types";
 
-export const ShareContent: React.FC<ShareContentProps> = ({
+export const ShareContent: React.FC<PropsWithChildren<ShareContentProps>> = ({
+  children,
   disabled,
   onSaveClick,
   saveEventId,
@@ -20,7 +21,13 @@ export const ShareContent: React.FC<ShareContentProps> = ({
         data-custom-event-id={saveEventId}
         data-custom-event-chart-name={saveEventId && title}
       >
-        Save <span className="govuk-visually-hidden">{title}</span> as image
+        {children ? (
+          children
+        ) : (
+          <>
+            Save <span className="govuk-visually-hidden">{title}</span> as image
+          </>
+        )}
       </button>
     </div>
   );

--- a/front-end-components/src/constants.tsx
+++ b/front-end-components/src/constants.tsx
@@ -20,3 +20,5 @@ export const LaSuggesterId = "la-suggester";
 export const TrustSuggesterId = "trust-suggester";
 export const BudgetForecastReturnsElementId = "budget-forecast-returns";
 export const ShareContentByElementIdDataAttr = "share-content-by-element-id";
+export const ShareContentByElementClassNameDataAttr =
+  "share-content-by-element-class-name";

--- a/front-end-components/src/hooks/useDownloadImage.ts
+++ b/front-end-components/src/hooks/useDownloadImage.ts
@@ -1,4 +1,5 @@
 import saveAs from "file-saver";
+import JSZip from "jszip";
 import { useCallback } from "react";
 import { ImageOptions, ImageService } from "src/services";
 
@@ -9,6 +10,17 @@ export type DownloadPngImageOptions<T> = {
   ref?: React.RefObject<T>;
   showTitle?: boolean;
   title?: string;
+} & Pick<ImageOptions, "filter">;
+
+type ElementAndTitle = {
+  element: HTMLElement;
+  title?: string;
+};
+
+export type DownloadPngImagesOptions = {
+  elementsSelector: () => ElementAndTitle[];
+  onImagesLoading?: (loading: boolean) => void;
+  showTitles?: boolean;
 } & Pick<ImageOptions, "filter">;
 
 const imageTitleHeight = 50;
@@ -22,16 +34,7 @@ export function useDownloadPngImage<T>({
   ref,
   title,
 }: DownloadPngImageOptions<T>) {
-  const fileName = title
-    ? `${title
-        .toLowerCase()
-        .replace(/\W/g, " ")
-        .replace(/\s{2,}/g, " ")
-        .trim()
-        .replace(/\s/g, "-")}.png`
-    : fileNameProp
-      ? fileNameProp
-      : "download.png";
+  const fileName = getFileName(title, fileNameProp);
 
   const downloadPng = useCallback(async () => {
     const element = elementSelector(ref?.current || undefined);
@@ -39,35 +42,11 @@ export function useDownloadPngImage<T>({
       return;
     }
 
-    let height = element.clientHeight;
-
-    // use customised onCloned() callback to add additional elements to the DOM once already
-    // cloned for the purpose of generating the image (so as to not affect the original DOM,
-    // but still be able to apply styles and fonts as resolved from class names).
-    let onCloned: (node: HTMLElement) => void | undefined;
-    if (title && showTitle) {
-      height += imageTitleHeight;
-      onCloned = (node) => {
-        const child = document.createElement("h2");
-        child.innerText = title;
-        child.classList.add("govuk-heading-s");
-        child.style.height = `${imageTitleHeight}px`;
-        child.style.margin = `${imageTitleHeight / 2}px 0 -${imageTitleHeight / 2}px ${imageTitleHeight / 2}px`;
-        child.style.padding = "0";
-        node.insertBefore(child, node.firstChild);
-      };
-    }
-
     const download = async () => {
-      const blob = await ImageService.toBlob(element, {
-        cacheBust: true,
-        backgroundColor: "#fff",
-        type: "image/png",
-        filter,
-        width: element.clientWidth,
-        height,
-        onCloned,
-      });
+      const blob = await ImageService.toBlob(
+        element,
+        getImageOptions(element, title, showTitle, filter)
+      );
 
       if (blob) {
         if (window.saveAs) {
@@ -108,3 +87,118 @@ export function useDownloadPngImage<T>({
 
   return downloadPng;
 }
+
+export function useDownloadPngImages({
+  elementsSelector,
+  filter,
+  onImagesLoading,
+  showTitles,
+}: DownloadPngImagesOptions) {
+  const fileName = "download.zip";
+
+  const downloadPng = useCallback(async () => {
+    const elements = elementsSelector();
+    if (!elements?.length) {
+      return;
+    }
+
+    const download = async () => {
+      const zip = new JSZip();
+
+      for (let i = 0; i < elements.length; i++) {
+        const { element, title } = elements[i];
+
+        const blob = await ImageService.toBlob(
+          element,
+          getImageOptions(element, title, showTitles, filter)
+        );
+
+        if (blob) {
+          zip.file(
+            getFileName(title ? title : `${element.tagName}-${i}`),
+            blob
+          );
+        }
+      }
+
+      const blob = await zip.generateAsync({ type: "blob" });
+      if (blob) {
+        if (window.saveAs) {
+          window.saveAs(blob, fileName);
+        } else {
+          saveAs.saveAs(blob, fileName);
+        }
+      }
+    };
+
+    if (onImagesLoading) {
+      onImagesLoading(true);
+
+      // If loader event is subscribed, allow it to be triggered before the actual generate and download PNG process
+      // due to the latter performing a synchronous XMLHttpRequest on the main thread which is documented as being
+      // detrimental effects to the end user's experience (see `Issues` in browser DevTools for more information).
+      setTimeout(async () => {
+        try {
+          await download();
+        } catch (err) {
+          console.error(`Unable to download images`, err);
+        } finally {
+          onImagesLoading(false);
+        }
+      }, 100);
+    } else {
+      await download();
+    }
+  }, [elementsSelector, filter, onImagesLoading, showTitles]);
+
+  return downloadPng;
+}
+
+const getFileName = (title?: string, fileName?: string) => {
+  return title
+    ? `${title
+        .toLowerCase()
+        .replace(/\W/g, " ")
+        .replace(/\s{2,}/g, " ")
+        .trim()
+        .replace(/\s/g, "-")}.png`
+    : fileName
+      ? fileName
+      : "download.png";
+};
+
+const getImageOptions = (
+  element: HTMLElement,
+  title?: string,
+  showTitle?: boolean,
+  filter?: (domNode: HTMLElement) => boolean
+): ImageOptions => {
+  let height = element.clientHeight;
+
+  // use customised onCloned() callback to add additional elements to the DOM once already
+  // cloned for the purpose of generating the image (so as to not affect the original DOM,
+  // but still be able to apply styles and fonts as resolved from class names).
+  let onCloned: ((node: HTMLElement) => void) | undefined;
+  if (title && showTitle) {
+    height += imageTitleHeight;
+    onCloned = (node) => {
+      const child = document.createElement("h2");
+      child.innerText = title;
+      child.classList.add("govuk-heading-s");
+      child.style.height = `${imageTitleHeight}px`;
+      child.style.margin = `${imageTitleHeight / 2}px 0 -${imageTitleHeight / 2}px ${imageTitleHeight / 2}px`;
+      child.style.padding = "0";
+      node.insertBefore(child, node.firstChild);
+    };
+  }
+
+  return {
+    cacheBust: true,
+    backgroundColor: "#fff",
+    type: "image/png",
+    filter,
+    width: element.clientWidth,
+    height,
+    onCloned,
+  };
+};

--- a/front-end-components/src/hooks/useDownloadImage.ts
+++ b/front-end-components/src/hooks/useDownloadImage.ts
@@ -20,6 +20,7 @@ type ElementAndTitle = {
 export type DownloadPngImagesOptions = {
   elementsSelector: () => ElementAndTitle[];
   onImagesLoading?: (loading: boolean) => void;
+  onProgress?: (percentage: number) => void;
   showTitles?: boolean;
 } & Pick<ImageOptions, "filter">;
 
@@ -92,6 +93,7 @@ export function useDownloadPngImages({
   elementsSelector,
   filter,
   onImagesLoading,
+  onProgress,
   showTitles,
 }: DownloadPngImagesOptions) {
   const fileName = "download.zip";
@@ -107,6 +109,9 @@ export function useDownloadPngImages({
 
       for (let i = 0; i < elements.length; i++) {
         const { element, title } = elements[i];
+        if (onProgress) {
+          onProgress(((i + 1) / elements.length) * 100);
+        }
 
         const blob = await ImageService.toBlob(
           element,
@@ -149,7 +154,7 @@ export function useDownloadPngImages({
     } else {
       await download();
     }
-  }, [elementsSelector, filter, onImagesLoading, showTitles]);
+  }, [elementsSelector, filter, onImagesLoading, onProgress, showTitles]);
 
   return downloadPng;
 }

--- a/front-end-components/src/index.css
+++ b/front-end-components/src/index.css
@@ -531,7 +531,7 @@ ul.autocomplete__menu {
   padding-left: 12px;
 }
 
-div[data-share-content-by-element-id] {
+div[data-share-content-by-element-id], div[data-share-content-by-element-class-name] {
   min-height: 40px;
 }
 

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -901,36 +901,39 @@ const shareContentByElementClassNameElements =
 
 if (shareContentByElementClassNameElements) {
   shareContentByElementClassNameElements.forEach((element) => {
-    const { elementClassName, elementTitleAttr, label, showTitles } =
-      element.dataset;
+    const {
+      elementClassName,
+      elementTitleAttr,
+      label,
+      showProgress,
+      showTitles,
+    } = element.dataset;
     if (elementClassName && label) {
-      const el = document.getElementsByClassName(elementClassName);
-      if (el.length > 0) {
-        const root = ReactDOM.createRoot(element);
-        root.render(
-          <React.StrictMode>
-            <ShareContentByElements
-              elementsSelector={() => {
-                const results = [];
-                const elements =
-                  document.getElementsByClassName(elementClassName);
+      const root = ReactDOM.createRoot(element);
+      root.render(
+        <React.StrictMode>
+          <ShareContentByElements
+            elementsSelector={() => {
+              const results = [];
+              const elements =
+                document.getElementsByClassName(elementClassName);
 
-                for (let i = 0; i < elements.length; i++) {
-                  const element = elements[i] as HTMLElement;
-                  const title = elementTitleAttr
-                    ? element.getAttribute(elementTitleAttr) || undefined
-                    : undefined;
-                  results.push({ element, title });
-                }
+              for (let i = 0; i < elements.length; i++) {
+                const element = elements[i] as HTMLElement;
+                const title = elementTitleAttr
+                  ? element.getAttribute(elementTitleAttr) || undefined
+                  : undefined;
+                results.push({ element, title });
+              }
 
-                return results;
-              }}
-              label={label}
-              showTitles={showTitles === "true"}
-            />
-          </React.StrictMode>
-        );
-      }
+              return results;
+            }}
+            label={label}
+            showProgress={showProgress === "true"}
+            showTitles={showTitles === "true"}
+          />
+        </React.StrictMode>
+      );
     }
   });
 }

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -32,6 +32,7 @@ import {
   LineChart2SeriesElementId,
   BudgetForecastReturnsElementId,
   ShareContentByElementIdDataAttr,
+  ShareContentByElementClassNameDataAttr,
 } from "src/constants";
 import { HorizontalBarChart } from "./components/charts/horizontal-bar-chart";
 import { VerticalBarChart } from "./components/charts/vertical-bar-chart";
@@ -60,6 +61,7 @@ import { TrustDataTooltip } from "./components/charts/trust-data-tooltip";
 import { TrustChartData } from "./components/charts/table-chart";
 import { BudgetForecastReturns } from "./views/budget-forecast-returns";
 import { ShareContentByElement } from "./components/share-content-by-element";
+import { ShareContentByElements } from "./components/share-content-by-elements";
 
 const historicDataElement = document.getElementById(HistoricDataElementId);
 if (historicDataElement) {
@@ -884,6 +886,47 @@ if (shareContentByElementIdElements) {
               }
               showTitle={showTitle === "true"}
               title={title}
+            />
+          </React.StrictMode>
+        );
+      }
+    }
+  });
+}
+
+const shareContentByElementClassNameElements =
+  document.querySelectorAll<HTMLElement>(
+    `[data-${ShareContentByElementClassNameDataAttr}]`
+  );
+
+if (shareContentByElementClassNameElements) {
+  shareContentByElementClassNameElements.forEach((element) => {
+    const { elementClassName, elementTitleAttr, label, showTitles } =
+      element.dataset;
+    if (elementClassName && label) {
+      const el = document.getElementsByClassName(elementClassName);
+      if (el.length > 0) {
+        const root = ReactDOM.createRoot(element);
+        root.render(
+          <React.StrictMode>
+            <ShareContentByElements
+              elementsSelector={() => {
+                const results = [];
+                const elements =
+                  document.getElementsByClassName(elementClassName);
+
+                for (let i = 0; i < elements.length; i++) {
+                  const element = elements[i] as HTMLElement;
+                  const title = elementTitleAttr
+                    ? element.getAttribute(elementTitleAttr) || undefined
+                    : undefined;
+                  results.push({ element, title });
+                }
+
+                return results;
+              }}
+              label={label}
+              showTitles={showTitles === "true"}
             />
           </React.StrictMode>
         );

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -913,6 +913,19 @@ if (shareContentByElementClassNameElements) {
       root.render(
         <React.StrictMode>
           <ShareContentByElements
+            onClick={async () => {
+              const radio = document.getElementById(
+                "mode-chart"
+              ) as HTMLInputElement;
+              if (radio && radio.checked === false) {
+                radio.click();
+                await new Promise<void>((resolve) => {
+                  setTimeout(() => {
+                    resolve();
+                  }, 1000);
+                });
+              }
+            }}
             elementsSelector={() => {
               const results = [];
               const elements =

--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -393,7 +393,7 @@ hr.govuk-section-break--print {
 
 .app-resources {
   margin-top: govuk-spacing(6);
-  
+
   @include govuk-media-query('tablet') {
     margin-top: 0;
   }
@@ -405,4 +405,8 @@ hr.govuk-section-break--print {
   @include govuk-media-query('tablet') {
     padding-top: govuk-spacing(2);
   }
+}
+
+.save-charts {
+  float: right;
 }

--- a/web/src/Web.App/Views/SchoolComparison/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/Index.cshtml
@@ -11,6 +11,11 @@
     @await Html.PartialAsync("_IncompleteFinances")
 }
 
+@if (!hasMissingComparatorSet)
+{
+    @await Html.PartialAsync("_SaveChartsButton")
+}
+
 @await Component.InvokeAsync("EstablishmentHeading", new
 {
     title = ViewData[ViewDataKeys.Title],

--- a/web/src/Web.App/Views/Shared/_SaveChartsButton.cshtml
+++ b/web/src/Web.App/Views/Shared/_SaveChartsButton.cshtml
@@ -1,0 +1,9 @@
+<div class="save-charts">
+    <div
+        data-share-content-by-element-class-name
+        data-element-class-name="chart-wrapper"
+        data-label="Save all chart images"
+        data-element-title-attr="aria-label"
+        data-show-titles="true"
+        data-show-progress="true"></div>
+</div>

--- a/web/src/Web.App/Views/TrustComparison/Index.cshtml
+++ b/web/src/Web.App/Views/TrustComparison/Index.cshtml
@@ -1,27 +1,35 @@
-﻿@using Web.App.Extensions
-@using Newtonsoft.Json
+﻿@using Newtonsoft.Json
+@using Web.App.Extensions
 @model Web.App.ViewModels.TrustComparisonViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.TrustComparison;
 }
 
-@await Component.InvokeAsync("EstablishmentHeading", new { title = ViewData[ViewDataKeys.Title], name = Model.Name, id = Model.CompanyNumber, kind = OrganisationTypes.Trust })
+@await Html.PartialAsync("_SaveChartsButton")
+
+@await Component.InvokeAsync("EstablishmentHeading", new
+{
+    title = ViewData[ViewDataKeys.Title],
+    name = Model.Name,
+    id = Model.CompanyNumber,
+    kind = OrganisationTypes.Trust
+})
 
 @await Component.InvokeAsync("DataSource", new
 {
     organisationType = OrganisationTypes.Trust,
     sourceType = DataSourceTypes.Spending,
-    isPartOfTrust = true, 
+    isPartOfTrust = true,
     additionText = new[] { "View the spending between schools in this trust." }
 })
 
 @if (Model.NumberOfSchools > 0)
 {
-    <div id="compare-your-costs" 
-         data-type="@OrganisationTypes.Trust" 
-         data-id="@Model.CompanyNumber" 
+    <div id="compare-your-costs"
+         data-type="@OrganisationTypes.Trust"
+         data-id="@Model.CompanyNumber"
          data-phases="@Model.Phases.ToJson(Formatting.None)">
-    </div>    
+    </div>
 }
 
 @await Component.InvokeAsync("TrustFinanceTools", new

--- a/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingComparison.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingComparison.cs
@@ -127,7 +127,7 @@ public class WhenViewingComparison(SchoolBenchmarkingWebAppClient client)
         var comparisonComponent = page.GetElementById("compare-your-costs");
         Assert.NotNull(comparisonComponent);
 
-        var toolsListSection = page.Body.SelectSingleNode("//main/div/div[5]");
+        var toolsListSection = page.Body.SelectSingleNode("//main/div/div[6]");
         DocumentAssert.Heading2(toolsListSection, "Benchmarking and planning tools");
 
         var toolsLinks = toolsListSection.ChildNodes.QuerySelectorAll("ul> li > h3 > a").ToList();

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingComparison.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingComparison.cs
@@ -107,7 +107,7 @@ public class WhenViewingComparison(SchoolBenchmarkingWebAppClient client) : Page
         Assert.Equal(expectedPhases.ToJson(Formatting.None), dataPhases);
 
 
-        var toolsSection = page.Body.SelectSingleNode("//main/div/div[4]");
+        var toolsSection = page.Body.SelectSingleNode("//main/div/div[5]");
         DocumentAssert.Heading2(toolsSection, "Benchmarking and planning tools");
 
         var toolsLinks = toolsSection.ChildNodes.QuerySelectorAll("ul> li > h3 > a").ToList();


### PR DESCRIPTION
### Context
[AB#246636](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/246636) [AB#242099](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/242099)

### Change proposed in this pull request
- Added `<ShareContentByElements />` component for use with any HTMLElement that generates `.png`s for each matching element and bundles them into a `.zip` which is then sent to the client
- Added default implementation to be to select by matching element class name(s), which may be outside the React context
- Added optional progress indicator to `<ShareContentByElements />` component
- Added 'save all' button to School and Trust comparison pages
- Ensured if 'table' mode selected in chart radios then first select 'chart' before saving chart images

### Guidance to review 
Multiple image save feature may be demoed in the `vite` dev server. To view in the web app, build `front-end-components` and copy to `Web` before visiting the affected pages. Seems to be performant even on the largest Trust, but it is anticipated that a future design crit may raise additional work, especially:
- around the 'progress' indicator that provides additional context to the user during the potentially long-running task
- visibility/disabled state/location of the button

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~