### PR TITLE
Added 'copy to clipboard' button to charts alongside existing 'save as image'

### DIFF
--- a/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
@@ -49,6 +49,7 @@ import {
 import { useDownloadPngImage } from "src/hooks/useDownloadImage";
 import { Props } from "recharts/types/component/Label";
 import { CartesianViewBox } from "recharts/types/util/types";
+import { DownloadMode } from "src/services";
 
 function HorizontalBarChartInner<TData extends ChartDataSeries>(
   props: HorizontalBarChartProps<TData>,
@@ -68,6 +69,7 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
     labels,
     legend,
     margin: _margin,
+    onImageCopied,
     onImageLoading,
     seriesConfig,
     seriesLabelField,
@@ -99,7 +101,8 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
   const rechartsRef = useRef<CategoricalChartWrapper>(null);
   const downloadPng = useDownloadPngImage({
     ref: rechartsRef,
-    onImageLoading,
+    onCopied: onImageCopied,
+    onLoading: onImageLoading,
     elementSelector: (ref) => ref?.container,
     filter: (node) => {
       const exclusionClasses = ["recharts-tooltip-wrapper"];
@@ -112,8 +115,8 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
   });
 
   useImperativeHandle(ref, () => ({
-    async download() {
-      await downloadPng();
+    async download(mode: DownloadMode) {
+      await downloadPng(mode);
     },
   }));
 

--- a/front-end-components/src/components/charts/line-chart/component.tsx
+++ b/front-end-components/src/components/charts/line-chart/component.tsx
@@ -27,6 +27,7 @@ import {
 import classNames from "classnames";
 import { useDownloadPngImage } from "src/hooks/useDownloadImage";
 import { LineChartDot } from "../line-chart-dot";
+import { DownloadMode } from "src/services";
 
 function LineChartInner<TData extends ChartDataSeries>(
   {
@@ -48,6 +49,7 @@ function LineChartInner<TData extends ChartDataSeries>(
     legendWrapperStyle,
     margin: _margin,
     multiLineAxisLabel,
+    onImageCopied,
     onImageLoading,
     seriesConfig,
     seriesFormatter,
@@ -63,15 +65,16 @@ function LineChartInner<TData extends ChartDataSeries>(
   const rechartsRef = useRef<CategoricalChartWrapper>(null);
   const downloadPng = useDownloadPngImage({
     ref: rechartsRef,
-    onImageLoading,
+    onCopied: onImageCopied,
+    onLoading: onImageLoading,
     elementSelector: (ref) => ref?.container,
     title: chartTitle,
     showTitle: true,
   });
 
   useImperativeHandle(ref, () => ({
-    async download() {
-      await downloadPng();
+    async download(mode: DownloadMode) {
+      await downloadPng(mode);
     },
   }));
 

--- a/front-end-components/src/components/charts/types.tsx
+++ b/front-end-components/src/components/charts/types.tsx
@@ -11,6 +11,7 @@ import {
 } from "recharts/types/component/DefaultTooltipContent";
 import { ContentType } from "recharts/types/component/Tooltip";
 import { CartesianTickItem } from "recharts/types/util/types";
+import { DownloadMode } from "src/services";
 
 export interface ChartProps<TData extends ChartDataSeries>
   extends ValueFormatterProps {
@@ -34,6 +35,7 @@ export interface ChartProps<TData extends ChartDataSeries>
   legendWrapperStyle?: CSSProperties;
   margin?: number;
   multiLineAxisLabel?: boolean;
+  onImageCopied?: (fileName: string) => void;
   onImageLoading?: (loading: boolean) => void;
   ref?: Ref<ChartHandler>;
   seriesConfig?: ChartSeriesConfig<TData>;
@@ -70,7 +72,7 @@ export type TickProps = SVGProps<SVGGElement> & {
 };
 
 export type ChartHandler = {
-  download: () => Promise<void>;
+  download: (mode: DownloadMode) => Promise<void>;
 };
 
 export type ChartSortDirection = "asc" | "desc";

--- a/front-end-components/src/components/charts/vertical-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/vertical-bar-chart/component.tsx
@@ -31,6 +31,7 @@ import {
   TickProps,
 } from "src/components";
 import { useDownloadPngImage } from "src/hooks/useDownloadImage";
+import { DownloadMode } from "src/services";
 
 function VerticalBarChartInner<TData extends ChartDataSeries>(
   props: VerticalBarChartProps<TData>,
@@ -49,6 +50,7 @@ function VerticalBarChartInner<TData extends ChartDataSeries>(
     legend,
     margin: _margin,
     multiLineAxisLabel,
+    onImageCopied,
     onImageLoading,
     seriesConfig,
     seriesLabel,
@@ -60,15 +62,16 @@ function VerticalBarChartInner<TData extends ChartDataSeries>(
   const rechartsRef = useRef<CategoricalChartWrapper>(null);
   const downloadPng = useDownloadPngImage({
     ref: rechartsRef,
-    onImageLoading,
+    onCopied: onImageCopied,
+    onLoading: onImageLoading,
     elementSelector: (ref) => ref?.container,
     title: chartTitle,
     showTitle: true,
   });
 
   useImperativeHandle(ref, () => ({
-    async download() {
-      await downloadPng();
+    async download(mode: DownloadMode) {
+      await downloadPng(mode);
     },
   }));
 

--- a/front-end-components/src/components/share-content-by-element/component.tsx
+++ b/front-end-components/src/components/share-content-by-element/component.tsx
@@ -11,17 +11,29 @@ export const ShareContentByElement: React.FC<ShareContentByElementProps> = ({
   ...props
 }) => {
   const [imageLoading, setImageLoading] = useState<boolean>();
+  const [imageCopied, setImageCopied] = useState<boolean>();
+
+  const handleImageCopied = () => {
+    setImageCopied(true);
+    setTimeout(() => {
+      setImageCopied(false);
+    }, 2000);
+  };
+
   const downloadPng = useDownloadPngImage({
     elementSelector,
-    onImageLoading: setImageLoading,
+    onCopied: handleImageCopied,
+    onLoading: setImageLoading,
     title,
     showTitle,
   });
 
   return (
     <ShareContent
+      copied={imageCopied}
       disabled={imageLoading || disabled}
-      onSaveClick={async () => await downloadPng()}
+      onCopyClick={async () => await downloadPng("copy")}
+      onSaveClick={async () => await downloadPng("save")}
       title={title}
       {...props}
     />

--- a/front-end-components/src/components/share-content-by-element/types.tsx
+++ b/front-end-components/src/components/share-content-by-element/types.tsx
@@ -2,7 +2,7 @@ import { ShareContentProps } from "../share-content/types";
 
 export type ShareContentByElementProps = Omit<
   ShareContentProps,
-  "onSaveClick"
+  "onSaveClick" | "onCopyClick"
 > & {
   elementSelector: () => HTMLElement | undefined;
 };

--- a/front-end-components/src/components/share-content-by-elements/component.tsx
+++ b/front-end-components/src/components/share-content-by-elements/component.tsx
@@ -34,7 +34,7 @@ export const ShareContentByElements: React.FC<ShareContentByElementsProps> = ({
   return (
     <ShareContent
       disabled={imagesLoading || disabled}
-      hideCopy
+      showSave
       onSaveClick={async () => {
         if (onClick) {
           await onClick();

--- a/front-end-components/src/components/share-content-by-elements/component.tsx
+++ b/front-end-components/src/components/share-content-by-elements/component.tsx
@@ -34,6 +34,7 @@ export const ShareContentByElements: React.FC<ShareContentByElementsProps> = ({
   return (
     <ShareContent
       disabled={imagesLoading || disabled}
+      hideCopy
       onSaveClick={async () => {
         if (onClick) {
           await onClick();

--- a/front-end-components/src/components/share-content/component.tsx
+++ b/front-end-components/src/components/share-content/component.tsx
@@ -4,13 +4,17 @@ import { ShareContentProps } from "./types";
 
 export const ShareContent: React.FC<PropsWithChildren<ShareContentProps>> = ({
   children,
+  copied,
   disabled,
+  hideCopy,
+  onCopyClick,
   onSaveClick,
+  copyEventId,
   saveEventId,
   title,
 }) => {
   return (
-    <div>
+    <div className="share-buttons">
       <button
         className="govuk-button govuk-button--secondary share-button share-button--save"
         data-module="govuk-button"
@@ -29,6 +33,28 @@ export const ShareContent: React.FC<PropsWithChildren<ShareContentProps>> = ({
           </>
         )}
       </button>
+      {!hideCopy && (
+        <button
+          className="govuk-button govuk-button--secondary share-button share-button--copy"
+          data-module="govuk-button"
+          data-prevent-double-click="true"
+          onClick={onCopyClick}
+          disabled={disabled}
+          aria-disabled={disabled}
+          data-custom-event-id={copyEventId}
+          data-custom-event-chart-name={copyEventId && title}
+        >
+          {copied ? (
+            "Copied"
+          ) : children ? (
+            children
+          ) : (
+            <>
+              Copy <span className="govuk-visually-hidden">{title}</span> image
+            </>
+          )}
+        </button>
+      )}
     </div>
   );
 };

--- a/front-end-components/src/components/share-content/component.tsx
+++ b/front-end-components/src/components/share-content/component.tsx
@@ -1,51 +1,59 @@
 import React, { PropsWithChildren } from "react";
 import "src/components/share-content/styles.css";
 import { ShareContentProps } from "./types";
+import classNames from "classnames";
 
 export const ShareContent: React.FC<PropsWithChildren<ShareContentProps>> = ({
   children,
   copied,
+  copiedLabel,
   disabled,
-  hideCopy,
   onCopyClick,
   onSaveClick,
   copyEventId,
   saveEventId,
+  showCopy,
+  showSave,
   title,
 }) => {
+  const classes = "govuk-button govuk-button--secondary share-button";
+  const props = {
+    "data-module": "govuk-button",
+    "data-prevent-double-click": "true",
+    disabled: disabled,
+    ariaDisabled: disabled,
+  };
+
   return (
     <div className="share-buttons">
-      <button
-        className="govuk-button govuk-button--secondary share-button share-button--save"
-        data-module="govuk-button"
-        data-prevent-double-click="true"
-        onClick={onSaveClick}
-        disabled={disabled}
-        aria-disabled={disabled}
-        data-custom-event-id={saveEventId}
-        data-custom-event-chart-name={saveEventId && title}
-      >
-        {children ? (
-          children
-        ) : (
-          <>
-            Save <span className="govuk-visually-hidden">{title}</span> as image
-          </>
-        )}
-      </button>
-      {!hideCopy && (
+      {showSave && (
         <button
-          className="govuk-button govuk-button--secondary share-button share-button--copy"
-          data-module="govuk-button"
-          data-prevent-double-click="true"
+          className={classNames(classes, "share-button--save")}
+          onClick={onSaveClick}
+          data-custom-event-chart-name={saveEventId && title}
+          data-custom-event-id={saveEventId}
+          {...props}
+        >
+          {children ? (
+            children
+          ) : (
+            <>
+              Save <span className="govuk-visually-hidden">{title}</span> as
+              image
+            </>
+          )}
+        </button>
+      )}
+      {showCopy && (
+        <button
+          className={classNames(classes, "share-button--copy")}
           onClick={onCopyClick}
-          disabled={disabled}
-          aria-disabled={disabled}
-          data-custom-event-id={copyEventId}
           data-custom-event-chart-name={copyEventId && title}
+          data-custom-event-id={copyEventId}
+          {...props}
         >
           {copied ? (
-            "Copied"
+            (copiedLabel ?? "Copied")
           ) : children ? (
             children
           ) : (

--- a/front-end-components/src/components/share-content/styles.css
+++ b/front-end-components/src/components/share-content/styles.css
@@ -1,6 +1,7 @@
 .share-buttons {
     display: flex;
     gap: 10px;
+    justify-content: flex-end;
     margin-bottom: 15px;
 }
 

--- a/front-end-components/src/components/share-content/styles.css
+++ b/front-end-components/src/components/share-content/styles.css
@@ -1,0 +1,10 @@
+.share-buttons {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 15px;
+}
+
+button.govuk-button.share-button {
+  margin: 0;
+  width: auto;
+}

--- a/front-end-components/src/components/share-content/types.tsx
+++ b/front-end-components/src/components/share-content/types.tsx
@@ -6,10 +6,12 @@ export type ShareContentProps = Pick<
   "showTitle" | "title"
 > & {
   copied?: boolean;
+  copiedLabel?: string;
   disabled?: boolean;
-  hideCopy?: boolean;
   onCopyClick?: MouseEventHandler<HTMLButtonElement> | undefined;
   onSaveClick?: MouseEventHandler<HTMLButtonElement> | undefined;
   copyEventId?: string;
   saveEventId?: string;
+  showCopy?: boolean;
+  showSave?: boolean;
 };

--- a/front-end-components/src/components/share-content/types.tsx
+++ b/front-end-components/src/components/share-content/types.tsx
@@ -5,7 +5,11 @@ export type ShareContentProps = Pick<
   DownloadPngImageOptions<HTMLElement>,
   "showTitle" | "title"
 > & {
+  copied?: boolean;
   disabled?: boolean;
+  hideCopy?: boolean;
+  onCopyClick?: MouseEventHandler<HTMLButtonElement> | undefined;
   onSaveClick?: MouseEventHandler<HTMLButtonElement> | undefined;
+  copyEventId?: string;
   saveEventId?: string;
 };

--- a/front-end-components/src/composed/historic-chart-2-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-2-composed/component.tsx
@@ -122,6 +122,8 @@ export function HistoricChart2<TData extends HistoryBase>({
               onSaveClick={() => chartRef.current?.download("save")}
               copyEventId="copy-chart-as-image"
               saveEventId="save-chart-as-image"
+              showCopy
+              showSave
               title={chartTitle}
             />
           </div>

--- a/front-end-components/src/composed/historic-chart-2-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-2-composed/component.tsx
@@ -37,6 +37,7 @@ export function HistoricChart2<TData extends HistoryBase>({
   const dimension = useContext(ChartDimensionContext);
   const chartRef = useRef<ChartHandler>(null);
   const [imageLoading, setImageLoading] = useState<boolean>();
+  const [imageCopied, setImageCopied] = useState<boolean>();
 
   const mergedData = useMemo(() => {
     const result: SchoolHistoryValue[] = [];
@@ -101,6 +102,13 @@ export function HistoricChart2<TData extends HistoryBase>({
     },
   };
 
+  const handleImageCopied = () => {
+    setImageCopied(true);
+    setTimeout(() => {
+      setImageCopied(false);
+    }, 2000);
+  };
+
   return (
     <>
       <div className="govuk-grid-row">
@@ -108,8 +116,11 @@ export function HistoricChart2<TData extends HistoryBase>({
         {chartMode == ChartModeChart && (
           <div className="govuk-grid-column-one-quarter">
             <ShareContent
+              copied={imageCopied}
               disabled={imageLoading}
-              onSaveClick={() => chartRef.current?.download()}
+              onCopyClick={() => chartRef.current?.download("copy")}
+              onSaveClick={() => chartRef.current?.download("save")}
+              copyEventId="copy-chart-as-image"
               saveEventId="save-chart-as-image"
               title={chartTitle}
             />
@@ -133,6 +144,7 @@ export function HistoricChart2<TData extends HistoryBase>({
                 valueFormatter={shortValueFormatter}
                 valueUnit={valueUnit ?? dimension.unit}
                 ref={chartRef}
+                onImageCopied={handleImageCopied}
                 onImageLoading={setImageLoading}
                 tooltip={(t) => (
                   <HistoricDataTooltip

--- a/front-end-components/src/composed/historic-chart-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/component.tsx
@@ -49,6 +49,8 @@ export function HistoricChart<TData extends ChartDataSeries>({
               onSaveClick={() => chartRef.current?.download("save")}
               copyEventId="copy-chart-as-image"
               saveEventId="save-chart-as-image"
+              showCopy
+              showSave
               title={chartTitle}
             />
           </div>

--- a/front-end-components/src/composed/historic-chart-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/component.tsx
@@ -27,6 +27,14 @@ export function HistoricChart<TData extends ChartDataSeries>({
   const dimension = useContext(ChartDimensionContext);
   const chartRef = useRef<ChartHandler>(null);
   const [imageLoading, setImageLoading] = useState<boolean>();
+  const [imageCopied, setImageCopied] = useState<boolean>();
+
+  const handleImageCopied = () => {
+    setImageCopied(true);
+    setTimeout(() => {
+      setImageCopied(false);
+    }, 2000);
+  };
 
   return (
     <>
@@ -35,8 +43,11 @@ export function HistoricChart<TData extends ChartDataSeries>({
         {chartMode == ChartModeChart && (
           <div className="govuk-grid-column-one-quarter">
             <ShareContent
+              copied={imageCopied}
               disabled={imageLoading}
-              onSaveClick={() => chartRef.current?.download()}
+              onCopyClick={() => chartRef.current?.download("copy")}
+              onSaveClick={() => chartRef.current?.download("save")}
+              copyEventId="copy-chart-as-image"
               saveEventId="save-chart-as-image"
               title={chartTitle}
             />
@@ -60,6 +71,7 @@ export function HistoricChart<TData extends ChartDataSeries>({
                 valueFormatter={shortValueFormatter}
                 valueUnit={valueUnit ?? dimension.unit}
                 ref={chartRef}
+                onImageCopied={handleImageCopied}
                 onImageLoading={setImageLoading}
                 tooltip={(t) => (
                   <LineChartTooltip

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -177,6 +177,8 @@ export function HorizontalBarChartWrapper<
               onSaveClick={() => chartRef.current?.download("save")}
               copyEventId="copy-chart-as-image"
               saveEventId="save-chart-as-image"
+              showCopy
+              showSave
               title={chartTitle}
             />
           </div>

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -44,6 +44,7 @@ export function HorizontalBarChartWrapper<
   const selectedEstabishment = useContext(SelectedEstablishmentContext);
   const chartRef = useRef<ChartHandler>(null);
   const [imageLoading, setImageLoading] = useState<boolean>();
+  const [imageCopied, setImageCopied] = useState<boolean>();
   const [tickFocused, setTickFocused] = useState<Record<string, boolean>>({});
   const keyField = (trust ? "companyNumber" : "urn") as keyof TData;
   const seriesLabelField = (trust ? "trustName" : "schoolName") as keyof TData;
@@ -154,6 +155,13 @@ export function HorizontalBarChartWrapper<
     setTickFocused(Object.assign(tickFocused, { [key]: focused }));
   };
 
+  const handleImageCopied = () => {
+    setImageCopied(true);
+    setTimeout(() => {
+      setImageCopied(false);
+    }, 2000);
+  };
+
   const hasData = sortedDataPoints.length > 0;
 
   return (
@@ -163,8 +171,11 @@ export function HorizontalBarChartWrapper<
         {chartMode == ChartModeChart && (
           <div className="govuk-grid-column-one-third">
             <ShareContent
+              copied={imageCopied}
               disabled={imageLoading || !hasData}
-              onSaveClick={() => chartRef.current?.download()}
+              onCopyClick={() => chartRef.current?.download("copy")}
+              onSaveClick={() => chartRef.current?.download("save")}
+              copyEventId="copy-chart-as-image"
               saveEventId="save-chart-as-image"
               title={chartTitle}
             />
@@ -186,6 +197,7 @@ export function HorizontalBarChartWrapper<
                   }
                   specialItemKeys={{ partYear: partYearKeys }}
                   keyField={keyField}
+                  onImageCopied={handleImageCopied}
                   onImageLoading={setImageLoading}
                   labels
                   margin={20}

--- a/front-end-components/src/index.css
+++ b/front-end-components/src/index.css
@@ -538,8 +538,3 @@ ul.autocomplete__menu {
 div[data-share-content-by-element-id], div[data-share-content-by-element-class-name] {
   min-height: 40px;
 }
-
-button.govuk-button.share-button {
-  margin: 0;
-  width: auto;
-}

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -886,9 +886,11 @@ if (shareContentByElementIdElements) {
               elementSelector={() =>
                 document.getElementById(elementId) ?? undefined
               }
-              showTitle={showTitle === "true"}
               title={title}
               saveEventId={saveEventId}
+              showCopy
+              showSave
+              showTitle={showTitle === "true"}
             />
           </React.StrictMode>
         );
@@ -905,6 +907,7 @@ const shareContentByElementClassNameElements =
 if (shareContentByElementClassNameElements) {
   shareContentByElementClassNameElements.forEach((element) => {
     const {
+      copyEventId,
       elementClassName,
       elementTitleAttr,
       fileName,
@@ -948,6 +951,7 @@ if (shareContentByElementClassNameElements) {
             }}
             fileName={fileName}
             label={label}
+            copyEventId={copyEventId}
             saveEventId={saveEventId}
             showProgress={showProgress === "true"}
             showTitles={showTitles === "true"}

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -233,7 +233,7 @@ const HorizontalChart1Series = ({
         data-module="govuk-button"
         disabled={imageLoading}
         aria-disabled={imageLoading}
-        onClick={() => horizontalChart2SeriesRef?.current?.download()}
+        onClick={() => horizontalChart2SeriesRef?.current?.download("save")}
       >
         Download as image
       </button>
@@ -370,7 +370,9 @@ const HorizontalChartTrustFinancial = ({
         data-module="govuk-button"
         disabled={imageLoading}
         aria-disabled={imageLoading}
-        onClick={() => horizontalChart1SeriesStackedRef?.current?.download()}
+        onClick={() =>
+          horizontalChart1SeriesStackedRef?.current?.download("save")
+        }
       >
         Download as image
       </button>
@@ -477,7 +479,7 @@ const VerticalChart2Series = ({
         data-module="govuk-button"
         disabled={imageLoading}
         aria-disabled={imageLoading}
-        onClick={() => verticalChart2SeriesRef?.current?.download()}
+        onClick={() => verticalChart2SeriesRef?.current?.download("save")}
       >
         Download as image
       </button>
@@ -607,7 +609,7 @@ const LineChart1Series = ({
         data-module="govuk-button"
         disabled={imageLoading}
         aria-disabled={imageLoading}
-        onClick={() => lineChart1SeriesRef?.current?.download()}
+        onClick={() => lineChart1SeriesRef?.current?.download("save")}
       >
         Download as image
       </button>
@@ -705,7 +707,7 @@ const LineChart2Series = ({
         data-module="govuk-button"
         disabled={imageLoading}
         aria-disabled={imageLoading}
-        onClick={() => lineChart2SeriesRef?.current?.download()}
+        onClick={() => lineChart2SeriesRef?.current?.download("save")}
       >
         Download as image
       </button>

--- a/front-end-components/src/services/image-service.ts
+++ b/front-end-components/src/services/image-service.ts
@@ -78,3 +78,5 @@ export class ImageService {
     return blob;
   }
 }
+
+export type DownloadMode = "save" | "copy";

--- a/front-end-components/src/views/budget-forecast-returns/partials/bfr-chart.tsx
+++ b/front-end-components/src/views/budget-forecast-returns/partials/bfr-chart.tsx
@@ -7,7 +7,7 @@ import { forwardRef } from "react";
 import { ChartHandler } from "src/components";
 
 export const BfrChart = forwardRef<ChartHandler, BfrChartProps>(
-  ({ data, onImageLoading }, ref) => {
+  ({ data, onImageCopied, onImageLoading }, ref) => {
     return (
       <div className="govuk-grid-column-full" style={{ height: 400 }}>
         {data.length > 0 ? (
@@ -18,6 +18,7 @@ export const BfrChart = forwardRef<ChartHandler, BfrChartProps>(
             highlightActive
             keyField="periodEndDate"
             margin={20}
+            onImageCopied={onImageCopied}
             onImageLoading={onImageLoading}
             ref={ref}
             seriesConfig={{

--- a/front-end-components/src/views/budget-forecast-returns/partials/types.tsx
+++ b/front-end-components/src/views/budget-forecast-returns/partials/types.tsx
@@ -9,6 +9,7 @@ export type BudgetForecastData = {
 
 export type BfrChartProps = {
   data: BudgetForecastData[];
+  onImageCopied: React.Dispatch<React.SetStateAction<string | undefined>>;
   onImageLoading: React.Dispatch<React.SetStateAction<boolean | undefined>>;
 };
 

--- a/front-end-components/src/views/budget-forecast-returns/partials/year-end.tsx
+++ b/front-end-components/src/views/budget-forecast-returns/partials/year-end.tsx
@@ -108,6 +108,8 @@ export const YearEnd: React.FC<{
             onSaveClick={() => chartRef.current?.download("save")}
             copyEventId="copy-chart-as-image"
             saveEventId="save-chart-as-image"
+            showCopy
+            showSave
             title={chartTitle}
           />
         </div>

--- a/front-end-components/src/views/budget-forecast-returns/partials/year-end.tsx
+++ b/front-end-components/src/views/budget-forecast-returns/partials/year-end.tsx
@@ -24,6 +24,7 @@ export const YearEnd: React.FC<{
   const [dimension, setDimension] = useState(Actual);
   const [data, setData] = useState<BudgetForecastReturn[] | null>();
   const [imageLoading, setImageLoading] = useState<boolean>();
+  const [imageCopied, setImageCopied] = useState<boolean>();
   const chartRef = useRef<ChartHandler>(null);
 
   const getData = useCallback(async () => {
@@ -83,6 +84,13 @@ export const YearEnd: React.FC<{
     setDimension(dimension);
   };
 
+  const handleImageCopied = () => {
+    setImageCopied(true);
+    setTimeout(() => {
+      setImageCopied(false);
+    }, 2000);
+  };
+
   const chartTitle = "Year-end revenue reserves";
   const hasData = chartData.length > 0;
 
@@ -94,8 +102,11 @@ export const YearEnd: React.FC<{
       <div className="govuk-grid-column-one-half">
         <div>
           <ShareContent
+            copied={imageCopied}
             disabled={imageLoading || !hasData}
-            onSaveClick={() => chartRef.current?.download()}
+            onCopyClick={() => chartRef.current?.download("copy")}
+            onSaveClick={() => chartRef.current?.download("save")}
+            copyEventId="copy-chart-as-image"
             saveEventId="save-chart-as-image"
             title={chartTitle}
           />
@@ -113,6 +124,7 @@ export const YearEnd: React.FC<{
       <BfrChart
         data={chartData}
         ref={chartRef}
+        onImageCopied={handleImageCopied}
         onImageLoading={setImageLoading}
       />
       <BfrTable data={data} />

--- a/web/README.md
+++ b/web/README.md
@@ -186,7 +186,8 @@ Add the following configuration in `appsetings.local.json` in the root of `Web.E
   "Authentication": {
     "Username": "<DSI_USERNAME>",
     "Password": "<DSI_PASSWORD>"
-  }
+  },
+  "Permissions": ["clipboard-read"]
 }
 ```
 

--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -410,7 +410,3 @@ hr.govuk-section-break--print {
 .save-charts {
   float: right;
 }
-
-.app-priorities-save-chart {
-  float: right;
-}

--- a/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
@@ -45,15 +45,13 @@
                 @if (!Model.IsCustomData)
                 {
                     <div class="govuk-grid-column-one-third">
-                        <div class="app-priorities-save-chart">
-                            <div
-                                data-share-content-by-element-id
-                                data-element-id="@categoryHeading"
-                                data-title="@categoryHeading"
-                                data-show-title="true"
-                                data-copy-event-id="copy-chart-as-image"
-                                data-save-event-id="save-chart-as-image">
-                            </div>
+                        <div
+                            data-share-content-by-element-id
+                            data-element-id="@categoryHeading"
+                            data-title="@categoryHeading"
+                            data-show-title="true"
+                            data-copy-event-id="copy-chart-as-image"
+                            data-save-event-id="save-chart-as-image">
                         </div>
                     </div>
                 }

--- a/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
@@ -51,13 +51,14 @@
                                 data-element-id="@categoryHeading"
                                 data-title="@categoryHeading"
                                 data-show-title="true"
+                                data-copy-event-id="copy-chart-as-image"
                                 data-save-event-id="save-chart-as-image">
                             </div>
                         </div>
                     </div>
                 }
                 <div class="govuk-grid-column-full">
-                    <p 
+                    <p
                         class="priority @category.Rating.PriorityTag?.Class govuk-body govuk-!-margin-bottom-0"
                         data-testid="@categoryHeading-rag-commentary">
                         @await Component.InvokeAsync("Tag", new

--- a/web/tests/Web.E2ETests/Drivers/PageDriver.cs
+++ b/web/tests/Web.E2ETests/Drivers/PageDriver.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using Microsoft.Playwright;
-using Reqnroll;
 
 namespace Web.E2ETests.Drivers;
 
@@ -75,6 +74,7 @@ public class PageDriver : IDisposable
         _browser ??= await InitialiseBrowser();
 
         var browserContext = await _browser.NewContextAsync(ContextOptions);
+        await browserContext.GrantPermissionsAsync(TestConfiguration.Permissions);
 
         var page = await browserContext.NewPageAsync();
         if (TestConfiguration.OutputPageResponse)

--- a/web/tests/Web.E2ETests/Features/LocalAuthority/BenchmarkCensus.feature
+++ b/web/tests/Web.E2ETests/Features/LocalAuthority/BenchmarkCensus.feature
@@ -9,6 +9,11 @@
         When I click on save as image for 'school workforce'
         Then the 'school workforce' chart image is downloaded
 
+    Scenario: Copy school workforce chart
+        Given I am on census page for local authority with code '201'
+        When I click on copy image for 'school workforce'
+        Then the 'school workforce' chart image is copied
+
     Scenario: Change dimension of school workforce
         Given I am on census page for local authority with code '201'
         When I change 'school workforce' dimension to 'pupils per staff role'
@@ -33,6 +38,7 @@
         When I click on view as table
         Then the table view is showing
         But save as image buttons are hidden
+        And copy image buttons are hidden
 
     Scenario: Change table view to chart view
         Given I am on census page for local authority with code '201'
@@ -40,6 +46,7 @@
         When I click on view as chart
         Then chart view is showing
         And save as image buttons are displayed
+        And copy image buttons are displayed
 
     Scenario Outline: Checking the charts dimension dropdown items
         Given I am on census page for local authority with code '201'

--- a/web/tests/Web.E2ETests/Features/LocalAuthority/CompareYourCosts.feature
+++ b/web/tests/Web.E2ETests/Features/LocalAuthority/CompareYourCosts.feature
@@ -5,6 +5,11 @@ Feature: Local Authority compare your costs
         When I click on save as image for 'total expenditure'
         Then the 'total expenditure' chart image is downloaded
 
+    Scenario: Copy total expenditure chart
+        Given I am on compare your costs page for local authority with code '201'
+        When I click on copy image for 'total expenditure'
+        Then the 'total expenditure' chart image is copied
+
     Scenario: Change dimension of total expenditure and change view to table
         Given I am on compare your costs page for local authority with code '201'
         And the 'total expenditure' dimension is '£ per pupil'
@@ -22,6 +27,7 @@ Feature: Local Authority compare your costs
           | Test school 237         | City of London  | Voluntary aided school | 231              | £1,597,953 |
           | Test school 1           | City of London  | Voluntary aided school | 232              | £1,580,913 |
         But save as image buttons are hidden
+        And copy image buttons are hidden
 
     Scenario: Show all should expand all sections
         Given I am on compare your costs page for local authority with code '201'
@@ -36,6 +42,7 @@ Feature: Local Authority compare your costs
         Then all sections on the page are expanded
         And are showing table view
         But save as image buttons are hidden
+        And copy image buttons are hidden
 
     Scenario: Hide single section
         Given I am on compare your costs page for local authority with code '201'

--- a/web/tests/Web.E2ETests/Features/School/BenchmarkCensus.feature
+++ b/web/tests/Web.E2ETests/Features/School/BenchmarkCensus.feature
@@ -9,6 +9,11 @@
         When I click on save as image for 'school workforce'
         Then the 'school workforce' chart image is downloaded
 
+    Scenario: Copy school workforce chart
+        Given I am on census page for school with URN '777042'
+        When I click on copy image for 'school workforce'
+        Then the 'school workforce' chart image is copied
+
     Scenario: Change dimension of school workforce
         Given I am on census page for school with URN '777042'
         When I change 'school workforce' dimension to 'pupils per staff role'
@@ -33,6 +38,7 @@
         When I click on view as table
         Then the table view is showing
         But save as image buttons are hidden
+        And copy image buttons are hidden
 
     Scenario: Change table view to chart view
         Given I am on census page for school with URN '777042'
@@ -40,6 +46,7 @@
         When I click on view as chart
         Then chart view is showing
         And save as image buttons are displayed
+        And copy image buttons are displayed
 
     Scenario Outline: Checking the charts dimension dropdown items
         Given I am on census page for school with URN '777042'

--- a/web/tests/Web.E2ETests/Features/School/CompareYourCosts.feature
+++ b/web/tests/Web.E2ETests/Features/School/CompareYourCosts.feature
@@ -5,6 +5,11 @@ Feature: School compare your costs
         When I click on save as image for 'total expenditure'
         Then the 'total expenditure' chart image is downloaded
 
+    Scenario: Copy total expenditure chart
+        Given I am on compare your costs page for school with URN '777042'
+        When I click on copy image for 'total expenditure'
+        Then the 'total expenditure' chart image is copied
+
     Scenario: Change dimension of total expenditure and change view to table
         Given I am on compare your costs page for school with URN '777042'
         And the 'total expenditure' dimension is '£ per pupil'
@@ -49,43 +54,44 @@ Feature: School compare your costs
           | Test academy school 435 | Bradford                | Academy sponsor led                | 204              | £1,424,986  |
           | Test academy school 333 | Hampshire               | Free schools alternative provision | 190              | £1,179,475  |
         But save as image buttons are hidden
+        And copy image buttons are hidden
 
     Scenario: Table view for total expenditure for school(s) with part-year data
         Given I am on compare your costs page for school with URN '777045'
         And table view is selected
         And the 'total expenditure' dimension is '£ per pupil'
         Then the following is shown for 'total expenditure'
-          | School name                                                                                                               | Local Authority                   | School type                    | Number of pupils | Amount  |
-          | Test academy school 273                                                                                                   | Kensington and Chelsea            | Academy converter              | 114              | £13,051 |
-          | Test school 88                                                                                                            | Slough                            | Community school               | 134              | £9,916  |
-          | Test part year with pupil and without building comparator\n!\nWarning\nThis school only has 3 months of data available.   | Bromley                           | Pupil referral unit            | 260              | £9,068  |
-          | Test school 197                                                                                                           | Windsor and Maidenhead            | Community school               | 167              | £9,050  |
-          | Test academy school 470                                                                                                   | Waltham Forest                    | Academy 16-19 converter        | 167              | £9,050  |
-          | Test academy school 77                                                                                                    | Hartlepool                        | Academy converter              | 1040             | £9,023  |
-          | Test academy school 469                                                                                                   | Hillingdon                        | Free school 16 to 19           | 235              | £8,981  |
-          | Test school 198                                                                                                           | West Berkshire                    | Community school               | 174              | £8,882  |
-          | Test academy school 255                                                                                                   | Stockton-on-Tees                  | Academy converter              | 174              | £8,882  |
-          | Test school 181                                                                                                           | Dorset                            | Voluntary aided school         | 399              | £8,584  |
-          | Test school 87                                                                                                            | Reading                           | Foundation school              | 206              | £8,224  |
-          | Test school 124                                                                                                           | Newham                            | Voluntary aided school         | 769              | £8,089  |
-          | Test academy school 82                                                                                                    | Bournemouth Christchurch & Poole  | Academy converter              | 991              | £8,088  |
-          | Test academy school 53                                                                                                    | Salford                           | Free school                    | 407              | £8,028  |
-          | Test school 260                                                                                                           | Kingston upon Thames              | Community school               | 853              | £7,880  |
-          | Test academy school 450                                                                                                   | Surrey                            | Academy 16-19 converter        | 367              | £7,703  |
-          | Test Part year school with pupil and builiding comparators\n!\nWarning\nThis school only has 10 months of data available. | Bracknell Forest                  | Foundation school              | 214              | £7,470  |
-          | Test school 205                                                                                                           | Plymouth                          | Community school               | 196              | £7,385  |
-          | Test academy school 20                                                                                                    | Waltham Forest                    | Academy converter              | 449              | £7,356  |
-          | Test academy school 98                                                                                                    | Southwark                         | Academy converter              | 449              | £7,356  |
-          | Test academy school 244                                                                                                   | Islington                         | Academy converter              | 446              | £7,342  |
-          | Test school 68                                                                                                            | Derbyshire                        | Local authority nursery school | 339              | £7,318  |
-          | Test academy school 37                                                                                                    | North Lincolnshire                | Academy converter              | 339              | £7,318  |
-          | Test school 270                                                                                                           | Solihull                          | Voluntary aided school         | 230              | £7,281  |
-          | Test school 237                                                                                                           | City of London                    | Voluntary aided school         | 231              | £6,918  |
-          | Test academy school 465                                                                                                   | Enfield                           | Academy 16-19 converter        | 231              | £6,918  |
-          | Test academy school 375                                                                                                   | Reading                           | Academy special sponsor led    | 232              | £6,814  |
-          | Test school 132                                                                                                           | Solihull                          | Community school               | 418              | £6,676  |
-          | Test academy school 32                                                                                                    | Stockton-on-Tees                  | Academy converter              | 418              | £6,676  |
-          | Test academy school 160                                                                                                   | West Sussex                       | Academy special converter      | 190              | £6,208  |
+          | School name                                                                                                               | Local Authority                  | School type                    | Number of pupils | Amount  |
+          | Test academy school 273                                                                                                   | Kensington and Chelsea           | Academy converter              | 114              | £13,051 |
+          | Test school 88                                                                                                            | Slough                           | Community school               | 134              | £9,916  |
+          | Test part year with pupil and without building comparator\n!\nWarning\nThis school only has 3 months of data available.   | Bromley                          | Pupil referral unit            | 260              | £9,068  |
+          | Test school 197                                                                                                           | Windsor and Maidenhead           | Community school               | 167              | £9,050  |
+          | Test academy school 470                                                                                                   | Waltham Forest                   | Academy 16-19 converter        | 167              | £9,050  |
+          | Test academy school 77                                                                                                    | Hartlepool                       | Academy converter              | 1040             | £9,023  |
+          | Test academy school 469                                                                                                   | Hillingdon                       | Free school 16 to 19           | 235              | £8,981  |
+          | Test school 198                                                                                                           | West Berkshire                   | Community school               | 174              | £8,882  |
+          | Test academy school 255                                                                                                   | Stockton-on-Tees                 | Academy converter              | 174              | £8,882  |
+          | Test school 181                                                                                                           | Dorset                           | Voluntary aided school         | 399              | £8,584  |
+          | Test school 87                                                                                                            | Reading                          | Foundation school              | 206              | £8,224  |
+          | Test school 124                                                                                                           | Newham                           | Voluntary aided school         | 769              | £8,089  |
+          | Test academy school 82                                                                                                    | Bournemouth Christchurch & Poole | Academy converter              | 991              | £8,088  |
+          | Test academy school 53                                                                                                    | Salford                          | Free school                    | 407              | £8,028  |
+          | Test school 260                                                                                                           | Kingston upon Thames             | Community school               | 853              | £7,880  |
+          | Test academy school 450                                                                                                   | Surrey                           | Academy 16-19 converter        | 367              | £7,703  |
+          | Test Part year school with pupil and builiding comparators\n!\nWarning\nThis school only has 10 months of data available. | Bracknell Forest                 | Foundation school              | 214              | £7,470  |
+          | Test school 205                                                                                                           | Plymouth                         | Community school               | 196              | £7,385  |
+          | Test academy school 20                                                                                                    | Waltham Forest                   | Academy converter              | 449              | £7,356  |
+          | Test academy school 98                                                                                                    | Southwark                        | Academy converter              | 449              | £7,356  |
+          | Test academy school 244                                                                                                   | Islington                        | Academy converter              | 446              | £7,342  |
+          | Test school 68                                                                                                            | Derbyshire                       | Local authority nursery school | 339              | £7,318  |
+          | Test academy school 37                                                                                                    | North Lincolnshire               | Academy converter              | 339              | £7,318  |
+          | Test school 270                                                                                                           | Solihull                         | Voluntary aided school         | 230              | £7,281  |
+          | Test school 237                                                                                                           | City of London                   | Voluntary aided school         | 231              | £6,918  |
+          | Test academy school 465                                                                                                   | Enfield                          | Academy 16-19 converter        | 231              | £6,918  |
+          | Test academy school 375                                                                                                   | Reading                          | Academy special sponsor led    | 232              | £6,814  |
+          | Test school 132                                                                                                           | Solihull                         | Community school               | 418              | £6,676  |
+          | Test academy school 32                                                                                                    | Stockton-on-Tees                 | Academy converter              | 418              | £6,676  |
+          | Test academy school 160                                                                                                   | West Sussex                      | Academy special converter      | 190              | £6,208  |
 
     Scenario: Benchmarking for school with missing comparators does not display comparators
         Given I am on compare your costs page for missing comparator school with URN '990754'
@@ -104,6 +110,7 @@ Feature: School compare your costs
         Then all sections on the page are expanded
         And are showing table view
         But save as image buttons are hidden
+        And copy image buttons are hidden
 
     Scenario: Hide single section
         Given I am on compare your costs page for school with URN '777042'

--- a/web/tests/Web.E2ETests/Features/Trust/BenchmarkCensus.feature
+++ b/web/tests/Web.E2ETests/Features/Trust/BenchmarkCensus.feature
@@ -9,6 +9,11 @@
         When I click on save as image for 'school workforce'
         Then the 'school workforce' chart image is downloaded
 
+    Scenario: Copy school workforce chart
+        Given I am on census page for trust with company number '8104190'
+        When I click on copy image for 'school workforce'
+        Then the 'school workforce' chart image is copied
+
     Scenario: Change dimension of school workforce
         Given I am on census page for trust with company number '8104190'
         When I change 'school workforce' dimension to 'pupils per staff role'
@@ -33,6 +38,7 @@
         When I click on view as table
         Then the table view is showing
         But save as image buttons are hidden
+        And copy image buttons are hidden
 
     Scenario: Change table view to chart view
         Given I am on census page for trust with company number '8104190'
@@ -40,6 +46,7 @@
         When I click on view as chart
         Then chart view is showing
         And save as image buttons are displayed
+        And copy image buttons are displayed
 
     Scenario Outline: Checking the charts dimension dropdown items
         Given I am on census page for trust with company number '8104190'

--- a/web/tests/Web.E2ETests/Features/Trust/CompareYourCosts.feature
+++ b/web/tests/Web.E2ETests/Features/Trust/CompareYourCosts.feature
@@ -5,6 +5,11 @@ Feature: Trust compare your costs
         When I click on save as image for 'total expenditure'
         Then the 'total expenditure' chart image is downloaded
 
+    Scenario: Copy total expenditure chart
+        Given I am on compare your costs page for trust with company number '10074054'
+        When I click on copy image for 'total expenditure'
+        Then the 'total expenditure' chart image is copied
+
     Scenario: Change dimension of total expenditure and change view to table
         Given I am on compare your costs page for trust with company number '10074054'
         And the 'total expenditure' dimension is '£ per pupil'
@@ -21,6 +26,7 @@ Feature: Trust compare your costs
           | Test academy school 375 | Reading         | Academy special sponsor led | 232              | £1,580,913 |
           | Test academy school 392 | Trafford        | Academy special converter   | 204              | £1,424,986 |
         But save as image buttons are hidden
+        And copy image buttons are hidden
 
     Scenario: Table view for total expenditure for trust(s) with part-year data
         Given I am on compare your costs page for trust with company number '8104190'
@@ -48,6 +54,7 @@ Feature: Trust compare your costs
         Then all sections on the page are expanded
         And are showing table view
         But save as image buttons are hidden
+        And copy image buttons are hidden
 
     Scenario: Hide single section
         Given I am on compare your costs page for trust with company number '10074054'

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/BenchmarkCensusPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/BenchmarkCensusPage.cs
@@ -30,10 +30,16 @@ public class BenchmarkCensusPage(IPage page)
     private ILocator TotalTeachersTable => page.Locator(Selectors.Table).Nth(1);
     private ILocator Tables => page.Locator(Selectors.Table);
     private ILocator SaveImageSchoolWorkforce => page.Locator(Selectors.SchoolWorkforceSaveAsImage);
+    private ILocator CopyImageSchoolWorkforce => page.Locator(Selectors.SchoolWorkforceCopyImage);
     private ILocator SaveAsImageButtons =>
         page.Locator(Selectors.Button, new PageLocatorOptions
         {
             HasTextRegex = Regexes.SaveAsImageRegex()
+        });
+    private ILocator CopyImageButtons =>
+        page.Locator(Selectors.Button, new PageLocatorOptions
+        {
+            HasTextRegex = Regexes.CopyImageRegex()
         });
 
     private ILocator ChartBars => page.Locator(Selectors.ChartBars);
@@ -60,6 +66,17 @@ public class BenchmarkCensusPage(IPage page)
         };
 
         await chartToDownload.Click();
+    }
+
+    public async Task ClickCopyImage(CensusChartNames chartName)
+    {
+        var chartToCopy = chartName switch
+        {
+            CensusChartNames.SchoolWorkforce => CopyImageSchoolWorkforce,
+            _ => throw new ArgumentOutOfRangeException(nameof(chartName))
+        };
+
+        await chartToCopy.Click();
     }
 
     public async Task SelectDimensionForChart(CensusChartNames chartName, string value)
@@ -114,6 +131,21 @@ public class BenchmarkCensusPage(IPage page)
     public async Task AreSaveAsImageButtonsDisplayed(bool isVisible = true)
     {
         var buttons = await SaveAsImageButtons.AllAsync();
+        if (isVisible)
+        {
+            Assert.Equal(8, buttons.Count);
+            await buttons.ShouldBeVisible();
+        }
+        else
+        {
+            Assert.Empty(buttons);
+            await buttons.ShouldNotBeVisible();
+        }
+    }
+
+    public async Task AreCopyImageButtonsDisplayed(bool isVisible = true)
+    {
+        var buttons = await CopyImageButtons.AllAsync();
         if (isVisible)
         {
             Assert.Equal(8, buttons.Count);

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/CompareYourCostsPage.cs
@@ -21,6 +21,7 @@ public class CompareYourCostsPage(IPage page)
 {
     private ILocator PageH1Heading => page.Locator(Selectors.H1);
     private ILocator SaveImageTotalExpenditure => page.Locator(Selectors.TotalExpenditureSaveAsImage);
+    private ILocator CopyImageTotalExpenditure => page.Locator(Selectors.TotalExpenditureCopyImage);
     private ILocator TotalExpenditureDimension => page.Locator(Selectors.TotalExpenditureDimension);
     private ILocator TotalExpenditureChart => page.Locator(Selectors.TotalExpenditureChart);
     private ILocator ViewAsTableRadio => page.Locator(Selectors.ModeTable);
@@ -50,6 +51,11 @@ public class CompareYourCostsPage(IPage page)
         {
             HasTextRegex = Regexes.SaveAsImageRegex()
         });
+    private ILocator CopyImageButtons =>
+        page.Locator(Selectors.Button, new PageLocatorOptions
+        {
+            HasTextRegex = Regexes.CopyImageRegex()
+        });
 
     private ILocator ChartBars => page.Locator(Selectors.ChartBars);
     private ILocator ChartTicks => page.Locator(Selectors.ChartYTicks);
@@ -60,6 +66,7 @@ public class CompareYourCostsPage(IPage page)
     {
         await PageH1Heading.ShouldBeVisible();
         await SaveImageTotalExpenditure.ShouldBeVisible();
+        await CopyImageTotalExpenditure.ShouldBeVisible();
         await TotalExpenditureDimension.ShouldBeVisible();
         await TotalExpenditureChart.ShouldBeVisible();
         await ShowHideAllSectionsLink.ShouldBeVisible();
@@ -75,6 +82,17 @@ public class CompareYourCostsPage(IPage page)
         var chartToDownload = chartName switch
         {
             ComparisonChartNames.TotalExpenditure => SaveImageTotalExpenditure,
+            _ => throw new ArgumentOutOfRangeException(nameof(chartName))
+        };
+
+        await chartToDownload.Click();
+    }
+
+    public async Task ClickCopyImage(ComparisonChartNames chartName)
+    {
+        var chartToDownload = chartName switch
+        {
+            ComparisonChartNames.TotalExpenditure => CopyImageTotalExpenditure,
             _ => throw new ArgumentOutOfRangeException(nameof(chartName))
         };
 
@@ -108,6 +126,21 @@ public class CompareYourCostsPage(IPage page)
         if (isVisible)
         {
             Assert.Equal(44, buttons.Count);
+            await buttons.ShouldBeVisible();
+        }
+        else
+        {
+            Assert.Empty(buttons);
+            await buttons.ShouldNotBeVisible();
+        }
+    }
+
+    public async Task AreCopyImageButtonsDisplayed(bool isVisible = true)
+    {
+        var buttons = await CopyImageButtons.AllAsync();
+        if (isVisible)
+        {
+            Assert.Equal(8, buttons.Count);
             await buttons.ShouldBeVisible();
         }
         else
@@ -202,6 +235,7 @@ public class CompareYourCostsPage(IPage page)
     {
         await TotalExpenditureDimension.FocusAsync();
         await page.Keyboard.PressAsync("Tab"); // save as image button
+        await page.Keyboard.PressAsync("Tab"); // copy image button
         await page.Keyboard.PressAsync("Tab"); // first trust
     }
 

--- a/web/tests/Web.E2ETests/Pages/School/BenchmarkCensusPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/BenchmarkCensusPage.cs
@@ -31,11 +31,18 @@ public class BenchmarkCensusPage(IPage page)
     private ILocator TotalTeachersTable => page.Locator(Selectors.Table).Nth(1);
     private ILocator Tables => page.Locator(Selectors.Table);
     private ILocator SaveImageSchoolWorkforce => page.Locator(Selectors.SchoolWorkforceSaveAsImage);
+    private ILocator CopyImageSchoolWorkforce => page.Locator(Selectors.SchoolWorkforceCopyImage);
 
     private ILocator SaveAsImageButtons =>
         page.Locator(Selectors.Button, new PageLocatorOptions
         {
             HasTextRegex = Regexes.SaveAsImageRegex()
+        });
+
+    private ILocator CopyImageButtons =>
+        page.Locator(Selectors.Button, new PageLocatorOptions
+        {
+            HasTextRegex = Regexes.CopyImageRegex()
         });
 
     private ILocator ComparatorSetDetails =>
@@ -75,6 +82,7 @@ public class BenchmarkCensusPage(IPage page)
             await CustomDataLink.ShouldBeVisible();
 
             await AreSaveAsImageButtonsDisplayed();
+            await AreCopyImageButtonsDisplayed();
             await AreChartsDisplayed();
             return;
         }
@@ -93,6 +101,17 @@ public class BenchmarkCensusPage(IPage page)
         };
 
         await chartToDownload.Click();
+    }
+
+    public async Task ClickCopyImage(CensusChartNames chartName)
+    {
+        var chartToCopy = chartName switch
+        {
+            CensusChartNames.SchoolWorkforce => CopyImageSchoolWorkforce,
+            _ => throw new ArgumentOutOfRangeException(nameof(chartName))
+        };
+
+        await chartToCopy.Click();
     }
 
     public async Task SelectDimensionForChart(CensusChartNames chartName, string value)
@@ -147,6 +166,21 @@ public class BenchmarkCensusPage(IPage page)
     public async Task AreSaveAsImageButtonsDisplayed(bool isVisible = true)
     {
         var buttons = await SaveAsImageButtons.AllAsync();
+        if (isVisible)
+        {
+            Assert.Equal(8, buttons.Count);
+            await buttons.ShouldBeVisible();
+        }
+        else
+        {
+            Assert.Empty(buttons);
+            await buttons.ShouldNotBeVisible();
+        }
+    }
+
+    public async Task AreCopyImageButtonsDisplayed(bool isVisible = true)
+    {
+        var buttons = await CopyImageButtons.AllAsync();
         if (isVisible)
         {
             Assert.Equal(8, buttons.Count);

--- a/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
@@ -23,6 +23,7 @@ public class CompareYourCostsPage(IPage page)
     private ILocator PageH1Heading => page.Locator(Selectors.H1);
     //private ILocator Breadcrumbs => page.Locator(Selectors.GovBreadcrumbs);
     private ILocator SaveImageTotalExpenditure => page.Locator(Selectors.TotalExpenditureSaveAsImage);
+    private ILocator CopyImageTotalExpenditure => page.Locator(Selectors.TotalExpenditureCopyImage);
     private ILocator TotalExpenditureDimension => page.Locator(Selectors.TotalExpenditureDimension);
     private ILocator TotalExpenditureChart => page.Locator(Selectors.TotalExpenditureChart);
     private ILocator ViewAsTableRadio => page.Locator(Selectors.ModeTable);
@@ -54,6 +55,12 @@ public class CompareYourCostsPage(IPage page)
         {
             HasTextRegex = Regexes.SaveAsImageRegex()
         });
+    private ILocator CopyImageButtons =>
+        page.Locator(Selectors.Button, new PageLocatorOptions
+        {
+            HasTextRegex = Regexes.CopyImageRegex()
+        });
+
     private ILocator ComparatorSetDetails =>
         page.Locator(Selectors.GovLink,
             new PageLocatorOptions
@@ -102,6 +109,7 @@ public class CompareYourCostsPage(IPage page)
         if (!isMissingComparatorSet)
         {
             await SaveImageTotalExpenditure.ShouldBeVisible();
+            await CopyImageTotalExpenditure.ShouldBeVisible();
             await TotalExpenditureDimension.ShouldBeVisible();
             await TotalExpenditureChart.ShouldBeVisible();
             await ShowHideAllSectionsLink.ShouldBeVisible();
@@ -127,6 +135,17 @@ public class CompareYourCostsPage(IPage page)
         var chartToDownload = chartName switch
         {
             ComparisonChartNames.TotalExpenditure => SaveImageTotalExpenditure,
+            _ => throw new ArgumentOutOfRangeException(nameof(chartName))
+        };
+
+        await chartToDownload.Click();
+    }
+
+    public async Task ClickCopyImage(ComparisonChartNames chartName)
+    {
+        var chartToDownload = chartName switch
+        {
+            ComparisonChartNames.TotalExpenditure => CopyImageTotalExpenditure,
             _ => throw new ArgumentOutOfRangeException(nameof(chartName))
         };
 
@@ -172,6 +191,21 @@ public class CompareYourCostsPage(IPage page)
         if (isVisible)
         {
             Assert.Equal(44, buttons.Count);
+            await buttons.ShouldBeVisible();
+        }
+        else
+        {
+            Assert.Empty(buttons);
+            await buttons.ShouldNotBeVisible();
+        }
+    }
+
+    public async Task AreCopyImageButtonsDisplayed(bool isVisible = true)
+    {
+        var buttons = await CopyImageButtons.AllAsync();
+        if (isVisible)
+        {
+            Assert.Equal(8, buttons.Count);
             await buttons.ShouldBeVisible();
         }
         else
@@ -261,6 +295,7 @@ public class CompareYourCostsPage(IPage page)
     {
         await TotalExpenditureDimension.FocusAsync();
         await page.Keyboard.PressAsync("Tab"); // save as image button
+        await page.Keyboard.PressAsync("Tab"); // copy image button
         await page.Keyboard.PressAsync("Tab"); // first school
     }
 

--- a/web/tests/Web.E2ETests/Pages/Trust/BenchmarkCensusPage.cs
+++ b/web/tests/Web.E2ETests/Pages/Trust/BenchmarkCensusPage.cs
@@ -30,10 +30,16 @@ public class BenchmarkCensusPage(IPage page)
     private ILocator TotalTeachersTable => page.Locator(Selectors.Table).Nth(1);
     private ILocator Tables => page.Locator(Selectors.Table);
     private ILocator SaveImageSchoolWorkforce => page.Locator(Selectors.SchoolWorkforceSaveAsImage);
+    private ILocator CopyImageSchoolWorkforce => page.Locator(Selectors.SchoolWorkforceCopyImage);
     private ILocator SaveAsImageButtons =>
         page.Locator(Selectors.Button, new PageLocatorOptions
         {
             HasTextRegex = Regexes.SaveAsImageRegex()
+        });
+    private ILocator CopyImageButtons =>
+        page.Locator(Selectors.Button, new PageLocatorOptions
+        {
+            HasTextRegex = Regexes.CopyImageRegex()
         });
 
     private ILocator ChartBars => page.Locator(Selectors.ChartBars);
@@ -60,6 +66,17 @@ public class BenchmarkCensusPage(IPage page)
         };
 
         await chartToDownload.Click();
+    }
+
+    public async Task ClickCopyImage(CensusChartNames chartName)
+    {
+        var chartToCopy = chartName switch
+        {
+            CensusChartNames.SchoolWorkforce => CopyImageSchoolWorkforce,
+            _ => throw new ArgumentOutOfRangeException(nameof(chartName))
+        };
+
+        await chartToCopy.Click();
     }
 
     public async Task SelectDimensionForChart(CensusChartNames chartName, string value)
@@ -114,6 +131,21 @@ public class BenchmarkCensusPage(IPage page)
     public async Task AreSaveAsImageButtonsDisplayed(bool isVisible = true)
     {
         var buttons = await SaveAsImageButtons.AllAsync();
+        if (isVisible)
+        {
+            Assert.Equal(8, buttons.Count);
+            await buttons.ShouldBeVisible();
+        }
+        else
+        {
+            Assert.Empty(buttons);
+            await buttons.ShouldNotBeVisible();
+        }
+    }
+
+    public async Task AreCopyImageButtonsDisplayed(bool isVisible = true)
+    {
+        var buttons = await CopyImageButtons.AllAsync();
         if (isVisible)
         {
             Assert.Equal(8, buttons.Count);

--- a/web/tests/Web.E2ETests/Pages/Trust/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/Trust/CompareYourCostsPage.cs
@@ -21,6 +21,7 @@ public class CompareYourCostsPage(IPage page)
 {
     private ILocator PageH1Heading => page.Locator(Selectors.H1);
     private ILocator SaveImageTotalExpenditure => page.Locator(Selectors.TotalExpenditureSaveAsImage);
+    private ILocator CopyImageTotalExpenditure => page.Locator(Selectors.TotalExpenditureCopyImage);
     private ILocator TotalExpenditureDimension => page.Locator(Selectors.TotalExpenditureDimension);
     private ILocator TotalExpenditureChart => page.Locator(Selectors.TotalExpenditureChart);
     private ILocator ViewAsTableRadio => page.Locator(Selectors.ModeTable);
@@ -50,6 +51,11 @@ public class CompareYourCostsPage(IPage page)
         {
             HasTextRegex = Regexes.SaveAsImageRegex()
         });
+    private ILocator CopyImageButtons =>
+        page.Locator(Selectors.Button, new PageLocatorOptions
+        {
+            HasTextRegex = Regexes.CopyImageRegex()
+        });
 
     private ILocator ChartBars => page.Locator(Selectors.ChartBars);
     private ILocator ChartTicks => page.Locator(Selectors.ChartYTicks);
@@ -60,6 +66,7 @@ public class CompareYourCostsPage(IPage page)
     {
         await PageH1Heading.ShouldBeVisible();
         await SaveImageTotalExpenditure.ShouldBeVisible();
+        await CopyImageTotalExpenditure.ShouldBeVisible();
         await TotalExpenditureDimension.ShouldBeVisible();
         await TotalExpenditureChart.ShouldBeVisible();
         await ShowHideAllSectionsLink.ShouldBeVisible();
@@ -75,6 +82,17 @@ public class CompareYourCostsPage(IPage page)
         var chartToDownload = chartName switch
         {
             ComparisonChartNames.TotalExpenditure => SaveImageTotalExpenditure,
+            _ => throw new ArgumentOutOfRangeException(nameof(chartName))
+        };
+
+        await chartToDownload.Click();
+    }
+
+    public async Task ClickCopyImage(ComparisonChartNames chartName)
+    {
+        var chartToDownload = chartName switch
+        {
+            ComparisonChartNames.TotalExpenditure => CopyImageTotalExpenditure,
             _ => throw new ArgumentOutOfRangeException(nameof(chartName))
         };
 
@@ -108,6 +126,21 @@ public class CompareYourCostsPage(IPage page)
         if (isVisible)
         {
             Assert.Equal(44, buttons.Count);
+            await buttons.ShouldBeVisible();
+        }
+        else
+        {
+            Assert.Empty(buttons);
+            await buttons.ShouldNotBeVisible();
+        }
+    }
+
+    public async Task AreCopyImageButtonsDisplayed(bool isVisible = true)
+    {
+        var buttons = await CopyImageButtons.AllAsync();
+        if (isVisible)
+        {
+            Assert.Equal(8, buttons.Count);
             await buttons.ShouldBeVisible();
         }
         else
@@ -202,6 +235,7 @@ public class CompareYourCostsPage(IPage page)
     {
         await TotalExpenditureDimension.FocusAsync();
         await page.Keyboard.PressAsync("Tab"); // save as image button
+        await page.Keyboard.PressAsync("Tab"); // copy image button
         await page.Keyboard.PressAsync("Tab"); // first trust
     }
 

--- a/web/tests/Web.E2ETests/Regexes.cs
+++ b/web/tests/Web.E2ETests/Regexes.cs
@@ -18,4 +18,7 @@ public static partial class Regexes
 
     [GeneratedRegex("Save.+as image")]
     public static partial Regex SaveAsImageRegex();
+
+    [GeneratedRegex("Copy.+ image")]
+    public static partial Regex CopyImageRegex();
 }

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -62,14 +62,16 @@ public static class Selectors
     public const string ComparisonChartsAndTables = "#compare-your-costs";
     public const string ComparisonTables = "#compare-your-costs table.govuk-table";
 
-    public const string TotalExpenditureSaveAsImage = "xpath=//*[@data-custom-event-chart-name='Total expenditure']";
+    public const string TotalExpenditureSaveAsImage = "xpath=//*[@data-custom-event-chart-name='Total expenditure'][@data-custom-event-id='save-chart-as-image']";
+    public const string TotalExpenditureCopyImage = "xpath=//*[@data-custom-event-chart-name='Total expenditure'][@data-custom-event-id='copy-chart-as-image']";
     public const string TotalExpenditureDimension = "#total-expenditure-dimension";
     public const string TotalExpenditureChart = "//*[@aria-label='Total expenditure']";
 
     public const string PremisesDimension = "#total-premises-staff-and-service-costs-dimension";
 
     public const string SchoolWorkforceDimension = "#school-workforce-full-time-equivalent-dimension";
-    public const string SchoolWorkforceSaveAsImage = "xpath=//*[@data-custom-event-chart-name='School workforce (Full Time Equivalent)']";
+    public const string SchoolWorkforceSaveAsImage = "xpath=//*[@data-custom-event-chart-name='School workforce (Full Time Equivalent)'][@data-custom-event-id='save-chart-as-image']";
+    public const string SchoolWorkforceCopyImage = "xpath=//*[@data-custom-event-chart-name='School workforce (Full Time Equivalent)'][@data-custom-event-id='copy-chart-as-image']";
 
     public const string TotalNumberOfTeacherDimension = "#total-number-of-teachers-full-time-equivalent-dimension";
     public const string SeniorLeadershipDimension = "#senior-leadership-full-time-equivalent-dimension";

--- a/web/tests/Web.E2ETests/Steps/LocalAuthority/BenchmarkCensusSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/LocalAuthority/BenchmarkCensusSteps.cs
@@ -40,6 +40,20 @@ public class BenchmarkCensusSteps(PageDriver driver)
         ChartDownloaded(chartName);
     }
 
+    [When("I click on copy image for '(.*)'")]
+    public async Task WhenIClickOnCopyImageFor(string chartName)
+    {
+        Assert.NotNull(_censusPage);
+        await _censusPage.ClickCopyImage(ChartNameFromFriendlyName(chartName));
+    }
+
+    [Then("the '(.*)' chart image is copied")]
+    public async Task ThenTheChartImageIsCopied(string chartName)
+    {
+        Assert.NotNull(_censusPage);
+        await ChartCopied(chartName);
+    }
+
     [When("I change '(.*)' dimension to '(.*)'")]
     public async Task WhenIChangeDimensionTo(string chartName, string value)
     {
@@ -76,6 +90,13 @@ public class BenchmarkCensusSteps(PageDriver driver)
         await _censusPage.AreSaveAsImageButtonsDisplayed(false);
     }
 
+    [Then("copy image buttons are hidden")]
+    public async Task ThenCopyImageButtonsAreHidden()
+    {
+        Assert.NotNull(_censusPage);
+        await _censusPage.AreCopyImageButtonsDisplayed(false);
+    }
+
     [Given("table view is selected")]
     [When("I click on view as table")]
     public async Task GivenTableViewIsSelected()
@@ -103,6 +124,13 @@ public class BenchmarkCensusSteps(PageDriver driver)
     {
         Assert.NotNull(_censusPage);
         await _censusPage.AreSaveAsImageButtonsDisplayed();
+    }
+
+    [Then("copy image buttons are displayed")]
+    public async Task ThenCopyImageButtonsAreDisplayed()
+    {
+        Assert.NotNull(_censusPage);
+        await _censusPage.AreCopyImageButtonsDisplayed();
     }
 
     [When("I click the dimension for '(.*)'")]
@@ -154,6 +182,15 @@ public class BenchmarkCensusSteps(PageDriver driver)
 
         var downloadedFilePath = _download.SuggestedFilename;
         Assert.Equal($"{downloadedFileName}.png", downloadedFilePath);
+    }
+
+    private async Task ChartCopied(string chartName)
+    {
+        const string exp = "navigator.clipboard.read()";
+        var page = await driver.Current;
+        var actual = await page.EvaluateAsync<object[]>(exp);
+        Assert.NotNull(actual);
+        Assert.Single(actual);
     }
 
     private static CensusChartNames ChartNameFromFriendlyName(string chartName)

--- a/web/tests/Web.E2ETests/Steps/LocalAuthority/CompareYourCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/LocalAuthority/CompareYourCostsSteps.cs
@@ -44,6 +44,20 @@ public class CompareYourCostsSteps(PageDriver driver)
         ChartDownloaded(chartName);
     }
 
+    [When("I click on copy image for '(.*)'")]
+    public async Task WhenIClickOnCopyImageFor(string chartName)
+    {
+        Assert.NotNull(_comparisonPage);
+        await _comparisonPage.ClickCopyImage(ChartNameFromFriendlyName(chartName));
+    }
+
+    [Then("the '(.*)' chart image is copied")]
+    public async Task ThenTheChartImageIsCopied(string chartName)
+    {
+        Assert.NotNull(_comparisonPage);
+        await ChartCopied(chartName);
+    }
+
     [Given("the '(.*)' dimension is '(.*)'")]
     [When("I change '(.*)' dimension to '(.*)'")]
     public async Task GivenTheDimensionIs(string chartName, string value)
@@ -87,6 +101,13 @@ public class CompareYourCostsSteps(PageDriver driver)
     {
         Assert.NotNull(_comparisonPage);
         await _comparisonPage.AreSaveAsImageButtonsDisplayed(false);
+    }
+
+    [Then("copy image buttons are hidden")]
+    public async Task ThenCopyImageButtonsAreHidden()
+    {
+        Assert.NotNull(_comparisonPage);
+        await _comparisonPage.AreCopyImageButtonsDisplayed(false);
     }
 
     [When("I click on show all sections")]
@@ -244,6 +265,15 @@ public class CompareYourCostsSteps(PageDriver driver)
 
         var downloadedFilePath = _download.SuggestedFilename;
         Assert.Equal($"{downloadedFileName}.png", downloadedFilePath);
+    }
+
+    private async Task ChartCopied(string chartName)
+    {
+        const string exp = "navigator.clipboard.read()";
+        var page = await driver.Current;
+        var actual = await page.EvaluateAsync<object[]>(exp);
+        Assert.NotNull(actual);
+        Assert.Single(actual);
     }
 
     private static ComparisonChartNames ChartNameFromFriendlyName(string chartName)

--- a/web/tests/Web.E2ETests/Steps/School/BenchmarkCensusSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/BenchmarkCensusSteps.cs
@@ -2,6 +2,7 @@ using Microsoft.Playwright;
 using Web.E2ETests.Drivers;
 using Web.E2ETests.Pages.School;
 using Xunit;
+
 namespace Web.E2ETests.Steps.School;
 
 [Binding]
@@ -45,6 +46,20 @@ public class BenchmarkCensusSteps(PageDriver driver)
         ChartDownloaded(chartName);
     }
 
+    [When("I click on copy image for '(.*)'")]
+    public async Task WhenIClickOnCopyImageFor(string chartName)
+    {
+        Assert.NotNull(_censusPage);
+        await _censusPage.ClickCopyImage(ChartNameFromFriendlyName(chartName));
+    }
+
+    [Then("the '(.*)' chart image is copied")]
+    public async Task ThenTheChartImageIsCopied(string chartName)
+    {
+        Assert.NotNull(_censusPage);
+        await ChartCopied(chartName);
+    }
+
     [When("I change '(.*)' dimension to '(.*)'")]
     public async Task WhenIChangeDimensionTo(string chartName, string value)
     {
@@ -81,6 +96,13 @@ public class BenchmarkCensusSteps(PageDriver driver)
         await _censusPage.AreSaveAsImageButtonsDisplayed(false);
     }
 
+    [Then("copy image buttons are hidden")]
+    public async Task ThenCopyImageButtonsAreHidden()
+    {
+        Assert.NotNull(_censusPage);
+        await _censusPage.AreCopyImageButtonsDisplayed(false);
+    }
+
     [Given("table view is selected")]
     [When("I click on view as table")]
     public async Task GivenTableViewIsSelected()
@@ -108,6 +130,13 @@ public class BenchmarkCensusSteps(PageDriver driver)
     {
         Assert.NotNull(_censusPage);
         await _censusPage.AreSaveAsImageButtonsDisplayed();
+    }
+
+    [Then("copy image buttons are displayed")]
+    public async Task ThenCopyImageButtonsAreDisplayed()
+    {
+        Assert.NotNull(_censusPage);
+        await _censusPage.AreCopyImageButtonsDisplayed();
     }
 
     [When("I click the dimension for '(.*)'")]
@@ -159,6 +188,15 @@ public class BenchmarkCensusSteps(PageDriver driver)
 
         var downloadedFilePath = _download.SuggestedFilename;
         Assert.Equal($"{downloadedFileName}.png", downloadedFilePath);
+    }
+
+    private async Task ChartCopied(string chartName)
+    {
+        const string exp = "navigator.clipboard.read()";
+        var page = await driver.Current;
+        var actual = await page.EvaluateAsync<object[]>(exp);
+        Assert.NotNull(actual);
+        Assert.Single(actual);
     }
 
     private static CensusChartNames ChartNameFromFriendlyName(string chartName)

--- a/web/tests/Web.E2ETests/Steps/School/CompareYourCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/CompareYourCostsSteps.cs
@@ -3,6 +3,7 @@ using Web.E2ETests.Drivers;
 using Web.E2ETests.Pages.School;
 using Web.E2ETests.Pages.School.Comparators;
 using Xunit;
+
 namespace Web.E2ETests.Steps.School;
 
 [Binding]
@@ -66,6 +67,20 @@ public class CompareYourCostsSteps(PageDriver driver)
         ChartDownloaded(chartName);
     }
 
+    [When("I click on copy image for '(.*)'")]
+    public async Task WhenIClickOnCopyImageFor(string chartName)
+    {
+        Assert.NotNull(_comparisonPage);
+        await _comparisonPage.ClickCopyImage(ChartNameFromFriendlyName(chartName));
+    }
+
+    [Then("the '(.*)' chart image is copied")]
+    public async Task ThenTheChartImageIsCopied(string chartName)
+    {
+        Assert.NotNull(_comparisonPage);
+        await ChartCopied(chartName);
+    }
+
     [Given("the '(.*)' dimension is '(.*)'")]
     [When("I change '(.*)' dimension to '(.*)'")]
     public async Task GivenTheDimensionIs(string chartName, string value)
@@ -110,6 +125,13 @@ public class CompareYourCostsSteps(PageDriver driver)
     {
         Assert.NotNull(_comparisonPage);
         await _comparisonPage.AreSaveAsImageButtonsDisplayed(false);
+    }
+
+    [Then("copy image buttons are hidden")]
+    public async Task ThenCopyImageButtonsAreHidden()
+    {
+        Assert.NotNull(_comparisonPage);
+        await _comparisonPage.AreCopyImageButtonsDisplayed(false);
     }
 
     [When("I click on show all sections")]
@@ -333,6 +355,15 @@ public class CompareYourCostsSteps(PageDriver driver)
 
         var downloadedFilePath = _download.SuggestedFilename;
         Assert.Equal($"{downloadedFileName}.png", downloadedFilePath);
+    }
+
+    private async Task ChartCopied(string chartName)
+    {
+        const string exp = "navigator.clipboard.read()";
+        var page = await driver.Current;
+        var actual = await page.EvaluateAsync<object[]>(exp);
+        Assert.NotNull(actual);
+        Assert.Single(actual);
     }
 
     private static ComparisonChartNames ChartNameFromFriendlyName(string chartName)

--- a/web/tests/Web.E2ETests/Steps/Trust/BenchmarkCensusSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/Trust/BenchmarkCensusSteps.cs
@@ -3,6 +3,7 @@ using Web.E2ETests.Drivers;
 using Web.E2ETests.Pages.Trust;
 using Xunit;
 using HomePage = Web.E2ETests.Pages.School.HomePage;
+
 namespace Web.E2ETests.Steps.Trust;
 
 [Binding]
@@ -37,6 +38,20 @@ public class BenchmarkCensusSteps(PageDriver driver)
     {
         Assert.NotNull(_censusPage);
         ChartDownloaded(chartName);
+    }
+
+    [When("I click on copy image for '(.*)'")]
+    public async Task WhenIClickOnCopyImageFor(string chartName)
+    {
+        Assert.NotNull(_censusPage);
+        await _censusPage.ClickCopyImage(ChartNameFromFriendlyName(chartName));
+    }
+
+    [Then("the '(.*)' chart image is copied")]
+    public async Task ThenTheChartImageIsCopied(string chartName)
+    {
+        Assert.NotNull(_censusPage);
+        await ChartCopied(chartName);
     }
 
     [When("I change '(.*)' dimension to '(.*)'")]
@@ -75,6 +90,13 @@ public class BenchmarkCensusSteps(PageDriver driver)
         await _censusPage.AreSaveAsImageButtonsDisplayed(false);
     }
 
+    [Then("copy image buttons are hidden")]
+    public async Task ThenCopyImageButtonsAreHidden()
+    {
+        Assert.NotNull(_censusPage);
+        await _censusPage.AreCopyImageButtonsDisplayed(false);
+    }
+
     [Given("table view is selected")]
     [When("I click on view as table")]
     public async Task GivenTableViewIsSelected()
@@ -102,6 +124,13 @@ public class BenchmarkCensusSteps(PageDriver driver)
     {
         Assert.NotNull(_censusPage);
         await _censusPage.AreSaveAsImageButtonsDisplayed();
+    }
+
+    [Then("copy image buttons are displayed")]
+    public async Task ThenCopyImageButtonsAreDisplayed()
+    {
+        Assert.NotNull(_censusPage);
+        await _censusPage.AreCopyImageButtonsDisplayed();
     }
 
     [When("I click the dimension for '(.*)'")]
@@ -153,6 +182,15 @@ public class BenchmarkCensusSteps(PageDriver driver)
 
         var downloadedFilePath = _download.SuggestedFilename;
         Assert.Equal($"{downloadedFileName}.png", downloadedFilePath);
+    }
+
+    private async Task ChartCopied(string chartName)
+    {
+        const string exp = "navigator.clipboard.read()";
+        var page = await driver.Current;
+        var actual = await page.EvaluateAsync<object[]>(exp);
+        Assert.NotNull(actual);
+        Assert.Single(actual);
     }
 
     private static CensusChartNames ChartNameFromFriendlyName(string chartName)

--- a/web/tests/Web.E2ETests/Steps/Trust/CompareYourCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/Trust/CompareYourCostsSteps.cs
@@ -1,9 +1,9 @@
 using Microsoft.Playwright;
-using Reqnroll;
 using Web.E2ETests.Drivers;
 using Web.E2ETests.Pages.Trust;
 using Xunit;
 using HomePage = Web.E2ETests.Pages.School.HomePage;
+
 namespace Web.E2ETests.Steps.Trust;
 
 [Binding]
@@ -42,6 +42,20 @@ public class CompareYourCostsSteps(PageDriver driver)
     {
         Assert.NotNull(_comparisonPage);
         ChartDownloaded(chartName);
+    }
+
+    [When("I click on copy image for '(.*)'")]
+    public async Task WhenIClickOnCopyImageFor(string chartName)
+    {
+        Assert.NotNull(_comparisonPage);
+        await _comparisonPage.ClickCopyImage(ChartNameFromFriendlyName(chartName));
+    }
+
+    [Then("the '(.*)' chart image is copied")]
+    public async Task ThenTheChartImageIsCopied(string chartName)
+    {
+        Assert.NotNull(_comparisonPage);
+        await ChartCopied(chartName);
     }
 
     [Given("the '(.*)' dimension is '(.*)'")]
@@ -87,6 +101,13 @@ public class CompareYourCostsSteps(PageDriver driver)
     {
         Assert.NotNull(_comparisonPage);
         await _comparisonPage.AreSaveAsImageButtonsDisplayed(false);
+    }
+
+    [Then("copy image buttons are hidden")]
+    public async Task ThenCopyImageButtonsAreHidden()
+    {
+        Assert.NotNull(_comparisonPage);
+        await _comparisonPage.AreCopyImageButtonsDisplayed(false);
     }
 
     [When("I click on show all sections")]
@@ -244,6 +265,15 @@ public class CompareYourCostsSteps(PageDriver driver)
 
         var downloadedFilePath = _download.SuggestedFilename;
         Assert.Equal($"{downloadedFileName}.png", downloadedFilePath);
+    }
+
+    private async Task ChartCopied(string chartName)
+    {
+        const string exp = "navigator.clipboard.read()";
+        var page = await driver.Current;
+        var actual = await page.EvaluateAsync<object[]>(exp);
+        Assert.NotNull(actual);
+        Assert.Single(actual);
     }
 
     private static ComparisonChartNames ChartNameFromFriendlyName(string chartName)

--- a/web/tests/Web.E2ETests/TestConfiguration.cs
+++ b/web/tests/Web.E2ETests/TestConfiguration.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Configuration;
+using Microsoft.Playwright;
 
 namespace Web.E2ETests;
 
@@ -17,4 +18,11 @@ public static class TestConfiguration
     public static string LoginPassword => Instance.GetValue<string>("Authentication:Password") ?? throw new Exception("Login password is missing");
     public static bool Headless => Instance.GetValue<bool?>("Headless") ?? true;
     public static bool OutputPageResponse => Instance.GetValue<bool?>("OutputPageResponse") ?? false;
+
+    /// <inheritdoc cref="IBrowserContext.GrantPermissionsAsync" />
+    public static string[] Permissions => Instance.GetSection("Permissions")
+        .GetChildren()
+        .Where(c => !string.IsNullOrWhiteSpace(c.Value))
+        .Select(c => c.Value!)
+        .ToArray();
 }

--- a/web/tests/Web.E2ETests/appsettings.json
+++ b/web/tests/Web.E2ETests/appsettings.json
@@ -4,5 +4,8 @@
   "Authentication": {
     "Username": "__dfe-signin-test-username__",
     "Password": "__dfe-signin-test-password__"
-  }
+  },
+  "Permissions": [
+    "clipboard-read"
+  ]
 }


### PR DESCRIPTION
### Context
AB#246835 AB#242101

### Change proposed in this pull request
Addition of 'copy' buttons to affected chart pages.

### Guidance to review 
A design crit will likely follow, especially around user feedback. Currently the button label briefly changes to <kbd>Copied</kbd> but this is open to discussion.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~


