### PR TITLE
E2E tests for 'Save all chart images' button and modal

### DIFF
--- a/front-end-components/src/components/modals/modal/component.tsx
+++ b/front-end-components/src/components/modals/modal/component.tsx
@@ -111,7 +111,7 @@ function ModalInner(
           <div className="govuk-button-group">
             {ok && (
               <button
-                className="govuk-button"
+                className="govuk-button govuk-button--ok"
                 data-module="govuk-button"
                 data-prevent-double-click="true"
                 onClick={onOK}
@@ -123,7 +123,7 @@ function ModalInner(
             )}
             {cancel && (
               <button
-                className="govuk-button govuk-button--secondary"
+                className="govuk-button govuk-button--secondary govuk-button--cancel"
                 data-module="govuk-button"
                 onClick={() => (onCancel ? onCancel() : onClose())}
               >
@@ -132,8 +132,8 @@ function ModalInner(
             )}
           </div>
           <button
-            className="govuk-button govuk-button--secondary govuk-button--close"
             aria-label="Close modal dialog"
+            className="govuk-button govuk-button--secondary govuk-button--close"
             data-module="govuk-button"
             onClick={onClose}
           >

--- a/web/tests/Web.E2ETests/Extensions/LocatorExtensions.cs
+++ b/web/tests/Web.E2ETests/Extensions/LocatorExtensions.cs
@@ -78,6 +78,12 @@ public static class LocatorExtensions
         return locator;
     }
 
+    public static async Task<ILocator> ShouldBeDisabled(this ILocator locator)
+    {
+        await Assertions.Expect(locator).ToBeDisabledAsync();
+        return locator;
+    }
+
     public static async Task<ILocator> ShouldHaveTableContent(this ILocator locator, List<List<string>> expectedData,
         bool includeHeaderRow)
     {

--- a/web/tests/Web.E2ETests/Features/SaveAllImagesModal.feature
+++ b/web/tests/Web.E2ETests/Features/SaveAllImagesModal.feature
@@ -1,0 +1,35 @@
+﻿Feature: Save all images modal
+
+    Scenario: Save all chart images button opens modal
+        Given I am on spending and costs page for school with URN '777042'
+        Then the save all images button is visible
+        When I click the save all images button
+        Then the save all images modal is visible
+        And the start button is enabled
+        And the cancel button is visible
+        And the close button is visible
+
+    Scenario: Cancel closes modal
+        Given I am on spending and costs page for school with URN '777042'
+        When I click the save all images button
+        And I click the cancel button
+        Then the save all images modal is not visible
+
+    Scenario: Close closes modal
+        Given I am on spending and costs page for school with URN '777042'
+        When I click the save all images button
+        And I click the close button
+        Then the save all images modal is not visible
+
+    Scenario: Esc key closes modal
+        Given I am on spending and costs page for school with URN '777042'
+        When I click the save all images button
+        And I press the Escape key
+        Then the save all images modal is not visible
+
+    Scenario: Start begins download
+        Given I am on spending and costs page for school with URN '777042'
+        When I click the save all images button
+        And I click the start button
+        Then the start button is disabled
+        And the 'spending-priorities-777042.zip' file is downloaded

--- a/web/tests/Web.E2ETests/Features/School/CompareYourCosts.feature
+++ b/web/tests/Web.E2ETests/Features/School/CompareYourCosts.feature
@@ -55,6 +55,7 @@ Feature: School compare your costs
           | Test academy school 333 | Hampshire               | Free schools alternative provision | 190              | £1,179,475  |
         But save as image buttons are hidden
         And copy image buttons are hidden
+        And the save all images button is visible
 
     Scenario: Table view for total expenditure for school(s) with part-year data
         Given I am on compare your costs page for school with URN '777045'
@@ -111,6 +112,7 @@ Feature: School compare your costs
         And are showing table view
         But save as image buttons are hidden
         And copy image buttons are hidden
+        And the save all images button is visible
 
     Scenario: Hide single section
         Given I am on compare your costs page for school with URN '777042'
@@ -264,3 +266,9 @@ Feature: School compare your costs
     Scenario: Charts have correct dimension options
         Given I am on compare your costs page for school with URN '777042'
         Then all sections on the page have the correct dimension options
+
+    Scenario: Save all chart images button opens modal
+        Given I am on compare your costs page for school with URN '777042'
+        Then the save all images button is visible
+        When I click the save all images button
+        Then the save all images modal is visible

--- a/web/tests/Web.E2ETests/Features/School/SpendingCosts.feature
+++ b/web/tests/Web.E2ETests/Features/School/SpendingCosts.feature
@@ -121,3 +121,9 @@
           | Similar schools spend | £67 per pupil, on average |
           | This school spends    | £30(44.2%) less per pupil |
         And the message stating reason for less schools is visible for 'Educational ICT'
+
+    Scenario: Save all chart images button opens modal
+        Given I am on spending and costs page for school with URN '777042'
+        Then the save all images button is visible
+        When I click the save all images button
+        Then the save all images modal is visible

--- a/web/tests/Web.E2ETests/Features/Trust/CompareYourCosts.feature
+++ b/web/tests/Web.E2ETests/Features/Trust/CompareYourCosts.feature
@@ -27,6 +27,7 @@ Feature: Trust compare your costs
           | Test academy school 392 | Trafford        | Academy special converter   | 204              | £1,424,986 |
         But save as image buttons are hidden
         And copy image buttons are hidden
+        And the save all images button is visible
 
     Scenario: Table view for total expenditure for trust(s) with part-year data
         Given I am on compare your costs page for trust with company number '8104190'
@@ -55,6 +56,7 @@ Feature: Trust compare your costs
         And are showing table view
         But save as image buttons are hidden
         And copy image buttons are hidden
+        And the save all images button is visible
 
     Scenario: Hide single section
         Given I am on compare your costs page for trust with company number '10074054'
@@ -130,3 +132,9 @@ Feature: Trust compare your costs
     Scenario: Charts have correct dimension options
         Given I am on compare your costs page for trust with company number '10074054'
         Then all sections on the page have the correct dimension options
+
+    Scenario: Save all chart images button opens modal
+        Given I am on compare your costs page for trust with company number '10074054'
+        Then the save all images button is visible
+        When I click the save all images button
+        Then the save all images modal is visible

--- a/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
@@ -68,6 +68,16 @@ public class CompareYourCostsPage(IPage page)
         {
             HasTextRegex = Regexes.CopyImageRegex()
         });
+    private ILocator SaveAllImagesButton =>
+        page.Locator(Selectors.Button, new PageLocatorOptions
+        {
+            HasText = "Save all chart images"
+        });
+    private ILocator SaveAllImagesModal =>
+        page.Locator(Selectors.Modal, new PageLocatorOptions
+        {
+            HasText = "Save all chart images"
+        });
 
     private ILocator ComparatorSetDetails =>
         page.Locator(Selectors.GovLink,
@@ -450,6 +460,21 @@ public class CompareYourCostsPage(IPage page)
                 "percentage of expenditure",
                 "percentage of income"
         ]);
+    }
+
+    public async Task IsSaveAllImagesButtonDisplayed()
+    {
+        await SaveAllImagesButton.ShouldBeVisible();
+    }
+
+    public async Task ClickSaveAllImagesButton()
+    {
+        await SaveAllImagesButton.ClickAsync();
+    }
+
+    public async Task IsSaveAllImagesModalDisplayed()
+    {
+        await SaveAllImagesModal.ShouldBeVisible();
     }
 
     private ILocator SectionLink(ComparisonChartNames chartName)

