### PR TITLE
feat: make temp. table names unique

### DIFF
--- a/data-pipeline/src/pipeline/database.py
+++ b/data-pipeline/src/pipeline/database.py
@@ -39,21 +39,7 @@ def get_engine() -> sqlalchemy.engine.Engine:
         query={"driver": "ODBC Driver 18 for SQL Server"} | args,
     )
 
-    engine = create_engine(connection_url)
-
-    @event.listens_for(engine, "before_cursor_execute")
-    def receive_before_cursor_execute(
-        conn, cursor, statement, params, context, executemany
-    ):
-        logger.debug("before_cursor_execute event received.")
-
-        if executemany:
-            cursor.fast_executemany = True
-            logger.debug(
-                "before_cursor_execute event for executemany; fast_executemany set."
-            )
-
-    return engine
+    return create_engine(connection_url, fast_executemany=True)
 
 
 def _get_temp_table(table: str, run_id: str) -> str:

--- a/data-pipeline/tests/unit/database.py
+++ b/data-pipeline/tests/unit/database.py
@@ -1,0 +1,31 @@
+import uuid
+
+from pipeline import database
+
+
+def test_unique_temp_table_names():
+    random_run_id = str(uuid.uuid4())
+    table_names = [
+        "ComparatorSet",
+        "MetricRAG",
+        "School",
+        "LocalAuthority",
+        "Trust",
+        "NonFinancial",
+        "Financial",
+        "TrustFinancial",
+        "BudgetForecastReturnMetric",
+        "BudgetForecastReturn",
+    ]
+
+    temp_tables = [
+        temp_table
+        for table in table_names
+        for temp_table in [
+            database._get_temp_table(table, "2021"),
+            database._get_temp_table(table, random_run_id),
+            database._get_temp_table(table, str(uuid.uuid4())),
+        ]
+    ]
+
+    assert len(temp_tables) == len(set(temp_tables))


### PR DESCRIPTION
### Context

Currently temp. table names are created as `{table_name}_temp`, meaning that should two jobs attempt to write to the same table, one will end up disrupting the other (which can legitimately happen if a `default` and `custom` run happen in parallel, for instance).

[AB#240689](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/240689)  

### Change proposed in this pull request

Firstly, include both the `RunId` value and the current epoch time in the table name (no two jobs occuring at the same time should ever have the same `RunId`).

Secondly, change the Pandas `DataFrame.to_sql()` call to `fail` if there _is_ a collision (this circumstance should never occur and should result in an error).

Thirdly, a refactor of the `pipeline.database` module to avoid the global `engine` variable:

- this was prohibiting unit-testing of this module as it would always attempt to instantiate a SQLAlchemy Engine
- maintain the existing behaviour _by default_ to avoid a large refactor of dependent modules
- allow dependency-injection of an alternative `sqlalchemy.engine.Engine` for testing

Finally, a fix:

- by default, SQLAlchemy/Pandas will make one `INSERT` per row
- [`fast_executemany`](https://docs.sqlalchemy.org/en/20/dialects/mssql.html#fast-executemany-mode) allows multiple rows per `INSERT` _but_ was being incorrectly set at the _cursor_ level, by which point only a single row was being inserted
- set this at the point `create_engine()` is called instead

### Guidance to review 

- I've run the pipeline locally and it writes to the database as previously
- does the refactor for the `engine` seem sensible

**Note**: it's worth checking the "Hide whitespace" option when reviewing as it's clearer that some code has been moved, rather than removed.

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~You have reviewed with UX/Design~

