### PR TITLE
Added 'Save all chart images' button to School spending priorities page

### DIFF
--- a/front-end-components/src/components/share-content-by-elements/component.tsx
+++ b/front-end-components/src/components/share-content-by-elements/component.tsx
@@ -7,6 +7,7 @@ import { Progress } from "../progress";
 export const ShareContentByElements: React.FC<ShareContentByElementsProps> = ({
   disabled,
   elementsSelector,
+  fileName,
   showProgress,
   showTitles,
   label,
@@ -18,6 +19,7 @@ export const ShareContentByElements: React.FC<ShareContentByElementsProps> = ({
 
   const downloadPngs = useDownloadPngImages({
     elementsSelector,
+    fileName,
     onImagesLoading: setImagesLoading,
     onProgress: setProgress,
     showTitles,

--- a/front-end-components/src/components/share-content-by-elements/types.tsx
+++ b/front-end-components/src/components/share-content-by-elements/types.tsx
@@ -10,6 +10,7 @@ export type ShareContentByElementsProps = Omit<
   "elementSelector" | "title" | "showTitle"
 > & {
   elementsSelector: () => ElementAndTitle[];
+  fileName?: string;
   label: string;
   onClick: () => Promise<void>;
   showProgress?: boolean;

--- a/front-end-components/src/hooks/useDownloadImage.ts
+++ b/front-end-components/src/hooks/useDownloadImage.ts
@@ -189,9 +189,12 @@ const getImageOptions = (
     onCloned = (node) => {
       const child = document.createElement("h2");
       child.innerText = title;
-      child.classList.add("govuk-heading-s");
+      child.style.fontFamily = '"GDS Transport", arial, sans-serif';
+      child.style.fontSize = "1.1875rem";
+      child.style.fontWeight = "700";
       child.style.height = `${imageTitleHeight}px`;
-      child.style.margin = `${imageTitleHeight / 2}px 0 -${imageTitleHeight / 2}px ${imageTitleHeight / 2}px`;
+      child.style.height = `${imageTitleHeight}px`;
+      child.style.margin = `${imageTitleHeight / 2}px 0 -${imageTitleHeight / 2}px ${imageTitleHeight / 4}px`;
       child.style.padding = "0";
       node.insertBefore(child, node.firstChild);
     };

--- a/front-end-components/src/hooks/useDownloadImage.ts
+++ b/front-end-components/src/hooks/useDownloadImage.ts
@@ -19,6 +19,7 @@ type ElementAndTitle = {
 
 export type DownloadPngImagesOptions = {
   elementsSelector: () => ElementAndTitle[];
+  fileName?: string;
   onImagesLoading?: (loading: boolean) => void;
   onProgress?: (percentage: number) => void;
   showTitles?: boolean;
@@ -91,12 +92,13 @@ export function useDownloadPngImage<T>({
 
 export function useDownloadPngImages({
   elementsSelector,
+  fileName: fileNameProp,
   filter,
   onImagesLoading,
   onProgress,
   showTitles,
 }: DownloadPngImagesOptions) {
-  const fileName = "download.zip";
+  const fileName = fileNameProp ?? "download.zip";
 
   const downloadPng = useCallback(async () => {
     const elements = elementsSelector();
@@ -154,7 +156,14 @@ export function useDownloadPngImages({
     } else {
       await download();
     }
-  }, [elementsSelector, filter, onImagesLoading, onProgress, showTitles]);
+  }, [
+    elementsSelector,
+    fileName,
+    filter,
+    onImagesLoading,
+    onProgress,
+    showTitles,
+  ]);
 
   return downloadPng;
 }

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -904,6 +904,7 @@ if (shareContentByElementClassNameElements) {
     const {
       elementClassName,
       elementTitleAttr,
+      fileName,
       label,
       showProgress,
       showTitles,
@@ -941,6 +942,7 @@ if (shareContentByElementClassNameElements) {
 
               return results;
             }}
+            fileName={fileName}
             label={label}
             showProgress={showProgress === "true"}
             showTitles={showTitles === "true"}

--- a/web/src/Web.App/Views/SchoolComparison/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/Index.cshtml
@@ -13,7 +13,10 @@
 
 @if (!hasMissingComparatorSet)
 {
-    @await Html.PartialAsync("_SaveChartsButton")
+    @await Html.PartialAsync("_SaveChartsButton", null, new ViewDataDictionary(ViewData)
+    {
+        { "FileName", $"benchmark-spending-{Model.Urn}.zip" }
+    })
 }
 
 @await Component.InvokeAsync("EstablishmentHeading", new

--- a/web/src/Web.App/Views/SchoolSpending/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/Index.cshtml
@@ -4,6 +4,15 @@
     ViewData[ViewDataKeys.Title] = PageTitles.Spending;
 }
 
+@if (Model.HighPriorityCosts.Any() || Model.MediumPriorityCosts.Any())
+{
+    @await Html.PartialAsync("_SaveChartsButton", null, new ViewDataDictionary(ViewData)
+    {
+        { "ClassName", "costs-chart-wrapper" },
+        { "TitleAttribute", "data-title" }
+    })
+}
+
 @await Component.InvokeAsync("EstablishmentHeading", new
 {
     title = ViewData[ViewDataKeys.Title],

--- a/web/src/Web.App/Views/SchoolSpending/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/Index.cshtml
@@ -9,6 +9,7 @@
     @await Html.PartialAsync("_SaveChartsButton", null, new ViewDataDictionary(ViewData)
     {
         { "ClassName", "costs-chart-wrapper" },
+        { "FileName", $"spending-priorities-{Model.Urn}.zip" },
         { "TitleAttribute", "data-title" }
     })
 }

--- a/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
@@ -12,12 +12,16 @@
     {
         var category = costs[i];
 
-        var data = category.Values.Select(x => new { urn = x.Key, amount = x.Value.Value }).ToArray();
+        var data = category.Values.Select(x => new
+        {
+            urn = x.Key,
+            amount = x.Value.Value
+        }).ToArray();
 
         var filteredData = data.Where(x => x.urn == Model.Urn || x.amount > 0).ToArray();
 
         var hasNegativeOrZeroValues = data.Length > filteredData.Length;
-        
+
         var categoryHeading = category.Rating.Category == Category.NonEducationalSupportStaff
             ? "Non-educational support staff"
             : category.Rating.Category;
@@ -55,27 +59,30 @@
 
                     @if (hasNegativeOrZeroValues)
                     {
-                    <div class="govuk-warning-text">
-                        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                        <strong class="govuk-warning-text__text">
-                            <span class="govuk-visually-hidden">Warning</span>
-                            Only displaying schools with positive expenditure.
-                        </strong>
-                    </div>
+                        <div class="govuk-warning-text">
+                            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                            <strong class="govuk-warning-text__text">
+                                <span class="govuk-visually-hidden">Warning</span>
+                                Only displaying schools with positive expenditure.
+                            </strong>
+                        </div>
                     }
 
-                    <div class="govuk-!-margin-bottom-2 composed-container"
+                    <div class="govuk-!-margin-bottom-2 composed-container costs-chart-wrapper"
                          data-spending-and-costs-composed
                          data-json="@filteredData.ToJson(Formatting.None)"
                          data-highlight="@Model.Urn"
                          data-suffix="@category.Rating.Unit"
                          data-sort-direction="asc"
                          data-stats="@SchoolSpendingViewModel.Stats(category.Rating).ToJson(Formatting.None)"
-                         data-has-incomplete-data="@Model.HasIncompleteData">
+                         data-has-incomplete-data="@Model.HasIncompleteData"
+                         data-title="@categoryHeading">
                     </div>
 
                     <p class="govuk-body category-commentary">
-                        <a href="@categoryUri#@category.Rating.CostCategoryAnchorId" class="govuk-link govuk-link--no-visited-state">View all @category.Rating.Category?.ToLower(true) costs</a>@(category.SubCategories.Any() ? ". " : string.Empty)
+                        <a href="@categoryUri#@category.Rating.CostCategoryAnchorId"
+                           class="govuk-link govuk-link--no-visited-state">View
+                            all @category.Rating.Category?.ToLower(true) costs</a>@(category.SubCategories.Any() ? ". " : string.Empty)
                         @if (category.SubCategories.Any())
                         {
                             @:This includes

--- a/web/src/Web.App/Views/Shared/_SaveChartsButton.cshtml
+++ b/web/src/Web.App/Views/Shared/_SaveChartsButton.cshtml
@@ -1,9 +1,14 @@
+@{
+    var className = ViewData["ClassName"] ?? "chart-wrapper";
+    var titleAttr = ViewData["TitleAttribute"] ?? "aria-label";
+}
+
 <div class="save-charts">
     <div
         data-share-content-by-element-class-name
-        data-element-class-name="chart-wrapper"
+        data-element-class-name="@className"
         data-label="Save all chart images"
-        data-element-title-attr="aria-label"
+        data-element-title-attr="@titleAttr"
         data-show-titles="true"
         data-show-progress="true"></div>
 </div>

--- a/web/src/Web.App/Views/Shared/_SaveChartsButton.cshtml
+++ b/web/src/Web.App/Views/Shared/_SaveChartsButton.cshtml
@@ -1,5 +1,6 @@
 @{
     var className = ViewData["ClassName"] ?? "chart-wrapper";
+    var fileName = ViewData["FileName"] ?? "charts.zip";
     var titleAttr = ViewData["TitleAttribute"] ?? "aria-label";
 }
 
@@ -10,5 +11,6 @@
         data-label="Save all chart images"
         data-element-title-attr="@titleAttr"
         data-show-titles="true"
-        data-show-progress="true"></div>
+        data-show-progress="true"
+        data-file-name="@fileName"></div>
 </div>

--- a/web/src/Web.App/Views/TrustComparison/Index.cshtml
+++ b/web/src/Web.App/Views/TrustComparison/Index.cshtml
@@ -5,7 +5,10 @@
     ViewData[ViewDataKeys.Title] = PageTitles.TrustComparison;
 }
 
-@await Html.PartialAsync("_SaveChartsButton")
+@await Html.PartialAsync("_SaveChartsButton", null, new ViewDataDictionary(ViewData)
+{
+    { "FileName", $"benchmark-spending-{Model.CompanyNumber}.zip" }
+})
 
 @await Component.InvokeAsync("EstablishmentHeading", new
 {


### PR DESCRIPTION
### Context
[AB#246709](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/246709) [AB#242099](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/242099) #1798

### Change proposed in this pull request
- Added 'save all' button to School spending priority page
- Changed filename of 'save all' .zip file to match page and URN/company number

### Guidance to review 
To validate locally, build `front-end-components` and copy to `Web` before visiting the affected pages. 

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~