### PR TITLE
chore: bump `front-end` to `1.1.41`

### DIFF
--- a/web/src/Web.App/package-lock.json
+++ b/web/src/Web.App/package-lock.json
@@ -1456,9 +1456,9 @@
       }
     },
     "node_modules/front-end": {
-      "version": "1.1.39",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-1.1.39.tgz",
-      "integrity": "sha1-FSEM8uKAgFxJxL2qrs5EwBZfw2Y=",
+      "version": "1.1.41",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-1.1.41.tgz",
+      "integrity": "sha1-t1llV1aYsabaWoZVppQgPYAw93g=",
       "dependencies": {
         "accessible-autocomplete": "^3.0.0",
         "classnames": "^2.5.1",


### PR DESCRIPTION
### Context
[AB#248237](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/248237) - [AB#248283](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/248283)

#1879 #1880 

### Change proposed in this pull request
update `front-end` package to `1.1.41`

### Guidance to review 
Failing e2e tests should now pass

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

