### PR TITLE
Ensured `Failed finished pipeline messages alert` is triggered on failed finished messages only

### DIFF
--- a/support-analytics/terraform/alerts.tf
+++ b/support-analytics/terraform/alerts.tf
@@ -192,9 +192,9 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "failed-finished-pipel
     threshold               = var.configuration[var.environment].thresholds.error
 
     dimension {
-      name     = "dimension"
-      operator = "Include"
-      values   = ["False", "True"]
+      name     = "Success"
+      operator = "Exclude"
+      values   = ["True"]
     }
 
     failing_periods {

--- a/support-analytics/terraform/queries/pipeline-messages-finished.kql
+++ b/support-analytics/terraform/queries/pipeline-messages-finished.kql
@@ -7,21 +7,21 @@ let mainTable = union customEvents
 let byTable = mainTable;
 let queryTable = () {
     byTable
-    | extend dimension = customDimensions["Success"]
-    | extend dimension = iif(isempty(dimension), "<undefined>", dimension)
+    | extend Success = customDimensions["Success"]
+    | extend Success = iif(isempty(Success), "<undefined>", Success)
 };
 let byCohortTable = queryTable
-    | project dimension, timestamp;
+    | project Success, timestamp;
 let topSegments = byCohortTable
-    | summarize Events = count() by dimension
+    | summarize Events = count() by Success
     | top 10 by Events
-    | summarize makelist(dimension);
+    | summarize makelist(Success);
 let topEventMetrics = byCohortTable
-    | where dimension in (topSegments);
+    | where Success in (topSegments);
 let otherEventUsers = byCohortTable
-    | where dimension !in (topSegments)
-    | extend dimension = "Other";
+    | where Success !in (topSegments)
+    | extend Success = "Other";
 otherEventUsers
 | union topEventMetrics
-| summarize Events = count() by dimension
-| order by dimension asc
+| summarize Events = count() by Success
+| order by Success asc


### PR DESCRIPTION
### Context
[AB#247562](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/247562) [AB#247561](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/247561) #1822

### Change proposed in this pull request
Fix to query and rules from #1822

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~~Your code builds clean without any errors or warnings~~
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~



