### PR TITLE
Extended time to wait for 'Save all' file download to complete in E2E test

### DIFF
--- a/web/tests/Web.E2ETests/Extensions/PageExtensions.cs
+++ b/web/tests/Web.E2ETests/Extensions/PageExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Playwright;
+
 namespace Web.E2ETests;
 
 public static class PageExtensions
@@ -14,4 +15,9 @@ public static class PageExtensions
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
         return response;
     }
+
+    public static Task<IDownload> WaitForDownloadAsync(this IPage page, TimeSpan timeout) => page.WaitForDownloadAsync(new PageWaitForDownloadOptions
+    {
+        Timeout = Convert.ToSingle(timeout.TotalMilliseconds)
+    });
 }

--- a/web/tests/Web.E2ETests/Steps/SaveAllImagesModalSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/SaveAllImagesModalSteps.cs
@@ -42,7 +42,7 @@ public class SaveAllImagesModalSteps(PageDriver driver)
     {
         Assert.NotNull(_spendingCostsPage);
         var page = await driver.Current;
-        var downloadTask = page.WaitForDownloadAsync();
+        var downloadTask = page.WaitForDownloadAsync(new TimeSpan(0, 1, 0));
         await _spendingCostsPage.ClickSaveAllImagesModalOkButton();
         _download = await downloadTask;
     }


### PR DESCRIPTION
### Context
[AB#247366](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/247366) [AB#242099](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/242099) #1902

### Change proposed in this pull request
As per commentary on #1902, timeouts were occurring when running in the Azure pipeline. Locally this takes < 2,000 ms to complete, but timeout set to 60,000 ms here.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

