### PR TITLE
chore: update e2e tests for historic data save as image

### DIFF
--- a/web/tests/Web.E2ETests/Pages/School/HistoricDataPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/HistoricDataPage.cs
@@ -187,6 +187,10 @@ public class HistoricDataPage(IPage page)
     private ILocator BalanceChartsStats => BalanceTabContent.Locator(Selectors.LineChartStats);
     private ILocator AllCensusCharts => CensusTabContent.Locator(Selectors.Charts);
     private ILocator CensusChartsStats => CensusTabContent.Locator(Selectors.LineChartStats);
+    private ILocator SaveImageTotalExpenditure => page.Locator(Selectors.TotalExpenditureSaveAsImage);
+    private ILocator SaveImageTotalIncome => page.Locator(Selectors.TotalIncomeSaveAsImage);
+    private ILocator SaveImageInYearBalance => page.Locator(Selectors.InYearBalanceSaveAsImage);
+    private ILocator SaveImagePupilsOnRoll => page.Locator(Selectors.PupilsOnRollSaveAsImage);
 
     public async Task IsDisplayed(HistoryTabs? tab = null)
     {
@@ -210,6 +214,7 @@ public class HistoricDataPage(IPage page)
                 await SpendingChartsStats.First.ShouldBeVisible();
                 await AssertCategoryNames(_spendingCategories, selectedTab);
                 await ExpenditureDimension.ShouldHaveSelectedOption("actuals");
+                await SaveImageTotalExpenditure.ShouldBeVisible();
                 break;
             case HistoryTabs.Income:
                 await IncomeDimension.ShouldBeVisible();
@@ -226,6 +231,7 @@ public class HistoricDataPage(IPage page)
                 await AllIncomeCharts.First.ShouldBeVisible();
                 await IncomeChartsStats.First.ShouldBeVisible();
                 await AssertCategoryNames(_incomeCategories, selectedTab);
+                await SaveImageTotalIncome.ShouldBeVisible();
                 break;
             case HistoryTabs.Balance:
                 await BalanceDimension.ShouldBeVisible();
@@ -241,6 +247,7 @@ public class HistoricDataPage(IPage page)
                 await AreChartStatsVisible(selectedTab);
                 await AreChartsVisible(selectedTab);
                 await AssertCategoryNames(_balanceCategories, selectedTab);
+                await SaveImageInYearBalance.ShouldBeVisible();
                 break;
             case HistoryTabs.Census:
                 await CensusDimension.ShouldBeVisible();
@@ -256,6 +263,7 @@ public class HistoricDataPage(IPage page)
                 await AreChartStatsVisible(selectedTab);
                 await AreChartsVisible(selectedTab);
                 await AssertCategoryNames(_censusCategories, selectedTab);
+                await SaveImagePupilsOnRoll.ShouldBeVisible();
                 break;
         }
     }

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -177,4 +177,8 @@ public static class Selectors
     public const string AccordionSchoolContent = "#accordion-schools-content-";
     public const string ForecastRisksDimension = "#year-end-reserves-dimension";
     public const string EducationIctSpendingCosts = "#spending-priorities-educational-ict";
+    
+    public const string TotalIncomeSaveAsImage = "xpath=//*[@data-custom-event-chart-name='Total income'][@data-custom-event-id='save-chart-as-image']";
+    public const string InYearBalanceSaveAsImage = "xpath=//*[@data-custom-event-chart-name='In-year balance'][@data-custom-event-id='save-chart-as-image']";
+    public const string PupilsOnRollSaveAsImage = "xpath=//*[@data-custom-event-chart-name='Pupils on roll'][@data-custom-event-id='save-chart-as-image']";
 }


### PR DESCRIPTION
### Context
[AB#244349](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/244349) - [AB#245861](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/245861)

### Change proposed in this pull request
Amends e2e tests for historic data page to confirm behaviour of new save chart as image functionality

### Guidance to review 
`isDisplayed()` has previously been updated for the spending priorities page - see #1809 

### Checklist (add/remove as appropriate)
- [ ] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally
