### PR TITLE
 Replaced `<HorizontalBarChartWrapper>` chart download by ref with selection by unique attribute

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -99,7 +99,7 @@
       data-id="02387916"
       data-phases='["Secondary","Primary","Post-16"]'
     ></div>-->
-    <div id="compare-your-costs" data-type="school" data-id="119376" data-suppress-negative-or-zero="true"></div>
+    <div id="compare-your-costs" data-type="school" data-id="990332" data-suppress-negative-or-zero="true"></div>
     <!--<div id="historic-data" data-type="school" data-id="990095"></div>-->
     <!--<div id="historic-data-2" data-type="school" data-id="123456" data-phase="Primary" data-finance-type="Maintained"></div>-->
     <!--<div

--- a/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
@@ -105,7 +105,10 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
     onLoading: onImageLoading,
     elementSelector: (ref) => ref?.container,
     filter: (node) => {
-      const exclusionClasses = ["recharts-tooltip-wrapper"];
+      const exclusionClasses = [
+        "recharts-tooltip-wrapper",
+        "govuk-visually-hidden",
+      ];
       return !exclusionClasses.some((classname) =>
         node.classList?.contains(classname)
       );

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo, useRef, useState } from "react";
+import { useContext, useMemo, useState } from "react";
 import { HorizontalBarChart } from "src/components/charts/horizontal-bar-chart";
 import {
   TableChart,
@@ -11,11 +11,7 @@ import {
   useChartModeContext,
 } from "src/contexts";
 import { Loading } from "src/components/loading";
-import {
-  ChartHandler,
-  ChartSeriesConfigItem,
-  SpecialItemFlag,
-} from "src/components/charts";
+import { ChartSeriesConfigItem, SpecialItemFlag } from "src/components/charts";
 import { HorizontalBarChartWrapperProps } from "src/composed/horizontal-bar-chart-wrapper";
 import { ChartModeChart, ChartModeTable } from "src/components";
 import {
@@ -33,7 +29,8 @@ import {
   ValueType,
 } from "recharts/types/component/DefaultTooltipContent";
 import { SchoolExpenditure } from "src/services";
-import { ShareContent } from "src/components/share-content";
+import { ShareContentByElement } from "src/components/share-content-by-element";
+import { v4 as uuidv4 } from "uuid";
 
 export function HorizontalBarChartWrapper<
   TData extends SchoolChartData | TrustChartData,
@@ -50,7 +47,6 @@ export function HorizontalBarChartWrapper<
   const { chartMode } = useChartModeContext();
   const dimension = useContext(ChartDimensionContext);
   const selectedEstabishment = useContext(SelectedEstablishmentContext);
-  const chartRef = useRef<ChartHandler>(null);
   const [imageLoading, setImageLoading] = useState<boolean>();
   const [imageCopied, setImageCopied] = useState<boolean>();
   const [tickFocused, setTickFocused] = useState<Record<string, boolean>>({});
@@ -171,6 +167,7 @@ export function HorizontalBarChartWrapper<
   };
 
   const hasData = sortedDataPoints.length > 0;
+  const uuid = uuidv4();
 
   return (
     <>
@@ -178,22 +175,26 @@ export function HorizontalBarChartWrapper<
         <div className="govuk-grid-column-two-thirds">{children}</div>
         {chartMode == ChartModeChart && (
           <div className="govuk-grid-column-one-third">
-            <ShareContent
+            <ShareContentByElement
               copied={imageCopied}
               disabled={imageLoading || !hasData}
-              onCopyClick={() => chartRef.current?.download("copy")}
-              onSaveClick={() => chartRef.current?.download("save")}
+              elementSelector={() =>
+                document.querySelector(
+                  `div[data-chart-uuid='${uuid}']`
+                ) as HTMLElement
+              }
               copyEventId="copy-chart-as-image"
               saveEventId="save-chart-as-image"
               showCopy={showCopyImageButton}
               showSave
+              showTitle
               title={chartTitle}
             />
           </div>
         )}
       </div>
       <div className="govuk-grid-row">
-        <div className="govuk-grid-column-full">
+        <div className="govuk-grid-column-full" data-chart-uuid={uuid}>
           {hasData ? (
             <>
               {chartMode == ChartModeChart && (
@@ -211,7 +212,6 @@ export function HorizontalBarChartWrapper<
                   onImageLoading={setImageLoading}
                   labels
                   margin={20}
-                  ref={chartRef}
                   seriesConfig={seriesConfig as object}
                   seriesLabelField={seriesLabelField}
                   tickWidth={400}

--- a/front-end-components/src/hooks/useDownloadImage.ts
+++ b/front-end-components/src/hooks/useDownloadImage.ts
@@ -250,11 +250,11 @@ const getImageOptions = (
       const child = document.createElement("h2");
       child.innerText = title;
       child.style.fontFamily = '"GDS Transport", arial, sans-serif';
-      child.style.fontSize = "1.1875rem";
+      child.style.fontSize = "1.25rem";
       child.style.fontWeight = "700";
       child.style.height = `${imageTitleHeight}px`;
       child.style.height = `${imageTitleHeight}px`;
-      child.style.margin = `${imageTitleHeight / 2}px 0 -${imageTitleHeight / 2}px ${imageTitleHeight / 4}px`;
+      child.style.margin = `${imageTitleHeight / 4}px 0 -${imageTitleHeight / 4}px 0`;
       child.style.padding = "0";
       node.insertBefore(child, node.firstChild);
     };

--- a/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
@@ -36,6 +36,8 @@
                 urn = Model.Urn
             });
 
+        var uuid = Guid.NewGuid();
+
         <section id="spending-priorities-@category.Rating.CostCategoryAnchorId">
             <div class="govuk-grid-row govuk-!-margin-bottom-2"
                  @(i == 0 ? $"id={Model.Id}" : "")>
@@ -47,7 +49,7 @@
                     <div class="govuk-grid-column-one-third">
                         <div
                             data-share-content-by-element-id
-                            data-element-id="@categoryHeading"
+                            data-element-id="@uuid"
                             data-title="@categoryHeading"
                             data-show-title="true"
                             data-copy-event-id="copy-chart-as-image"
@@ -73,7 +75,7 @@
 
             <div class="govuk-grid-row govuk-!-margin-bottom-4">
                 <div class="govuk-grid-column-two-thirds">
-                    <div id="@categoryHeading">
+                    <div id="@uuid">
                         @if (hasNegativeOrZeroValues)
                         {
                             <div class="govuk-warning-text">


### PR DESCRIPTION
### Context
[AB#248359](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/248359) [AB#247363](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/247363)

### Change proposed in this pull request
Also updated equivalent for Spending Priorities to use unique ID.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] You have reviewed with UX/Design

