### PR TITLE
Modified positioning of `<HistoricChart2>` legend to fix save-as-image functionality

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -101,7 +101,7 @@
     ></div>-->
     <!--<div id="compare-your-costs" data-type="school" data-id="990095"></div>-->
     <!--<div id="historic-data" data-type="school" data-id="990095"></div>-->
-    <!--<div id="historic-data-2" data-type="school" data-id="123456" data-phase="Primary" data-finance-type="Maintained"></div>-->
+    <div id="historic-data-2" data-type="school" data-id="123456" data-phase="Primary" data-finance-type="Maintained"></div>
     <!--<div
       id="compare-your-costs"
       data-type="local-authority"
@@ -125,7 +125,7 @@
     <svg id="test-element-id" height="100" width="100" xmlns="http://www.w3.org/2000/svg">
       <circle r="45" cx="50" cy="50" fill="red" />
     </svg> -->
-    <div data-share-content-by-element-class-name data-element-class-name="test-element-class" data-label="Save all" data-element-title-attr="aria-label"></div>
+    <!--<div data-share-content-by-element-class-name data-element-class-name="test-element-class" data-label="Save all" data-element-title-attr="aria-label"></div>
     <svg class="test-element-class" aria-label="Red" height="100" width="100" xmlns="http://www.w3.org/2000/svg">
       <circle r="45" cx="50" cy="50" fill="red" />
     </svg>
@@ -134,7 +134,7 @@
     </svg>
     <svg class="test-element-class" height="100" width="100" xmlns="http://www.w3.org/2000/svg">
       <circle r="45" cx="50" cy="50" fill="blue" />
-    </svg>
+    </svg>-->
     <script type="module" src="/src/main.tsx"></script>
     <script
       type="module"

--- a/front-end-components/src/components/charts/line-chart/component.tsx
+++ b/front-end-components/src/components/charts/line-chart/component.tsx
@@ -45,6 +45,7 @@ function LineChartInner<TData extends ChartDataSeries>(
     legendIconType,
     legendHorizontalAlign,
     legendVerticalAlign,
+    legendWrapperStyle,
     margin: _margin,
     multiLineAxisLabel,
     onImageLoading,
@@ -271,6 +272,7 @@ function LineChartInner<TData extends ChartDataSeries>(
                     : legendIconType
                   : "plainline"
               }
+              wrapperStyle={legendWrapperStyle}
             />
           )}
         </RechartsLineChart>

