### PR TITLE
Downgraded `azurerm` to `4.17.0` in Web

### DIFF
--- a/web/Directory.Packages.props
+++ b/web/Directory.Packages.props
@@ -29,7 +29,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
     <PackageVersion Include="AngleSharp" Version="1.2.0" />
-    <PackageVersion Include="AngleSharp.Css" Version="1.0.0-beta.144" />
+    <PackageVersion Include="AngleSharp.Css" Version="1.0.0-beta.151" />
     <PackageVersion Include="AngleSharp.XPath" Version="2.0.4" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.12" />
     <PackageVersion Include="Moq" Version="4.20.72" />

--- a/web/terraform/README.md
+++ b/web/terraform/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.8 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.18.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.17.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.18.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.17.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
 
 ## Modules

--- a/web/terraform/provider.tf
+++ b/web/terraform/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.18.0"
+      version = "~> 4.17.0"
     }
   }
   backend "azurerm" {}

--- a/web/tests/Web.Integration.Tests/packages.lock.json
+++ b/web/tests/Web.Integration.Tests/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "AngleSharp.Css": {
         "type": "Direct",
-        "requested": "[1.0.0-beta.144, )",
-        "resolved": "1.0.0-beta.144",
-        "contentHash": "WfyZ1zi5o7fNPgTv0O74nmzyxt9w4tjypwpOCSoeoZDOHtgghc/JqyGHRbQh7Y9sZlJiivQhrQNtm4XAy9LHYA==",
+        "requested": "[1.0.0-beta.151, )",
+        "resolved": "1.0.0-beta.151",
+        "contentHash": "oEnqXQcwpc/kkUIi2rxWHfFrmKlcJFpZZZjhEIHVc+aEJFo3U+5cptOHByQh+FW0PCW6ssVJ+GGBgbgyN8YPiw==",
         "dependencies": {
           "AngleSharp": "[1.0.0, 2.0.0)"
         }


### PR DESCRIPTION
### Context
[AB#248374](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/248374) [AB#248372](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/248372) #1888

### Change proposed in this pull request
Downgrade due to bug on newly introduced `js_challenge_cookie_expiration_in_minutes` (see [issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/28716)).

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your branch has been rebased onto main

