### PR TITLE
chore: bump `front-end` to `1.1.35`

### DIFF
--- a/web/src/Web.App/package-lock.json
+++ b/web/src/Web.App/package-lock.json
@@ -1456,9 +1456,9 @@
       }
     },
     "node_modules/front-end": {
-      "version": "1.1.31",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-1.1.31.tgz",
-      "integrity": "sha1-ifEgIRG2wrxSziLI3Upo4KZyOMs=",
+      "version": "1.1.35",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-1.1.35.tgz",
+      "integrity": "sha1-lpnsV7LazWsfPjAUkCQo8inZ+/4=",
       "dependencies": {
         "accessible-autocomplete": "^3.0.0",
         "classnames": "^2.5.1",
@@ -1466,6 +1466,7 @@
         "file-saver": "^2.0.5",
         "govuk-frontend": "^5.6.0",
         "html-to-image": "^1.11.11",
+        "jszip": "^3.10.1",
         "punycode": "^2.3.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1951,6 +1952,12 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+      "license": "MIT"
+    },
     "node_modules/immutable": {
       "version": "5.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/immutable/-/immutable-5.0.3.tgz",
@@ -2189,6 +2196,48 @@
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "license": "MIT"
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha1-NK7nDrGOofrsL1iSCKFX0f6wkcI=",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha1-kRJegEK7obmIf0k0X2J3Anzovps=",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/last-run": {
       "version": "2.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/last-run/-/last-run-2.0.0.tgz",
@@ -2205,6 +2254,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha1-3Pgt7lRfRgdNryAMfBxaCOD0D2o=",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/liftoff": {
@@ -2416,6 +2474,12 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8=",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parse-filepath": {
       "version": "1.0.2",
@@ -2896,6 +2960,12 @@
       "engines": {
         "node": ">= 10.13.0"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",


### PR DESCRIPTION
### Context
[AB#244349](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/244349)
### Change proposed in this pull request
Bump `front-end` package

### Guidance to review 
n/a

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

