### PR TITLE
feat: adds save as image functionality to historic data charts

### DIFF
--- a/front-end-components/src/composed/historic-chart-2-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-2-composed/component.tsx
@@ -179,7 +179,7 @@ export function HistoricChart2<TData extends HistoryBase>({
       ) : (
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-full">
-            <table className="govuk-table">
+            <table className="govuk-table" data-testid={`${chartName}-table`}>
               <thead className="govuk-table__head">
                 <tr className="govuk-table__row">
                   <th className="govuk-table__header govuk-!-width-one-quarter">

--- a/front-end-components/src/composed/historic-chart-2-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-2-composed/component.tsx
@@ -19,7 +19,7 @@ import { ShareContent } from "src/components/share-content";
 
 export function HistoricChart2<TData extends HistoryBase>({
   axisLabel,
-  chartName,
+  chartTitle,
   children,
   columnHeading,
   data,
@@ -110,7 +110,7 @@ export function HistoricChart2<TData extends HistoryBase>({
               disabled={imageLoading}
               onSaveClick={() => chartRef.current?.download()}
               saveEventId="save-chart-as-image"
-              title={chartName}
+              title={chartTitle}
             />
           </div>
         )}
@@ -120,7 +120,7 @@ export function HistoricChart2<TData extends HistoryBase>({
           <div className="govuk-grid-column-three-quarters">
             <div style={{ height: 200 }}>
               <LineChart
-                chartTitle={chartName}
+                chartTitle={chartTitle}
                 className="historic-chart-2"
                 data={mergedData}
                 grid
@@ -164,7 +164,7 @@ export function HistoricChart2<TData extends HistoryBase>({
           </div>
           <aside className="govuk-grid-column-one-quarter">
             <ResolvedStat
-              chartTitle={`Most recent ${chartName.toLowerCase()}`}
+              chartTitle={`Most recent ${chartTitle.toLowerCase()}`}
               className="chart-stat-line-chart"
               compactValue
               data={data.school || []}
@@ -179,7 +179,7 @@ export function HistoricChart2<TData extends HistoryBase>({
       ) : (
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-full">
-            <table className="govuk-table" data-testid={`${chartName}-table`}>
+            <table className="govuk-table" data-testid={`${chartTitle}-table`}>
               <thead className="govuk-table__head">
                 <tr className="govuk-table__row">
                   <th className="govuk-table__header govuk-!-width-one-quarter">

--- a/front-end-components/src/composed/historic-chart-2-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-2-composed/component.tsx
@@ -1,5 +1,5 @@
-import { useContext, useMemo } from "react";
-import { ChartModeChart } from "src/components";
+import { useContext, useMemo, useRef, useState } from "react";
+import { ChartModeChart, ChartHandler } from "src/components";
 import {
   HistoricChart2Props,
   SchoolHistoryValue,
@@ -15,6 +15,7 @@ import { ChartDimensionContext, useChartModeContext } from "src/contexts";
 import { HistoryBase } from "src/services";
 import { HistoricDataTooltip } from "src/components/charts/historic-data-tooltip";
 import { ResolvedStat } from "src/components/charts/resolved-stat";
+import { ShareContent } from "src/components/share-content";
 
 export function HistoricChart2<TData extends HistoryBase>({
   axisLabel,
@@ -33,6 +34,8 @@ export function HistoricChart2<TData extends HistoryBase>({
 }: HistoricChart2Props<TData>) {
   const { chartMode } = useChartModeContext();
   const dimension = useContext(ChartDimensionContext);
+  const chartRef = useRef<ChartHandler>(null);
+  const [imageLoading, setImageLoading] = useState<boolean>();
 
   const mergedData = useMemo(() => {
     const result: SchoolHistoryValue[] = [];
@@ -99,7 +102,19 @@ export function HistoricChart2<TData extends HistoryBase>({
 
   return (
     <>
-      {children}
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-three-quarters">{children}</div>
+        {chartMode == ChartModeChart && (
+          <div className="govuk-grid-column-one-quarter">
+            <ShareContent
+              disabled={imageLoading}
+              onSaveClick={() => chartRef.current?.download()}
+              saveEventId="save-chart-as-image"
+              title={chartName}
+            />
+          </div>
+        )}
+      </div>
       {chartMode == ChartModeChart ? (
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-three-quarters">
@@ -116,6 +131,8 @@ export function HistoricChart2<TData extends HistoryBase>({
                 seriesLabelField="term"
                 valueFormatter={shortValueFormatter}
                 valueUnit={valueUnit ?? dimension.unit}
+                ref={chartRef}
+                onImageLoading={setImageLoading}
                 tooltip={(t) => (
                   <HistoricDataTooltip
                     {...t}

--- a/front-end-components/src/composed/historic-chart-2-composed/types.tsx
+++ b/front-end-components/src/composed/historic-chart-2-composed/types.tsx
@@ -17,7 +17,7 @@ export interface HistoricChart2Props<T extends HistoryBase>
     | "legendHorizontalAlign"
     | "legendVerticalAlign"
   > {
-  chartName: string;
+  chartTitle: string;
   data: SchoolHistoryComparison<T>;
   valueField: ResolvedStatProps<T>["valueField"];
   children?: ReactNode;

--- a/front-end-components/src/composed/historic-chart-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/component.tsx
@@ -14,7 +14,7 @@ import { ChartDimensionContext, useChartModeContext } from "src/contexts";
 import { ShareContent } from "src/components/share-content";
 
 export function HistoricChart<TData extends ChartDataSeries>({
-  chartName,
+  chartTitle,
   data,
   seriesConfig,
   valueField,
@@ -38,7 +38,7 @@ export function HistoricChart<TData extends ChartDataSeries>({
               disabled={imageLoading}
               onSaveClick={() => chartRef.current?.download()}
               saveEventId="save-chart-as-image"
-              title={chartName}
+              title={chartTitle}
             />
           </div>
         )}
@@ -48,7 +48,7 @@ export function HistoricChart<TData extends ChartDataSeries>({
           <div className="govuk-grid-column-three-quarters">
             <div style={{ height: 200 }}>
               <LineChart
-                chartTitle={chartName}
+                chartTitle={chartTitle}
                 data={data}
                 grid
                 highlightActive
@@ -76,7 +76,7 @@ export function HistoricChart<TData extends ChartDataSeries>({
           </div>
           <aside className="govuk-grid-column-one-quarter">
             <ResolvedStat
-              chartTitle={`Most recent ${chartName.toLowerCase()}`}
+              chartTitle={`Most recent ${chartTitle.toLowerCase()}`}
               className="chart-stat-line-chart"
               compactValue
               data={data}

--- a/front-end-components/src/composed/historic-chart-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/component.tsx
@@ -1,5 +1,5 @@
-import { useContext } from "react";
-import { ChartModeChart } from "src/components";
+import { useContext, useRef, useState } from "react";
+import { ChartModeChart, ChartHandler } from "src/components";
 import { HistoricChartProps } from "src/composed/historic-chart-composed";
 import { LineChart } from "src/components/charts/line-chart";
 import {
@@ -11,6 +11,7 @@ import { LineChartTooltip } from "src/components/charts/line-chart-tooltip";
 import { ResolvedStat } from "src/components/charts/resolved-stat";
 import { ChartDataSeries } from "src/components/charts/types";
 import { ChartDimensionContext, useChartModeContext } from "src/contexts";
+import { ShareContent } from "src/components/share-content";
 
 export function HistoricChart<TData extends ChartDataSeries>({
   chartName,
@@ -24,10 +25,24 @@ export function HistoricChart<TData extends ChartDataSeries>({
 }: HistoricChartProps<TData>) {
   const { chartMode } = useChartModeContext();
   const dimension = useContext(ChartDimensionContext);
+  const chartRef = useRef<ChartHandler>(null);
+  const [imageLoading, setImageLoading] = useState<boolean>();
 
   return (
     <>
-      {children}
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-three-quarters">{children}</div>
+        {chartMode == ChartModeChart && (
+          <div className="govuk-grid-column-one-quarter">
+            <ShareContent
+              disabled={imageLoading}
+              onSaveClick={() => chartRef.current?.download()}
+              saveEventId="save-chart-as-image"
+              title={chartName}
+            />
+          </div>
+        )}
+      </div>
       {chartMode == ChartModeChart ? (
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-three-quarters">
@@ -44,6 +59,8 @@ export function HistoricChart<TData extends ChartDataSeries>({
                 seriesLabelField="term"
                 valueFormatter={shortValueFormatter}
                 valueUnit={valueUnit ?? dimension.unit}
+                ref={chartRef}
+                onImageLoading={setImageLoading}
                 tooltip={(t) => (
                   <LineChartTooltip
                     {...t}

--- a/front-end-components/src/composed/historic-chart-composed/types.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/types.tsx
@@ -7,7 +7,7 @@ import {
 import { ResolvedStatProps } from "src/components/charts/resolved-stat";
 
 export interface HistoricChartProps<T extends ChartDataSeries> {
-  chartName: string;
+  chartTitle: string;
   data: T[];
   seriesConfig: ChartProps<T>["seriesConfig"];
   valueField: ResolvedStatProps<T>["valueField"];

--- a/front-end-components/src/views/budget-forecast-returns/partials/year-end.tsx
+++ b/front-end-components/src/views/budget-forecast-returns/partials/year-end.tsx
@@ -83,13 +83,13 @@ export const YearEnd: React.FC<{
     setDimension(dimension);
   };
 
-  const chartName = "Year-end revenue reserves";
+  const chartTitle = "Year-end revenue reserves";
   const hasData = chartData.length > 0;
 
   return (
     <div className="govuk-grid-row govuk-!-margin-top-5">
       <div className="govuk-grid-column-one-half">
-        <h2 className="govuk-heading-m">{chartName}</h2>
+        <h2 className="govuk-heading-m">{chartTitle}</h2>
       </div>
       <div className="govuk-grid-column-one-half">
         <div>
@@ -97,7 +97,7 @@ export const YearEnd: React.FC<{
             disabled={imageLoading || !hasData}
             onSaveClick={() => chartRef.current?.download()}
             saveEventId="save-chart-as-image"
-            title={chartName}
+            title={chartTitle}
           />
         </div>
         <div>

--- a/front-end-components/src/views/historic-data-2/partials/catering-costs-history-chart.tsx
+++ b/front-end-components/src/views/historic-data-2/partials/catering-costs-history-chart.tsx
@@ -7,14 +7,17 @@ import { useState } from "react";
 import { TotalCateringCostsType } from "src/components/total-catering-costs-type";
 
 export function CateringCostsHistoryChart<T extends HistoryBase>(
-  props: Pick<HistoricChart2Props<T>, "data" | "chartName" | "perUnitDimension">
+  props: Pick<
+    HistoricChart2Props<T>,
+    "data" | "chartTitle" | "perUnitDimension"
+  >
 ) {
   const [totalCateringCostsField, setTotalCateringCostsField] =
     useState<TotalCateringCostsField>("totalGrossCateringCosts");
 
   return (
     <HistoricChart2 valueField={totalCateringCostsField as keyof T} {...props}>
-      <h3 className="govuk-heading-s">{props.chartName}</h3>
+      <h3 className="govuk-heading-s">{props.chartTitle}</h3>
       <TotalCateringCostsType
         field={totalCateringCostsField}
         onChange={setTotalCateringCostsField}

--- a/front-end-components/src/views/historic-data-2/partials/census-section.tsx
+++ b/front-end-components/src/views/historic-data-2/partials/census-section.tsx
@@ -116,7 +116,7 @@ export const CensusSection: React.FC<HistoricData2Props> = ({
             return (
               <section key={chart.field}>
                 <HistoricChart2
-                  chartName={chart.name}
+                  chartTitle={chart.name}
                   data={data}
                   valueField={chart.field}
                   key={chart.field}

--- a/front-end-components/src/views/historic-data-2/partials/spending-section.tsx
+++ b/front-end-components/src/views/historic-data-2/partials/spending-section.tsx
@@ -117,7 +117,7 @@ export const SpendingSection: React.FC<HistoricData2Props> = ({
       {data.school?.length ? (
         <section>
           <HistoricChart2
-            chartName="Total expenditure"
+            chartTitle="Total expenditure"
             data={data}
             valueField="totalExpenditure"
             perUnitDimension={PoundsPerPupil}
@@ -159,13 +159,13 @@ export const SpendingSection: React.FC<HistoricData2Props> = ({
                   <section key={chart.field}>
                     {(chart.field as string) === "totalCateringCostsField" ? (
                       <CateringCostsHistoryChart
-                        chartName={chart.name}
+                        chartTitle={chart.name}
                         data={data}
                         perUnitDimension={chart.perUnitDimension}
                       />
                     ) : (
                       <HistoricChart2
-                        chartName={chart.name}
+                        chartTitle={chart.name}
                         data={data}
                         valueField={chart.field}
                         perUnitDimension={chart.perUnitDimension}

--- a/front-end-components/src/views/historic-data/partials/balance-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/balance-section.tsx
@@ -66,7 +66,7 @@ export const BalanceSection: React.FC<{
       {data.length > 0 ? (
         <>
           <HistoricChart
-            chartName="In-year balance"
+            chartTitle="In-year balance"
             data={data}
             seriesConfig={{
               inYearBalance: {
@@ -80,7 +80,7 @@ export const BalanceSection: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Revenue reserve"
+            chartTitle="Revenue reserve"
             data={data}
             seriesConfig={{
               revenueReserve: {

--- a/front-end-components/src/views/historic-data/partials/census-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/census-section.tsx
@@ -65,7 +65,7 @@ export const CensusSection: React.FC<{ id: string; load: boolean }> = ({
       {data.length > 0 ? (
         <>
           <HistoricChart
-            chartName="Pupils on roll"
+            chartTitle="Pupils on roll"
             data={data}
             seriesConfig={{
               totalPupils: {
@@ -82,7 +82,7 @@ export const CensusSection: React.FC<{ id: string; load: boolean }> = ({
           </HistoricChart>
 
           <HistoricChart
-            chartName="School workforce (full time equivalent)"
+            chartTitle="School workforce (full time equivalent)"
             data={data}
             seriesConfig={{
               workforce: {
@@ -116,7 +116,7 @@ export const CensusSection: React.FC<{ id: string; load: boolean }> = ({
             </div>
           </details>
           <HistoricChart
-            chartName="Total number of teachers (full time equivalent)"
+            chartTitle="Total number of teachers (full time equivalent)"
             data={data}
             seriesConfig={{
               teachers: {
@@ -145,7 +145,7 @@ export const CensusSection: React.FC<{ id: string; load: boolean }> = ({
             </div>
           </details>
           <HistoricChart
-            chartName="Teachers with qualified teacher status (%)"
+            chartTitle="Teachers with qualified teacher status (%)"
             data={data}
             seriesConfig={{
               percentTeacherWithQualifiedStatus: {
@@ -177,7 +177,7 @@ export const CensusSection: React.FC<{ id: string; load: boolean }> = ({
             </div>
           </details>
           <HistoricChart
-            chartName="Senior leadership (full time equivalent)"
+            chartTitle="Senior leadership (full time equivalent)"
             data={data}
             seriesConfig={{
               seniorLeadership: {
@@ -211,7 +211,7 @@ export const CensusSection: React.FC<{ id: string; load: boolean }> = ({
             </div>
           </details>
           <HistoricChart
-            chartName="Teaching assistants (full time equivalent)"
+            chartTitle="Teaching assistants (full time equivalent)"
             data={data}
             seriesConfig={{
               teachingAssistant: {
@@ -245,7 +245,7 @@ export const CensusSection: React.FC<{ id: string; load: boolean }> = ({
             </div>
           </details>
           <HistoricChart
-            chartName="Non-classroom support staff - excluding auxiliary staff (full time
+            chartTitle="Non-classroom support staff - excluding auxiliary staff (full time
             equivalent)"
             data={data}
             seriesConfig={{
@@ -280,7 +280,7 @@ export const CensusSection: React.FC<{ id: string; load: boolean }> = ({
             </div>
           </details>
           <HistoricChart
-            chartName="Auxiliary staff (full time equivalent)"
+            chartTitle="Auxiliary staff (full time equivalent)"
             data={data}
             seriesConfig={{
               auxiliaryStaff: {
@@ -312,7 +312,7 @@ export const CensusSection: React.FC<{ id: string; load: boolean }> = ({
             </div>
           </details>
           <HistoricChart
-            chartName="School workforce (headcount)"
+            chartTitle="School workforce (headcount)"
             data={data}
             seriesConfig={{
               workforceHeadcount: {

--- a/front-end-components/src/views/historic-data/partials/income-section-direct-revenue.tsx
+++ b/front-end-components/src/views/historic-data/partials/income-section-direct-revenue.tsx
@@ -11,7 +11,7 @@ export const IncomeSectionDirectRevenue: React.FC<{
       {data.length > 0 ? (
         <>
           <HistoricChart
-            chartName="Direct revenue financing (capital reserves transfers)"
+            chartTitle="Direct revenue financing (capital reserves transfers)"
             data={data}
             seriesConfig={{
               directRevenueFinancing: {

--- a/front-end-components/src/views/historic-data/partials/income-section-grant-funding.tsx
+++ b/front-end-components/src/views/historic-data/partials/income-section-grant-funding.tsx
@@ -10,7 +10,7 @@ export const IncomeSectionGrantFunding: React.FC<{
       {data.length > 0 ? (
         <>
           <HistoricChart
-            chartName="Grant funding total"
+            chartTitle="Grant funding total"
             data={data}
             seriesConfig={{
               totalGrantFunding: {
@@ -24,7 +24,7 @@ export const IncomeSectionGrantFunding: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Direct grants"
+            chartTitle="Direct grants"
             data={data}
             seriesConfig={{
               directGrants: {
@@ -61,7 +61,7 @@ export const IncomeSectionGrantFunding: React.FC<{
             </div>
           </details>
           <HistoricChart
-            chartName="Pre-16 and post-16 funding"
+            chartTitle="Pre-16 and post-16 funding"
             data={data}
             seriesConfig={{
               prePost16Funding: {
@@ -75,7 +75,7 @@ export const IncomeSectionGrantFunding: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Other DfE/EFA revenue grants"
+            chartTitle="Other DfE/EFA revenue grants"
             data={data}
             seriesConfig={{
               otherDfeGrants: {
@@ -89,7 +89,7 @@ export const IncomeSectionGrantFunding: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Other income (local authority and other government grants)"
+            chartTitle="Other income (local authority and other government grants)"
             data={data}
             seriesConfig={{
               otherIncomeGrants: {
@@ -106,7 +106,7 @@ export const IncomeSectionGrantFunding: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Government source (non-grant)"
+            chartTitle="Government source (non-grant)"
             data={data}
             seriesConfig={{
               governmentSource: {
@@ -120,7 +120,7 @@ export const IncomeSectionGrantFunding: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Community grants"
+            chartTitle="Community grants"
             data={data}
             seriesConfig={{
               communityGrants: {
@@ -134,7 +134,7 @@ export const IncomeSectionGrantFunding: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Academies"
+            chartTitle="Academies"
             data={data}
             seriesConfig={{
               academies: {

--- a/front-end-components/src/views/historic-data/partials/income-section-self-generated.tsx
+++ b/front-end-components/src/views/historic-data/partials/income-section-self-generated.tsx
@@ -10,7 +10,7 @@ export const IncomeSectionSelfGenerated: React.FC<{
       {data.length > 0 ? (
         <>
           <HistoricChart
-            chartName="Self-generated funding total"
+            chartTitle="Self-generated funding total"
             data={data}
             seriesConfig={{
               totalSelfGeneratedFunding: {
@@ -24,7 +24,7 @@ export const IncomeSectionSelfGenerated: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Income from facilities and services"
+            chartTitle="Income from facilities and services"
             data={data}
             seriesConfig={{
               incomeFacilitiesServices: {
@@ -102,7 +102,7 @@ export const IncomeSectionSelfGenerated: React.FC<{
             </div>
           </details>
           <HistoricChart
-            chartName="Income from catering"
+            chartTitle="Income from catering"
             data={data}
             seriesConfig={{
               incomeCatering: {
@@ -142,7 +142,7 @@ export const IncomeSectionSelfGenerated: React.FC<{
             </div>
           </details>
           <HistoricChart
-            chartName="Donations and/or voluntary funds"
+            chartTitle="Donations and/or voluntary funds"
             data={data}
             seriesConfig={{
               donationsVoluntaryFunds: {
@@ -192,7 +192,7 @@ export const IncomeSectionSelfGenerated: React.FC<{
             </div>
           </details>
           <HistoricChart
-            chartName="Receipts from supply teacher insurance claims"
+            chartTitle="Receipts from supply teacher insurance claims"
             data={data}
             seriesConfig={{
               receiptsSupplyTeacherInsuranceClaims: {
@@ -234,7 +234,7 @@ export const IncomeSectionSelfGenerated: React.FC<{
             </div>
           </details>
           <HistoricChart
-            chartName="Investment income"
+            chartTitle="Investment income"
             data={data}
             seriesConfig={{
               investmentIncome: {
@@ -264,7 +264,7 @@ export const IncomeSectionSelfGenerated: React.FC<{
           </details>
 
           <HistoricChart
-            chartName="Other self-generated income"
+            chartTitle="Other self-generated income"
             data={data}
             seriesConfig={{
               otherSelfGeneratedIncome: {

--- a/front-end-components/src/views/historic-data/partials/income-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/income-section.tsx
@@ -68,7 +68,7 @@ export const IncomeSection: React.FC<{
       <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-0" />
       {data.length > 0 ? (
         <HistoricChart
-          chartName="Total income"
+          chartTitle="Total income"
           data={data}
           seriesConfig={{
             totalIncome: {

--- a/front-end-components/src/views/historic-data/partials/spending-section-administrative-supplies.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section-administrative-supplies.tsx
@@ -9,7 +9,7 @@ export const SpendingSectionAdministrativeSupplies: React.FC<{
     <>
       {data.length > 0 ? (
         <HistoricChart
-          chartName="Administration supplies (non educational) costs"
+          chartTitle="Administration supplies (non educational) costs"
           data={data}
           seriesConfig={{
             administrativeSuppliesNonEducationalCosts: {

--- a/front-end-components/src/views/historic-data/partials/spending-section-catering-services.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section-catering-services.tsx
@@ -15,7 +15,7 @@ export const SpendingSectionCateringServices: React.FC<{
       {data.length > 0 ? (
         <>
           <HistoricChart
-            chartName="Total catering costs"
+            chartTitle="Total catering costs"
             data={data}
             seriesConfig={{
               totalGrossCateringCosts: {
@@ -37,7 +37,7 @@ export const SpendingSectionCateringServices: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Catering staff costs"
+            chartTitle="Catering staff costs"
             data={data}
             seriesConfig={{
               cateringStaffCosts: {
@@ -51,7 +51,7 @@ export const SpendingSectionCateringServices: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Catering supplies costs"
+            chartTitle="Catering supplies costs"
             data={data}
             seriesConfig={{
               cateringSuppliesCosts: {

--- a/front-end-components/src/views/historic-data/partials/spending-section-educational-ict.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section-educational-ict.tsx
@@ -9,7 +9,7 @@ export const SpendingSectionEducationalIct: React.FC<{
     <>
       {data.length > 0 ? (
         <HistoricChart
-          chartName="ICT learning resources costs"
+          chartTitle="ICT learning resources costs"
           data={data}
           seriesConfig={{
             learningResourcesIctCosts: {

--- a/front-end-components/src/views/historic-data/partials/spending-section-educational-supplies.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section-educational-supplies.tsx
@@ -10,7 +10,7 @@ export const SpendingSectionEducationalSupplies: React.FC<{
       {data.length > 0 ? (
         <>
           <HistoricChart
-            chartName="Total educational supplies costs"
+            chartTitle="Total educational supplies costs"
             data={data}
             seriesConfig={{
               totalEducationalSuppliesCosts: {
@@ -26,7 +26,7 @@ export const SpendingSectionEducationalSupplies: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Examination fees costs"
+            chartTitle="Examination fees costs"
             data={data}
             seriesConfig={{
               examinationFeesCosts: {
@@ -40,7 +40,7 @@ export const SpendingSectionEducationalSupplies: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Learning resources (non ICT equipment) costs"
+            chartTitle="Learning resources (non ICT equipment) costs"
             data={data}
             seriesConfig={{
               learningResourcesNonIctCosts: {

--- a/front-end-components/src/views/historic-data/partials/spending-section-non-educational-staff-costs.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section-non-educational-staff-costs.tsx
@@ -10,7 +10,7 @@ export const SpendingSectionNonEducationalStaffCosts: React.FC<{
       {data.length > 0 ? (
         <>
           <HistoricChart
-            chartName="Total non-educational support staff costs"
+            chartTitle="Total non-educational support staff costs"
             data={data}
             seriesConfig={{
               totalNonEducationalSupportStaffCosts: {
@@ -26,7 +26,7 @@ export const SpendingSectionNonEducationalStaffCosts: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Administrative and clerical staff costs"
+            chartTitle="Administrative and clerical staff costs"
             data={data}
             seriesConfig={{
               administrativeClericalStaffCosts: {
@@ -42,7 +42,7 @@ export const SpendingSectionNonEducationalStaffCosts: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Auditor costs"
+            chartTitle="Auditor costs"
             data={data}
             seriesConfig={{
               auditorsCosts: {
@@ -56,7 +56,7 @@ export const SpendingSectionNonEducationalStaffCosts: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Other staff costs"
+            chartTitle="Other staff costs"
             data={data}
             seriesConfig={{
               otherStaffCosts: {
@@ -70,7 +70,7 @@ export const SpendingSectionNonEducationalStaffCosts: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Professional services (non-curriculum) cost"
+            chartTitle="Professional services (non-curriculum) cost"
             data={data}
             seriesConfig={{
               professionalServicesNonCurriculumCosts: {

--- a/front-end-components/src/views/historic-data/partials/spending-section-other.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section-other.tsx
@@ -11,7 +11,7 @@ export const SpendingSectionOther: React.FC<{
       {data.length > 0 ? (
         <>
           <HistoricChart
-            chartName="Total other costs"
+            chartTitle="Total other costs"
             data={data}
             seriesConfig={{
               totalOtherCosts: {
@@ -25,7 +25,7 @@ export const SpendingSectionOther: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Direct revenue financing costs"
+            chartTitle="Direct revenue financing costs"
             data={data}
             seriesConfig={{
               directRevenueFinancingCosts: {
@@ -39,7 +39,7 @@ export const SpendingSectionOther: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Grounds maintenance costs"
+            chartTitle="Grounds maintenance costs"
             data={data}
             seriesConfig={{
               groundsMaintenanceCosts: {
@@ -53,7 +53,7 @@ export const SpendingSectionOther: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Indirect employee expenses costs"
+            chartTitle="Indirect employee expenses costs"
             data={data}
             seriesConfig={{
               indirectEmployeeExpenses: {
@@ -69,7 +69,7 @@ export const SpendingSectionOther: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Interest changes for loan and bank costs"
+            chartTitle="Interest changes for loan and bank costs"
             data={data}
             seriesConfig={{
               interestChargesLoanBank: {
@@ -85,7 +85,7 @@ export const SpendingSectionOther: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Other insurance premiums costs"
+            chartTitle="Other insurance premiums costs"
             data={data}
             seriesConfig={{
               otherInsurancePremiumsCosts: {
@@ -99,7 +99,7 @@ export const SpendingSectionOther: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="PFI charges costs"
+            chartTitle="PFI charges costs"
             data={data}
             seriesConfig={{
               privateFinanceInitiativeCharges: {
@@ -113,7 +113,7 @@ export const SpendingSectionOther: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Rents and rates costs"
+            chartTitle="Rents and rates costs"
             data={data}
             seriesConfig={{
               rentRatesCosts: {
@@ -127,7 +127,7 @@ export const SpendingSectionOther: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Special facilities costs"
+            chartTitle="Special facilities costs"
             data={data}
             seriesConfig={{
               specialFacilitiesCosts: {
@@ -141,7 +141,7 @@ export const SpendingSectionOther: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Staff development and training costs"
+            chartTitle="Staff development and training costs"
             data={data}
             seriesConfig={{
               staffDevelopmentTrainingCosts: {
@@ -157,7 +157,7 @@ export const SpendingSectionOther: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Staff-related insurance costs"
+            chartTitle="Staff-related insurance costs"
             data={data}
             seriesConfig={{
               staffRelatedInsuranceCosts: {
@@ -171,7 +171,7 @@ export const SpendingSectionOther: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Supply teacher insurance costs"
+            chartTitle="Supply teacher insurance costs"
             data={data}
             seriesConfig={{
               supplyTeacherInsurableCosts: {
@@ -187,7 +187,7 @@ export const SpendingSectionOther: React.FC<{
           {type === "school" && (
             <>
               <HistoricChart
-                chartName="Community focused school staff (maintained schools only)"
+                chartTitle="Community focused school staff (maintained schools only)"
                 data={data}
                 seriesConfig={{
                   communityFocusedSchoolStaff: {
@@ -203,7 +203,7 @@ export const SpendingSectionOther: React.FC<{
                 </h3>
               </HistoricChart>
               <HistoricChart
-                chartName="Community focused school staff (maintained schools only)"
+                chartTitle="Community focused school staff (maintained schools only)"
                 data={data}
                 seriesConfig={{
                   communityFocusedSchoolCosts: {

--- a/front-end-components/src/views/historic-data/partials/spending-section-premises-services.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section-premises-services.tsx
@@ -10,7 +10,7 @@ export const SpendingSectionPremisesServices: React.FC<{
       {data.length > 0 ? (
         <>
           <HistoricChart
-            chartName="Total premises staff and services costs"
+            chartTitle="Total premises staff and services costs"
             data={data}
             seriesConfig={{
               totalPremisesStaffServiceCosts: {
@@ -26,7 +26,7 @@ export const SpendingSectionPremisesServices: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Cleaning and caretaking costs"
+            chartTitle="Cleaning and caretaking costs"
             data={data}
             seriesConfig={{
               cleaningCaretakingCosts: {
@@ -40,7 +40,7 @@ export const SpendingSectionPremisesServices: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Maintenance of premises costs"
+            chartTitle="Maintenance of premises costs"
             data={data}
             seriesConfig={{
               maintenancePremisesCosts: {
@@ -54,7 +54,7 @@ export const SpendingSectionPremisesServices: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Other occupation costs"
+            chartTitle="Other occupation costs"
             data={data}
             seriesConfig={{
               otherOccupationCosts: {
@@ -68,7 +68,7 @@ export const SpendingSectionPremisesServices: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Premises staff costs"
+            chartTitle="Premises staff costs"
             data={data}
             seriesConfig={{
               premisesStaffCosts: {

--- a/front-end-components/src/views/historic-data/partials/spending-section-teaching-costs.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section-teaching-costs.tsx
@@ -10,7 +10,7 @@ export const SpendingSectionTeachingCosts: React.FC<{
       {data.length > 0 ? (
         <>
           <HistoricChart
-            chartName="Total teaching and teaching support staff costs"
+            chartTitle="Total teaching and teaching support staff costs"
             data={data}
             seriesConfig={{
               totalTeachingSupportStaffCosts: {
@@ -26,7 +26,7 @@ export const SpendingSectionTeachingCosts: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Teaching staff costs"
+            chartTitle="Teaching staff costs"
             data={data}
             seriesConfig={{
               teachingStaffCosts: {
@@ -40,7 +40,7 @@ export const SpendingSectionTeachingCosts: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Supply teaching staff"
+            chartTitle="Supply teaching staff"
             data={data}
             seriesConfig={{
               supplyTeachingStaffCosts: {
@@ -54,7 +54,7 @@ export const SpendingSectionTeachingCosts: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Educational consultancy"
+            chartTitle="Educational consultancy"
             data={data}
             seriesConfig={{
               educationalConsultancyCosts: {
@@ -68,7 +68,7 @@ export const SpendingSectionTeachingCosts: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Education support staff"
+            chartTitle="Education support staff"
             data={data}
             seriesConfig={{
               educationSupportStaffCosts: {
@@ -82,7 +82,7 @@ export const SpendingSectionTeachingCosts: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Agency supply teaching staff"
+            chartTitle="Agency supply teaching staff"
             data={data}
             seriesConfig={{
               agencySupplyTeachingStaffCosts: {

--- a/front-end-components/src/views/historic-data/partials/spending-section-utilities.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section-utilities.tsx
@@ -10,7 +10,7 @@ export const SpendingSectionUtilities: React.FC<{
       {data.length > 0 ? (
         <>
           <HistoricChart
-            chartName="Total utilities costs"
+            chartTitle="Total utilities costs"
             data={data}
             seriesConfig={{
               totalUtilitiesCosts: {
@@ -24,7 +24,7 @@ export const SpendingSectionUtilities: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Energy costs"
+            chartTitle="Energy costs"
             data={data}
             seriesConfig={{
               energyCosts: {
@@ -38,7 +38,7 @@ export const SpendingSectionUtilities: React.FC<{
           </HistoricChart>
 
           <HistoricChart
-            chartName="Water and sewerage costs"
+            chartTitle="Water and sewerage costs"
             data={data}
             seriesConfig={{
               waterSewerageCosts: {

--- a/front-end-components/src/views/historic-data/partials/spending-section.tsx
+++ b/front-end-components/src/views/historic-data/partials/spending-section.tsx
@@ -78,7 +78,7 @@ export const SpendingSection: React.FC<{
       <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-0" />
       {data.length > 0 ? (
         <HistoricChart
-          chartName="Total expenditure"
+          chartTitle="Total expenditure"
           data={data}
           seriesConfig={{
             totalExpenditure: {

--- a/web/tests/Web.E2ETests/Pages/School/HistoricDataPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/HistoricDataPage.cs
@@ -419,8 +419,7 @@ public class HistoricDataPage(IPage page)
 
     public async Task ChartTableContains(string chartName, DataTable expected)
     {
-        var parent = page.Locator($"h2:has-text('{chartName}') + div");
-        var table = parent.Locator(Tables);
+        var table = page.GetByTestId($"{chartName}-table");
         await table.ShouldBeVisible();
 
         var set = new List<dynamic>();

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -62,14 +62,14 @@ public static class Selectors
     public const string ComparisonChartsAndTables = "#compare-your-costs";
     public const string ComparisonTables = "#compare-your-costs table.govuk-table";
 
-    public const string TotalExpenditureSaveAsImage = "xpath=//*[@id='compare-your-costs']/div[2]/div[2]/button";
+    public const string TotalExpenditureSaveAsImage = "xpath=//*[@data-custom-event-chart-name='Total expenditure']";
     public const string TotalExpenditureDimension = "#total-expenditure-dimension";
     public const string TotalExpenditureChart = "//*[@aria-label='Total expenditure']";
 
     public const string PremisesDimension = "#total-premises-staff-and-service-costs-dimension";
 
     public const string SchoolWorkforceDimension = "#school-workforce-full-time-equivalent-dimension";
-    public const string SchoolWorkforceSaveAsImage = "xpath=//*[@id='compare-your-census']/div[2]/div[2]/button";
+    public const string SchoolWorkforceSaveAsImage = "xpath=//*[@data-custom-event-chart-name='School workforce (Full Time Equivalent)']";
 
     public const string TotalNumberOfTeacherDimension = "#total-number-of-teachers-full-time-equivalent-dimension";
     public const string SeniorLeadershipDimension = "#senior-leadership-full-time-equivalent-dimension";


### PR DESCRIPTION
### Context
[AB#244349](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/244349) - [AB#246622](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/246622)

### Change proposed in this pull request
- Adds save as image functionality to both versions of the historic data charts in `HistoricChart` and `HistoricChart2` using `ShareContent`
- updates now failing E2E tests
  - updates selectors for save as image
  - updates table in `HistoricChart2` to use a test id and updates the steps for those tests.


### Guidance to review 
Subsequent bump to `front-end` package will be required.
New E2E tests to follow on a later PR

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

