### PR TITLE
Chart vs Table value precision on Compare Costs pages

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -99,7 +99,7 @@
       data-id="02387916"
       data-phases='["Secondary","Primary","Post-16"]'
     ></div>-->
-    <!--<div id="compare-your-costs" data-type="school" data-id="990095"></div>-->
+    <div id="compare-your-costs" data-type="school" data-id="119376" data-suppress-negative-or-zero="true"></div>
     <!--<div id="historic-data" data-type="school" data-id="990095"></div>-->
     <!--<div id="historic-data-2" data-type="school" data-id="123456" data-phase="Primary" data-finance-type="Maintained"></div>-->
     <!--<div

--- a/front-end-components/src/components/charts/utils.test.ts
+++ b/front-end-components/src/components/charts/utils.test.ts
@@ -107,6 +107,9 @@ describe("Chart utils", () => {
         { input: 0, expected: "£0" },
         { input: 1, expected: "£1" },
         { input: 2.3456789, expected: "£2.35" },
+        { input: 0.27, expected: "£0.27" },
+        { input: 0.9, expected: "£0.90" },
+        { input: 55.3, expected: "£55.30" },
         { input: 12345.67, expected: "£12k" },
         { input: 890123456, expected: "£890m" },
         { input: "not-a-number", expected: "not-a-number" },
@@ -319,10 +322,13 @@ describe("Chart utils", () => {
 
       describe("with currency option", () => {
         const theories: { input: ValueFormatterValue; expected: string }[] = [
-          { input: -987.65, expected: "-£988" },
-          { input: 0, expected: "£0" },
-          { input: 1, expected: "£1" },
-          { input: 2.3456789, expected: "£2" },
+          { input: -987.65, expected: "-£987.65" },
+          { input: 0, expected: "£0.00" },
+          { input: 1, expected: "£1.00" },
+          { input: 2.3456789, expected: "£2.35" },
+          { input: 0.27, expected: "£0.27" },
+          { input: 0.9, expected: "£0.90" },
+          { input: 55.3, expected: "£55.30" },
           { input: 12345.67, expected: "£12,346" },
           { input: 890123456, expected: "£890,123,456" },
           { input: "not-a-number", expected: "not-a-number" },

--- a/front-end-components/src/components/charts/utils.ts
+++ b/front-end-components/src/components/charts/utils.ts
@@ -96,7 +96,9 @@ export function fullValueFormatter(
     currency: options?.valueUnit === "currency" ? "GBP" : undefined,
     maximumFractionDigits:
       options?.valueUnit === "currency"
-        ? 0
+        ? Math.abs(value) < 1000 // decimal less than 1000 and greater than -1000
+          ? 2
+          : 0
         : options?.valueUnit === "%"
           ? 1
           : 2,

--- a/web/tests/Web.E2ETests/Features/School/CompareYourCosts.feature
+++ b/web/tests/Web.E2ETests/Features/School/CompareYourCosts.feature
@@ -259,10 +259,10 @@ Feature: School compare your costs
         And Section 'Teaching and teaching support staff' is visible
         Then the following is shown in 'Teaching and teaching support staff' sub category 'Supply teaching staff costs'
           | School name             | Local Authority         | School type             | Number of pupils | Amount |
-          | Test academy school 456 | Westmorland and Furness | Academy 16-19 converter | 339              | £30    |
-          | Test school 102         | Hammersmith and Fulham  | Community school        | 212              | £0     |
+          | Test academy school 456 | Westmorland and Furness | Academy 16-19 converter | 339              | £30.36 |
+          | Test school 102         | Hammersmith and Fulham  | Community school        | 212              | £0.00  |
         And the message stating reason for less schools is visible in 'Supply teaching staff costs' section
-        
+
     Scenario: Charts have correct dimension options
         Given I am on compare your costs page for school with URN '777042'
         Then all sections on the page have the correct dimension options
@@ -272,3 +272,41 @@ Feature: School compare your costs
         Then the save all images button is visible
         When I click the save all images button
         Then the save all images modal is visible
+
+    Scenario: Table view for 'per unit' total premises staff and service costs should display correct decimal places
+        Given I am on compare your costs page for school with URN '777054'
+        And table view is selected
+        When I click on show all sections
+        And I change 'total premises staff and service costs' dimension to '£ per m²'
+        Then the following is shown for 'total premises staff and service costs'
+          | School name                                                                                                         | Local Authority                  | School type                        | Number of pupils | Amount  |
+          | Test academy school 250                                                                                             | North Somerset                   | Academy sponsor led                | 184              | £159.41 |
+          | Test part year with no pupil and builiding comprator\n!\nWarning\nThis school only has 11 months of data available. | Wandsworth                       | Community special school           | 227              | £114.45 |
+          | Test school 56                                                                                                      | Redcar and Cleveland             | Voluntary aided school             | 270              | £92.75  |
+          | Test school 101                                                                                                     | Hackney                          | Pupil referral unit                | 190              | £91.97  |
+          | Test academy school 405                                                                                             | Lancashire                       | Academy sponsor led                | 335              | £74.19  |
+          | Test academy school 427                                                                                             | Kingston upon Thames             | Academy converter                  | 167              | £70.40  |
+          | Test school 142                                                                                                     | Oldham                           | Community special school           | 449              | £67.36  |
+          | Test academy school 418                                                                                             | Kensington and Chelsea           | Academy converter                  | 232              | £64.63  |
+          | Test school 234                                                                                                     | West Northamptonshire            | Community school                   | 236              | £61.90  |
+          | Test academy school 419                                                                                             | Lambeth                          | Academy sponsor led                | 236              | £61.90  |
+          | Test academy school 167                                                                                             | Greenwich                        | Free school                        | 303              | £57.89  |
+          | Test academy school 41                                                                                              | Bedford                          | Academy converter                  | 230              | £55.30  |
+          | Test school 70                                                                                                      | Bournemouth Christchurch & Poole | Local authority nursery school     | 407              | £53.87  |
+          | Test school 183                                                                                                     | County Durham                    | Voluntary aided school             | 450              | £53.06  |
+          | Test school 143                                                                                                     | Rochdale                         | Community special school           | 446              | £47.84  |
+          | Test school 88                                                                                                      | Slough                           | Community school                   | 134              | £46.79  |
+          | Test academy school 78                                                                                              | Derbyshire                       | Academy sponsor led                | 1326             | £46.03  |
+          | Test academy school 483                                                                                             | Bolton                           | Academy 16-19 converter            | 1326             | £46.03  |
+          | Test school 158                                                                                                     | Newcastle upon Tyne              | Community school                   | 206              | £44.07  |
+          | Test school 269                                                                                                     | Dudley                           | Community school                   | 407              | £43.87  |
+          | Test school 133                                                                                                     | Walsall                          | Community school                   | 367              | £43.83  |
+          | Test academy school 364                                                                                             | North East Lincolnshire          | Academy special converter          | 367              | £43.83  |
+          | Test academy school 410                                                                                             | Shropshire                       | Academy sponsor led                | 216              | £43.43  |
+          | Test academy school 28                                                                                              | Liverpool                        | Academy converter                  | 191              | £43.36  |
+          | Test academy school 310                                                                                             | Waltham Forest                   | Free schools alternative provision | 1135             | £34.01  |
+          | Test school 55                                                                                                      | Middlesbrough                    | Voluntary aided school             | 991              | £32.16  |
+          | Test academy school 444                                                                                             | Lincolnshire                     | Academy sponsor led                | 991              | £32.16  |
+          | Test school 124                                                                                                     | Newham                           | Voluntary aided school             | 769              | £29.55  |
+          | Test academy school 136                                                                                             | Merton                           | Academy special converter          | 1040             | £13.09  |
+          | Test academy school 134                                                                                             | Hounslow                         | Academy special converter          | 883              | £0.19   |

--- a/web/tests/Web.E2ETests/Features/Trust/Comparators.feature
+++ b/web/tests/Web.E2ETests/Features/Trust/Comparators.feature
@@ -15,9 +15,9 @@ Feature: View Trust comparator set
         And I click on view as table
         Then the table for 'Total expenditure' contains the following:
           | TrustName                | TotalAmount | SchoolAmount | CentralAmount |
-          | FBIT Multi Academy Trust | £18,519     | £18,519      | £0            |
-          | Test Company/Trust 309   | £9,807      | £9,807       | £0            |
-          | Test Company/Trust 108   | £7,684      | £7,684       | £0            |
+          | FBIT Multi Academy Trust | £18,519     | £18,519      | £0.00         |
+          | Test Company/Trust 309   | £9,807      | £9,807       | £0.00         |
+          | Test Company/Trust 108   | £7,684      | £7,684       | £0.00         |
 
     Scenario: Can view comparator trusts data excluding central spending
         When I select the option By Name and click continue

--- a/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
@@ -15,7 +15,8 @@ public enum ComparisonChartNames
     EducationalIct,
     EducationalSupplies,
     Other,
-    Utilities
+    Utilities,
+    TotalPremisesStaffAndServiceCosts
 }
 
 public class CompareYourCostsPage(IPage page)
@@ -45,6 +46,7 @@ public class CompareYourCostsPage(IPage page)
     private ILocator CateringStaffAndServicesDimension => page.Locator(Selectors.CateringStaffAndServicesDimension);
     private ILocator CateringStaffAndServicesTables => page.Locator(Selectors.CateringStaffAndServicesTables);
     private ILocator TeachingAndTeachingSupportStaffTables => page.Locator(Selectors.TeachingAndTeachingSupportStaffTables);
+    private ILocator TotalPremisesStaffAndServiceCostsTables => page.Locator(Selectors.TotalPremisesStaffAndServiceCostsTables);
     private ILocator ViewAsGrossRadio => page.Locator(Selectors.TypeGross);
     private ILocator ViewAsNetRadio => page.Locator(Selectors.TypeNet);
     private ILocator ChartTooltip => page.Locator(Selectors.ChartTooltips).First;
@@ -57,6 +59,7 @@ public class CompareYourCostsPage(IPage page)
     private ILocator AdministrativeSuppliesDimension => page.Locator(Selectors.AdministrativeSuppliesDimension);
     private ILocator CateringServicesDimension => page.Locator(Selectors.CateringServicesDimension);
     private ILocator OtherDimension => page.Locator(Selectors.OtherDimension);
+    private ILocator TotalPremisesStaffAndServiceCostsDimension => page.Locator(Selectors.TotalPremisesStaffAndServiceCostsDimension);
 
     private ILocator SaveAsImageButtons =>
         page.Locator(Selectors.Button, new PageLocatorOptions
@@ -394,7 +397,7 @@ public class CompareYourCostsPage(IPage page)
                 "£ per pupil",
                 "actuals",
                 "percentage of income"
-        ]);
+            ]);
 
         await HasDimensionValuesForChart(
             ComparisonChartNames.TeachingAndTeachingSupplyStaff, [
@@ -402,7 +405,7 @@ public class CompareYourCostsPage(IPage page)
                 "actuals",
                 "percentage of expenditure",
                 "percentage of income"
-        ]);
+            ]);
 
         await HasDimensionValuesForChart(
             ComparisonChartNames.NonEducationalSupportStaff, [
@@ -410,56 +413,56 @@ public class CompareYourCostsPage(IPage page)
                 "actuals",
                 "percentage of expenditure",
                 "percentage of income"
-        ]);
+            ]);
         await HasDimensionValuesForChart(
             ComparisonChartNames.EducationalSupplies, [
                 "£ per pupil",
                 "actuals",
                 "percentage of expenditure",
                 "percentage of income"
-        ]);
+            ]);
         await HasDimensionValuesForChart(
             ComparisonChartNames.EducationalIct, [
                 "£ per pupil",
                 "actuals",
                 "percentage of expenditure",
                 "percentage of income"
-        ]);
+            ]);
         await HasDimensionValuesForChart(
             ComparisonChartNames.Premises, [
                 "£ per m²",
                 "actuals",
                 "percentage of expenditure",
                 "percentage of income"
-        ]);
+            ]);
         await HasDimensionValuesForChart(
             ComparisonChartNames.Utilities, [
                 "£ per m²",
                 "actuals",
                 "percentage of expenditure",
                 "percentage of income"
-        ]);
+            ]);
         await HasDimensionValuesForChart(
             ComparisonChartNames.AdministrativeSupplies, [
                 "£ per pupil",
                 "actuals",
                 "percentage of expenditure",
                 "percentage of income"
-        ]);
+            ]);
         await HasDimensionValuesForChart(
             ComparisonChartNames.CateringStaffAndServices, [
                 "£ per pupil",
                 "actuals",
                 "percentage of expenditure",
                 "percentage of income"
-        ]);
+            ]);
         await HasDimensionValuesForChart(
             ComparisonChartNames.Other, [
                 "£ per pupil",
                 "actuals",
                 "percentage of expenditure",
                 "percentage of income"
-        ]);
+            ]);
     }
 
     public async Task IsSaveAllImagesButtonDisplayed()
