### PR TITLE
 Bumped `front-end` to `1.1.36`

### DIFF
--- a/web/src/Web.App/package-lock.json
+++ b/web/src/Web.App/package-lock.json
@@ -1456,9 +1456,9 @@
       }
     },
     "node_modules/front-end": {
-      "version": "1.1.35",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-1.1.35.tgz",
-      "integrity": "sha1-lpnsV7LazWsfPjAUkCQo8inZ+/4=",
+      "version": "1.1.36",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-1.1.36.tgz",
+      "integrity": "sha1-Txvlj3WkoJM4y4wNH/RuwZyrRjM=",
       "dependencies": {
         "accessible-autocomplete": "^3.0.0",
         "classnames": "^2.5.1",


### PR DESCRIPTION
### Context
[AB#246709](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/246709) [AB#242099](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/242099) https://github.com/DFE-Digital/education-benchmarking-and-insights/pull/1799

### Change proposed in this pull request
Bumped `front-end` to `1.1.36`

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)

