### PR TITLE
CSV download of School Census data in a ZIP archive

### DIFF
--- a/web/src/Web.App/ActionResults/CsvResult.cs
+++ b/web/src/Web.App/ActionResults/CsvResult.cs
@@ -1,0 +1,43 @@
+using System.Net;
+using System.Text;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Net.Http.Headers;
+
+namespace Web.App.ActionResults;
+
+public class CsvResult(IEnumerable<object>? items, string? fileName = null) : ActionResult, IStatusCodeActionResult
+{
+    /// <summary>
+    ///     Gets the <see cref="System.Net.Http.Headers.MediaTypeHeaderValue" /> representing the Content-Type header
+    ///     of the response.
+    /// </summary>
+    public string? ContentType { get; } = new MediaTypeHeaderValue("text/csv")
+    {
+        Encoding = Encoding.UTF8
+    }.ToString();
+
+    /// <summary>
+    ///     Gets the items to be formatted.
+    /// </summary>
+    public IEnumerable<object>? Items { get; } = items;
+
+    /// <summary>
+    ///     Gets the target file name for the output file.
+    /// </summary>
+    public string? FileName { get; } = fileName;
+
+    /// <summary>
+    ///     Gets the HTTP status code.
+    /// </summary>
+    public int? StatusCode => (int)HttpStatusCode.OK;
+
+    public override Task ExecuteResultAsync(ActionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var services = context.HttpContext.RequestServices;
+        var executor = services.GetRequiredService<IActionResultExecutor<CsvResult>>();
+        return executor.ExecuteAsync(context, this);
+    }
+}

--- a/web/src/Web.App/ActionResults/CsvResultActionResultExecutor.cs
+++ b/web/src/Web.App/ActionResults/CsvResultActionResultExecutor.cs
@@ -1,0 +1,62 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Net.Http.Headers;
+using Web.App.Services;
+
+namespace Web.App.ActionResults;
+
+public partial class CsvResultActionResultExecutor(ICsvService csvService, ILogger<CsvResultActionResultExecutor> logger) : IActionResultExecutor<CsvResult>
+{
+    public async Task ExecuteAsync(ActionContext context, CsvResult result)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(result);
+
+        var response = context.HttpContext.Response;
+        if (result.StatusCode != null)
+        {
+            response.StatusCode = result.StatusCode.Value;
+        }
+
+        response.ContentType = result.ContentType;
+
+        if (!string.IsNullOrWhiteSpace(result.FileName))
+        {
+            response.Headers.Append(HeaderNames.ContentDisposition, $"attachment; filename=\"{result.FileName}\"");
+        }
+
+        Log.CsvResultExecuting(logger, result.Items);
+
+        try
+        {
+            if (result.Items != null && result.Items.Any())
+            {
+                var csv = csvService.SaveToCsv(result.Items);
+                await response.WriteAsync(csv);
+                await response.CompleteAsync();
+            }
+        }
+        catch (OperationCanceledException) when (context.HttpContext.RequestAborted.IsCancellationRequested)
+        {
+        }
+    }
+
+    [ExcludeFromCodeCoverage]
+    private static partial class Log
+    {
+        [LoggerMessage(1, LogLevel.Information, "Executing CsvResult, writing value of type '{Type}'.", EventName = "CsvResultExecuting", SkipEnabledCheck = true)]
+        private static partial void CsvResultExecuting(ILogger logger, string? type);
+
+        public static void CsvResultExecuting(ILogger logger, object? value)
+        {
+            if (!logger.IsEnabled(LogLevel.Information))
+            {
+                return;
+            }
+
+            var type = value == null ? "null" : value.GetType().FullName;
+            CsvResultExecuting(logger, type);
+        }
+    }
+}

