### PR TITLE
Added custom telemetry events to Orchestrator

### DIFF
--- a/platform/src/abstractions/Platform.Domain/Pipeline.cs
+++ b/platform/src/abstractions/Platform.Domain/Pipeline.cs
@@ -29,4 +29,14 @@ public static class Pipeline
         public const string ComparatorSetPayload = nameof(ComparatorSetPayload);
         public const string CustomDataPayload = nameof(CustomDataPayload);
     }
+
+    public static class Events
+    {
+        public const string PipelinePendingMessageReceived = nameof(PipelinePendingMessageReceived);
+        public const string PipelinePendingMessageOrchestrated = nameof(PipelinePendingMessageOrchestrated);
+        public const string PipelineStartDefaultMessageReceived = nameof(PipelineStartDefaultMessageReceived);
+        public const string PipelineStartCustomMessageReceived = nameof(PipelineStartCustomMessageReceived);
+        public const string PipelineFinishedMessageReceived = nameof(PipelineFinishedMessageReceived);
+        public const string PipelineStatusReceived = nameof(PipelineStatusReceived);
+    }
 }

--- a/platform/src/apis/Platform.Orchestrator/PipelineDb.cs
+++ b/platform/src/apis/Platform.Orchestrator/PipelineDb.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Dapper;
 using Dapper.Contrib.Extensions;
+using Platform.Domain;
 using Platform.Sql;
 // ReSharper disable UnusedMember.Global
 // ReSharper disable UnusedAutoPropertyAccessor.Global
@@ -21,13 +22,11 @@ public class PipelineDb(IDatabaseFactory dbFactory) : IPipelineDb
 {
     public async Task UpdateStatus(PipelineStatus status)
     {
-        var sql = status.Success
-            ? "UPDATE UserData SET Status = 'complete' where Id = @Id"
-            : "UPDATE UserData SET Status = 'failed' where Id = @Id";
-
+        const string sql = "UPDATE UserData SET Status = @status where Id = @Id";
         var parameters = new
         {
-            status.Id
+            status.Id,
+            status = status.Success ? Pipeline.JobStatus.Complete : Pipeline.JobStatus.Failed
         };
 
         using var conn = await dbFactory.GetConnection();


### PR DESCRIPTION
### Context
[AB#246761](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/246761) [AB#246760](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/246760)

### Change proposed in this pull request
- Custom event tracking in App Insights from the Orchestrator functions

### Guidance to review 
Run Orchestrator locally - pointing to a known App Insights instance - and add some messages to the queue(s). If data pipeline not configured to pull messages off that queue, manually copy a 'start' message into the 'finished' queue appending `{ "success": true }` or `false` to the payload to validate the different scenarios. Inspect the Custom Events in App Insights.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

