### PR TITLE
Replaced `APPINSIGHTS_INSTRUMENTATIONKEY` with `APPLICATIONINSIGHTS_CONNECTION_STRING`

### DIFF
--- a/platform/src/apis/Platform.Orchestrator/host.json
+++ b/platform/src/apis/Platform.Orchestrator/host.json
@@ -6,7 +6,8 @@
       "Host.Aggregator": "Trace",
       "Host.Results": "Information",
       "Function": "Warning",
-      "Microsoft": "Warning"
+      "Microsoft": "Warning",
+      "Azure.Core": "Warning"
     },
     "applicationInsights": {
       "samplingSettings": {

--- a/platform/terraform/modules/functions/README.md
+++ b/platform/terraform/modules/functions/README.md
@@ -49,7 +49,6 @@ No modules.
 | <a name="input_environment-prefix"></a> [environment-prefix](#input\_environment-prefix) | n/a | `string` | n/a | yes |
 | <a name="input_function-name"></a> [function-name](#input\_function-name) | n/a | `string` | n/a | yes |
 | <a name="input_instrumentation-conn-string"></a> [instrumentation-conn-string](#input\_instrumentation-conn-string) | n/a | `string` | `null` | no |
-| <a name="input_instrumentation-key"></a> [instrumentation-key](#input\_instrumentation-key) | n/a | `string` | `null` | no |
 | <a name="input_key-vault-id"></a> [key-vault-id](#input\_key-vault-id) | n/a | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | n/a | `string` | n/a | yes |
 | <a name="input_log-analytics-id"></a> [log-analytics-id](#input\_log-analytics-id) | n/a | `string` | n/a | yes |

--- a/platform/terraform/modules/functions/main.tf
+++ b/platform/terraform/modules/functions/main.tf
@@ -56,7 +56,6 @@ resource "azurerm_windows_function_app" "func-app" {
   site_config {
     always_on                              = var.always-on
     http2_enabled                          = true
-    application_insights_key               = var.instrumentation-key
     application_insights_connection_string = var.instrumentation-conn-string
     use_32_bit_worker                      = var.use-32-bit-worker
 

--- a/platform/terraform/modules/functions/variables.tf
+++ b/platform/terraform/modules/functions/variables.tf
@@ -37,12 +37,6 @@ variable "subnet_ids" {
   type = list(string)
 }
 
-variable "instrumentation-key" {
-  type     = string
-  nullable = true
-  default  = null
-}
-
 variable "instrumentation-conn-string" {
   type     = string
   nullable = true

--- a/web/src/Web.App/ViewComponents/AnalyticsViewComponent.cs
+++ b/web/src/Web.App/ViewComponents/AnalyticsViewComponent.cs
@@ -1,20 +1,21 @@
 ﻿using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.AspNetCore.Mvc;
 using Web.App.ViewModels.Components;
+
 namespace Web.App.ViewComponents;
 
 public class AnalyticsViewComponent : ViewComponent
 {
     public IViewComponentResult Invoke()
     {
-        var instrumentationKey = Environment.GetEnvironmentVariable("APPINSIGHTS_INSTRUMENTATIONKEY");
-        if (string.IsNullOrWhiteSpace(instrumentationKey))
+        var connectionString = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING");
+        if (string.IsNullOrWhiteSpace(connectionString))
         {
             return new EmptyContentView();
         }
 
         var cookiePolicy = HttpContext.Request.Cookies[Constants.CookieSettingsName];
-        var vm = new AnalyticsViewModel(instrumentationKey, cookiePolicy == "enabled");
+        var vm = new AnalyticsViewModel(connectionString, cookiePolicy == "enabled");
 
         var telemetry = HttpContext.Features.Get<RequestTelemetry>();
         if (telemetry != null)

--- a/web/src/Web.App/ViewModels/Components/AnalyticsViewModel.cs
+++ b/web/src/Web.App/ViewModels/Components/AnalyticsViewModel.cs
@@ -1,8 +1,8 @@
 namespace Web.App.ViewModels.Components;
 
-public class AnalyticsViewModel(string instrumentationKey, bool analyticsCookiesEnabled)
+public class AnalyticsViewModel(string connectionString, bool analyticsCookiesEnabled)
 {
-    public string InstrumentationKey => instrumentationKey;
+    public string ConnectionString => connectionString;
     public string? OperationId { get; set; }
     public bool AnalyticsCookiesEnabled => analyticsCookiesEnabled;
 }

--- a/web/src/Web.App/Views/Shared/Components/Analytics/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/Analytics/Default.cshtml
@@ -2,6 +2,10 @@
 @using Web.App.TagHelpers
 @model Web.App.ViewModels.Components.AnalyticsViewModel
 
+@* There is currently no alternative to providing the App Insights connection string directly *@
+@* on client side without going to such lengths as (e.g.) implementing a reverse proxy:       *@
+@*   - https://github.com/microsoft/ApplicationInsights-JS/issues/281                         *@
+@*   - https://stenbrinke.nl/blog/hide-app-insights-key-from-the-browser/                     *@
 <script type="text/javascript" src="https://js.monitor.azure.com/scripts/b/ext/ai.clck.2.min.js"></script>
 <script type="text/javascript" add-nonce="true">
     var clickPluginInstance = new Microsoft.ApplicationInsights.ClickAnalyticsPlugin();
@@ -13,12 +17,12 @@
     };
     var cookiesEnabled = true;
     var configObj = {
-        instrumentationKey: "@Model.InstrumentationKey",
+        connectionString: "@Model.ConnectionString",
         extensions: [
             clickPluginInstance
         ],
         extensionConfig: {
-            [clickPluginInstance.identifier] : clickPluginConfig
+            [clickPluginInstance.identifier]: clickPluginConfig
         },
         cookieCfg: {
             enabled: @Model.AnalyticsCookiesEnabled.ToString().ToLower()

--- a/web/terraform/app-service.tf
+++ b/web/terraform/app-service.tf
@@ -64,7 +64,7 @@ resource "azurerm_windows_web_app" "education-benchmarking-as" {
 
   app_settings = {
     "ASPNETCORE_ENVIRONMENT"                                  = "Production"
-    "APPINSIGHTS_INSTRUMENTATIONKEY"                          = data.azurerm_application_insights.application-insights.instrumentation_key
+    "APPLICATIONINSIGHTS_CONNECTION_STRING"                   = data.azurerm_application_insights.application-insights.connection_string
     "FeatureManagement__CurriculumFinancialPlanning"          = var.configuration[var.environment].features.CurriculumFinancialPlanning
     "FeatureManagement__CustomData"                           = var.configuration[var.environment].features.CustomData
     "FeatureManagement__Trusts"                               = var.configuration[var.environment].features.Trusts


### PR DESCRIPTION
### Context
[AB#248488](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/248488) [AB#246758](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/246758)

### Change proposed in this pull request
Environment variable changes in Terraform. Web change to App Insights JS SDK configuration to use connection string instead of instrumentation key. Log level change in Orchestrator to reduce noise.

### Guidance to review 
Deployed to `d19` feature environment for validation. Data still feeds through to App Insights. Log level reduction in Orchestrator may also clearly be seen in effect over time:

![image](https://github.com/user-attachments/assets/f5033851-55ae-4e2f-99e7-2b71b1e70fb8)

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