--- a/web/src/Web.App/ActionResults/CsvResultActionResultExecutor.cs
+++ b/web/src/Web.App/ActionResults/CsvResultActionResultExecutor.cs
@@ -21,9 +21,9 @@ public partial class CsvResultActionResultExecutor(ICsvService csvService, ILogg
 
         response.ContentType = result.ContentType;
 
-        if (!string.IsNullOrWhiteSpace(result.FileName))
+        if (!string.IsNullOrWhiteSpace(result.CsvFileName))
         {
-            response.Headers.Append(HeaderNames.ContentDisposition, $"attachment; filename=\"{result.FileName}\"");
+            response.Headers.Append(HeaderNames.ContentDisposition, $"attachment; filename=\"{result.CsvFileName}\"");
         }
 
         Log.CsvResultExecuting(logger, result.Items);

--- a/web/src/Web.App/ActionResults/CsvResults.cs
+++ b/web/src/Web.App/ActionResults/CsvResults.cs
@@ -1,31 +1,27 @@
 using System.Net;
-using System.Text;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Net.Http.Headers;
 
 namespace Web.App.ActionResults;
 
-public class CsvResult(IEnumerable<object>? items, string? csvFileName = null) : ActionResult, IStatusCodeActionResult
+public class CsvResults(IEnumerable<CsvResult> items, string? zipFileName = null) : ActionResult, IStatusCodeActionResult
 {
     /// <summary>
     ///     Gets the <see cref="System.Net.Http.Headers.MediaTypeHeaderValue" /> representing the Content-Type header
     ///     of the response.
     /// </summary>
-    public string? ContentType { get; } = new MediaTypeHeaderValue("text/csv")
-    {
-        Encoding = Encoding.UTF8
-    }.ToString();
+    public string? ContentType { get; } = new MediaTypeHeaderValue("application/zip").ToString();
 
     /// <summary>
     ///     Gets the items to be formatted.
     /// </summary>
-    public IEnumerable<object>? Items { get; } = items;
+    public IEnumerable<CsvResult> Items { get; } = items;
 
     /// <summary>
     ///     Gets the target file name for the output file.
     /// </summary>
-    public string? CsvFileName { get; } = csvFileName;
+    public string? ZipFileName { get; } = zipFileName;
 
     /// <summary>
     ///     Gets the HTTP status code.
@@ -37,7 +33,7 @@ public class CsvResult(IEnumerable<object>? items, string? csvFileName = null) :
         ArgumentNullException.ThrowIfNull(context);
 
         var services = context.HttpContext.RequestServices;
-        var executor = services.GetRequiredService<IActionResultExecutor<CsvResult>>();
+        var executor = services.GetRequiredService<IActionResultExecutor<CsvResults>>();
         return executor.ExecuteAsync(context, this);
     }
 }

--- a/web/src/Web.App/ActionResults/CsvResultsActionResultExecutor.cs
+++ b/web/src/Web.App/ActionResults/CsvResultsActionResultExecutor.cs
@@ -1,0 +1,79 @@
+using System.Diagnostics.CodeAnalysis;
+using System.IO.Compression;
+using System.Text;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Net.Http.Headers;
+using Web.App.Services;
+
+namespace Web.App.ActionResults;
+
+public partial class CsvResultsActionResultExecutor(ICsvService csvService, ILogger<CsvResultsActionResultExecutor> logger) : IActionResultExecutor<CsvResults>
+{
+    public async Task ExecuteAsync(ActionContext context, CsvResults result)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(result);
+
+        var response = context.HttpContext.Response;
+        if (result.StatusCode != null)
+        {
+            response.StatusCode = result.StatusCode.Value;
+        }
+
+        response.ContentType = result.ContentType;
+
+        if (!string.IsNullOrWhiteSpace(result.ZipFileName))
+        {
+            response.Headers.Append(HeaderNames.ContentDisposition, $"attachment; filename=\"{result.ZipFileName}\"");
+        }
+
+        Log.CsvResultsExecuting(logger, result.Items);
+
+        try
+        {
+            if (result.Items.Any())
+            {
+                using var zipStream = new MemoryStream();
+                using (var archive = new ZipArchive(zipStream, ZipArchiveMode.Create, true))
+                {
+                    var i = 0;
+                    foreach (var item in result.Items.Where(m => m.Items != null))
+                    {
+                        i++;
+                        var entry = archive.CreateEntry(item.CsvFileName ?? $"file-{i}.csv");
+                        await using var entryStream = entry.Open();
+                        await using var writer = new StreamWriter(entryStream, Encoding.UTF8);
+                        var csv = csvService.SaveToCsv(item.Items!);
+                        await writer.WriteAsync(csv);
+                    }
+                }
+
+                zipStream.Seek(0, SeekOrigin.Begin);
+                await response.Body.WriteAsync(zipStream.ToArray());
+                await response.CompleteAsync();
+            }
+        }
+        catch (OperationCanceledException) when (context.HttpContext.RequestAborted.IsCancellationRequested)
+        {
+        }
+    }
+
+    [ExcludeFromCodeCoverage]
+    private static partial class Log
+    {
+        [LoggerMessage(1, LogLevel.Information, "Executing CsvResults, writing value of type '{Type}'.", EventName = "CsvResultsExecuting", SkipEnabledCheck = true)]
+        private static partial void CsvResultsExecuting(ILogger logger, string? type);
+
+        public static void CsvResultsExecuting(ILogger logger, object? value)
+        {
+            if (!logger.IsEnabled(LogLevel.Information))
+            {
+                return;
+            }
+
+            var type = value == null ? "null" : value.GetType().FullName;
+            CsvResultsExecuting(logger, type);
+        }
+    }
+}

