### PR TITLE
Added scheduled query alert for excessive failed pipeline finished messages

### DIFF
--- a/support-analytics/terraform/README.md
+++ b/support-analytics/terraform/README.md
@@ -78,6 +78,7 @@ No modules.
 | [azurerm_monitor_metric_alert.insight_api_error_alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.memory_alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.web_app_error_alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert_v2.failed-finished-pipeline-messages](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_smart_detector_alert_rule.dependency-performance-degradation-detector](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_smart_detector_alert_rule) | resource |
 | [azurerm_monitor_smart_detector_alert_rule.exception-volume-changed-detector](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_smart_detector_alert_rule) | resource |
 | [azurerm_monitor_smart_detector_alert_rule.failure-anomalies-detector](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_smart_detector_alert_rule) | resource |

--- a/support-analytics/terraform/alerts.tf
+++ b/support-analytics/terraform/alerts.tf
@@ -1,3 +1,7 @@
+locals {
+  pipeline-messages-finished-query = file("${path.module}/queries/pipeline-messages-finished.kql")
+}
+
 resource "azurerm_monitor_metric_alert" "availability-alert" {
   name                = "availability-alert"
   resource_group_name = azurerm_resource_group.resource-group.name
@@ -163,5 +167,43 @@ resource "azurerm_monitor_metric_alert" "insight_api_error_alert" {
 
   action {
     action_group_id = azurerm_monitor_action_group.service-support-action.id
+  }
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "failed-finished-pipeline-messages" {
+  name                    = "failed-finished-pipeline-messages-alert"
+  resource_group_name     = azurerm_resource_group.resource-group.name
+  scopes                  = [data.azurerm_application_insights.application-insights.id]
+  location                = azurerm_resource_group.resource-group.location
+  display_name            = "Failed finished pipeline messages alert"
+  description             = "Alert if number of failed finished pipeline messages exceeds ${var.configuration[var.environment].thresholds.error}"
+  severity                = 2
+  evaluation_frequency    = "PT10M"
+  window_duration         = "PT30M"
+  auto_mitigation_enabled = true
+  enabled                 = var.configuration[var.environment].alerts_enabled
+  tags                    = local.common-tags
+
+  criteria {
+    query                   = local.pipeline-messages-finished-query
+    time_aggregation_method = "Total"
+    metric_measure_column   = "Events"
+    operator                = "GreaterThan"
+    threshold               = var.configuration[var.environment].thresholds.error
+
+    dimension {
+      name     = "dimension"
+      operator = "Include"
+      values   = ["False", "True"]
+    }
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.service-support-action.id]
   }
 }

--- a/support-analytics/terraform/queries/pipeline-messages-finished.kql
+++ b/support-analytics/terraform/queries/pipeline-messages-finished.kql
@@ -1,0 +1,27 @@
+let usg_events = dynamic(["PipelineFinishedMessageReceived"]);
+let mainTable = union customEvents
+    | where isempty(operation_SyntheticSource)
+    | extend name =replace("\n", "", name)
+    | extend name =replace("\r", "", name)
+    | where '*' in (usg_events) or name in (usg_events);
+let byTable = mainTable;
+let queryTable = () {
+    byTable
+    | extend dimension = customDimensions["Success"]
+    | extend dimension = iif(isempty(dimension), "<undefined>", dimension)
+};
+let byCohortTable = queryTable
+    | project dimension, timestamp;
+let topSegments = byCohortTable
+    | summarize Events = count() by dimension
+    | top 10 by Events
+    | summarize makelist(dimension);
+let topEventMetrics = byCohortTable
+    | where dimension in (topSegments);
+let otherEventUsers = byCohortTable
+    | where dimension !in (topSegments)
+    | extend dimension = "Other";
+otherEventUsers
+| union topEventMetrics
+| summarize Events = count() by dimension
+| order by dimension asc


### PR DESCRIPTION
### Context
AB#246788 AB#246760

### Change proposed in this pull request
New alert added to support and analytics Terraform.

### Guidance to review 
Deployed to `d11` feature environment. Previously manually created and tested in `d01` environment by failing a number of 'finished' pipeline messages on purpose.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

