### PR TITLE
feat: adds save as image functionality to spending priorities charts 

### DIFF
--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -410,3 +410,7 @@ hr.govuk-section-break--print {
 .save-charts {
   float: right;
 }
+
+.app-priorities-save-chart {
+  float: right;
+}

--- a/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
@@ -57,7 +57,9 @@
                     </div>
                 }
                 <div class="govuk-grid-column-full">
-                    <p class="priority @category.Rating.PriorityTag?.Class govuk-body govuk-!-margin-bottom-0">
+                    <p 
+                        class="priority @category.Rating.PriorityTag?.Class govuk-body govuk-!-margin-bottom-0"
+                        data-testid="@categoryHeading-rag-commentary">
                         @await Component.InvokeAsync("Tag", new
                         {
                             rating = new RatingViewModel(category.Rating.PriorityTag?.Colour, category.Rating.PriorityTag?.DisplayText)

--- a/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
@@ -39,8 +39,24 @@
         <section id="spending-priorities-@category.Rating.CostCategoryAnchorId">
             <div class="govuk-grid-row govuk-!-margin-bottom-2"
                  @(i == 0 ? $"id={Model.Id}" : "")>
-                <div class="govuk-grid-column-full">
+                <div class="govuk-grid-column-two-thirds">
                     <h3 class="govuk-heading-s govuk-!-font-size-27">@categoryHeading</h3>
+                </div>
+                @if (!Model.IsCustomData)
+                {
+                    <div class="govuk-grid-column-one-third">
+                        <div class="app-priorities-save-chart">
+                            <div
+                                data-share-content-by-element-id
+                                data-element-id="@categoryHeading"
+                                data-title="@categoryHeading"
+                                data-show-title="true"
+                                data-save-event-id="save-chart-as-image">
+                            </div>
+                        </div>
+                    </div>
+                }
+                <div class="govuk-grid-column-full">
                     <p class="priority @category.Rating.PriorityTag?.Class govuk-body govuk-!-margin-bottom-0">
                         @await Component.InvokeAsync("Tag", new
                         {
@@ -56,27 +72,28 @@
 
             <div class="govuk-grid-row govuk-!-margin-bottom-4">
                 <div class="govuk-grid-column-two-thirds">
+                    <div id="@categoryHeading">
+                        @if (hasNegativeOrZeroValues)
+                        {
+                            <div class="govuk-warning-text">
+                                <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                                <strong class="govuk-warning-text__text">
+                                    <span class="govuk-visually-hidden">Warning</span>
+                                    Only displaying schools with positive expenditure.
+                                </strong>
+                            </div>
+                        }
 
-                    @if (hasNegativeOrZeroValues)
-                    {
-                        <div class="govuk-warning-text">
-                            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                            <strong class="govuk-warning-text__text">
-                                <span class="govuk-visually-hidden">Warning</span>
-                                Only displaying schools with positive expenditure.
-                            </strong>
+                        <div class="govuk-!-margin-bottom-2 composed-container costs-chart-wrapper"
+                             data-spending-and-costs-composed
+                             data-json="@filteredData.ToJson(Formatting.None)"
+                             data-highlight="@Model.Urn"
+                             data-suffix="@category.Rating.Unit"
+                             data-sort-direction="asc"
+                             data-stats="@SchoolSpendingViewModel.Stats(category.Rating).ToJson(Formatting.None)"
+                             data-has-incomplete-data="@Model.HasIncompleteData"
+                             data-title="@categoryHeading">
                         </div>
-                    }
-
-                    <div class="govuk-!-margin-bottom-2 composed-container costs-chart-wrapper"
-                         data-spending-and-costs-composed
-                         data-json="@filteredData.ToJson(Formatting.None)"
-                         data-highlight="@Model.Urn"
-                         data-suffix="@category.Rating.Unit"
-                         data-sort-direction="asc"
-                         data-stats="@SchoolSpendingViewModel.Stats(category.Rating).ToJson(Formatting.None)"
-                         data-has-incomplete-data="@Model.HasIncompleteData"
-                         data-title="@categoryHeading">
                     </div>
 
                     <p class="govuk-body category-commentary">

--- a/web/tests/Web.E2ETests/Pages/School/SpendingCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/SpendingCostsPage.cs
@@ -141,7 +141,7 @@ public class SpendingCostsPage(IPage page)
         var categoryHeader = page.Locator("h3").And(page.GetByText(categoryName));
         Assert.NotNull(categoryHeader);
 
-        var priority = categoryHeader.Locator("//following-sibling::p[1]");
+        var priority = page.GetByTestId($"{categoryName}-rag-commentary");
         Assert.NotNull(priority);
 
         var text = await priority.InnerTextAsync();


### PR DESCRIPTION
### Context
[AB#244349](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/244349) - [AB#246623](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/246623)

### Change proposed in this pull request
Adds usage of the `ShareContentByElement` component to save the image for each chart on the spending priorities page.
Updates now failing E2E test - adds a test id to rag commentary

### Guidance to review 
- New E2E tests to follow on a subsequent PR
- Only for the default spending priorities page, not custom data
- Possible further work required for this implementation following design crit.
  - placement of button
  - inclusion of rag commentary in this saved image.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