--- a/web/src/Web.App/Controllers/Api/CensusProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/CensusProxyController.cs
@@ -65,7 +65,7 @@ public class CensusProxyController(
                 var result = customDataId is not null
                     ? await GetCustomAsync(id, null, "Total", customDataId)
                     : await GetDefaultAsync(type, id, null, "Total", null);
-                return new CsvResult(result, $"census-{id}.csv");
+                return new CsvResults([new CsvResult(result, $"census-{id}.csv")], $"census-{id}.zip");
             }
             catch (Exception e)
             {

--- a/web/src/Web.App/Extensions/ServiceCollectionExtensions.cs
+++ b/web/src/Web.App/Extensions/ServiceCollectionExtensions.cs
@@ -271,5 +271,6 @@ public static class ServiceCollectionExtensions
 
     public static IServiceCollection AddActionResults(this IServiceCollection services) => services
         .AddSingleton<IActionResultExecutor<CsvResult>, CsvResultActionResultExecutor>()
+        .AddSingleton<IActionResultExecutor<CsvResults>, CsvResultsActionResultExecutor>()
         .AddSingleton<ICsvService, CsvService>();
 }

--- a/web/src/Web.App/Extensions/ServiceCollectionExtensions.cs
+++ b/web/src/Web.App/Extensions/ServiceCollectionExtensions.cs
@@ -3,8 +3,10 @@ using IdentityModel.Client;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
+using Web.App.ActionResults;
 using Web.App.Identity;
 using Web.App.Identity.Models;
 using Web.App.Infrastructure.Apis;
@@ -266,4 +268,8 @@ public static class ServiceCollectionExtensions
                 };
             });
     }
+
+    public static IServiceCollection AddActionResults(this IServiceCollection services) => services
+        .AddSingleton<IActionResultExecutor<CsvResult>, CsvResultActionResultExecutor>()
+        .AddSingleton<ICsvService, CsvService>();
 }

--- a/web/src/Web.App/Program.cs
+++ b/web/src/Web.App/Program.cs
@@ -43,7 +43,8 @@ builder.Services
     .AddScoped<IFinancialPlanStageValidator, FinancialPlanStageValidator>()
     .AddScoped<ICustomDataService, CustomDataService>()
     .AddScoped<IUserDataService, UserDataService>()
-    .AddScoped<IClaimsIdentifierService, ClaimsIdentifierService>();
+    .AddScoped<IClaimsIdentifierService, ClaimsIdentifierService>()
+    .AddActionResults();
 
 builder.Services.AddHealthChecks()
     .AddCheck<ApiHealthCheck>("API Health Check");