--- a/web/tests/Web.E2ETests/Pages/School/SpendingCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/SpendingCostsPage.cs
@@ -102,6 +102,17 @@ public class SpendingCostsPage(IPage page)
     private ILocator SaveImageTeachingAndTeachingSupportStaff => page.Locator(Selectors.TeachingAndTeachingSupportStaffSaveAsImage);
     private ILocator CopyImageTeachingAndTeachingSupportStaff => page.Locator(Selectors.TeachingAndTeachingSupportStaffCopyImage);
     private ILocator SaveAllChartImagesButton => page.Locator(Selectors.SaveAllChartImages);
+
+    private ILocator SaveAllImagesButton =>
+        page.Locator(Selectors.Button, new PageLocatorOptions
+        {
+            HasText = "Save all chart images"
+        });
+    private ILocator SaveAllImagesModal =>
+        page.Locator(Selectors.Modal, new PageLocatorOptions
+        {
+            HasText = "Save all chart images"
+        });
     private ILocator ChartStatsSummary(ILocator chart) => chart.Locator(".chart-stat-summary");
 
     public async Task IsDisplayed()
@@ -221,6 +232,21 @@ public class SpendingCostsPage(IPage page)
             _ => throw new ArgumentOutOfRangeException(nameof(categoryName))
         };
         await warningMessage.ShouldBeVisible();
