### PR TITLE
fix: compare your costs utilities dimension

### DIFF
--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/utilities.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/utilities.tsx
@@ -100,7 +100,11 @@ export const Utilities: React.FC<CompareYourCostsProps> = ({ type, id }) => {
   return (
     <AccordionSection
       charts={[
-        { data: totalUtilitiesCostsBarData, title: "Total utilities costs" },
+        {
+          data: totalUtilitiesCostsBarData,
+          title: "Total utilities costs",
+          dimensions: PremisesCategories,
+        },
         {
           data: energyBarData,
           title: "Energy costs",

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/utilities.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/utilities.tsx
@@ -106,7 +106,11 @@ export const Utilities: React.FC<{
   return (
     <AccordionSection
       charts={[
-        { data: totalUtilitiesCostsBarData, title: "Total utilities costs" },
+        {
+          data: totalUtilitiesCostsBarData,
+          title: "Total utilities costs",
+          dimensions: PremisesCategories,
+        },
         {
           data: energyBarData,
           title: "Energy costs",

--- a/web/tests/Web.E2ETests/Features/LocalAuthority/CompareYourCosts.feature
+++ b/web/tests/Web.E2ETests/Features/LocalAuthority/CompareYourCosts.feature
@@ -98,3 +98,7 @@ Feature: Local Authority compare your costs
           | Test academy school 239 | City of London  | Academy converter      | 399              | £109,578 |
           | Test school 237         | City of London  | Voluntary aided school | 231              | £99,307  |
           | Test school 1           | City of London  | Voluntary aided school | 232              | £42,585  |
+          
+    Scenario: Charts have correct dimension options
+        Given I am on compare your costs page for local authority with code '201'
+        Then all sections on the page have the correct dimension options

--- a/web/tests/Web.E2ETests/Features/School/CompareYourCosts.feature
+++ b/web/tests/Web.E2ETests/Features/School/CompareYourCosts.feature
@@ -260,3 +260,7 @@ Feature: School compare your costs
           | Test academy school 456 | Westmorland and Furness | Academy 16-19 converter | 339              | £30    |
           | Test school 102         | Hammersmith and Fulham  | Community school        | 212              | £0     |
         And the message stating reason for less schools is visible in 'Supply teaching staff costs' section
+        
+    Scenario: Charts have correct dimension options
+        Given I am on compare your costs page for school with URN '777042'
+        Then all sections on the page have the correct dimension options

--- a/web/tests/Web.E2ETests/Features/Trust/CompareYourCosts.feature
+++ b/web/tests/Web.E2ETests/Features/Trust/CompareYourCosts.feature
@@ -126,3 +126,7 @@ Feature: Trust compare your costs
           | School name             | Local Authority | School type                 | Number of pupils | Amount  |
           | Test academy school 392 | Trafford        | Academy special converter   | 204              | £53,473 |
           | Test academy school 375 | Reading         | Academy special sponsor led | 232              | £42,585 |
+          
+    Scenario: Charts have correct dimension options
+        Given I am on compare your costs page for trust with company number '10074054'
+        Then all sections on the page have the correct dimension options

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/CompareYourCostsPage.cs
@@ -45,6 +45,14 @@ public class CompareYourCostsPage(IPage page)
     private ILocator ViewAsGrossRadio => page.Locator(Selectors.TypeGross);
     private ILocator ViewAsNetRadio => page.Locator(Selectors.TypeNet);
     private ILocator ChartTooltip => page.Locator(Selectors.ChartTooltips).First;
+    private ILocator TeachingAndSupportDimension => page.Locator(Selectors.TeachingAndSupportDimension);
+    private ILocator NonEducationSupportStaffDimension => page.Locator(Selectors.NonEducationSupportStaffDimension);
+    private ILocator EducationalSuppliesDimension => page.Locator(Selectors.EducationalSuppliesDimension);
+    private ILocator EducationalIctDimension => page.Locator(Selectors.EducationalIctDimension);
+    private ILocator UtilitiesDimension => page.Locator(Selectors.UtilitiesDimension);
+    private ILocator AdministrativeSuppliesDimension => page.Locator(Selectors.AdministrativeSuppliesDimension);
+    private ILocator CateringServicesDimension => page.Locator(Selectors.CateringServicesDimension);
+    private ILocator OtherDimension => page.Locator(Selectors.OtherDimension);
 
     private ILocator SaveAsImageButtons =>
         page.Locator(Selectors.Button, new PageLocatorOptions
@@ -312,13 +320,87 @@ public class CompareYourCostsPage(IPage page)
         }
     }
 
+    public async Task HasCorrectDimensionValues()
+    {
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.TotalExpenditure, [
+                "£ per pupil",
+                "actuals",
+                "percentage of income"
+        ]);
+
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.TeachingAndTeachingSupplyStaff, [
+                "£ per pupil",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.NonEducationalSupportStaff, [
+                "£ per pupil",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+        await HasDimensionValuesForChart(ComparisonChartNames.EducationalSupplies, [
+                "£ per pupil",
+            "actuals",
+            "percentage of expenditure",
+            "percentage of income"
+        ]);
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.EducationalIct, [
+                "£ per pupil",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.Premises, [
+                "£ per m²",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.Utilities, [
+                "£ per m²",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.AdministrativeSupplies, [
+                "£ per pupil",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.CateringStaffAndServices, [
+                "£ per pupil",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.Other, [
+                "£ per pupil",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+    }
+
     private async Task HasDimensionValuesForChart(ComparisonChartNames chartName, string[] expected)
     {
         const string exp = "(select) => Array.from(select.options).map(option => option.label)";
         var dropdown = ChartDimensionDropdown(chartName);
         var actual = await dropdown.EvaluateAsync<string[]>(exp);
 
-        Assert.Equal(expected, actual);
+        Assert.True(expected.SequenceEqual(actual), $"Test fails on {chartName}. Expected: {string.Join(", ", expected)}, Actual: {string.Join(", ", actual)}");
     }
 
     private ILocator ChartTable(ComparisonChartNames chartName)
@@ -337,9 +419,16 @@ public class CompareYourCostsPage(IPage page)
     {
         var chart = chartName switch
         {
-            ComparisonChartNames.Premises => PremisesDimension,
             ComparisonChartNames.TotalExpenditure => TotalExpenditureDimension,
-            ComparisonChartNames.CateringStaffAndServices => CateringStaffAndServicesDimension,
+            ComparisonChartNames.TeachingAndTeachingSupplyStaff => TeachingAndSupportDimension,
+            ComparisonChartNames.NonEducationalSupportStaff => NonEducationSupportStaffDimension,
+            ComparisonChartNames.EducationalSupplies => EducationalSuppliesDimension,
+            ComparisonChartNames.EducationalIct => EducationalIctDimension,
+            ComparisonChartNames.Premises => PremisesDimension,
+            ComparisonChartNames.Utilities => UtilitiesDimension,
+            ComparisonChartNames.AdministrativeSupplies => AdministrativeSuppliesDimension,
+            ComparisonChartNames.CateringStaffAndServices => CateringServicesDimension,
+            ComparisonChartNames.Other => OtherDimension,
             _ => throw new ArgumentOutOfRangeException(nameof(chartName))
         };
 

--- a/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
@@ -49,6 +49,14 @@ public class CompareYourCostsPage(IPage page)
     private ILocator ViewAsNetRadio => page.Locator(Selectors.TypeNet);
     private ILocator ChartTooltip => page.Locator(Selectors.ChartTooltips).First;
     private ILocator IncompleteFinancialBanner => page.Locator(Selectors.GovWarning);
+    private ILocator TeachingAndSupportDimension => page.Locator(Selectors.TeachingAndSupportDimension);
+    private ILocator NonEducationSupportStaffDimension => page.Locator(Selectors.NonEducationSupportStaffDimension);
+    private ILocator EducationalSuppliesDimension => page.Locator(Selectors.EducationalSuppliesDimension);
+    private ILocator EducationalIctDimension => page.Locator(Selectors.EducationalIctDimension);
+    private ILocator UtilitiesDimension => page.Locator(Selectors.UtilitiesDimension);
+    private ILocator AdministrativeSuppliesDimension => page.Locator(Selectors.AdministrativeSuppliesDimension);
+    private ILocator CateringServicesDimension => page.Locator(Selectors.CateringServicesDimension);
+    private ILocator OtherDimension => page.Locator(Selectors.OtherDimension);
 
     private ILocator SaveAsImageButtons =>
         page.Locator(Selectors.Button, new PageLocatorOptions
@@ -369,6 +377,81 @@ public class CompareYourCostsPage(IPage page)
 
     }
 
+    public async Task HasCorrectDimensionValues()
+    {
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.TotalExpenditure, [
+                "£ per pupil",
+                "actuals",
+                "percentage of income"
+        ]);
+
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.TeachingAndTeachingSupplyStaff, [
+                "£ per pupil",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.NonEducationalSupportStaff, [
+                "£ per pupil",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.EducationalSupplies, [
+                "£ per pupil",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.EducationalIct, [
+                "£ per pupil",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.Premises, [
+                "£ per m²",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.Utilities, [
+                "£ per m²",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.AdministrativeSupplies, [
+                "£ per pupil",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.CateringStaffAndServices, [
+                "£ per pupil",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.Other, [
+                "£ per pupil",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+    }
+
     private ILocator SectionLink(ComparisonChartNames chartName)
     {
         var link = chartName switch
@@ -422,7 +505,7 @@ public class CompareYourCostsPage(IPage page)
         var dropdown = ChartDimensionDropdown(chartName);
         var actual = await dropdown.EvaluateAsync<string[]>(exp);
 
-        Assert.Equal(expected, actual);
+        Assert.True(expected.SequenceEqual(actual), $"Test fails on {chartName}. Expected: {string.Join(", ", expected)}, Actual: {string.Join(", ", actual)}");
     }
 
     private ILocator ChartTable(ComparisonChartNames chartName)
@@ -442,9 +525,16 @@ public class CompareYourCostsPage(IPage page)
     {
         var chart = chartName switch
         {
-            ComparisonChartNames.Premises => PremisesDimension,
             ComparisonChartNames.TotalExpenditure => TotalExpenditureDimension,
-            ComparisonChartNames.CateringStaffAndServices => CateringStaffAndServicesDimension,
+            ComparisonChartNames.TeachingAndTeachingSupplyStaff => TeachingAndSupportDimension,
+            ComparisonChartNames.NonEducationalSupportStaff => NonEducationSupportStaffDimension,
+            ComparisonChartNames.EducationalSupplies => EducationalSuppliesDimension,
+            ComparisonChartNames.EducationalIct => EducationalIctDimension,
+            ComparisonChartNames.Premises => PremisesDimension,
+            ComparisonChartNames.Utilities => UtilitiesDimension,
+            ComparisonChartNames.AdministrativeSupplies => AdministrativeSuppliesDimension,
+            ComparisonChartNames.CateringStaffAndServices => CateringServicesDimension,
+            ComparisonChartNames.Other => OtherDimension,
             _ => throw new ArgumentOutOfRangeException(nameof(chartName))
         };
 

--- a/web/tests/Web.E2ETests/Pages/Trust/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/Trust/CompareYourCostsPage.cs
@@ -45,6 +45,14 @@ public class CompareYourCostsPage(IPage page)
     private ILocator ViewAsGrossRadio => page.Locator(Selectors.TypeGross);
     private ILocator ViewAsNetRadio => page.Locator(Selectors.TypeNet);
     private ILocator ChartTooltip => page.Locator(Selectors.ChartTooltips).First;
+    private ILocator TeachingAndSupportDimension => page.Locator(Selectors.TeachingAndSupportDimension);
+    private ILocator NonEducationSupportStaffDimension => page.Locator(Selectors.NonEducationSupportStaffDimension);
+    private ILocator EducationalSuppliesDimension => page.Locator(Selectors.EducationalSuppliesDimension);
+    private ILocator EducationalIctDimension => page.Locator(Selectors.EducationalIctDimension);
+    private ILocator UtilitiesDimension => page.Locator(Selectors.UtilitiesDimension);
+    private ILocator AdministrativeSuppliesDimension => page.Locator(Selectors.AdministrativeSuppliesDimension);
+    private ILocator CateringServicesDimension => page.Locator(Selectors.CateringServicesDimension);
+    private ILocator OtherDimension => page.Locator(Selectors.OtherDimension);
 
     private ILocator SaveAsImageButtons =>
         page.Locator(Selectors.Button, new PageLocatorOptions
@@ -312,13 +320,88 @@ public class CompareYourCostsPage(IPage page)
         }
     }
 
+    public async Task HasCorrectDimensionValues()
+    {
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.TotalExpenditure, [
+                "£ per pupil",
+                "actuals",
+                "percentage of income"
+        ]);
+
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.TeachingAndTeachingSupplyStaff, [
+                "£ per pupil",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.NonEducationalSupportStaff, [
+                "£ per pupil",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.EducationalSupplies, [
+                "£ per pupil",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.EducationalIct, [
+                "£ per pupil",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.Premises, [
+                "£ per m²",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.Utilities, [
+                "£ per m²",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.AdministrativeSupplies, [
+                "£ per pupil",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.CateringStaffAndServices, [
+                "£ per pupil",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+        await HasDimensionValuesForChart(
+            ComparisonChartNames.Other, [
+                "£ per pupil",
+                "actuals",
+                "percentage of expenditure",
+                "percentage of income"
+        ]);
+    }
+
     private async Task HasDimensionValuesForChart(ComparisonChartNames chartName, string[] expected)
     {
         const string exp = "(select) => Array.from(select.options).map(option => option.label)";
         var dropdown = ChartDimensionDropdown(chartName);
         var actual = await dropdown.EvaluateAsync<string[]>(exp);
 
-        Assert.Equal(expected, actual);
+        Assert.True(expected.SequenceEqual(actual), $"Test fails on {chartName}. Expected: {string.Join(", ", expected)}, Actual: {string.Join(", ", actual)}");
     }
 
     private ILocator ChartTable(ComparisonChartNames chartName)
@@ -337,9 +420,16 @@ public class CompareYourCostsPage(IPage page)
     {
         var chart = chartName switch
         {
-            ComparisonChartNames.Premises => PremisesDimension,
             ComparisonChartNames.TotalExpenditure => TotalExpenditureDimension,
-            ComparisonChartNames.CateringStaffAndServices => CateringStaffAndServicesDimension,
+            ComparisonChartNames.TeachingAndTeachingSupplyStaff => TeachingAndSupportDimension,
+            ComparisonChartNames.NonEducationalSupportStaff => NonEducationSupportStaffDimension,
+            ComparisonChartNames.EducationalSupplies => EducationalSuppliesDimension,
+            ComparisonChartNames.EducationalIct => EducationalIctDimension,
+            ComparisonChartNames.Premises => PremisesDimension,
+            ComparisonChartNames.Utilities => UtilitiesDimension,
+            ComparisonChartNames.AdministrativeSupplies => AdministrativeSuppliesDimension,
+            ComparisonChartNames.CateringStaffAndServices => CateringServicesDimension,
+            ComparisonChartNames.Other => OtherDimension,
             _ => throw new ArgumentOutOfRangeException(nameof(chartName))
         };
 

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -177,4 +177,13 @@ public static class Selectors
     public const string AccordionSchoolContent = "#accordion-schools-content-";
     public const string ForecastRisksDimension = "#year-end-reserves-dimension";
     public const string EducationIctSpendingCosts = "#spending-priorities-educational-ict";
+
+    public const string TeachingAndSupportDimension = "#total-teaching-and-teaching-support-staff-costs-dimension";
+    public const string NonEducationSupportStaffDimension = "#total-non-educational-support-staff-costs-dimension";
+    public const string EducationalSuppliesDimension = "#total-educational-supplies-costs-dimension";
+    public const string EducationalIctDimension = "#educational-learning-resources-costs-dimension";
+    public const string UtilitiesDimension = "#total-utilities-costs-dimension";
+    public const string AdministrativeSuppliesDimension = "#administrative-supplies-non-educational-dimension";
+    public const string CateringServicesDimension = "#total-catering-costs-dimension";
+    public const string OtherDimension = "#total-other-costs-dimension";
 }

--- a/web/tests/Web.E2ETests/Steps/LocalAuthority/CompareYourCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/LocalAuthority/CompareYourCostsSteps.cs
@@ -254,6 +254,13 @@ public class CompareYourCostsSteps(PageDriver driver)
         await _comparisonPage.IsWarningIconDisplayedOnGraphTick(nth);
     }
 
+    [Then("all sections on the page have the correct dimension options")]
+    public async Task AllSectionsOnPageHaveCorrectDimensionOptions()
+    {
+        Assert.NotNull(_comparisonPage);
+        await _comparisonPage.HasCorrectDimensionValues();
+    }
+
     private void ChartDownloaded(string chartName)
     {
         Assert.NotNull(_download);

--- a/web/tests/Web.E2ETests/Steps/School/CompareYourCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/CompareYourCostsSteps.cs
@@ -344,6 +344,13 @@ public class CompareYourCostsSteps(PageDriver driver)
 
     }
 
+    [Then("all sections on the page have the correct dimension options")]
+    public async Task AllSectionsOnPageHaveCorrectDimensionOptions()
+    {
+        Assert.NotNull(_comparisonPage);
+        await _comparisonPage.HasCorrectDimensionValues();
+    }
+
     private void ChartDownloaded(string chartName)
     {
         Assert.NotNull(_download);

--- a/web/tests/Web.E2ETests/Steps/Trust/CompareYourCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/Trust/CompareYourCostsSteps.cs
@@ -254,6 +254,13 @@ public class CompareYourCostsSteps(PageDriver driver)
         await _comparisonPage.IsWarningIconDisplayedOnGraphTick(nth);
     }
 
+    [Then("all sections on the page have the correct dimension options")]
+    public async Task AllSectionsOnPageHaveCorrectDimensionOptions()
+    {
+        Assert.NotNull(_comparisonPage);
+        await _comparisonPage.HasCorrectDimensionValues();
+    }
+
     private void ChartDownloaded(string chartName)
     {
         Assert.NotNull(_download);


### PR DESCRIPTION
### Context
[AB#248237](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/248237) - [AB#248239](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/248239)

### Change proposed in this pull request
- pass `PremisesCategories` as `dimensions` in the first chart in `charts` prop to `AccordionSection` in `views/compare-your-costs/partials/accordion-sections/utilities.tsx` so it does not fallback to `CostCategories` when passed to `ChartDimensions` in `DimensionedChart`
- Add new E2E tests for la, trust and school versions of this page.

### Guidance to review 
Will require a bump to `front-end` package following this PR

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