--- a/web/src/Web.App/Services/CsvService.cs
+++ b/web/src/Web.App/Services/CsvService.cs
@@ -1,0 +1,55 @@
+using System.ComponentModel;
+
+namespace Web.App.Services;
+
+public interface ICsvService
+{
+    /// <summary>
+    ///     Saves a collection of data objects to a CSV string.
+    ///     <a href="https://stackoverflow.com/a/76324305/504477">ref</a>
+    /// </summary>
+    /// <param name="items">The collection of data objects.</param>
+    /// <returns>A string representation of the CSV file.</returns>
+    string SaveToCsv(IEnumerable<object?> items);
+}
+
+public class CsvService : ICsvService
+{
+    public string SaveToCsv(IEnumerable<object?> items)
+    {
+        // get properties       
+        var rows = items.Where(i => i != null).Cast<object>().ToArray();
+        var objectType = rows.FirstOrDefault()?.GetType();
+        if (objectType == null)
+        {
+            return string.Empty;
+        }
+
+        var props = TypeDescriptor.GetProperties(objectType).OfType<PropertyDescriptor>();
+        var propertyNames = props.Select(p => p.Name).ToArray();
+        var lines = new List<string>();
+
+        // build header
+        var header = string.Join(",", propertyNames);
+        lines.Add(header);
+
+        // build rows
+        var valueLines = rows
+            .Select(row =>
+            {
+                var values = propertyNames.Select(propertyName =>
+                {
+                    var propertyValue = row?.GetType().GetProperty(propertyName)?.GetValue(row, null);
+                    var valueString = propertyValue?.ToString();
+
+                    // quote values if they contain commas
+                    return valueString?.Contains(',') == true ? $"\"{valueString}\"" : valueString;
+                });
+
+                return string.Join(",", values);
+            });
+
+        lines.AddRange(valueLines);
+        return string.Join(Environment.NewLine, lines);
+    }
+}

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -103,6 +103,7 @@ public static class Paths
     public static string ApiExpenditureHistoryComparison(string? type, string? id, string dimension, string? phase, string? financeType) => $"api/expenditure/history/comparison?type={type}&id={id}&dimension={dimension}&phase={phase}&financeType={financeType}";
     public static string ApiExpenditureUserDefined(string? type, string? id, string dimension, string? category) => $"api/expenditure/user-defined?type={type}&id={id}&dimension={dimension}&category={category}";
     public static string ApiCensus(string id, string type, string category, string dimension) => $"api/census?id={id}&type={type}&category={category}&dimension={dimension}";
+    public static string ApiCensusDownload(string id, string type) => $"api/census/download?id={id}&type={type}";
     public static string ApiCensusHistoryComparison(string id, string dimension, string? phase, string? financeType) => $"api/census/history/comparison?id={id}&dimension={dimension}&phase={phase}&financeType={financeType}";
     public static string LocalAuthorityHome(string? code) => $"/local-authority/{code}";
     public static string LocalAuthorityResources(string? code) => $"/local-authority/{code}/find-ways-to-spend-less";