+    }
+
+    public async Task IsSaveAllImagesButtonDisplayed()
+    {
+        await SaveAllImagesButton.ShouldBeVisible();
+    }
+
+    public async Task ClickSaveAllImagesButton()
+    {
+        await SaveAllImagesButton.ClickAsync();
+    }
+
+    public async Task IsSaveAllImagesModalDisplayed()
+    {
+        await SaveAllImagesModal.ShouldBeVisible();
     }
 
     private async Task<List<(string Description, string Value)>> GetCostCategoryData(CostCategoryNames costCategory)

--- a/web/tests/Web.E2ETests/Pages/School/SpendingCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/SpendingCostsPage.cs
@@ -16,7 +16,7 @@ public enum CostCategoryNames
     Utilities
 }
 
-public class SpendingCostsPage(IPage page)
+public partial class SpendingCostsPage(IPage page)
 {
     private readonly string[] _h3Names =
     [
@@ -105,11 +105,6 @@ public class SpendingCostsPage(IPage page)
 
     private ILocator SaveAllImagesButton =>
         page.Locator(Selectors.Button, new PageLocatorOptions
-        {
-            HasText = "Save all chart images"
-        });
-    private ILocator SaveAllImagesModal =>
-        page.Locator(Selectors.Modal, new PageLocatorOptions
         {
             HasText = "Save all chart images"
         });
@@ -242,11 +237,6 @@ public class SpendingCostsPage(IPage page)
     public async Task ClickSaveAllImagesButton()
     {
         await SaveAllImagesButton.ClickAsync();
-    }
-
-    public async Task IsSaveAllImagesModalDisplayed()
-    {
-        await SaveAllImagesModal.ShouldBeVisible();
     }
 
     private async Task<List<(string Description, string Value)>> GetCostCategoryData(CostCategoryNames costCategory)

--- a/web/tests/Web.E2ETests/Pages/School/SpendingCostsPageModal.cs
+++ b/web/tests/Web.E2ETests/Pages/School/SpendingCostsPageModal.cs
@@ -1,0 +1,78 @@
+using Microsoft.Playwright;
+
+namespace Web.E2ETests.Pages.School;
+
+public partial class SpendingCostsPage
+{
+    private ILocator SaveAllImagesModal =>
+        page.Locator(Selectors.Modal, new PageLocatorOptions
+        {
+            HasText = "Save all chart images"
+        });
+
+    private ILocator SaveAllImagesModalOkButton => page.Locator($"{Selectors.ModalButton}.govuk-button--ok");
+    private ILocator SaveAllImagesModalCancelButton => page.Locator($"{Selectors.ModalButton}.govuk-button--cancel");
+    private ILocator SaveAllImagesModalCloseButton => page.Locator($"{Selectors.ModalButton}.govuk-button--close");
+
+    public async Task IsSaveAllImagesModalDisplayed(bool visible)
+    {
+        if (visible)
+        {
+            await SaveAllImagesModal.ShouldBeVisible();
+        }
+        else
+        {
+            await SaveAllImagesModal.ShouldNotBeVisible();
+        }
+    }
+
+    public async Task IsSaveAllImagesModalStartButtonEnabled(bool enabled)
+    {
+        await SaveAllImagesModalOkButton.ShouldHaveText("Start");
+        await SaveAllImagesModalOkButton.ShouldBeVisible();
+
+        if (enabled)
+        {
+            await SaveAllImagesModalOkButton.ShouldBeEnabled();
+        }
+        else
+        {
+            await SaveAllImagesModalOkButton.ShouldBeDisabled();
+        }
+    }
+
+    public async Task IsSaveAllImagesModalCancelButtonVisible()
+    {
+        await SaveAllImagesModalCancelButton.ShouldHaveText("Cancel");
+        await SaveAllImagesModalCancelButton.ShouldBeVisible();
+        await SaveAllImagesModalCancelButton.ShouldBeEnabled();
+    }
+
+    public async Task IsSaveAllImagesModalCloseButtonVisible()
+    {
+        await SaveAllImagesModalCloseButton.ShouldHaveText("\u00d7");
+        await SaveAllImagesModalCloseButton.ShouldHaveAttribute("aria-label", "Close modal dialog");
+        await SaveAllImagesModalCloseButton.ShouldBeVisible();
+        await SaveAllImagesModalCloseButton.ShouldBeEnabled();
+    }
+
+    public async Task ClickSaveAllImagesModalOkButton()
+    {
+        await SaveAllImagesModalOkButton.ClickAsync();
+    }
+
+    public async Task ClickSaveAllImagesModalCancelButton()
+    {
+        await SaveAllImagesModalCancelButton.ClickAsync();
+    }
+
+    public async Task ClickSaveAllImagesModalCloseButton()
+    {
+        await SaveAllImagesModalCloseButton.ClickAsync();
+    }
+
+    public async Task PressEscapeKey()
+    {
+        await page.Keyboard.PressAsync("Escape");
+    }
+}

--- a/web/tests/Web.E2ETests/Pages/Trust/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/Trust/CompareYourCostsPage.cs
@@ -64,6 +64,16 @@ public class CompareYourCostsPage(IPage page)
         {
             HasTextRegex = Regexes.CopyImageRegex()
         });
+    private ILocator SaveAllImagesButton =>
+        page.Locator(Selectors.Button, new PageLocatorOptions
+        {
+            HasText = "Save all chart images"
+        });
+    private ILocator SaveAllImagesModal =>
+        page.Locator(Selectors.Modal, new PageLocatorOptions
+        {
+            HasText = "Save all chart images"
+        });
 
     private ILocator ChartBars => page.Locator(Selectors.ChartBars);
     private ILocator ChartTicks => page.Locator(Selectors.ChartYTicks);
@@ -289,6 +299,21 @@ public class CompareYourCostsPage(IPage page)
     public async Task IsWarningIconDisplayedOnGraphTick(int nth)
     {
         await ChartTicks.Nth(nth).Locator("circle").ShouldBeVisible();
+    }
+
+    public async Task IsSaveAllImagesButtonDisplayed()
+    {
+        await SaveAllImagesButton.ShouldBeVisible();
+    }
+
+    public async Task ClickSaveAllImagesButton()
+    {
+        await SaveAllImagesButton.ClickAsync();
+    }
+
+    public async Task IsSaveAllImagesModalDisplayed()
+    {
+        await SaveAllImagesModal.ShouldBeVisible();
     }
 
     private async Task IsSectionContentVisible(ComparisonChartNames chartName, bool visibility, string chartMode)

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -60,6 +60,7 @@ public static class Selectors
     public const string Table = "table";
     public const string Button = "button";
     public const string Aside = "aside";
+    public const string Modal = "div.modal";
 
     public const string ComparisonChartsAndTables = "#compare-your-costs";
     public const string ComparisonTables = "#compare-your-costs table.govuk-table";

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -61,6 +61,7 @@ public static class Selectors
     public const string Button = "button";
     public const string Aside = "aside";
     public const string Modal = "div.modal";
+    public const string ModalButton = $"{Modal} {Button}";
 
     public const string ComparisonChartsAndTables = "#compare-your-costs";
     public const string ComparisonTables = "#compare-your-costs table.govuk-table";

--- a/web/tests/Web.E2ETests/Steps/SaveAllImagesModalSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/SaveAllImagesModalSteps.cs
@@ -1,0 +1,123 @@
+﻿using Microsoft.Playwright;
+using Web.E2ETests.Drivers;
+using Web.E2ETests.Pages.School;
+using Xunit;
+
+namespace Web.E2ETests.Steps;
+
+[Binding]
+[Scope(Feature = "Save all images modal")]
+public class SaveAllImagesModalSteps(PageDriver driver)
+{
+    private SpendingCostsPage? _spendingCostsPage;
+    private IDownload? _download;
+
+    [Given(@"I am on spending and costs page for school with URN '(.*)'")]
+    public async Task GivenIAmOnSpendingAndCostsPageForSchoolWithUrn(string urn)
+    {
+        var url = SpendingCostsUrl(urn);
+        var page = await driver.Current;
+        await page.GotoAndWaitForLoadAsync(url);
+
+        _spendingCostsPage = new SpendingCostsPage(page);
+        await _spendingCostsPage.IsDisplayed();
+    }
+
+    [Then("the save all images button is visible")]
+    public async Task ThenTheSaveAllImagesButtonIsVisible()
+    {
+        Assert.NotNull(_spendingCostsPage);
+        await _spendingCostsPage.IsSaveAllImagesButtonDisplayed();
+    }
+
+    [When("I click the save all images button")]
+    public async Task WhenIClickTheSaveAllImagesButton()
+    {
+        Assert.NotNull(_spendingCostsPage);
+        await _spendingCostsPage.ClickSaveAllImagesButton();
+    }
+
+    [When("I click the start button")]
+    public async Task WhenIClickTheStartButton()
+    {
+        Assert.NotNull(_spendingCostsPage);
+        var page = await driver.Current;
+        var downloadTask = page.WaitForDownloadAsync();
+        await _spendingCostsPage.ClickSaveAllImagesModalOkButton();
+        _download = await downloadTask;
+    }
+
+    [When("I click the cancel button")]
+    public async Task WhenIClickTheCancelButton()
+    {
+        Assert.NotNull(_spendingCostsPage);
+        await _spendingCostsPage.ClickSaveAllImagesModalCancelButton();
+    }
+
+    [When("I click the close button")]
+    public async Task WhenIClickTheCloseButton()
+    {
+        Assert.NotNull(_spendingCostsPage);
+        await _spendingCostsPage.ClickSaveAllImagesModalCloseButton();
+    }
+
+    [When("I press the Escape key")]
+    public async Task WhenIPressTheEscapeKey()
+    {
+        Assert.NotNull(_spendingCostsPage);
+        await _spendingCostsPage.PressEscapeKey();
+    }
+
+    [Then("the save all images modal is visible")]
+    public async Task ThenTheSaveAllImagesModalIsVisible()
+    {
+        Assert.NotNull(_spendingCostsPage);
+        await _spendingCostsPage.IsSaveAllImagesModalDisplayed(true);
+    }
+
+    [Then("the save all images modal is not visible")]
+    public async Task ThenTheSaveAllImagesModalIsNotVisible()
+    {
+        Assert.NotNull(_spendingCostsPage);
+        await _spendingCostsPage.IsSaveAllImagesModalDisplayed(false);
+    }
+
+    [Then("the start button is enabled")]
+    public async Task ThenTheStartButtonIsEnabled()
+    {
+        Assert.NotNull(_spendingCostsPage);
+        await _spendingCostsPage.IsSaveAllImagesModalStartButtonEnabled(true);
+    }
+
+    [Then("the start button is disabled")]
+    public async Task ThenTheStartButtonIsDisabled()
+    {
+        Assert.NotNull(_spendingCostsPage);
+        await _spendingCostsPage.IsSaveAllImagesModalStartButtonEnabled(false);
+    }
+
+    [Then("the cancel button is visible")]
+    public async Task ThenTheCancelButtonIsVisible()
+    {
+        Assert.NotNull(_spendingCostsPage);
+        await _spendingCostsPage.IsSaveAllImagesModalCancelButtonVisible();
+    }
+
+    [Then("the close button is visible")]
+    public async Task ThenTheCloseButtonIsVisible()
+    {
+        Assert.NotNull(_spendingCostsPage);
+        await _spendingCostsPage.IsSaveAllImagesModalCloseButtonVisible();
+    }
+
+    [Then("the '(.*)' file is downloaded")]
+    public void ThenTheFileIsDownloaded(string fileName)
+    {
+        Assert.NotNull(_spendingCostsPage);
+        var downloadedFilePath = _download?.SuggestedFilename;
+        Assert.Equal(fileName, downloadedFilePath);
+    }
+
+    private static string SpendingCostsUrl(string urn) =>
+        $"{TestConfiguration.ServiceUrl}/school/{urn}/spending-and-costs";
+}

--- a/web/tests/Web.E2ETests/Steps/School/CompareYourCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/CompareYourCostsSteps.cs
@@ -351,6 +351,27 @@ public class CompareYourCostsSteps(PageDriver driver)
         await _comparisonPage.HasCorrectDimensionValues();
     }
 
