### PR TITLE
Used correct TF variable to determine Teams channel variable to assign to Logic App

### DIFF
--- a/support-analytics/terraform/logic-app.tf
+++ b/support-analytics/terraform/logic-app.tf
@@ -1,7 +1,7 @@
 locals {
-  teams-channel-id = (var.environment-prefix == "pre-production"
+  teams-channel-id = (var.environment == "pre-production"
     ? var.teams-channel-id-preprod
-    : var.environment-prefix == "production"
+    : var.environment == "production"
     ? var.teams-channel-id
   : var.teams-channel-id-dev)
 }


### PR DESCRIPTION
### Context
[AB#248972](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/248972) [AB#247561](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/247561) #1822

### Change proposed in this pull request
Pre-prod and Prod should use their designated Teams channels for alerts. The logic to determine this in #1822 was using the wrong variable to distinguish this and so were set to use the Development channel on the earlier deployment.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [ ] ~~You have tested by running locally~~
- [ ] ~~You have reviewed with UX/Design~~

