### PR TITLE
E2E for Trust-to-Trust comparison tables

### DIFF
--- a/web/tests/Web.E2ETests/Features/Trust/Comparators.feature
+++ b/web/tests/Web.E2ETests/Features/Trust/Comparators.feature
@@ -1,0 +1,35 @@
+Feature: View Trust comparator set
+
+    Background:
+        Given I am on the service home
+        And I have signed in with organisation '010: FBIT TEST - Multi-Academy Trust (Open)'
+        And I am on compare by page for trust with company number '00000001'
+
+    Scenario: Can view comparator trusts data including central spending
+        When I select the option By Name and click continue
+        And I select the trust with company number '10074054' from suggester
+        And I click the choose trust button
+        And I select the trust with company number '8076374' from suggester
+        And I click the choose trust button
+        And I click the create set button
+        And I click on view as table
+        Then the table for 'Total expenditure' contains the following:
+          | TrustName                | TotalAmount | SchoolAmount | CentralAmount |
+          | FBIT Multi Academy Trust | £18,519     | £18,519      | £0.00         |
+          | Test Company/Trust 309   | £9,807      | £9,807       | £0.00         |
+          | Test Company/Trust 108   | £7,684      | £7,684       | £0.00         |
+
+    Scenario: Can view comparator trusts data excluding central spending
+        When I select the option By Name and click continue
+        And I select the trust with company number '10074054' from suggester
+        And I click the choose trust button
+        And I select the trust with company number '8076374' from suggester
+        And I click the choose trust button
+        And I click the create set button
+        And I click on view as table
+        And I click on exclude central spending
+        Then the table for 'Total expenditure' contains the following:
+          | TrustName                | TotalAmount |
+          | FBIT Multi Academy Trust | £18,519     |
+          | Test Company/Trust 309   | £9,807      |
+          | Test Company/Trust 108   | £7,684      |

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -25,6 +25,8 @@ public static class Selectors
     public const string ChangeSchoolLink = ":text('Change school')";
     public const string ModeChart = "#mode-chart";
     public const string ModeTable = "#mode-table";
+    public const string SpendingModeTable = "#spending-mode-table";
+    public const string CentralSpendingModeExclude = "#spending-exclude-breakdown";
     public const string SectionTable = ".govuk-accordion__section .govuk-table";
     public const string SectionHeading1 = "#accordion-heading-1";
     public const string SectionContent1 = "#accordion-content-1";
@@ -61,6 +63,8 @@ public static class Selectors
 
     public const string ComparisonChartsAndTables = "#compare-your-costs";
     public const string ComparisonTables = "#compare-your-costs table.govuk-table";
+    public const string TrustComparisonTitles = "#compare-your-trust h2";
+    public const string TrustComparisonTables = "#compare-your-trust table.govuk-table";
 
     public const string TotalExpenditureSaveAsImage = "xpath=//*[@data-custom-event-chart-name='Total expenditure'][@data-custom-event-id='save-chart-as-image']";
     public const string TotalExpenditureCopyImage = "xpath=//*[@data-custom-event-chart-name='Total expenditure'][@data-custom-event-id='copy-chart-as-image']";

--- a/web/tests/Web.E2ETests/Steps/Trust/ComparatorsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/Trust/ComparatorsSteps.cs
@@ -1,0 +1,80 @@
+using Web.E2ETests.Drivers;
+using Web.E2ETests.Pages.Trust.Benchmarking;
+using Web.E2ETests.Pages.Trust.Comparators;
+using Xunit;
+
+namespace Web.E2ETests.Steps.Trust;
+
+[Binding]
+[Scope(Feature = "View Trust comparator set")]
+public class ComparatorsSteps(PageDriver driver)
+{
+    private CreateComparatorsByNamePage? _createComparatorsByNamePage;
+    private CreateComparatorsByPage? _createComparatorsByPage;
+    private TrustBenchmarkSpendingPage? _trustBenchmarkSpendingPage;
+
+    [Given("I am on compare by page for trust with company number '(.*)'")]
+    public async Task GivenIAmOnCompareByPageForTrustWithCompanyNumber(string companyNumber)
+    {
+        var url = CreateComparatorsByUrl(companyNumber);
+        var page = await driver.Current;
+        await page.GotoAndWaitForLoadAsync(url);
+
+        _createComparatorsByPage = new CreateComparatorsByPage(page);
+        await _createComparatorsByPage.IsDisplayed();
+    }
+
+    [When("I select the option By Name and click continue")]
+    public async Task WhenISelectTheOptionByNameAndClickContinue()
+    {
+        Assert.NotNull(_createComparatorsByPage);
+        await _createComparatorsByPage.SelectComparatorsBy(ComparatorsByTypes.Name);
+        _createComparatorsByNamePage = await _createComparatorsByPage.ClickContinue(ComparatorsByTypes.Name) as CreateComparatorsByNamePage;
+    }
+
+    [When("I select the trust with company number '(.*)' from suggester")]
+    public async Task WhenISelectTheTrustWithCompanyNumberFromSuggester(string companyNumber)
+    {
+        Assert.NotNull(_createComparatorsByNamePage);
+        await _createComparatorsByNamePage.TypeIntoTrustSearchBox(companyNumber);
+        await _createComparatorsByNamePage.SelectItemFromSuggester();
+    }
+
+    [When("I click the choose trust button")]
+    public async Task WhenIClickTheChooseTrustButton()
+    {
+        Assert.NotNull(_createComparatorsByNamePage);
+        await _createComparatorsByNamePage.ClickChooseTrustButton();
+    }
+
+    [When("I click the create set button")]
+    public async Task WhenIClickTheCreateSetButton()
+    {
+        Assert.NotNull(_createComparatorsByNamePage);
+        _trustBenchmarkSpendingPage = await _createComparatorsByNamePage.ClickCreateSetButton();
+    }
+
+    [When("I click on view as table")]
+    public async Task WhenIClickOnViewAsTable()
+    {
+        Assert.NotNull(_trustBenchmarkSpendingPage);
+        await _trustBenchmarkSpendingPage.IsDisplayed();
+        await _trustBenchmarkSpendingPage.ClickViewAsTable();
+    }
+
+    [When("I click on exclude central spending")]
+    public async Task WhenIClickOnExcludeCentralSpending()
+    {
+        Assert.NotNull(_trustBenchmarkSpendingPage);
+        await _trustBenchmarkSpendingPage.ClickExcludeCentralSpending();
+    }
+
+    [Then("the table for '(.*)' contains the following:")]
+    public async Task ThenTheTableForContainsTheFollowing(string category, DataTable table)
+    {
+        Assert.NotNull(_trustBenchmarkSpendingPage);
+        await _trustBenchmarkSpendingPage.TableContainsValues(category, table);
+    }
+
+    private static string CreateComparatorsByUrl(string urn) => $"{TestConfiguration.ServiceUrl}/trust/{urn}/comparators/create/by";
+}


### PR DESCRIPTION
### Context
[AB#248827](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/248827) [AB#248789](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/248789) #1895 

### Change proposed in this pull request
Additional test coverage as a follow-up to #1895. `£0.00` values are expected due to `NULL`s for all `xxxCS` columns across all `TrustFinancial` rows in `d02`

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