+    [Then("the save all images button is visible")]
+    public async Task ThenTheSaveAllImagesButtonIsVisible()
+    {
+        Assert.NotNull(_comparisonPage);
+        await _comparisonPage.IsSaveAllImagesButtonDisplayed();
+    }
+
+    [When("I click the save all images button")]
+    public async Task WhenIClickTheSaveAllImagesButton()
+    {
+        Assert.NotNull(_comparisonPage);
+        await _comparisonPage.ClickSaveAllImagesButton();
+    }
+
+    [Then("the save all images modal is visible")]
+    public async Task ThenTheSaveAllImagesModalIsVisible()
+    {
+        Assert.NotNull(_comparisonPage);
+        await _comparisonPage.IsSaveAllImagesModalDisplayed();
+    }
+
     private void ChartDownloaded(string chartName)
     {
         Assert.NotNull(_download);

--- a/web/tests/Web.E2ETests/Steps/School/SpendingCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/SpendingCostsSteps.cs
@@ -2,6 +2,7 @@
 using Web.E2ETests.Pages;
 using Web.E2ETests.Pages.School;
 using Xunit;
+
 namespace Web.E2ETests.Steps.School;
 
 [Binding]
@@ -30,11 +31,7 @@ public class SpendingCostsSteps(PageDriver driver)
         var expectedOrder = new List<string[]>();
         foreach (var row in table.Rows)
         {
-            string[] chartPriorityArray =
-            {
-                row["Name"],
-                row["Priority"]
-            };
+            string[] chartPriorityArray = { row["Name"], row["Priority"] };
             expectedOrder.Add(chartPriorityArray);
         }
 
@@ -134,6 +131,27 @@ public class SpendingCostsSteps(PageDriver driver)
     {
         Assert.NotNull(_spendingCostsPage);
         await _spendingCostsPage.IsWarningMessageVisibleForCategory(CostCategoryFromFriendlyName(categoryName));
+    }
+
+    [Then("the save all images button is visible")]
+    public async Task ThenTheSaveAllImagesButtonIsVisible()
+    {
+        Assert.NotNull(_spendingCostsPage);
+        await _spendingCostsPage.IsSaveAllImagesButtonDisplayed();
+    }
+
+    [When("I click the save all images button")]
+    public async Task WhenIClickTheSaveAllImagesButton()
+    {
+        Assert.NotNull(_spendingCostsPage);
+        await _spendingCostsPage.ClickSaveAllImagesButton();
+    }
+
+    [Then("the save all images modal is visible")]
+    public async Task ThenTheSaveAllImagesModalIsVisible()
+    {
+        Assert.NotNull(_spendingCostsPage);
+        await _spendingCostsPage.IsSaveAllImagesModalDisplayed();
     }
 
     private static string SpendingCostsUrl(string urn) =>

--- a/web/tests/Web.E2ETests/Steps/School/SpendingCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/SpendingCostsSteps.cs
@@ -151,7 +151,7 @@ public class SpendingCostsSteps(PageDriver driver)
     public async Task ThenTheSaveAllImagesModalIsVisible()
     {
         Assert.NotNull(_spendingCostsPage);
-        await _spendingCostsPage.IsSaveAllImagesModalDisplayed();
+        await _spendingCostsPage.IsSaveAllImagesModalDisplayed(true);
     }
 
     private static string SpendingCostsUrl(string urn) =>

--- a/web/tests/Web.E2ETests/Steps/Trust/CompareYourCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/Trust/CompareYourCostsSteps.cs
@@ -261,6 +261,27 @@ public class CompareYourCostsSteps(PageDriver driver)
         await _comparisonPage.HasCorrectDimensionValues();
     }
 
+    [Then("the save all images button is visible")]
+    public async Task ThenTheSaveAllImagesButtonIsVisible()
+    {
+        Assert.NotNull(_comparisonPage);
+        await _comparisonPage.IsSaveAllImagesButtonDisplayed();
+    }
+
+    [When("I click the save all images button")]
+    public async Task WhenIClickTheSaveAllImagesButton()
+    {
+        Assert.NotNull(_comparisonPage);
+        await _comparisonPage.ClickSaveAllImagesButton();
+    }
+
+    [Then("the save all images modal is visible")]
+    public async Task ThenTheSaveAllImagesModalIsVisible()
+    {
+        Assert.NotNull(_comparisonPage);
+        await _comparisonPage.IsSaveAllImagesModalDisplayed();
+    }
+
     private void ChartDownloaded(string chartName)
     {
         Assert.NotNull(_download);


### PR DESCRIPTION
### Context
[AB#247366](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/247366) [AB#242099](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/242099) #1824

### Change proposed in this pull request
E2E test coverage.

### Guidance to review 
Dependency on #1824. This will fail in the `Web` pipeline until `front-end` is bumped on a follow-up PR.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

