### PR TITLE
Backfilled original workforce data in custom data workforce validation

### DIFF
--- a/web/Web.sln.DotSettings
+++ b/web/Web.sln.DotSettings
@@ -28,6 +28,7 @@
 	<s:Boolean x:Key="/Default/Environment/UnitTesting/CaptureOutputInternal/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/Housekeeping/UnitTestingMru/UnitTestRunner/LoggingInternal/@EntryValue">VERBOSE</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=actuals/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=backfill/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=esfa/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fbis/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fbit/@EntryIndexedValue">True</s:Boolean>

--- a/web/src/Web.App/Extensions/MvcOptionsExtensions.cs
+++ b/web/src/Web.App/Extensions/MvcOptionsExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+using Web.App.ViewModels.ModelBinders;
 
 namespace Web.App.Extensions;
 
@@ -9,6 +11,11 @@ public static partial class MvcOptionsExtensions
     public static void SetModelBindingOptions(this MvcOptions options)
     {
         options.ModelBindingMessageProvider.SetAttemptedValueIsInvalidAccessor(SetAttemptedValueIsInvalidAccessor);
+
+        // add custom binder provider that assigns custom binders on a per-Type basis
+        var fallbackProvider = options.ModelBinderProviders.First(p => p is ComplexObjectModelBinderProvider);
+        var customProvider = new CustomModelBinderProvider(fallbackProvider);
+        options.ModelBinderProviders.Insert(0, customProvider);
     }
 
     internal static string SetAttemptedValueIsInvalidAccessor(string value, string field)

--- a/web/src/Web.App/ViewModels/ModelBinders/CustomModelBinderProvider.cs
+++ b/web/src/Web.App/ViewModels/ModelBinders/CustomModelBinderProvider.cs
@@ -1,0 +1,33 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace Web.App.ViewModels.ModelBinders;
+
+[ExcludeFromCodeCoverage]
+public class CustomModelBinderProvider(IModelBinderProvider rootProvider) : IModelBinderProvider
+{
+    public IModelBinder? GetBinder(ModelBinderProviderContext context)
+    {
+        IModelBinder? rootBinder;
+        Type binderType;
+
+        var typeName = context.Metadata.ModelType.Name;
+        switch (typeName)
+        {
+            case nameof(WorkforceDataCustomDataViewModel):
+                rootBinder = rootProvider.GetBinder(context);
+                binderType = typeof(WorkforceDataCustomDataViewModelBinder);
+                break;
+            default:
+                return null;
+        }
+
+        if (rootBinder == null)
+        {
+            throw new InvalidOperationException($"Root {rootProvider.GetType()} did not provide an {nameof(IModelBinder)} for {typeName}.");
+        }
+
+        // wrap specific model binder in another binder that resolves dependency injected services
+        return new ModelBinderWithRequestServices(binderType, rootBinder);
+    }
+}

--- a/web/src/Web.App/ViewModels/ModelBinders/ModelBinderWithRequestServices.cs
+++ b/web/src/Web.App/ViewModels/ModelBinders/ModelBinderWithRequestServices.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace Web.App.ViewModels.ModelBinders;
+
+[ExcludeFromCodeCoverage]
+internal class ModelBinderWithRequestServices(IModelBinder rootBinder) : IModelBinder
+{
+    private readonly ObjectFactory? _factory;
+
+    public ModelBinderWithRequestServices(Type binderType, IModelBinder rootBinder) : this(rootBinder)
+    {
+        if (!typeof(IModelBinder).IsAssignableFrom(binderType))
+        {
+            throw new ArgumentException($"Binder type must derive from {nameof(IModelBinder)}.", nameof(binderType));
+        }
+
+        _factory = ActivatorUtilities.CreateFactory(binderType, [typeof(IModelBinder)]);
+    }
+
+    public async Task BindModelAsync(ModelBindingContext bindingContext)
+    {
+        var requestServices = bindingContext.HttpContext.RequestServices;
+        if (_factory?.Invoke(requestServices, [rootBinder]) is IModelBinder binder)
+        {
+            await binder.BindModelAsync(bindingContext);
+        }
+    }
+}

