### PR TITLE
Moved `/download` endpoints from proxy to alongside actions to which they are relevant

### DIFF
--- a/web/src/Web.App/Controllers/Api/CensusProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/CensusProxyController.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
-using Web.App.ActionResults;
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.Establishment;
@@ -38,34 +37,6 @@ public class CensusProxyController(
                     ? await GetCustomAsync(id, category, dimension, customDataId)
                     : await GetDefaultAsync(type, id, category, dimension, phase);
                 return new JsonResult(result);
-            }
-            catch (Exception e)
-            {
-                logger.LogError(e, "An error getting census data: {DisplayUrl}", Request.GetDisplayUrl());
-                return StatusCode(500);
-            }
-        }
-    }
-
-    [HttpGet]
-    [Produces("application/zip")]
-    [ProducesResponseType<byte[]>(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    [Route("download")]
-    public async Task<IActionResult> Download([FromQuery] string type, [FromQuery] string id, [FromQuery] string? customDataId)
-    {
-        using (logger.BeginScope(new
-        {
-            type,
-            id
-        }))
-        {
-            try
-            {
-                var result = customDataId is not null
-                    ? await GetCustomAsync(id, null, "Total", customDataId)
-                    : await GetDefaultAsync(type, id, null, "Total", null);
-                return new CsvResults([new CsvResult(result, $"census-{id}.csv")], $"census-{id}.zip");
             }
             catch (Exception e)
             {

--- a/web/src/Web.App/Controllers/Api/ExpenditureProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/ExpenditureProxyController.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
-using Web.App.ActionResults;
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.Establishment;
@@ -65,53 +64,6 @@ public class ExpenditureProxyController(
             catch (Exception e)
             {
                 logger.LogError(e, "An error getting expenditure data: {DisplayUrl}", Request.GetDisplayUrl());
-                return StatusCode(500);
-            }
-        }
-    }
-
-    [HttpGet]
-    [Produces("application/zip")]
-    [ProducesResponseType<byte[]>(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    [Route("download")]
-    public async Task<IActionResult> Download([FromQuery] string type, [FromQuery] string id, [FromQuery] string? customDataId)
-    {
-        using (logger.BeginScope(new
-        {
-            type,
-            id
-        }))
-        {
-            try
-            {
-                SchoolExpenditure[]? buildingResult;
-                SchoolExpenditure[]? pupilResult;
-                const string dimension = "Actuals";
-                switch (type.ToLower())
-                {
-                    case OrganisationTypes.School when customDataId is not null:
-                        buildingResult = await GetCustomSchoolExpenditure(id, true, null, dimension, customDataId);
-                        pupilResult = await GetCustomSchoolExpenditure(id, false, null, dimension, customDataId);
-                        break;
-                    case OrganisationTypes.School:
-                        buildingResult = await GetDefaultSchoolExpenditure(id, true, null, dimension);
-                        pupilResult = await GetDefaultSchoolExpenditure(id, false, null, dimension);
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(type));
-                }
-
-                IEnumerable<CsvResult> csvResults =
-                [
-                    new(buildingResult, $"expenditure-{id}-building.csv"),
-                    new(pupilResult, $"expenditure-{id}-pupil.csv")
-                ];
-                return new CsvResults(csvResults, $"expenditure-{id}.zip");
-            }
-            catch (Exception e)
-            {
-                logger.LogError(e, "An error downloading expenditure data: {DisplayUrl}", Request.GetDisplayUrl());
                 return StatusCode(500);
             }
         }

--- a/web/src/Web.App/Views/SchoolCensus/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolCensus/Index.cshtml
@@ -12,10 +12,9 @@
     @await Component.InvokeAsync("PageActions", new
     {
         downloadButtonVisible = true,
-        downloadLink = Url.ActionLink("Download", "CensusProxy", new
+        downloadLink = Url.ActionLink("Download", "SchoolCensus", new
         {
-            type = "school",
-            id = Model.Urn,
+            urn = Model.Urn,
             customDataId = Model.CustomDataId
         })
     })

--- a/web/src/Web.App/Views/SchoolComparison/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/Index.cshtml
@@ -20,10 +20,9 @@
         downloadButtonVisible = true,
         saveFileName = $"benchmark-spending-{Model.Urn}.zip",
         waitForEventType = eventType,
-        downloadLink = Url.ActionLink("Download", "ExpenditureProxy", new
+        downloadLink = Url.ActionLink("Download", "SchoolComparison", new
         {
-            type = "school",
-            id = Model.Urn,
+            urn = Model.Urn,
             customDataId = Model.CustomDataId
         })
     })

--- a/web/tests/Web.Integration.Tests/Pages/Schools/Census/WhenRequestingCensusDownload.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/Census/WhenRequestingCensusDownload.cs
@@ -4,17 +4,17 @@ using AutoFixture;
 using Web.App.Domain;
 using Xunit;
 
-namespace Web.Integration.Tests.Proxy;
+namespace Web.Integration.Tests.Pages.Schools.Census;
 
 public class WhenRequestingCensusDownload : PageBase<SchoolBenchmarkingWebAppClient>
 {
-    private readonly Census[] _censuses;
+    private readonly App.Domain.Census[] _censuses;
     private readonly SchoolBenchmarkingWebAppClient _client;
 
     public WhenRequestingCensusDownload(SchoolBenchmarkingWebAppClient client) : base(client)
     {
         _client = client;
-        _censuses = Fixture.Build<Census>().CreateMany().ToArray();
+        _censuses = Fixture.Build<App.Domain.Census>().CreateMany().ToArray();
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public class WhenRequestingCensusDownload : PageBase<SchoolBenchmarkingWebAppCli
             .SetupEstablishment(school)
             .SetupComparatorSet(school, comparatorSet)
             .SetupCensus(_censuses)
-            .Get(Paths.ApiCensusDownload(school.URN!, "school"));
+            .Get(Paths.SchoolCensusDownload(school.URN!));
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         await foreach (var tuple in GetFilesFromZip(response))
@@ -54,7 +54,7 @@ public class WhenRequestingCensusDownload : PageBase<SchoolBenchmarkingWebAppCli
         var response = await _client
             .SetupComparatorSetApiWithException()
             .SetupCensusWithException()
-            .Get(Paths.ApiCensusDownload(urn, "school"));
+            .Get(Paths.SchoolCensusDownload(urn));
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
     }

--- a/web/tests/Web.Integration.Tests/Pages/Schools/Census/WhenViewingCensus.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/Census/WhenViewingCensus.cs
@@ -1,20 +1,19 @@
 ﻿using System.Net;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
-using AngleSharp.XPath;
 using AutoFixture;
 using Web.App.Domain;
 using Xunit;
 
-namespace Web.Integration.Tests.Pages.Schools;
+namespace Web.Integration.Tests.Pages.Schools.Census;
 
 public class WhenViewingCensus : PageBase<SchoolBenchmarkingWebAppClient>
 {
-    private readonly Census _census;
+    private readonly App.Domain.Census _census;
 
     public WhenViewingCensus(SchoolBenchmarkingWebAppClient client) : base(client)
     {
-        _census = Fixture.Build<Census>()
+        _census = Fixture.Build<App.Domain.Census>()
             .Create();
     }
 

--- a/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenRequestingComparisonDownload.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenRequestingComparisonDownload.cs
@@ -4,14 +4,14 @@ using AutoFixture;
 using Web.App.Domain;
 using Xunit;
 
-namespace Web.Integration.Tests.Proxy;
+namespace Web.Integration.Tests.Pages.Schools.Comparison;
 
-public class WhenRequestingExpenditureDownload : PageBase<SchoolBenchmarkingWebAppClient>
+public class WhenRequestingComparisonDownload : PageBase<SchoolBenchmarkingWebAppClient>
 {
     private readonly SchoolBenchmarkingWebAppClient _client;
     private readonly SchoolExpenditure[] _schoolExpenditures;
 
-    public WhenRequestingExpenditureDownload(SchoolBenchmarkingWebAppClient client) : base(client)
+    public WhenRequestingComparisonDownload(SchoolBenchmarkingWebAppClient client) : base(client)
     {
         _client = client;
         _schoolExpenditures = Fixture.Build<SchoolExpenditure>().CreateMany().ToArray();
@@ -33,7 +33,7 @@ public class WhenRequestingExpenditureDownload : PageBase<SchoolBenchmarkingWebA
             .SetupEstablishment(school)
             .SetupComparatorSet(school, comparatorSet)
             .SetupExpenditure(_schoolExpenditures)
-            .Get(Paths.ApiExpenditureDownload(school.URN!, "school"));
+            .Get(Paths.SchoolComparisonDownload(school.URN!));
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var expectedFileNames = new[] { "expenditure-12345-pupil.csv", "expenditure-12345-building.csv" };
@@ -55,7 +55,7 @@ public class WhenRequestingExpenditureDownload : PageBase<SchoolBenchmarkingWebA
         const string urn = "12345";
         var response = await _client
             .SetupComparatorSetApiWithException()
-            .Get(Paths.ApiExpenditureDownload(urn, "school"));
+            .Get(Paths.SchoolComparisonDownload(urn));
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
     }

--- a/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenViewingComparison.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenViewingComparison.cs
@@ -5,7 +5,8 @@ using AngleSharp.XPath;
 using AutoFixture;
 using Web.App.Domain;
 using Xunit;
-namespace Web.Integration.Tests.Pages.Schools;
+
+namespace Web.Integration.Tests.Pages.Schools.Comparison;
 
 public class WhenViewingComparison(SchoolBenchmarkingWebAppClient client)
     : PageBase<SchoolBenchmarkingWebAppClient>(client)

--- a/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataFinancialData.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataFinancialData.cs
@@ -12,7 +12,7 @@ namespace Web.Integration.Tests.Pages.Schools.CustomData;
 public class WhenViewingCustomDataFinancialData : PageBase<SchoolBenchmarkingWebAppClient>
 {
     private readonly SchoolBalance _balance;
-    private readonly Census _census;
+    private readonly App.Domain.Census _census;
     private readonly SchoolExpenditure _customExpenditure;
     private readonly SchoolIncome _customIncome;
     private readonly SchoolExpenditure _expenditure;
@@ -34,7 +34,7 @@ public class WhenViewingCustomDataFinancialData : PageBase<SchoolBenchmarkingWeb
         _customExpenditure = Fixture.Build<SchoolExpenditure>()
             .Create();
 
-        _census = Fixture.Build<Census>()
+        _census = Fixture.Build<App.Domain.Census>()
             .Create();
 
         _balance = Fixture.Build<SchoolBalance>()

--- a/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataNonFinancialData.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataNonFinancialData.cs
@@ -4,12 +4,13 @@ using AutoFixture;
 using Web.App.Domain;
 using Web.App.ViewModels;
 using Xunit;
+
 namespace Web.Integration.Tests.Pages.Schools.CustomData;
 
 public class WhenViewingCustomDataNonFinancialData : PageBase<SchoolBenchmarkingWebAppClient>
 {
-    private readonly Census _census;
-    private readonly Census _customCensus;
+    private readonly App.Domain.Census _census;
+    private readonly App.Domain.Census _customCensus;
     private readonly SchoolCharacteristic _customFloorAreaMetric;
     private readonly SchoolExpenditure _expenditure;
     private readonly SchoolCharacteristic _floorAreaMetric;
@@ -33,10 +34,10 @@ public class WhenViewingCustomDataNonFinancialData : PageBase<SchoolBenchmarking
         _customFloorAreaMetric = Fixture.Build<SchoolCharacteristic>()
             .Create();
 
-        _census = Fixture.Build<Census>()
+        _census = Fixture.Build<App.Domain.Census>()
             .Create();
 
-        _customCensus = Fixture.Build<Census>()
+        _customCensus = Fixture.Build<App.Domain.Census>()
             .Create();
 
         _formValues = new Dictionary<string, decimal?>

--- a/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataWorkforceData.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataWorkforceData.cs
@@ -9,7 +9,7 @@ namespace Web.Integration.Tests.Pages.Schools.CustomData;
 
 public class WhenViewingCustomDataWorkforceData : PageBase<SchoolBenchmarkingWebAppClient>
 {
-    private readonly Census _census;
+    private readonly App.Domain.Census _census;
     private readonly SchoolExpenditure _expenditure;
     private readonly SchoolCharacteristic _floorAreaMetric;
     private readonly Dictionary<string, decimal?> _formValues;
@@ -26,10 +26,10 @@ public class WhenViewingCustomDataWorkforceData : PageBase<SchoolBenchmarkingWeb
         _floorAreaMetric = Fixture.Build<SchoolCharacteristic>()
             .Create();
 
-        _census = Fixture.Build<Census>()
+        _census = Fixture.Build<App.Domain.Census>()
             .Create();
 
-        var customCensus = Fixture.Build<Census>()
+        var customCensus = Fixture.Build<App.Domain.Census>()
             .With(c => c.Workforce, Fixture.CreateDecimal(101, 200))
             .With(c => c.Teachers, Fixture.CreateDecimal(51, 90))
             .With(c => c.PercentTeacherWithQualifiedStatus, Fixture.CreateDecimal(91, 100))

--- a/web/tests/Web.Integration.Tests/Pages/Schools/FinancialPlanning/WhenViewingPlanningSelectYear.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/FinancialPlanning/WhenViewingPlanningSelectYear.cs
@@ -3,6 +3,7 @@ using AngleSharp.Html.Dom;
 using AutoFixture;
 using Web.App.Domain;
 using Xunit;
+
 namespace Web.Integration.Tests.Pages.Schools.FinancialPlanning;
 
 public class WhenViewingPlanningSelectYear(SchoolBenchmarkingWebAppClient client) : PageBase<SchoolBenchmarkingWebAppClient>(client)
@@ -197,7 +198,7 @@ public class WhenViewingPlanningSelectYear(SchoolBenchmarkingWebAppClient client
             .With(i => i.EducationSupportStaffCosts, educationSupportStaffCosts)
             .Create();
 
-        var census = Fixture.Build<Census>()
+        var census = Fixture.Build<App.Domain.Census>()
             .With(i => i.Teachers, teachers)
             .Create();
 

--- a/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingFinancialBenchmarkingInsightsSummary.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingFinancialBenchmarkingInsightsSummary.cs
@@ -4,6 +4,7 @@ using AngleSharp.XPath;
 using AutoFixture;
 using Web.App.Domain;
 using Xunit;
+
 namespace Web.Integration.Tests.Pages.Schools;
 
 public class WhenViewingFinancialBenchmarkingInsightsSummary(SchoolBenchmarkingWebAppClient client) : PageBase<SchoolBenchmarkingWebAppClient>(client)
@@ -100,7 +101,7 @@ public class WhenViewingFinancialBenchmarkingInsightsSummary(SchoolBenchmarkingW
         AssertWarning(page, school, commentary);
     }
 
-    private async Task<(IHtmlDocument page, School school, SchoolBalance balance, Census)> SetupNavigateInitPage(
+    private async Task<(IHtmlDocument page, School school, SchoolBalance balance, App.Domain.Census)> SetupNavigateInitPage(
         string financeType,
         bool isPartOfFederation = false,
         bool isLeadSchoolInFederation = false,
@@ -169,7 +170,7 @@ public class WhenViewingFinancialBenchmarkingInsightsSummary(SchoolBenchmarkingW
             }
         ];
 
-        var censuses = Fixture.Build<Census>().CreateMany().ToArray();
+        var censuses = Fixture.Build<App.Domain.Census>().CreateMany().ToArray();
         censuses.First().URN = school.URN;
 
         var comparatorSet = Fixture.Create<SchoolComparatorSet>();
@@ -268,7 +269,7 @@ public class WhenViewingFinancialBenchmarkingInsightsSummary(SchoolBenchmarkingW
         Assert.Equal(Paths.SchoolComparison(school.URN), links.Last().GetAttribute("href"));
     }
 
-    private static void AssertPupilWorkforceMetrics(IHtmlDocument page, School school, Census census)
+    private static void AssertPupilWorkforceMetrics(IHtmlDocument page, School school, App.Domain.Census census)
     {
         var pupilWorkforceMetricsSection = page.Body.SelectSingleNode("//main/div/section[5]");
         DocumentAssert.Heading2(pupilWorkforceMetricsSection, "Pupil and workforce metrics");

--- a/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingHomeAsFederation.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingHomeAsFederation.cs
@@ -5,6 +5,7 @@ using AngleSharp.XPath;
 using AutoFixture;
 using Web.App.Domain;
 using Xunit;
+
 namespace Web.Integration.Tests.Pages.Schools;
 
 public class WhenViewingHomeAsFederation(SchoolBenchmarkingWebAppClient client) : PageBase<SchoolBenchmarkingWebAppClient>(client)
@@ -140,7 +141,7 @@ public class WhenViewingHomeAsFederation(SchoolBenchmarkingWebAppClient client) 
             .With(x => x.PeriodCoveredByReturn, 12)
             .Create();
 
-        var census = Fixture.Build<Census>()
+        var census = Fixture.Build<App.Domain.Census>()
             .With(x => x.SchoolName, school.SchoolName)
             .With(x => x.URN, school.URN)
             .Create();

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -87,6 +87,7 @@ public static class Paths
     public static string SchoolComparatorsCreateSubmit(string? urn) => $"/school/{urn}/comparators/create/submit";
     public static string SchoolComparatorsCreateSubmitted(string? urn, bool? isEdit) => $"/school/{urn}/comparators/create/submitted{(isEdit == true ? "?updating=true" : string.Empty)}";
     public static string SchoolComparatorsRevert(string? urn) => $"/school/{urn}/comparators/revert";
+    public static string SchoolCensusDownload(string urn) => $"/school/{urn}/census/download";
 
     public static string TrustComparators(string? companyNumber) => $"/trust/{companyNumber}/comparators";
     public static string TrustComparatorsCreateBy(string? companyNumber) => $"/trust/{companyNumber}/comparators/create/by";
@@ -104,7 +105,6 @@ public static class Paths
     public static string ApiExpenditureUserDefined(string? type, string? id, string dimension, string? category) => $"api/expenditure/user-defined?type={type}&id={id}&dimension={dimension}&category={category}";
     public static string ApiExpenditureDownload(string id, string type) => $"api/expenditure/download?id={id}&type={type}";
     public static string ApiCensus(string id, string type, string category, string dimension) => $"api/census?id={id}&type={type}&category={category}&dimension={dimension}";
-    public static string ApiCensusDownload(string id, string type) => $"api/census/download?id={id}&type={type}";
     public static string ApiCensusHistoryComparison(string id, string dimension, string? phase, string? financeType) => $"api/census/history/comparison?id={id}&dimension={dimension}&phase={phase}&financeType={financeType}";
     public static string LocalAuthorityHome(string? code) => $"/local-authority/{code}";
     public static string LocalAuthorityResources(string? code) => $"/local-authority/{code}/find-ways-to-spend-less";

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -31,9 +31,11 @@ public static class Paths
         $"/school/{urn}/comparator-set?referrer={referrer}";
     public static string SchoolComparison(string? urn) => $"/school/{urn}/comparison";
     public static string SchoolComparisonCustomData(string? urn) => $"/school/{urn}/comparison/custom-data";
+    public static string SchoolComparisonDownload(string? urn) => $"/school/{urn}/comparison/download";
     public static string SchoolCensus(string? urn) => $"/school/{urn}/census";
     public static string SchoolFinancialBenchmarkingInsightsSummary(string? urn, string? referrer = null) => $"/school/{urn}/summary{(referrer == null ? string.Empty : $"?referrer={referrer}")}";
     public static string SchoolCensusCustomData(string? urn) => $"/school/{urn}/census/custom-data";
+    public static string SchoolCensusDownload(string? urn) => $"/school/{urn}/census/download";
     public static string SchoolSpending(string? urn) => $"/school/{urn}/spending-and-costs";
     public static string SchoolSpendingCustomData(string? urn) => $"/school/{urn}/spending-and-costs/custom-data";
     public static string SchoolInvestigation(string? urn) => $"/school/{urn}/investigation";
@@ -87,7 +89,6 @@ public static class Paths
     public static string SchoolComparatorsCreateSubmit(string? urn) => $"/school/{urn}/comparators/create/submit";
     public static string SchoolComparatorsCreateSubmitted(string? urn, bool? isEdit) => $"/school/{urn}/comparators/create/submitted{(isEdit == true ? "?updating=true" : string.Empty)}";
     public static string SchoolComparatorsRevert(string? urn) => $"/school/{urn}/comparators/revert";
-    public static string SchoolCensusDownload(string urn) => $"/school/{urn}/census/download";
 
     public static string TrustComparators(string? companyNumber) => $"/trust/{companyNumber}/comparators";
     public static string TrustComparatorsCreateBy(string? companyNumber) => $"/trust/{companyNumber}/comparators/create/by";
@@ -103,7 +104,6 @@ public static class Paths
     public static string ApiExpenditure(string? type, string? id, string category, string dimension) => $"api/expenditure?type={type}&id={id}&category={category}&dimension={dimension}";
     public static string ApiExpenditureHistoryComparison(string? type, string? id, string dimension, string? phase, string? financeType) => $"api/expenditure/history/comparison?type={type}&id={id}&dimension={dimension}&phase={phase}&financeType={financeType}";
     public static string ApiExpenditureUserDefined(string? type, string? id, string dimension, string? category) => $"api/expenditure/user-defined?type={type}&id={id}&dimension={dimension}&category={category}";
-    public static string ApiExpenditureDownload(string id, string type) => $"api/expenditure/download?id={id}&type={type}";
     public static string ApiCensus(string id, string type, string category, string dimension) => $"api/census?id={id}&type={type}&category={category}&dimension={dimension}";
     public static string ApiCensusHistoryComparison(string id, string dimension, string? phase, string? financeType) => $"api/census/history/comparison?id={id}&dimension={dimension}&phase={phase}&financeType={financeType}";
     public static string LocalAuthorityHome(string? code) => $"/local-authority/{code}";


### PR DESCRIPTION
### Context
[AB#249574](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249574) [AB#242097](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/242097) #1932

### Change proposed in this pull request
- Moved `/api/census/download` endpoint to `/school/{urn}/census/download`
- Moved `/api/expenditure/download` endpoint to `/school/{urn}/comparison/download`
- Dependent on #1932

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

