### PR TITLE
E2E test coverage over changes from 'Save all' chart images to 'Save some'

### DIFF
--- a/web/tests/Web.E2ETests/Extensions/LocatorExtensions.cs
+++ b/web/tests/Web.E2ETests/Extensions/LocatorExtensions.cs
@@ -190,6 +190,12 @@ public static class LocatorExtensions
         return locator;
     }
 
+    public static async Task<ILocator> Uncheck(this ILocator locator)
+    {
+        await locator.UncheckAsync();
+        return locator;
+    }
+
     public static async Task<int> Count(this ILocator locator) => await locator.CountAsync();
 
     public static async Task<ILocator> Fill(this ILocator locator, string inputValue)

--- a/web/tests/Web.E2ETests/Features/SaveImagesModal.feature
+++ b/web/tests/Web.E2ETests/Features/SaveImagesModal.feature
@@ -33,3 +33,19 @@
         And I click the start button
         Then the start button is disabled
         And the 'spending-priorities-777042.zip' file is downloaded
+
+    Scenario: Validation error if none selected
+        Given I am on spending and costs page for school with URN '777042'
+        When I click the save chart images button
+        And I uncheck the following items:
+          | Title                               |
+          | Teaching and Teaching support staff |
+          | Non-educational support staff       |
+          | Administrative supplies             |
+          | Educational supplies                |
+          | Catering staff and supplies         |
+          | Premises staff and services         |
+          | Utilities                           |
+          | Educational ICT                     |
+        And I click the start button without any items selected
+        Then the validation error is displayed

--- a/web/tests/Web.E2ETests/Pages/School/SpendingCostsPageModal.cs
+++ b/web/tests/Web.E2ETests/Pages/School/SpendingCostsPageModal.cs
@@ -13,6 +13,9 @@ public partial class SpendingCostsPage
     private ILocator SaveImagesModalOkButton => page.Locator($"{Selectors.ModalButton}.govuk-button--ok");
     private ILocator SaveImagesModalCancelButton => page.Locator($"{Selectors.ModalButton}.govuk-button--cancel");
     private ILocator SaveImagesModalCloseButton => page.Locator($"{Selectors.ModalButton}.govuk-button--close");
+    private ILocator SaveImagesModalCheckbox(string name) =>
+        page.Locator($".govuk-checkboxes__item input:has(+ label:has-text('{name}'))");
+    private ILocator SaveImagesModalValidationErrorMessage => page.Locator($"{Selectors.Modal} {Selectors.GovErrorSummary}");
 
     public async Task IsSaveImagesModalDisplayed(bool visible)
     {
@@ -74,5 +77,24 @@ public partial class SpendingCostsPage
     public async Task PressEscapeKey()
     {
         await page.Keyboard.PressAsync("Escape");
+    }
+
+    public async Task ToggleSaveImagesModalCheckbox(string item, bool check)
+    {
+        var checkbox = SaveImagesModalCheckbox(item);
+        if (check)
+        {
+            await checkbox.Check();
+        }
+        else
+        {
+            await checkbox.Uncheck();
+        }
+    }
+
+    public async Task IsSaveImagesModalValidationErrorMessageDisplayed()
+    {
+        await SaveImagesModalValidationErrorMessage.ShouldBeVisible();
+        await SaveImagesModalValidationErrorMessage.ShouldContainText("There is a problem\nSelect one or more items");
     }
 }

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -21,6 +21,7 @@ public static class Selectors
     public const string GovHeadingM = ".govuk-heading-m";
     public const string GovWarning = ".govuk-warning-text";
     public const string GovFooterLink = "footer .govuk-footer__link";
+    public const string GovErrorSummary = ".govuk-error-summary";
 
     public const string ChangeSchoolLink = ":text('Change school')";
     public const string ModeChart = "#mode-chart";

--- a/web/tests/Web.E2ETests/Steps/SaveImagesModalSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/SaveImagesModalSteps.cs
@@ -47,6 +47,13 @@ public class SaveImagesModalSteps(PageDriver driver)
         _download = await downloadTask;
     }
 
+    [When("I click the start button without any items selected")]
+    public async Task WhenIClickTheStartButtonWithoutAnyItemsSelected()
+    {
+        Assert.NotNull(_spendingCostsPage);
+        await _spendingCostsPage.ClickSaveImagesModalOkButton();
+    }
+
     [When("I click the cancel button")]
     public async Task WhenIClickTheCancelButton()
     {
@@ -116,6 +123,24 @@ public class SaveImagesModalSteps(PageDriver driver)
         Assert.NotNull(_spendingCostsPage);
         var downloadedFilePath = _download?.SuggestedFilename;
         Assert.Equal(fileName, downloadedFilePath);
+    }
+
+    [When("I uncheck the following items:")]
+    public async Task WhenIUncheckTheFollowingItems(DataTable table)
+    {
+        Assert.NotNull(_spendingCostsPage);
+
+        foreach (var row in table.Rows)
+        {
+            await _spendingCostsPage.ToggleSaveImagesModalCheckbox(row["Title"], false);
+        }
+    }
+
+    [Then("the validation error is displayed")]
+    public async Task ThenTheValidationErrorIsDisplayed()
+    {
+        Assert.NotNull(_spendingCostsPage);
+        await _spendingCostsPage.IsSaveImagesModalValidationErrorMessageDisplayed();
     }
 
     private static string SpendingCostsUrl(string urn) =>


### PR DESCRIPTION
### Context
[AB#248192](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/248192) [AB#245257](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/245257) #1883

### Change proposed in this pull request
E2E for validation within 'save images' modal.

### Guidance to review 
Dependency on #1883

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