--- a/front-end-components/src/components/charts/types.tsx
+++ b/front-end-components/src/components/charts/types.tsx
@@ -1,4 +1,4 @@
-import { PureComponent, Ref, SVGProps } from "react";
+import { CSSProperties, PureComponent, Ref, SVGProps } from "react";
 import { CategoricalChartState } from "recharts/types/chart/types";
 import {
   HorizontalAlignmentType,
@@ -31,6 +31,7 @@ export interface ChartProps<TData extends ChartDataSeries>
   legendIconType?: IconType | "default";
   legendHorizontalAlign?: HorizontalAlignmentType;
   legendVerticalAlign?: VerticalAlignmentType;
+  legendWrapperStyle?: CSSProperties;
   margin?: number;
   multiLineAxisLabel?: boolean;
   onImageLoading?: (loading: boolean) => void;

--- a/front-end-components/src/composed/historic-chart-2-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-2-composed/component.tsx
@@ -28,6 +28,7 @@ export function HistoricChart2<TData extends HistoryBase>({
   legendIconSize,
   legendIconType,
   legendVerticalAlign,
+  legendWrapperStyle,
   perUnitDimension,
   valueField,
   valueUnit,
@@ -158,6 +159,16 @@ export function HistoricChart2<TData extends HistoryBase>({
                   legendVerticalAlign === undefined
                     ? "bottom"
                     : legendVerticalAlign
+                }
+                legendWrapperStyle={
+                  (legendWrapperStyle ?? legendVerticalAlign === undefined)
+                    ? {
+                        position: "relative",
+                        left: "inherit",
+                        bottom: "inherit",
+                        marginTop: -40,
+                      }
+                    : undefined
                 }
               />
             </div>

--- a/front-end-components/src/composed/historic-chart-2-composed/types.tsx
+++ b/front-end-components/src/composed/historic-chart-2-composed/types.tsx
@@ -16,6 +16,7 @@ export interface HistoricChart2Props<T extends HistoryBase>
     | "legendIconType"
     | "legendHorizontalAlign"
     | "legendVerticalAlign"
+    | "legendWrapperStyle"
   > {
   chartTitle: string;
   data: SchoolHistoryComparison<T>;

--- a/front-end-components/src/index.css
+++ b/front-end-components/src/index.css
@@ -199,10 +199,14 @@
   color: var(--label-colour) !important;
 }
 
-.recharts-wrapper.historic-chart-2 .recharts-default-legend{
+.recharts-wrapper.historic-chart-2 .recharts-default-legend {
   display: flex;
   flex-direction: row-reverse;
   justify-content: center;
+}
+
+.recharts-wrapper.historic-chart-2 .recharts-default-legend .recharts-legend-item {
+  white-space: nowrap;
 }
 
 .recharts-wrapper .chart-active-dot.chart-active-dot-series-0,

--- a/web/tests/Web.E2ETests/Assist/DynamicTableHelpers.cs
+++ b/web/tests/Web.E2ETests/Assist/DynamicTableHelpers.cs
@@ -1,10 +1,10 @@
 using System.Dynamic;
-using System.Text.RegularExpressions;
 using Dynamitey;
+
 namespace Web.E2ETests.Assist;
 
 // source: https://github.com/marcusoftnet/SpecFlow.Assist.Dynamic/blob/master/SpecFlow.Assist.Dynamic/DynamicTableHelpers.cs
-public static partial class DynamicTableHelpers
+public static class DynamicTableHelpers
 {
     private const string ErrorMessagePropertyDiffSet = "Properties differs between the table and the set";
     private const string ErrorMessageInstanceTableFormat = "Can only create instances of tables with one row, or exactly 2 columns and several rows";
@@ -322,9 +322,6 @@ public static partial class DynamicTableHelpers
     private static string RemoveReservedChars(string orgPropertyName)
     {
         const string replacement = "";
-        return ReservedCharactersRegex().Replace(orgPropertyName, replacement);
+        return Regexes.ReservedCharactersRegex().Replace(orgPropertyName, replacement);
     }
-
-    [GeneratedRegex(@"[^\w\s]")]
-    private static partial Regex ReservedCharactersRegex();
 }

--- a/web/tests/Web.E2ETests/Extensions/StringExtensions.cs
+++ b/web/tests/Web.E2ETests/Extensions/StringExtensions.cs
@@ -1,7 +1,8 @@
 ﻿using System.Text.RegularExpressions;
+
 namespace Web.E2ETests;
 
-public static partial class StringExtensions
+public static class StringExtensions
 {
     public static string ToSlug(this string source)
     {
@@ -12,17 +13,11 @@ public static partial class StringExtensions
 
         return source
             .Trim()
-            .Replace(WhitespaceRegex(), "-")
-            .Replace(NonAlphanumericOrHyphenRegex(), string.Empty)
+            .Replace(Regexes.WhitespaceRegex(), "-")
+            .Replace(Regexes.NonAlphanumericOrHyphenRegex(), string.Empty)
             .ToLower();
     }
 
     private static string Replace(this string source, Regex regex, string replacement)
         => string.IsNullOrWhiteSpace(source) ? source : regex.Replace(source, replacement);
-
-    [GeneratedRegex("[^a-z0-9\\-]", RegexOptions.IgnoreCase, "en-GB")]
-    private static partial Regex NonAlphanumericOrHyphenRegex();
-
-    [GeneratedRegex("\\s+")]
-    private static partial Regex WhitespaceRegex();
 }

--- a/web/tests/Web.E2ETests/Pages/DataSourcesPage.cs
+++ b/web/tests/Web.E2ETests/Pages/DataSourcesPage.cs
@@ -1,9 +1,9 @@
-﻿using System.Text.RegularExpressions;
-using Microsoft.Playwright;
+﻿using Microsoft.Playwright;
 using Web.E2ETests.Assist;
+
 namespace Web.E2ETests.Pages;
 
-public partial class DataSourcesPage(IPage page) : BasePage(page)
+public class DataSourcesPage(IPage page) : BasePage(page)
 {
     private readonly IPage _page = page;
 
@@ -51,13 +51,10 @@ public partial class DataSourcesPage(IPage page) : BasePage(page)
             set.Add(new
             {
                 Label = text.Split("\n").FirstOrDefault(),
-                FileName = FileNameFromUrlRegex().Match(href!).Value
+                FileName = Regexes.FileNameFromUrlRegex().Match(href!).Value
             });
         }
 
         expected.CompareToDynamicSet(set, false);
     }
-
-    [GeneratedRegex("[^/]+(?=\\?)")]
-    private static partial Regex FileNameFromUrlRegex();
 }

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/BenchmarkCensusPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/BenchmarkCensusPage.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Playwright;
 using Xunit;
+
 namespace Web.E2ETests.Pages.LocalAuthority;
 
 public enum CensusChartNames
@@ -32,7 +33,7 @@ public class BenchmarkCensusPage(IPage page)
     private ILocator SaveAsImageButtons =>
         page.Locator(Selectors.Button, new PageLocatorOptions
         {
-            HasText = "Save"
+            HasTextRegex = Regexes.SaveAsImageRegex()
         });
 
     private ILocator ChartBars => page.Locator(Selectors.ChartBars);

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/CompareYourCostsPage.cs
@@ -1,5 +1,6 @@
 using Microsoft.Playwright;
 using Xunit;
+
 namespace Web.E2ETests.Pages.LocalAuthority;
 
 public enum ComparisonChartNames
@@ -47,7 +48,7 @@ public class CompareYourCostsPage(IPage page)
     private ILocator SaveAsImageButtons =>
         page.Locator(Selectors.Button, new PageLocatorOptions
         {
-            HasText = "Save"
+            HasTextRegex = Regexes.SaveAsImageRegex()
         });
 
     private ILocator ChartBars => page.Locator(Selectors.ChartBars);

--- a/web/tests/Web.E2ETests/Pages/School/BenchmarkCensusPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/BenchmarkCensusPage.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Playwright;
 using Xunit;
+
 namespace Web.E2ETests.Pages.School;
 
 public enum CensusChartNames
@@ -34,7 +35,7 @@ public class BenchmarkCensusPage(IPage page)
     private ILocator SaveAsImageButtons =>
         page.Locator(Selectors.Button, new PageLocatorOptions
         {
-            HasText = "Save"
+            HasTextRegex = Regexes.SaveAsImageRegex()
         });
 
     private ILocator ComparatorSetDetails =>

--- a/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
@@ -1,6 +1,7 @@
 using Microsoft.Playwright;
 using Web.E2ETests.Pages.School.Comparators;
 using Xunit;
+
 namespace Web.E2ETests.Pages.School;
 
 public enum ComparisonChartNames
@@ -51,7 +52,7 @@ public class CompareYourCostsPage(IPage page)
     private ILocator SaveAsImageButtons =>
         page.Locator(Selectors.Button, new PageLocatorOptions
         {
-            HasText = "Save"
+            HasTextRegex = Regexes.SaveAsImageRegex()
         });
     private ILocator ComparatorSetDetails =>
         page.Locator(Selectors.GovLink,

--- a/web/tests/Web.E2ETests/Pages/School/SpendingCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/SpendingCostsPage.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Playwright;
 using Xunit;
+
 namespace Web.E2ETests.Pages.School;
 
 public enum CostCategoryNames
@@ -97,8 +98,8 @@ public class SpendingCostsPage(IPage page)
 
     private ILocator PriorityTags => page.Locator($"{Selectors.MainContent} {Selectors.GovukTag}");
     private ILocator EducationIctCostCategory => page.Locator(Selectors.EducationIctSpendingCosts);
-    private ILocator ChartStatsSummary(ILocator chart) => chart.Locator(".chart-stat-summary");
     private ILocator EducationIctWarningText => page.Locator($"{Selectors.EducationIctSpendingCosts} {Selectors.GovWarning}");
+    private ILocator ChartStatsSummary(ILocator chart) => chart.Locator(".chart-stat-summary");
 
     public async Task IsDisplayed()
     {
@@ -122,11 +123,7 @@ public class SpendingCostsPage(IPage page)
             {
                 var chartName = chartNames[i];
                 var priorityTag = await priorityTags[i].TextContentAsync() ?? string.Empty;
-                var chartDetails = new[]
-                {
-                    chartName,
-                    priorityTag.Trim()
-                };
+                var chartDetails = new[] { chartName, priorityTag.Trim() };
                 actualOrder.Add(chartDetails);
             }
             else
@@ -198,7 +195,7 @@ public class SpendingCostsPage(IPage page)
     public async Task AssertCostCategoryData(CostCategoryNames costCategory, Table expectedTable)
     {
         var actualData = await GetCostCategoryData(costCategory);
-        for (int i = 0; i < expectedTable.Rows.Count; i++)
+        for (var i = 0; i < expectedTable.Rows.Count; i++)
         {
             var expectedDescription = expectedTable.Rows[i]["Description"];
             var expectedValue = expectedTable.Rows[i]["Value"];
@@ -222,7 +219,7 @@ public class SpendingCostsPage(IPage page)
 
     private async Task<List<(string Description, string Value)>> GetCostCategoryData(CostCategoryNames costCategory)
     {
-        var chartStats = ChartStatsSummary(await GetSelectorForCostCategory(costCategory));
+        var chartStats = ChartStatsSummary(GetSelectorForCostCategory(costCategory));
 
         if (chartStats == null)
         {
@@ -231,7 +228,7 @@ public class SpendingCostsPage(IPage page)
         var rows = new List<(string Description, string Value)>();
         var chartStatWrappers = chartStats.Locator(".chart-stat-wrapper");
         var count = await chartStatWrappers.CountAsync();
-        for (int i = 0; i < count; i++)
+        for (var i = 0; i < count; i++)
         {
             var wrapper = chartStatWrappers.Nth(i);
             var labelElement = wrapper.Locator(".chart-stat-label");
@@ -249,7 +246,7 @@ public class SpendingCostsPage(IPage page)
         return rows;
     }
 
-    private async Task<ILocator> GetSelectorForCostCategory(CostCategoryNames costCategoryName)
+    private ILocator GetSelectorForCostCategory(CostCategoryNames costCategoryName)
     {
         var chartSelector = costCategoryName switch
         {

--- a/web/tests/Web.E2ETests/Pages/Trust/BenchmarkCensusPage.cs
+++ b/web/tests/Web.E2ETests/Pages/Trust/BenchmarkCensusPage.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Playwright;
 using Xunit;
+
 namespace Web.E2ETests.Pages.Trust;
 
 public enum CensusChartNames
@@ -32,7 +33,7 @@ public class BenchmarkCensusPage(IPage page)
     private ILocator SaveAsImageButtons =>
         page.Locator(Selectors.Button, new PageLocatorOptions
         {
-            HasText = "Save"
+            HasTextRegex = Regexes.SaveAsImageRegex()
         });
 
     private ILocator ChartBars => page.Locator(Selectors.ChartBars);

--- a/web/tests/Web.E2ETests/Pages/Trust/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/Trust/CompareYourCostsPage.cs
@@ -1,5 +1,6 @@
 using Microsoft.Playwright;
 using Xunit;
+
 namespace Web.E2ETests.Pages.Trust;
 
 public enum ComparisonChartNames
@@ -47,7 +48,7 @@ public class CompareYourCostsPage(IPage page)
     private ILocator SaveAsImageButtons =>
         page.Locator(Selectors.Button, new PageLocatorOptions
         {
-            HasText = "Save"
+            HasTextRegex = Regexes.SaveAsImageRegex()
         });
 
     private ILocator ChartBars => page.Locator(Selectors.ChartBars);

--- a/web/tests/Web.E2ETests/Regexes.cs
+++ b/web/tests/Web.E2ETests/Regexes.cs
@@ -1,0 +1,21 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Web.E2ETests;
+
+public static partial class Regexes
+{
+    [GeneratedRegex("[^a-z0-9\\-]", RegexOptions.IgnoreCase, "en-GB")]
+    public static partial Regex NonAlphanumericOrHyphenRegex();
+
+    [GeneratedRegex("\\s+")]
+    public static partial Regex WhitespaceRegex();
+
+    [GeneratedRegex(@"[^\w\s]")]
+    public static partial Regex ReservedCharactersRegex();
+
+    [GeneratedRegex("[^/]+(?=\\?)")]
+    public static partial Regex FileNameFromUrlRegex();
+
+    [GeneratedRegex("Save.+as image")]
+    public static partial Regex SaveAsImageRegex();
+}


### PR DESCRIPTION
### Context
[AB#246743](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/246743) [AB#244349](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/244349)

### Change proposed in this pull request
CSS updates to `<Legend>` to support the modified height/margin when a title is appended to the chart cloned DOM when saving as an image.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