--- a/web/src/Web.App/ViewModels/ModelBinders/WorkforceDataCustomDataViewModelBinder.cs
+++ b/web/src/Web.App/ViewModels/ModelBinders/WorkforceDataCustomDataViewModelBinder.cs
@@ -1,0 +1,52 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Web.App.Domain;
+using Web.App.Infrastructure.Apis.Insight;
+using Web.App.Infrastructure.Extensions;
+
+namespace Web.App.ViewModels.ModelBinders;
+
+// Run default model binding, then add customisation (https://stackoverflow.com/a/73505409/504477)
+[ExcludeFromCodeCoverage]
+public class WorkforceDataCustomDataViewModelBinder(
+    IModelBinder defaultBinder,
+    IModelMetadataProvider metadataProvider,
+    ICensusApi censusApi,
+    ILoggerFactory loggerFactory) : IModelBinder
+{
+    private readonly ILogger<WorkforceDataCustomDataViewModelBinder> _logger = loggerFactory.CreateLogger<WorkforceDataCustomDataViewModelBinder>();
+
+    public async Task BindModelAsync(ModelBindingContext bindingContext)
+    {
+        _logger.LogDebug("Executing default binder");
+        await defaultBinder.BindModelAsync(bindingContext);
+
+        if (bindingContext.Model is not WorkforceDataCustomDataViewModel { HasValues: true } model)
+        {
+            return;
+        }
+
+        var urn = bindingContext.ModelState["urn"]?.AttemptedValue;
+        if (string.IsNullOrWhiteSpace(urn))
+        {
+            return;
+        }
+
+        // AB#246376: backfill missing dependent fields used for validation
+        _logger.LogDebug("Retrieving current census data for {URN}", urn);
+        var census = await censusApi.Get(urn).GetResultOrDefault<Census>();
+        model.WorkforceFte ??= census?.Workforce;
+        model.TeachersFte ??= census?.Teachers;
+
+        // Re-run data annotation validation (https://github.com/dotnet/aspnetcore/issues/18924)
+        _logger.LogDebug("Adding updated model to validation state");
+        bindingContext.ValidationState.Add(model, new ValidationStateEntry
+        {
+            Key = bindingContext.ModelName,
+            Metadata = metadataProvider.GetMetadataForType(typeof(WorkforceDataCustomDataViewModel))
+        });
+
+        bindingContext.Result = ModelBindingResult.Success(model);
+    }
+}

--- a/web/src/Web.App/ViewModels/WorkforceDataCustomDataViewModel.cs
+++ b/web/src/Web.App/ViewModels/WorkforceDataCustomDataViewModel.cs
@@ -19,14 +19,23 @@ public interface IWorkforceDataCustomDataViewModel : ICustomDataViewModel
 
 public record WorkforceDataCustomDataViewModel : IWorkforceDataCustomDataViewModel
 {
+    public bool HasValues => WorkforceFte != null
+                             || TeachersFte != null
+                             || QualifiedTeacherPercent != null
+                             || SeniorLeadershipFte != null
+                             || TeachingAssistantsFte != null
+                             || NonClassroomSupportStaffFte != null
+                             || AuxiliaryStaffFte != null
+                             || WorkforceHeadcount != null;
+
     [PositiveNumericValue]
     [Display(Name = SchoolCustomDataViewModelTitles.WorkforceFte)]
-    public decimal? WorkforceFte { get; init; }
+    public decimal? WorkforceFte { get; set; }
 
     [PositiveNumericValue]
     [Display(Name = SchoolCustomDataViewModelTitles.TeachersFte)]
     [CompareDecimalValue(nameof(WorkforceFte), Operator.LessThan)]
-    public decimal? TeachersFte { get; init; }
+    public decimal? TeachersFte { get; set; }
 
     [PositiveNumericValue]
     [Display(Name = SchoolCustomDataViewModelTitles.QualifiedTeacherPercent)]

--- a/web/tests/Web.E2ETests/Features/School/CreateCustomData.feature
+++ b/web/tests/Web.E2ETests/Features/School/CreateCustomData.feature
@@ -1,7 +1,7 @@
 Feature: School create custom data
 
     Background:
-        Given I am on create custom data page for school with URN '990234'
+        Given I am on create custom data page for school with URN '990023'
         And I have signed in with organisation '010: FBIT TEST - Multi-Academy Trust (Open)'
 
     Scenario: Can view create custom data page
@@ -20,6 +20,43 @@ Feature: School create custom data
         And I click continue
         And I supply the following workforce data:
           | Item                                    | Value |
-          | School workforce (full time equivalent) | 20    |
+          | School workforce (full time equivalent) | 250   |
         And I save the custom data
         Then the submitted page is displayed
+
+    Scenario: Cannot submit custom data with validation error on user-entered workforce FTE data
+        When I click start now
+        And I click continue
+        And I click continue
+        And I supply the following workforce data:
+          | Item                                      | Value |
+          | School workforce (full time equivalent)   | 250   |
+          | Number of teachers (full time equivalent) | 300   |
+        And I save the custom data
+        Then the validation errors are displayed:
+          | Error                                                                                                                |
+          | Number of teachers (full time equivalent) cannot be greater than or equal to school workforce (full time equivalent) |
+
+    Scenario: Cannot submit custom data with validation error on backfilled original workforce FTE data
+        When I click start now
+        And I click continue
+        And I click continue
+        And I supply the following workforce data:
+          | Item                                      | Value |
+          | Number of teachers (full time equivalent) | 300   |
+        And I save the custom data
+        Then the validation errors are displayed:
+          | Error                                                                                                                |
+          | Number of teachers (full time equivalent) cannot be greater than or equal to school workforce (full time equivalent) |
+
+    Scenario: Cannot submit custom data with validation error on backfilled original teachers FTE data
+        When I click start now
+        And I click continue
+        And I click continue
+        And I supply the following workforce data:
+          | Item                                     | Value |
+          | Senior leadership (full time equivalent) | 300   |
+        And I save the custom data
+        Then the validation errors are displayed:
+          | Error                                                                                                                 |
+          | Senior leadership (full time equivalent) cannot be greater than or equal to number of teachers (full time equivalent) |

--- a/web/tests/Web.E2ETests/Pages/School/CustomData/ChangeWorkforceDataPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/CustomData/ChangeWorkforceDataPage.cs
@@ -15,6 +15,7 @@ public class ChangeWorkforceDataPage(IPage page)
         {
             HasText = "Save changes to data"
         });