@@ -540,6 +543,7 @@ public class CompareYourCostsPage(IPage page)
             ComparisonChartNames.TotalExpenditure => TotalExpenditureTable,
             ComparisonChartNames.CateringStaffAndServices => CateringStaffAndServicesTables.First,
             ComparisonChartNames.TeachingAndTeachingSupplyStaff => TeachingAndTeachingSupportStaffTables,
+            ComparisonChartNames.TotalPremisesStaffAndServiceCosts => TotalPremisesStaffAndServiceCostsTables.First,
             _ => throw new ArgumentOutOfRangeException(nameof(chartName))
         };
 
@@ -560,6 +564,7 @@ public class CompareYourCostsPage(IPage page)
             ComparisonChartNames.AdministrativeSupplies => AdministrativeSuppliesDimension,
             ComparisonChartNames.CateringStaffAndServices => CateringServicesDimension,
             ComparisonChartNames.Other => OtherDimension,
+            ComparisonChartNames.TotalPremisesStaffAndServiceCosts => TotalPremisesStaffAndServiceCostsDimension,
             _ => throw new ArgumentOutOfRangeException(nameof(chartName))
         };
 

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -74,6 +74,8 @@ public static class Selectors
     public const string TotalExpenditureChart = "//*[@aria-label='Total expenditure']";
 
     public const string PremisesDimension = "#total-premises-staff-and-service-costs-dimension";
