### PR TITLE
Switched source Trust for user defined comparator set E2E tests

### DIFF
--- a/web/tests/Web.E2ETests/Features/Trust/Comparators.feature
+++ b/web/tests/Web.E2ETests/Features/Trust/Comparators.feature
@@ -3,11 +3,11 @@ Feature: View Trust comparator set
     Background:
         Given I am on the service home
         And I have signed in with organisation '010: FBIT TEST - Multi-Academy Trust (Open)'
-        And I am on compare by page for trust with company number '00000001'
+        And I am on compare by page for trust with company number '10074054'
 
     Scenario: Can view comparator trusts data including central spending
         When I select the option By Name and click continue
-        And I select the trust with company number '10074054' from suggester
+        And I select the trust with company number '00000001' from suggester
         And I click the choose trust button
         And I select the trust with company number '8076374' from suggester
         And I click the choose trust button
@@ -15,13 +15,13 @@ Feature: View Trust comparator set
         And I click on view as table
         Then the table for 'Total expenditure' contains the following:
           | TrustName                | TotalAmount | SchoolAmount | CentralAmount |
-          | FBIT Multi Academy Trust | £18,519     | £18,519      | £0.00         |
-          | Test Company/Trust 309   | £9,807      | £9,807       | £0.00         |
-          | Test Company/Trust 108   | £7,684      | £7,684       | £0.00         |
+          | FBIT Multi Academy Trust | £18,519     | £18,519      | £0            |
+          | Test Company/Trust 309   | £9,807      | £9,807       | £0            |
+          | Test Company/Trust 108   | £7,684      | £7,684       | £0            |
 
     Scenario: Can view comparator trusts data excluding central spending
         When I select the option By Name and click continue
-        And I select the trust with company number '10074054' from suggester
+        And I select the trust with company number '00000001' from suggester
         And I click the choose trust button
         And I select the trust with company number '8076374' from suggester
         And I click the choose trust button


### PR DESCRIPTION
### Context
[AB#248827](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/248827) [AB#248789](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/248789) #1897

### Change proposed in this pull request
Fixed failing E2E test from #1897 due to concurrent test runs selecting different comparator Trusts.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