+    private ILocator ValidationError => page.Locator(Selectors.GovErrorSummary);
     private ILocator CustomDataField(string item) => page.Locator($".table-custom-data > tbody > tr:has-text('{item}') > td input");
 
     public async Task IsDisplayed()
@@ -32,5 +33,15 @@ public class ChangeWorkforceDataPage(IPage page)
     {
         await SaveChangesButton.ClickAsync();
         return new CreateCustomDataSubmittedPage(page);
+    }
+
+    public async Task ValidationErrorIsDisplayed()
+    {
+        await ValidationError.ShouldBeVisible();
+    }
+
+    public async Task ValidationErrorContainsErrorMessage(string message)
+    {
+        await ValidationError.ShouldContainText(message);
     }
 }

--- a/web/tests/Web.E2ETests/Steps/School/CreateCustomDataSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/CreateCustomDataSteps.cs
@@ -102,5 +102,17 @@ public class CreateCustomDataSteps(PageDriver driver)
         await _createCustomDataSubmittedPage.IsDisplayed();
     }
 
+    [Then("the validation errors are displayed:")]
+    public async Task ThenTheValidationErrorsAreDisplayed(DataTable table)
+    {
+        Assert.NotNull(_changeWorkforceDataPage);
+        await _changeWorkforceDataPage.ValidationErrorIsDisplayed();
+
+        foreach (var row in table.Rows)
+        {
+            await _changeWorkforceDataPage.ValidationErrorContainsErrorMessage(row["Error"]);
+        }
+    }
+
     private static string CreateCustomDataUrl(string urn) => $"{TestConfiguration.ServiceUrl}/school/{urn}/custom-data";
 }


### PR DESCRIPTION
### Context
[AB#246244](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/246244) [AB#246376](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/246376)

### Change proposed in this pull request
Backfilled workforce data with original values when custom values not provided, but are a validation dependency. This involved creating and registering a custom `IModelBinder` for the `WorkforceDataCustomDataViewModel` type that performs default model binding (i.e. parse the posted `FormCollection` as `WorkforceDataCustomDataViewModel` then perform model validation) before backfilling any missing `Census` data, and then re-validating.

### Guidance to review 
Repro steps in the work item may be followed to validate the change. Integration and E2E test coverage is also present.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

