### PR TITLE
Revert custom data before running each E2E scenario for this feature

### DIFF
--- a/web/tests/Web.E2ETests/Features/School/CreateCustomData.feature
+++ b/web/tests/Web.E2ETests/Features/School/CreateCustomData.feature
@@ -1,8 +1,10 @@
 Feature: School create custom data
 
     Background:
-        Given I am on create custom data page for school with URN '990023'
+        Given I am on the service home
         And I have signed in with organisation '010: FBIT TEST - Multi-Academy Trust (Open)'
+        And I have removed any existing custom data for school with URN '990023'
+        And I am on create custom data page for school with URN '990023'
 
     Scenario: Can view create custom data page
         When I click start now

--- a/web/tests/Web.E2ETests/Pages/School/CustomData/RevertCustomDataPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/CustomData/RevertCustomDataPage.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Playwright;
+
+namespace Web.E2ETests.Pages.School.CustomData;
+
+public class RevertCustomDataPage(IPage page)
+{
+    private ILocator PageH1Heading => page.Locator(Selectors.H1,
+        new PageLocatorOptions
+        {
+            HasText = "Change back to the original data?"
+        });
+
+    private ILocator RemoveCustomDataButton => page.Locator(Selectors.GovButton,
+        new PageLocatorOptions
+        {
+            HasText = "Remove custom data"
+        });
+
+    public async Task IsDisplayed()
+    {
+        await PageH1Heading.ShouldBeVisible();
+    }
+
+    public async Task<HomePage> ClickRemoveCustomData()
+    {
+        await RemoveCustomDataButton.ClickAsync();
+        return new HomePage(page);
+    }
+}

--- a/web/tests/Web.E2ETests/Steps/School/CreateCustomDataSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/CreateCustomDataSteps.cs
@@ -1,4 +1,5 @@
 using Web.E2ETests.Drivers;
+using Web.E2ETests.Pages.School;
 using Web.E2ETests.Pages.School.CustomData;
 using Xunit;
 
@@ -13,6 +14,21 @@ public class CreateCustomDataSteps(PageDriver driver)
     private ChangeWorkforceDataPage? _changeWorkforceDataPage;
     private CreateCustomDataPage? _createCustomDataPage;
     private CreateCustomDataSubmittedPage? _createCustomDataSubmittedPage;
+    private RevertCustomDataPage? _revertCustomDataPage;
+    private HomePage? _schoolHomePage;
+
+    [Given("I have removed any existing custom data for school with URN '(.*)'")]
+    public async Task GivenIHaveRemovedAnyExistingCustomDataForSchoolWithURN(string urn)
+    {
+        var url = CreateCustomDataRevertUrl(urn);
+        var page = await driver.Current;
+        await page.GotoAndWaitForLoadAsync(url);
+
+        _revertCustomDataPage = new RevertCustomDataPage(page);
+        await _revertCustomDataPage.IsDisplayed();
+        _schoolHomePage = await _revertCustomDataPage.ClickRemoveCustomData();
+        await _schoolHomePage.IsDisplayed(isMissingRags: true);
+    }
 
     [Given("I am on create custom data page for school with URN '(.*)'")]
     public async Task GivenIAmOnCreateCustomDataPageForSchoolWithURN(string urn)
@@ -115,4 +131,5 @@ public class CreateCustomDataSteps(PageDriver driver)
     }
 
     private static string CreateCustomDataUrl(string urn) => $"{TestConfiguration.ServiceUrl}/school/{urn}/custom-data";
+    private static string CreateCustomDataRevertUrl(string urn) => $"{CreateCustomDataUrl(urn)}/revert";
 }


### PR DESCRIPTION
### Context
[AB#246244](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/246244) [AB#246376](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/246376) #1898

### Change proposed in this pull request
Fixed failing E2E tests from #1898.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

