### PR TITLE
Removed 'Copy' button from Census and History pages

### DIFF
--- a/front-end-components/src/components/charts/types.tsx
+++ b/front-end-components/src/components/charts/types.tsx
@@ -42,6 +42,7 @@ export interface ChartProps<TData extends ChartDataSeries>
   seriesLabel?: string;
   seriesLabelField: keyof TData;
   seriesFormatter?: (value: unknown) => string;
+  showCopyImageButton?: boolean;
   suffix?: string;
   tooltip?: ContentType<ValueType, NameType>;
   valueLabel?: string;

--- a/front-end-components/src/composed/dimensioned-chart/composed.tsx
+++ b/front-end-components/src/composed/dimensioned-chart/composed.tsx
@@ -19,7 +19,7 @@ export function DimensionedChart<
   hasNoData,
   options,
   topLevel,
-  trust,
+  ...props
 }: DimensionedChartProps<TData>) {
   const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
     event
@@ -45,11 +45,7 @@ export function DimensionedChart<
 
       return (
         <ChartDimensionContext.Provider key={chartId} value={dimension}>
-          <HorizontalBarChartWrapper
-            chartTitle={title}
-            data={data}
-            trust={trust}
-          >
+          <HorizontalBarChartWrapper chartTitle={title} data={data} {...props}>
             {topLevel ? (
               <h2 className="govuk-heading-m">{title}</h2>
             ) : (

--- a/front-end-components/src/composed/dimensioned-chart/types.tsx
+++ b/front-end-components/src/composed/dimensioned-chart/types.tsx
@@ -17,7 +17,10 @@ type DimensionedChart<TData extends SchoolChartData | TrustChartData> = Pick<
 
 export type DimensionedChartProps<
   TData extends SchoolChartData | TrustChartData,
-> = {
+> = Pick<
+  HorizontalBarChartWrapperProps<TData>,
+  "showCopyImageButton" | "trust"
+> & {
   charts: DimensionedChart<TData>[];
   dimension: Dimension;
   dimensions?: Dimension[];
@@ -25,5 +28,4 @@ export type DimensionedChartProps<
   hasNoData?: boolean;
   options?: ReactNode;
   topLevel?: boolean;
-  trust?: boolean;
 };

--- a/front-end-components/src/composed/historic-chart-2-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-2-composed/component.tsx
@@ -30,6 +30,7 @@ export function HistoricChart2<TData extends HistoryBase>({
   legendVerticalAlign,
   legendWrapperStyle,
   perUnitDimension,
+  showCopyImageButton,
   valueField,
   valueUnit,
 }: HistoricChart2Props<TData>) {
@@ -122,7 +123,7 @@ export function HistoricChart2<TData extends HistoryBase>({
               onSaveClick={() => chartRef.current?.download("save")}
               copyEventId="copy-chart-as-image"
               saveEventId="save-chart-as-image"
-              showCopy
+              showCopy={showCopyImageButton}
               showSave
               title={chartTitle}
             />

--- a/front-end-components/src/composed/historic-chart-2-composed/types.tsx
+++ b/front-end-components/src/composed/historic-chart-2-composed/types.tsx
@@ -17,6 +17,7 @@ export interface HistoricChart2Props<T extends HistoryBase>
     | "legendHorizontalAlign"
     | "legendVerticalAlign"
     | "legendWrapperStyle"
+    | "showCopyImageButton"
   > {
   chartTitle: string;
   data: SchoolHistoryComparison<T>;

--- a/front-end-components/src/composed/historic-chart-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/component.tsx
@@ -14,14 +14,15 @@ import { ChartDimensionContext, useChartModeContext } from "src/contexts";
 import { ShareContent } from "src/components/share-content";
 
 export function HistoricChart<TData extends ChartDataSeries>({
+  axisLabel,
   chartTitle,
+  children,
+  columnHeading,
   data,
   seriesConfig,
+  showCopyImageButton,
   valueField,
-  children,
   valueUnit,
-  axisLabel,
-  columnHeading,
 }: HistoricChartProps<TData>) {
   const { chartMode } = useChartModeContext();
   const dimension = useContext(ChartDimensionContext);
@@ -49,7 +50,7 @@ export function HistoricChart<TData extends ChartDataSeries>({
               onSaveClick={() => chartRef.current?.download("save")}
               copyEventId="copy-chart-as-image"
               saveEventId="save-chart-as-image"
-              showCopy
+              showCopy={showCopyImageButton}
               showSave
               title={chartTitle}
             />

--- a/front-end-components/src/composed/historic-chart-composed/types.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/types.tsx
@@ -5,8 +5,10 @@ import {
   ChartSeriesValueUnit,
 } from "src/components/charts/types";
 import { ResolvedStatProps } from "src/components/charts/resolved-stat";
+import { LineChartProps } from "src/components/charts/line-chart";
 
-export interface HistoricChartProps<T extends ChartDataSeries> {
+export interface HistoricChartProps<T extends ChartDataSeries>
+  extends Pick<LineChartProps<T>, "showCopyImageButton"> {
   chartTitle: string;
   data: T[];
   seriesConfig: ChartProps<T>["seriesConfig"];

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -38,7 +38,15 @@ import { ShareContent } from "src/components/share-content";
 export function HorizontalBarChartWrapper<
   TData extends SchoolChartData | TrustChartData,
 >(props: HorizontalBarChartWrapperProps<TData>) {
-  const { chartTitle, children, data, sort, trust, valueUnit } = props;
+  const {
+    chartTitle,
+    children,
+    data,
+    showCopyImageButton,
+    sort,
+    trust,
+    valueUnit,
+  } = props;
   const { chartMode } = useChartModeContext();
   const dimension = useContext(ChartDimensionContext);
   const selectedEstabishment = useContext(SelectedEstablishmentContext);
@@ -177,7 +185,7 @@ export function HorizontalBarChartWrapper<
               onSaveClick={() => chartRef.current?.download("save")}
               copyEventId="copy-chart-as-image"
               saveEventId="save-chart-as-image"
-              showCopy
+              showCopy={showCopyImageButton}
               showSave
               title={chartTitle}
             />

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/types.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/types.tsx
@@ -6,7 +6,10 @@ import {
 
 export type HorizontalBarChartWrapperProps<
   TData extends SchoolChartData | TrustChartData,
-> = Pick<ChartProps<TData>, "chartTitle" | "valueUnit"> & {
+> = Pick<
+  ChartProps<TData>,
+  "chartTitle" | "showCopyImageButton" | "valueUnit"
+> & {
   children?: React.ReactNode[] | React.ReactNode;
   data: HorizontalBarChartWrapperPropsData<TData>;
   sort?: ChartDataSeriesSortMode<TData>;

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/administrative-supplies.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/administrative-supplies.tsx
@@ -86,6 +86,7 @@ export const AdministrativeSupplies: React.FC<CompareYourCostsProps> = ({
       handleDimensionChange={handleDimensionChange}
       hasNoData={data?.length === 0}
       index={7}
+      showCopyImageButton
       title="Administrative supplies"
     />
   );

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
@@ -154,6 +154,7 @@ export const CateringStaffServices: React.FC<CompareYourCostsProps> = ({
           </div>
         </div>
       }
+      showCopyImageButton
       title="Catering staff and supplies"
     />
   );

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-ict.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-ict.tsx
@@ -81,6 +81,7 @@ export const EducationalIct: React.FC<CompareYourCostsProps> = ({
       handleDimensionChange={handleDimensionChange}
       hasNoData={data?.length === 0}
       index={4}
+      showCopyImageButton
       title="Educational ICT"
     />
   );

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-supplies.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-supplies.tsx
@@ -120,6 +120,7 @@ export const EducationalSupplies: React.FC<CompareYourCostsProps> = ({
       handleDimensionChange={handleDimensionChange}
       hasNoData={data?.length === 0}
       index={3}
+      showCopyImageButton
       title="Educational supplies"
     />
   );

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/non-educational-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/non-educational-support-staff.tsx
@@ -161,6 +161,7 @@ export const NonEducationalSupportStaff: React.FC<CompareYourCostsProps> = ({
       handleDimensionChange={handleDimensionChange}
       hasNoData={data?.length === 0}
       index={2}
+      showCopyImageButton
       title="Non-educational support staff and services"
     />
   );

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/other-costs.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/other-costs.tsx
@@ -306,6 +306,7 @@ export const OtherCosts: React.FC<CompareYourCostsProps> = ({ type, id }) => {
       handleDimensionChange={handleDimensionChange}
       hasNoData={data?.length === 0}
       index={9}
+      showCopyImageButton
       title="Other costs"
     />
   );

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
@@ -148,6 +148,7 @@ export const PremisesStaffServices: React.FC<CompareYourCostsProps> = ({
       handleDimensionChange={handleDimensionChange}
       hasNoData={data?.length === 0}
       index={5}
+      showCopyImageButton
       title="Premises staff and services"
     />
   );

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/teaching-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/teaching-support-staff.tsx
@@ -174,6 +174,7 @@ export const TeachingSupportStaff: React.FC<CompareYourCostsProps> = ({
       handleDimensionChange={handleDimensionChange}
       hasNoData={data?.length === 0}
       index={1}
+      showCopyImageButton
       title="Teaching and teaching support staff"
     />
   );

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/utilities.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/utilities.tsx
@@ -114,6 +114,7 @@ export const Utilities: React.FC<CompareYourCostsProps> = ({ type, id }) => {
       handleDimensionChange={handleDimensionChange}
       hasNoData={data?.length === 0}
       index={6}
+      showCopyImageButton
       title="Utilities"
     />
   );

--- a/front-end-components/src/views/compare-your-costs/partials/total-expenditure.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/total-expenditure.tsx
@@ -80,6 +80,7 @@ export const TotalExpenditure: React.FC<CompareYourCostsProps> = ({
       })}
       handleDimensionChange={handleDimensionChange}
       hasNoData={data?.length === 0}
+      showCopyImageButton
       topLevel
     />
   );

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/administrative-supplies.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/administrative-supplies.tsx
@@ -83,6 +83,7 @@ export const AdministrativeSupplies: React.FC<{
       handleDimensionChange={handleDimensionChange}
       hasNoData={data?.length === 0}
       index={7}
+      showCopyImageButton
       title="Administrative supplies"
       trust
     />

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/catering-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/catering-staff-services.tsx
@@ -165,6 +165,7 @@ export const CateringStaffServices: React.FC<{
           </div>
         </div>
       }
+      showCopyImageButton
       title="Catering staff and supplies"
       trust
     />

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-ict.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-ict.tsx
@@ -76,6 +76,7 @@ export const EducationalIct: React.FC<{
       handleDimensionChange={handleDimensionChange}
       hasNoData={data?.length === 0}
       index={4}
+      showCopyImageButton
       title="Educational ICT"
       trust
     />

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-supplies.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-supplies.tsx
@@ -128,6 +128,7 @@ export const EducationalSupplies: React.FC<{
       handleDimensionChange={handleDimensionChange}
       hasNoData={data?.length === 0}
       index={3}
+      showCopyImageButton
       title="Educational supplies"
       trust
     />

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/non-educational-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/non-educational-support-staff.tsx
@@ -178,6 +178,7 @@ export const NonEducationalSupportStaff: React.FC<{
       handleDimensionChange={handleDimensionChange}
       hasNoData={data?.length === 0}
       index={2}
+      showCopyImageButton
       title="Non-educational support staff and services"
       trust
     />

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/other-costs.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/other-costs.tsx
@@ -313,6 +313,7 @@ export const OtherCosts: React.FC<{
       handleDimensionChange={handleDimensionChange}
       hasNoData={data?.length === 0}
       index={9}
+      showCopyImageButton
       title="Other costs"
       trust
     />

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/premises-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/premises-staff-services.tsx
@@ -164,6 +164,7 @@ export const PremisesStaffServices: React.FC<{
       handleDimensionChange={handleDimensionChange}
       hasNoData={data?.length === 0}
       index={5}
+      showCopyImageButton
       title="Premises staff and services"
       trust
     />

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/teaching-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/teaching-support-staff.tsx
@@ -194,6 +194,7 @@ export const TeachingSupportStaff: React.FC<{ id: string }> = ({ id }) => {
       handleDimensionChange={handleDimensionChange}
       hasNoData={data?.length === 0}
       index={1}
+      showCopyImageButton
       title="Teaching and teaching support staff"
       trust
     />

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/utilities.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/utilities.tsx
@@ -120,6 +120,7 @@ export const Utilities: React.FC<{
       handleDimensionChange={handleDimensionChange}
       hasNoData={data?.length === 0}
       index={6}
+      showCopyImageButton
       title="Utilities"
       trust
     />

--- a/front-end-components/src/views/compare-your-trust/partials/balance.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/balance.tsx
@@ -87,6 +87,7 @@ export const Balance: React.FC<{
       dimension={dimension}
       dimensions={CostCategories}
       handleDimensionChange={handleDimensionChange}
+      showCopyImageButton
       topLevel
       trust
     />

--- a/front-end-components/src/views/compare-your-trust/partials/total-expenditure.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/total-expenditure.tsx
@@ -76,6 +76,7 @@ export const TotalExpenditure: React.FC<{
         return category !== PercentageExpenditure;
       })}
       handleDimensionChange={handleDimensionChange}
+      showCopyImageButton
       topLevel
       trust
     />

--- a/web/tests/Web.E2ETests/Features/LocalAuthority/BenchmarkCensus.feature
+++ b/web/tests/Web.E2ETests/Features/LocalAuthority/BenchmarkCensus.feature
@@ -9,11 +9,6 @@
         When I click on save as image for 'school workforce'
         Then the 'school workforce' chart image is downloaded
 
-    Scenario: Copy school workforce chart
-        Given I am on census page for local authority with code '201'
-        When I click on copy image for 'school workforce'
-        Then the 'school workforce' chart image is copied
-
     Scenario: Change dimension of school workforce
         Given I am on census page for local authority with code '201'
         When I change 'school workforce' dimension to 'pupils per staff role'
@@ -46,7 +41,6 @@
         When I click on view as chart
         Then chart view is showing
         And save as image buttons are displayed
-        And copy image buttons are displayed
 
     Scenario Outline: Checking the charts dimension dropdown items
         Given I am on census page for local authority with code '201'

--- a/web/tests/Web.E2ETests/Features/School/BenchmarkCensus.feature
+++ b/web/tests/Web.E2ETests/Features/School/BenchmarkCensus.feature
@@ -9,11 +9,6 @@
         When I click on save as image for 'school workforce'
         Then the 'school workforce' chart image is downloaded
 
-    Scenario: Copy school workforce chart
-        Given I am on census page for school with URN '777042'
-        When I click on copy image for 'school workforce'
-        Then the 'school workforce' chart image is copied
-
     Scenario: Change dimension of school workforce
         Given I am on census page for school with URN '777042'
         When I change 'school workforce' dimension to 'pupils per staff role'
@@ -46,7 +41,6 @@
         When I click on view as chart
         Then chart view is showing
         And save as image buttons are displayed
-        And copy image buttons are displayed
 
     Scenario Outline: Checking the charts dimension dropdown items
         Given I am on census page for school with URN '777042'

--- a/web/tests/Web.E2ETests/Features/Trust/BenchmarkCensus.feature
+++ b/web/tests/Web.E2ETests/Features/Trust/BenchmarkCensus.feature
@@ -9,11 +9,6 @@
         When I click on save as image for 'school workforce'
         Then the 'school workforce' chart image is downloaded
 
-    Scenario: Copy school workforce chart
-        Given I am on census page for trust with company number '8104190'
-        When I click on copy image for 'school workforce'
-        Then the 'school workforce' chart image is copied
-
     Scenario: Change dimension of school workforce
         Given I am on census page for trust with company number '8104190'
         When I change 'school workforce' dimension to 'pupils per staff role'
@@ -46,7 +41,6 @@
         When I click on view as chart
         Then chart view is showing
         And save as image buttons are displayed
-        And copy image buttons are displayed
 
     Scenario Outline: Checking the charts dimension dropdown items
         Given I am on census page for trust with company number '8104190'

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/BenchmarkCensusPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/BenchmarkCensusPage.cs
@@ -54,6 +54,7 @@ public class BenchmarkCensusPage(IPage page)
         await ViewAsChartRadio.ShouldBeVisible().ShouldBeChecked();
 
         await AreSaveAsImageButtonsDisplayed();
+        await AreCopyImageButtonsDisplayed(false);
         await AreChartsDisplayed();
     }
 

--- a/web/tests/Web.E2ETests/Pages/School/BenchmarkCensusPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/BenchmarkCensusPage.cs
@@ -82,7 +82,7 @@ public class BenchmarkCensusPage(IPage page)
             await CustomDataLink.ShouldBeVisible();
 
             await AreSaveAsImageButtonsDisplayed();
-            await AreCopyImageButtonsDisplayed();
+            await AreCopyImageButtonsDisplayed(false);
             await AreChartsDisplayed();
             return;
         }

--- a/web/tests/Web.E2ETests/Pages/Trust/BenchmarkCensusPage.cs
+++ b/web/tests/Web.E2ETests/Pages/Trust/BenchmarkCensusPage.cs
@@ -54,6 +54,7 @@ public class BenchmarkCensusPage(IPage page)
         await ViewAsChartRadio.ShouldBeVisible().ShouldBeChecked();
 
         await AreSaveAsImageButtonsDisplayed();
+        await AreCopyImageButtonsDisplayed(false);
         await AreChartsDisplayed();
     }
 


### PR DESCRIPTION
### Context
[AB#246997](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/246997) [AB#242101](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/242101)

### Change proposed in this pull request
Benchmark Census and School History pages were not included in the requirements for having the 'Copy' button present and so they have been removed.

### Guidance to review 
See work item for original context.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