--- a/web/tests/Web.Integration.Tests/Proxy/WhenRequestingCensusDownload.cs
+++ b/web/tests/Web.Integration.Tests/Proxy/WhenRequestingCensusDownload.cs
@@ -1,0 +1,57 @@
+using System.Net;
+using System.Text;
+using AutoFixture;
+using Web.App.Domain;
+using Xunit;
+
+namespace Web.Integration.Tests.Proxy;
+
+public class WhenRequestingCensusDownload : PageBase<SchoolBenchmarkingWebAppClient>
+{
+    private readonly Census[] _censuses;
+    private readonly SchoolBenchmarkingWebAppClient _client;
+
+    public WhenRequestingCensusDownload(SchoolBenchmarkingWebAppClient client) : base(client)
+    {
+        _client = client;
+        _censuses = Fixture.Build<Census>().CreateMany().ToArray();
+    }
+
+    [Fact]
+    public async Task CanReturnOk()
+    {
+        var school = Fixture.Build<School>()
+            .With(x => x.URN, "12345")
+            .Create();
+
+        var comparatorSet = Fixture.Build<SchoolComparatorSet>()
+            .With(x => x.Pupil, ["pupil"])
+            .Create();
+
+        var response = await _client
+            .SetupEstablishment(school)
+            .SetupComparatorSet(school, comparatorSet)
+            .SetupCensus(_censuses)
+            .Get(Paths.ApiCensusDownload(school.URN!, "school"));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        var csvLines = Encoding.UTF8.GetString(bytes).Split(Environment.NewLine);
+        Assert.Equal(
+            "SchoolName,SchoolType,LAName,URN,TotalPupils,Workforce,WorkforceHeadcount,Teachers,SeniorLeadership,TeachingAssistant,NonClassroomSupportStaff,AuxiliaryStaff,PercentTeacherWithQualifiedStatus",
+            csvLines.First());
+        Assert.Equal(_censuses.Length, csvLines.Length - 1);
+    }
+
+    [Fact]
+    public async Task CanReturnInternalServerError()
+    {
+        const string urn = "12345";
+        var response = await _client
+            .SetupComparatorSetApiWithException()
+            .SetupCensusWithException()
+            .Get(Paths.ApiCensusDownload(urn, "school"));
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+}

--- a/web/tests/Web.Tests/ActionResults/WhenCsvResultActionResultExecutorIsExecuted.cs
+++ b/web/tests/Web.Tests/ActionResults/WhenCsvResultActionResultExecutorIsExecuted.cs
@@ -1,0 +1,96 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Web.App.ActionResults;
+using Web.App.Services;
+using Xunit;
+
+namespace Web.Tests.ActionResults;
+
+public class WhenCsvResultActionResultExecutorIsExecuted
+{
+    private readonly ActionContext _actionContext;
+    private readonly CsvResultActionResultExecutor _executor;
+    private readonly DefaultHttpContext _httpContext;
+    private readonly Mock<ICsvService> _service;
+
+    public WhenCsvResultActionResultExecutorIsExecuted()
+    {
+        _service = new Mock<ICsvService>();
+        _executor = new CsvResultActionResultExecutor(_service.Object, NullLogger<CsvResultActionResultExecutor>.Instance);
+
+        _httpContext = new DefaultHttpContext
+        {
+            Response =
+            {
+                Body = new MemoryStream()
+            }
+        };
+        _actionContext = new ActionContext
+        {
+            HttpContext = _httpContext
+        };
+    }
+
+    [Fact]
+    public async Task ShouldSetResponseHeaders()
+    {
+        // arrange
+        var items = new List<TestObject>
+        {
+            new()
+            {
+                Id = 1,
+                Value = "Value"
+            }
+        };
+        const string fileName = nameof(fileName);
+
+        var result = new CsvResult(items, fileName);
+        const string csv = nameof(csv);
+        _service.Setup(s => s.SaveToCsv(items)).Returns(csv);
+
+        // act
+        await _executor.ExecuteAsync(_actionContext, result);
+
+        // assert
+        Assert.Equal(result.StatusCode, _httpContext.Response.StatusCode);
+        Assert.Equal(result.ContentType, _httpContext.Response.ContentType);
+        Assert.Equal($"attachment; filename=\"{fileName}\"", _httpContext.Response.Headers.ContentDisposition);
+    }
+
+    [Fact]
+    public async Task ShouldCallServiceAndSetResponseBody()
+    {
+        // arrange
+        var items = new List<TestObject>
+        {
+            new()
+            {
+                Id = 1,
+                Value = "Value"
+            }
+        };
+
+        var result = new CsvResult(items);
+        const string csv = nameof(csv);
+        _service.Setup(s => s.SaveToCsv(items)).Returns(csv);
+
+        // act
+        await _executor.ExecuteAsync(_actionContext, result);
+
+        // assert
+        _httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
+        using var reader = new StreamReader(_httpContext.Response.Body);
+        var body = await reader.ReadToEndAsync();
+
+        Assert.Equal(csv, body);
+    }
+
+    private class TestObject
+    {
+        public int Id { get; set; }
+        public string? Value { get; set; }
+    }
+}

--- a/web/tests/Web.Tests/ActionResults/WhenCsvResultIsExecuted.cs
+++ b/web/tests/Web.Tests/ActionResults/WhenCsvResultIsExecuted.cs
@@ -1,0 +1,84 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Web.App.ActionResults;
+using Xunit;
+
+// ReSharper disable ClassNeverInstantiated.Local
+
+namespace Web.Tests.ActionResults;
+
+public class WhenCsvResultIsExecuted
+{
+    private readonly Mock<IActionResultExecutor<CsvResult>> _actionResultExecutor;
+    private readonly string _fileName = nameof(_fileName);
+    private readonly TestObject[] _items = [];
+    private readonly IServiceCollection _services = new ServiceCollection();
+
+    public WhenCsvResultIsExecuted()
+    {
+        _actionResultExecutor = new Mock<IActionResultExecutor<CsvResult>>();
+        _services.AddScoped<IActionResultExecutor<CsvResult>>(_ => _actionResultExecutor.Object);
+    }
+
+    [Fact]
+    public void ShouldSetTheContentType()
+    {
+        var result = new CsvResult(_items, _fileName);
+
+        Assert.Equal("text/csv; charset=utf-8", result.ContentType);
+    }
+
+    [Fact]
+    public void ShouldSetTheItems()
+    {
+        var result = new CsvResult(_items, _fileName);
+
+        Assert.Equal(_items, result.Items);
+    }
+
+    [Fact]
+    public void ShouldSetTheFileName()
+    {
+        var result = new CsvResult(_items, _fileName);
+
+        Assert.Equal(_fileName, result.FileName);
+    }
+
+    [Fact]
+    public void ShouldSetTheStatusCode()
+    {
+        var result = new CsvResult(_items, _fileName);
+
+        Assert.Equal(200, result.StatusCode);
+    }
+
+    [Fact]
+    public async Task ShouldExecuteTheActionResultExecutor()
+    {
+        var provider = _services.BuildServiceProvider();
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = provider
+        };
+
+        var actionContext = new ActionContext
+        {
+            HttpContext = httpContext
+        };
+
+        var result = new CsvResult(_items, _fileName);
+
+        _actionResultExecutor
+            .Setup(e => e.ExecuteAsync(actionContext, result))
+            .Verifiable();
+
+        await result.ExecuteResultAsync(actionContext);
+
+        _actionResultExecutor.Verify();
+    }
+
+    private class TestObject;
+}