+    public const string TotalPremisesStaffAndServiceCostsDimension = "#total-premises-staff-and-service-costs-dimension";
+    public const string TotalPremisesStaffAndServiceCostsTables = "#premises-staff-and-services table";
 
     public const string SchoolWorkforceDimension = "#school-workforce-full-time-equivalent-dimension";
     public const string SchoolWorkforceSaveAsImage = "xpath=//*[@data-custom-event-chart-name='School workforce (Full Time Equivalent)'][@data-custom-event-id='save-chart-as-image']";

--- a/web/tests/Web.E2ETests/Steps/School/CompareYourCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/CompareYourCostsSteps.cs
@@ -403,6 +403,7 @@ public class CompareYourCostsSteps(PageDriver driver)
             "non educational support staff" => ComparisonChartNames.NonEducationalSupportStaff,
             "catering staff" => ComparisonChartNames.CateringStaffAndServices,
             "Teaching and teaching support staff" => ComparisonChartNames.TeachingAndTeachingSupplyStaff,
+            "total premises staff and service costs" => ComparisonChartNames.TotalPremisesStaffAndServiceCosts,
             _ => throw new ArgumentOutOfRangeException(nameof(chartName))
         };
     }


### PR DESCRIPTION
### Context
[AB#248694](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/248694) [AB#245786](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/245786)

### Change proposed in this pull request
Ensured values displayed in 'table' view on cost comparison pages follow similar formatting rules for currency decimal places.

### Guidance to review 
Repro steps in related bug. In `d02` URN `777054` may be used to validate, as implemented in the E2E tests.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