--- a/web/tests/Web.Tests/ActionResults/WhenCsvResultsIsExecuted.cs
+++ b/web/tests/Web.Tests/ActionResults/WhenCsvResultsIsExecuted.cs
@@ -10,47 +10,51 @@ using Xunit;
 
 namespace Web.Tests.ActionResults;
 
-public class WhenCsvResultIsExecuted
+public class WhenCsvResultsIsExecuted
 {
-    private readonly Mock<IActionResultExecutor<CsvResult>> _actionResultExecutor;
-    private readonly string _fileName = nameof(_fileName);
+    private readonly Mock<IActionResultExecutor<CsvResults>> _actionResultExecutor;
+    private readonly string _csvFileName = nameof(_csvFileName);
     private readonly TestObject[] _items = [];
     private readonly IServiceCollection _services = new ServiceCollection();
+    private readonly string _zipFileName = nameof(_zipFileName);
 
-    public WhenCsvResultIsExecuted()
+    public WhenCsvResultsIsExecuted()
     {
-        _actionResultExecutor = new Mock<IActionResultExecutor<CsvResult>>();
-        _services.AddScoped<IActionResultExecutor<CsvResult>>(_ => _actionResultExecutor.Object);
+        _actionResultExecutor = new Mock<IActionResultExecutor<CsvResults>>();
+        _services.AddScoped<IActionResultExecutor<CsvResults>>(_ => _actionResultExecutor.Object);
     }
 
     [Fact]
     public void ShouldSetTheContentType()
     {
-        var result = new CsvResult(_items, _fileName);
+        var result = new CsvResults([new CsvResult(_items, _csvFileName)], _zipFileName);
 
-        Assert.Equal("text/csv; charset=utf-8", result.ContentType);
+        Assert.Equal("application/zip", result.ContentType);
     }
 
     [Fact]
     public void ShouldSetTheItems()
     {
-        var result = new CsvResult(_items, _fileName);
+        var result = new CsvResults([new CsvResult(_items, _csvFileName)], _zipFileName);
 
-        Assert.Equal(_items, result.Items);
+        Assert.Single(result.Items);
+        Assert.Equal(_items, result.Items.First().Items);
     }
 
     [Fact]
     public void ShouldSetTheFileName()
     {
-        var result = new CsvResult(_items, _fileName);
+        var result = new CsvResults([new CsvResult(_items, _csvFileName)], _zipFileName);
 
-        Assert.Equal(_fileName, result.CsvFileName);
+        Assert.Equal(_zipFileName, result.ZipFileName);
+        Assert.Single(result.Items);
+        Assert.Equal(_csvFileName, result.Items.First().CsvFileName);
     }
 
     [Fact]
     public void ShouldSetTheStatusCode()
     {
-        var result = new CsvResult(_items, _fileName);
+        var result = new CsvResults([new CsvResult(_items, _csvFileName)], _zipFileName);
 
         Assert.Equal(200, result.StatusCode);
     }
@@ -69,7 +73,7 @@ public class WhenCsvResultIsExecuted
             HttpContext = httpContext
         };
 
-        var result = new CsvResult(_items, _fileName);
+        var result = new CsvResults([new CsvResult(_items, _csvFileName)], _zipFileName);
 
         _actionResultExecutor
             .Setup(e => e.ExecuteAsync(actionContext, result))

--- a/web/tests/Web.Tests/Services/WhenCsvServiceIsCalled.cs
+++ b/web/tests/Web.Tests/Services/WhenCsvServiceIsCalled.cs
@@ -1,0 +1,85 @@
+﻿using Web.App.Services;
+using Xunit;
+
+// ReSharper disable UnusedAutoPropertyAccessor.Local
+
+namespace Web.Tests.Services;
+
+public class WhenCsvServiceIsCalled
+{
+    private readonly CsvService _service = new();
+
+    [Fact]
+    public void ShouldReturnEmptyStringForEmptyCollection()
+    {
+        var items = Array.Empty<TestObject>();
+
+        var result = _service.SaveToCsv(items);
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void ShouldReturnCsvStringForValidCollection()
+    {
+        var items = new List<TestObject>
+        {
+            new()
+            {
+                Id = 1,
+                Value = "Value"
+            },
+            new()
+            {
+                Id = 2,
+                Value = "Another value"
+            },
+            new()
+            {
+                Id = 2,
+                Value = "Value, with a comma"
+            }
+        };
+
+        var result = _service.SaveToCsv(items);
+
+        var expected = $"Id,Value{Environment.NewLine}1,Value{Environment.NewLine}2,Another value{Environment.NewLine}2,\"Value, with a comma\"";
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ShouldReturnCsvStringForValidCollectionContainingNulls()
+    {
+        var items = new List<TestObject?>
+        {
+            null,
+            new()
+            {
+                Id = 1,
+                Value = "Value"
+            },
+            new()
+            {
+                Id = 2,
+                Value = "Another value"
+            },
+            new()
+            {
+                Id = 2,
+                Value = "Value, with a comma"
+            },
+            null
+        };
+
+        var result = _service.SaveToCsv(items);
+
+        var expected = $"Id,Value{Environment.NewLine}1,Value{Environment.NewLine}2,Another value{Environment.NewLine}2,\"Value, with a comma\"";
+        Assert.Equal(expected, result);
+    }
+
+    private class TestObject
+    {
+        public int Id { get; set; }
+        public string? Value { get; set; }
+    }
+}


### PR DESCRIPTION
### Context
[AB#249208](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249208) [AB#242097](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/242097)

### Change proposed in this pull request
- CSV download of School Census data via proxy controller, delivered in a ZIP archive
- Designed to honour whatever Pupil comparator set currently displayed for the current user
- Unit test and integration test coverage
- Iterative development included ability to download single CSV rather than via ZIP, which intentionally remains in this PR

### Guidance to review 
To download the ZIP file locally, send a `GET` to (e.g.)  `https://localhost:7095/api/census/download?type=school&id=123456`.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

