### PR TITLE
feat: add costs codes to spending priorities and benchmark spending page

### DIFF
--- a/front-end-components/src/components/cost-codes-list/component.tsx
+++ b/front-end-components/src/components/cost-codes-list/component.tsx
@@ -1,0 +1,20 @@
+import { CostCodesListProps } from "src/components/cost-codes-list";
+import { useCostCodeMapContext } from "src/contexts/hooks";
+
+export const CostCodesList: React.FC<CostCodesListProps> = (props) => {
+  const { category } = props;
+
+  const { categoryCostCodes } = useCostCodeMapContext(category);
+
+  return (
+    categoryCostCodes && (
+      <ul className="app-cost-code-list">
+        {categoryCostCodes.map((costCode) => (
+          <li key={costCode}>
+            <strong className="govuk-tag">{costCode}</strong>
+          </li>
+        ))}
+      </ul>
+    )
+  );
+};

--- a/front-end-components/src/components/cost-codes-list/index.tsx
+++ b/front-end-components/src/components/cost-codes-list/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/components/cost-codes-list/types";
+export * from "src/components/cost-codes-list/component";

--- a/front-end-components/src/components/cost-codes-list/types.tsx
+++ b/front-end-components/src/components/cost-codes-list/types.tsx
@@ -1,0 +1,3 @@
+export type CostCodesListProps = {
+  category: string;
+};

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -31,6 +31,7 @@ import {
 import { SchoolExpenditure } from "src/services";
 import { ShareContentByElement } from "src/components/share-content-by-element";
 import { v4 as uuidv4 } from "uuid";
+import { CostCodesList } from "src/components/cost-codes-list";
 import "./styles.scss";
 
 export function HorizontalBarChartWrapper<
@@ -198,6 +199,7 @@ export function HorizontalBarChartWrapper<
         <div className="govuk-grid-column-full" data-chart-uuid={uuid}>
           {hasData ? (
             <>
+              <CostCodesList category={chartTitle} />
               {chartMode == ChartModeChart && (
                 <HorizontalBarChart
                   barCategoryGap={3}

--- a/front-end-components/src/contexts/contexts.tsx
+++ b/front-end-components/src/contexts/contexts.tsx
@@ -40,3 +40,13 @@ export const SuppressNegativeOrZeroContext =
     suppressNegativeOrZero: false,
     message: "",
   });
+
+export const CostCodeMapContext = createContext<Record<string, string> | null>(
+  null
+);
+
+export interface CostCodeMapContextValues {
+  costCodeMap: Record<string, string> | null;
+  getCostCodes: (category: string) => string[];
+  categoryCostCodes: string[];
+}

--- a/front-end-components/src/contexts/hooks.tsx
+++ b/front-end-components/src/contexts/hooks.tsx
@@ -4,6 +4,8 @@ import {
   ChartModeContextValue,
   CentralServicesBreakdownContext,
   CentralServicesBreakdownContextValue,
+  CostCodeMapContext,
+  CostCodeMapContextValues,
 } from "./contexts";
 
 export const useChartModeContext = (
@@ -38,4 +40,215 @@ export const useCentralServicesBreakdownContext = (
   }
 
   return centralServicesBreakdownContext;
+};
+
+export const useCostCodeMapContext = (
+  category: string
+): CostCodeMapContextValues => {
+  const costCodeMap = useContext(CostCodeMapContext);
+
+  /**
+   * This function duplicates the mapping logic found in `CostCodes.cs` within Web.App.
+   * The duplication exists due to inconsistencies in chart-to-subcategory naming,
+   * requiring this mapping to be redefined here.
+   */
+  const getCostCodes = (category: string): string[] => {
+    if (!costCodeMap) {
+      return [];
+    }
+    switch (category) {
+      case "Total teaching and teaching support staff costs": {
+        return [
+          costCodeMap["teaching staff"],
+          costCodeMap["supply teaching staff"],
+          costCodeMap["agency supply teaching staff"],
+          costCodeMap["education support staff"],
+          costCodeMap["educational consultancy"],
+        ];
+      }
+      case "Teaching staff costs": {
+        return [costCodeMap["teaching staff"]];
+      }
+      case "Supply teaching staff costs": {
+        return [costCodeMap["supply teaching staff"]];
+      }
+      case "Agency supply teaching staff costs": {
+        return [costCodeMap["agency supply teaching staff"]];
+      }
+      case "Educational support staff costs": {
+        return [costCodeMap["education support staff"]];
+      }
+      case "Educational consultancy costs": {
+        return [costCodeMap["educational consultancy"]];
+      }
+
+      case "Total non-educational support staff costs": {
+        return [
+          costCodeMap["administrative and clerical staff"],
+          costCodeMap["auditor costs"],
+          costCodeMap["other staff"],
+          costCodeMap["professional services (non-curriculum)"],
+        ];
+      }
+      case "Administrative and clerical staff costs": {
+        return [costCodeMap["administrative and clerical staff"]];
+      }
+      case "Auditors costs": {
+        return [costCodeMap["auditor costs"]];
+      }
+      case "Other staff costs": {
+        return [costCodeMap["other staff"]];
+      }
+      case "Professional services (non-curriculum) costs": {
+        return [costCodeMap["professional services (non-curriculum)"]];
+      }
+
+      case "Total educational supplies costs": {
+        return [
+          costCodeMap["examination fees"],
+          costCodeMap["learning resources (not ICT equipment)"],
+        ];
+      }
+      case "Examination fees costs": {
+        return [costCodeMap["examination fees"]];
+      }
+      case "Learning resources (not ICT equipment) costs": {
+        return [costCodeMap["learning resources (not ICT equipment)"]];
+      }
+
+      case "Educational learning resources costs": {
+        return [costCodeMap["ict learning resources"]];
+      }
+
+      case "Total premises staff and service costs": {
+        return [
+          costCodeMap["cleaning and caretaking"],
+          costCodeMap["maintenance of premises"],
+          costCodeMap["other occupation costs"],
+          costCodeMap["premises staff"],
+        ];
+      }
+      case "Cleaning and caretaking costs": {
+        return [costCodeMap["cleaning and caretaking"]];
+      }
+      case "Maintenance of premises costs": {
+        return [costCodeMap["maintenance of premises"]];
+      }
+      case "Other occupation costs": {
+        return [costCodeMap["other occupation costs"]];
+      }
+      case "Premises staff costs": {
+        return [costCodeMap["premises staff"]];
+      }
+
+      case "Total utilities costs": {
+        return [costCodeMap["energy"], costCodeMap["water and sewerage"]];
+      }
+      case "Energy costs": {
+        return [costCodeMap["energy"]];
+      }
+      case "Water and sewerage costs": {
+        return [costCodeMap["water and sewerage"]];
+      }
+
+      case "Administrative supplies (Non-educational)": {
+        return [costCodeMap["administrative supplies (non-educational)"]];
+      }
+
+      case "Total catering costs (gross)": {
+        return [
+          costCodeMap["catering staff"],
+          costCodeMap["catering supplies"],
+        ];
+      }
+      case "Total catering costs (net)": {
+        return [
+          costCodeMap["catering staff"],
+          costCodeMap["catering supplies"],
+        ];
+      }
+      case "Catering staff costs": {
+        return [costCodeMap["catering staff"]];
+      }
+      case "Catering supplies costs": {
+        return [costCodeMap["catering supplies"]];
+      }
+
+      case "Total other costs": {
+        return [
+          costCodeMap["direct revenue financing"],
+          costCodeMap["grounds maintenance"],
+          costCodeMap["indirect employee expenses"],
+          costCodeMap["interest charges for loan and bank"],
+          costCodeMap["other insurance premiums"],
+          costCodeMap["private Finance Initiative (PFI) charges"],
+          costCodeMap["rent and rates"],
+          costCodeMap["special facilities"],
+          costCodeMap["staff development and training"],
+          costCodeMap["staff-related insurance"],
+          costCodeMap["supply teacher insurance"],
+          costCodeMap[
+            "community focused school staff (maintained schools only)"
+          ],
+          costCodeMap[
+            "community focused school costs (maintained schools only)"
+          ],
+        ];
+      }
+      case "Direct revenue financing costs": {
+        return [costCodeMap["direct revenue financing"]];
+      }
+      case "Ground maintenance costs": {
+        return [costCodeMap["grounds maintenance"]];
+      }
+      case "Indirect employee expenses": {
+        return [costCodeMap["indirect employee expenses"]];
+      }
+      case "Interest charges for loan and bank": {
+        return [costCodeMap["interest charges for loan and bank"]];
+      }
+      case "Other insurance premiums costs": {
+        return [costCodeMap["other insurance premiums"]];
+      }
+      case "PFI charges": {
+        return [costCodeMap["private Finance Initiative (PFI) charges"]];
+      }
+      case "Rent and rates costs": {
+        return [costCodeMap["rent and rates"]];
+      }
+      case "Special facilities costs": {
+        return [costCodeMap["special facilities"]];
+      }
+      case "Staff development and training costs": {
+        return [costCodeMap["staff development and training"]];
+      }
+      case "Staff-related insurance costs": {
+        return [costCodeMap["staff-related insurance"]];
+      }
+      case "Supply teacher insurance costs": {
+        return [costCodeMap["supply teacher insurance"]];
+      }
+      case "Community focused school staff (maintained schools only)": {
+        return [
+          costCodeMap[
+            "community focused school staff (maintained schools only)"
+          ],
+        ];
+      }
+      case "Community focused school costs (maintained schools only)": {
+        return [
+          costCodeMap[
+            "community focused school costs (maintained schools only)"
+          ],
+        ];
+      }
+      default: {
+        return [];
+      }
+    }
+  };
+
+  const categoryCostCodes = getCostCodes(category).filter((code) => !!code);
+
+  return { costCodeMap, getCostCodes, categoryCostCodes };
 };

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -133,10 +133,14 @@ if (compareCostsElement) {
     phases,
     suppressNegativeOrZero,
     type,
+    costCodeMap,
   } = compareCostsElement.dataset;
   if (type && id) {
     const root = ReactDOM.createRoot(compareCostsElement);
     const phasesParsed = phases ? (JSON.parse(phases) as string[]) : null;
+    const costCodeMapParsed = costCodeMap
+      ? (JSON.parse(costCodeMap) as Record<string, string>)
+      : null;
 
     root.render(
       <React.StrictMode>
@@ -147,6 +151,7 @@ if (compareCostsElement) {
           phases={phasesParsed}
           suppressNegativeOrZero={suppressNegativeOrZero === "true"}
           type={type as "school" | "trust"}
+          costCodeMap={costCodeMapParsed}
         />
       </React.StrictMode>
     );

--- a/front-end-components/src/views/compare-your-costs/types.tsx
+++ b/front-end-components/src/views/compare-your-costs/types.tsx
@@ -5,4 +5,5 @@ export type CompareYourCostsViewProps = CompareYourCostsProps & {
   dispatchEventType?: string;
   phases: string[] | null;
   suppressNegativeOrZero: boolean;
+  costCodeMap: Record<string, string> | null;
 };

--- a/front-end-components/src/views/compare-your-costs/view.tsx
+++ b/front-end-components/src/views/compare-your-costs/view.tsx
@@ -11,6 +11,7 @@ import {
   CustomDataContext,
   ChartModeProvider,
   SuppressNegativeOrZeroContext,
+  CostCodeMapContext,
 } from "src/contexts";
 import { useGovUk } from "src/hooks/useGovUk";
 import { ChartOptionsPhaseMode } from "src/components/chart-options-phase-mode";
@@ -22,6 +23,7 @@ export const CompareYourCosts: React.FC<CompareYourCostsViewProps> = ({
   phases,
   suppressNegativeOrZero,
   type,
+  costCodeMap,
 }) => {
   const [phase, setPhase] = useState<string | undefined>(
     phases ? phases[0] : undefined
@@ -48,18 +50,20 @@ export const CompareYourCosts: React.FC<CompareYourCostsViewProps> = ({
           <SuppressNegativeOrZeroContext.Provider
             value={{ suppressNegativeOrZero, message }}
           >
-            <ChartModeProvider initialValue={ChartModeChart}>
-              <ChartOptionsPhaseMode
-                phases={phases}
-                handlePhaseChange={setPhase}
-              />
-              <TotalExpenditure
-                id={id}
-                type={type}
-                onFetching={handleFetching}
-              />
-              <ExpenditureAccordion id={id} type={type} />
-            </ChartModeProvider>
+            <CostCodeMapContext.Provider value={costCodeMap}>
+              <ChartModeProvider initialValue={ChartModeChart}>
+                <ChartOptionsPhaseMode
+                  phases={phases}
+                  handlePhaseChange={setPhase}
+                />
+                <TotalExpenditure
+                  id={id}
+                  type={type}
+                  onFetching={handleFetching}
+                />
+                <ExpenditureAccordion id={id} type={type} />
+              </ChartModeProvider>
+            </CostCodeMapContext.Provider>
           </SuppressNegativeOrZeroContext.Provider>
         </CustomDataContext.Provider>
       </PhaseContext.Provider>

--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -434,3 +434,10 @@ hr.govuk-section-break--print {
 .composed-container {
   min-height: 335px;
 }
+.app-cost-code-list {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  list-style: none;
+  padding: 0;
+}

--- a/web/src/Web.App/Domain/CostCodes.cs
+++ b/web/src/Web.App/Domain/CostCodes.cs
@@ -1,0 +1,109 @@
+﻿namespace Web.App.Domain;
+
+public class CostCodes(bool isPartOfTrust)
+{
+    // TeachingStaffCostCodes
+    private string TeachingStaffCostCode { get; } = isPartOfTrust ? "BAE010-T" : "E01";
+    private string SupplyTeachingStaffCostCode { get; } = isPartOfTrust ? "BAE020-T" : "E02";
+    private string AgencySupplyTeachingStaffCostCode { get; } = isPartOfTrust ? "BAE240-T" : "E26";
+    private string EducationSupportStaffCostCode { get; } = isPartOfTrust ? "BAE030-T" : "E03";
+    private string EducationalConsultancyCostCode { get; } = isPartOfTrust ? "BAE230-T" : "E27";
+
+    // NonEducationalSupportStaffCostCodes
+    private string AdministrativeClericalStaffCostCode { get; } = isPartOfTrust ? "BAE040-T" : "E05";
+    private string AuditorsCostCode { get; } = isPartOfTrust ? "BAE260-T" : "";
+    private string OtherStaffCostCode { get; } = isPartOfTrust ? "BAE070-T" : "E07";
+    private string ProfessionalServicesNonCurriculumCostCode { get; } = isPartOfTrust ? "BAE300-T" : "E28a";
+
+    // EducationalSuppliesCostCodes
+    private string ExaminationFeesCostCode { get; } = isPartOfTrust ? "BAE220-T" : "E21";
+    private string LearningResourcesNonIctCostsCode { get; } = isPartOfTrust ? "BAE200-T" : "E19";
+
+    // EducationalIctCostCodes
+    private string LearningResourcesIctCostCode { get; } = isPartOfTrust ? "BAE210-T" : "E20";
+
+    // PremisesStaffServicesCostCodes
+    private string CleaningCaretakingCostCode { get; } = isPartOfTrust ? "BAE130-T" : "E14";
+    private string MaintenancePremisesCostCode { get; } = isPartOfTrust ? "BAE120-T" : "E12";
+    private string OtherOccupationCostCode { get; } = isPartOfTrust ? "BAE180-T" : "E18";
+    private string PremisesStaffCostCode { get; } = isPartOfTrust ? "BAE050-T" : "E04";
+
+    // UtilitiesCostCodes
+    private string EnergyCostCode { get; } = isPartOfTrust ? "BAE150-T" : "E16";
+    private string WaterSewerageCostCode { get; } = isPartOfTrust ? "BAE140-T" : "E15";
+
+    // AdministrativeSuppliesCostCodes
+    private string AdministrativeSuppliesNonEducationalCostCode { get; } = isPartOfTrust ? "BAE280-T" : "E22";
+
+    // CateringStaffServicesCostCodes
+    private string CateringStaffCostCode { get; } = isPartOfTrust ? "BAE060-T" : "E06";
+    private string CateringSuppliesCostCode { get; } = isPartOfTrust ? "BAE250-T" : "E25";
+
+    // OtherCostCodes
+    private string DirectRevenueFinancingCostCode { get; } = isPartOfTrust ? "BAE290-T" : "E30";
+    private string GroundsMaintenanceCostCode { get; } = isPartOfTrust ? "BAE320-T" : "E13";
+    private string IndirectEmployeeExpensesCostCode { get; } = isPartOfTrust ? "BAE080-T" : "E08";
+    private string InterestChargesLoanBankCostCode { get; } = isPartOfTrust ? "BAE320-T" : "E29";
+    private string OtherInsurancePremiumsCostCode { get; } = isPartOfTrust ? "BAE270-T" : "E23";
+    private string PrivateFinanceInitiativeChargesCostCode { get; } = isPartOfTrust ? "BAE310-T" : "E28b";
+    private string RentRatesCostCode { get; } = isPartOfTrust ? "BAE160-T" : "E17";
+    private string SpecialFacilitiesCostCode { get; } = isPartOfTrust ? "BAE190-T" : "E24";
+    private string StaffDevelopmentTrainingCostCode { get; } = isPartOfTrust ? "BAE090-T" : "E09";
+    private string StaffRelatedInsuranceCostCode { get; } = isPartOfTrust ? "BAE110-T" : "E11";
+    private string SupplyTeacherInsurableCostCode { get; } = isPartOfTrust ? "BAE100-T" : "E10";
+    private string CommunityFocusedSchoolCostCode { get; } = isPartOfTrust ? "" : "E32";
+    private string CommunityFocusedSchoolStaffCostCode { get; } = isPartOfTrust ? "" : "E31";
+
+    public Dictionary<string, string> SubCategoryToCostCodeMap => new Dictionary<string, string>
+        {
+            { SubCostCategories.TeachingStaff.TeachingStaffCosts, TeachingStaffCostCode },
+            { SubCostCategories.TeachingStaff.SupplyTeachingStaffCosts, SupplyTeachingStaffCostCode },
+            { SubCostCategories.TeachingStaff.AgencySupplyTeachingStaffCosts, AgencySupplyTeachingStaffCostCode },
+            { SubCostCategories.TeachingStaff.EducationSupportStaffCosts, EducationSupportStaffCostCode },
+            { SubCostCategories.TeachingStaff.EducationalConsultancyCosts, EducationalConsultancyCostCode },
+            {
+                SubCostCategories.NonEducationalSupportStaff.AdministrativeClericalStaffCosts,
+                AdministrativeClericalStaffCostCode
+            },
+            { SubCostCategories.NonEducationalSupportStaff.AuditorsCosts, AuditorsCostCode },
+            { SubCostCategories.NonEducationalSupportStaff.OtherStaffCosts, OtherStaffCostCode },
+            {
+                SubCostCategories.NonEducationalSupportStaff.ProfessionalServicesNonCurriculumCosts,
+                ProfessionalServicesNonCurriculumCostCode
+            },
+            { SubCostCategories.EducationalSupplies.ExaminationFeesCosts, ExaminationFeesCostCode },
+            { SubCostCategories.EducationalSupplies.LearningResourcesNonIctCosts, LearningResourcesNonIctCostsCode },
+            { SubCostCategories.EducationalIct.LearningResourcesIctCosts, LearningResourcesIctCostCode },
+            { SubCostCategories.PremisesStaffServices.CleaningCaretakingCosts, CleaningCaretakingCostCode },
+            { SubCostCategories.PremisesStaffServices.MaintenancePremisesCosts, MaintenancePremisesCostCode },
+            { SubCostCategories.PremisesStaffServices.OtherOccupationCosts, OtherOccupationCostCode },
+            { SubCostCategories.PremisesStaffServices.PremisesStaffCosts, PremisesStaffCostCode },
+            { SubCostCategories.Utilities.EnergyCosts, EnergyCostCode },
+            { SubCostCategories.Utilities.WaterSewerageCosts, WaterSewerageCostCode },
+            {
+                SubCostCategories.AdministrativeSupplies.AdministrativeSuppliesNonEducationalCosts,
+                AdministrativeSuppliesNonEducationalCostCode
+            },
+            { SubCostCategories.CateringStaffServices.CateringStaffCosts, CateringStaffCostCode },
+            { SubCostCategories.CateringStaffServices.CateringSuppliesCosts, CateringSuppliesCostCode },
+            { SubCostCategories.Other.DirectRevenueFinancingCosts, DirectRevenueFinancingCostCode },
+            { SubCostCategories.Other.GroundsMaintenanceCosts, GroundsMaintenanceCostCode },
+            { SubCostCategories.Other.IndirectEmployeeExpenses, IndirectEmployeeExpensesCostCode },
+            { SubCostCategories.Other.InterestChargesLoanBank, InterestChargesLoanBankCostCode },
+            { SubCostCategories.Other.OtherInsurancePremiumsCosts, OtherInsurancePremiumsCostCode },
+            { SubCostCategories.Other.PrivateFinanceInitiativeCharges, PrivateFinanceInitiativeChargesCostCode },
+            { SubCostCategories.Other.RentRatesCosts, RentRatesCostCode },
+            { SubCostCategories.Other.SpecialFacilitiesCosts, SpecialFacilitiesCostCode },
+            { SubCostCategories.Other.StaffDevelopmentTrainingCosts, StaffDevelopmentTrainingCostCode },
+            { SubCostCategories.Other.StaffRelatedInsuranceCosts, StaffRelatedInsuranceCostCode },
+            { SubCostCategories.Other.SupplyTeacherInsurableCosts, SupplyTeacherInsurableCostCode },
+            { SubCostCategories.Other.CommunityFocusedSchoolCosts, CommunityFocusedSchoolCostCode },
+            { SubCostCategories.Other.CommunityFocusedSchoolStaff, CommunityFocusedSchoolStaffCostCode }
+        }
+        .Where(kvp => !string.IsNullOrWhiteSpace(kvp.Value))
+        .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+    public string? GetCostCode(string subCategory) =>
+        SubCategoryToCostCodeMap.GetValueOrDefault(subCategory);
+
+}

--- a/web/src/Web.App/ViewModels/LocalAuthorityComparisonViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityComparisonViewModel.cs
@@ -12,4 +12,5 @@ public class LocalAuthorityComparisonViewModel(LocalAuthority localAuthority)
         .Select(x => x.Key)
         .OfType<string>()
         .ToArray();
+    public Dictionary<string, string> CostCodeMap => new CostCodes(false).SubCategoryToCostCodeMap;
 }

--- a/web/src/Web.App/ViewModels/SchoolComparisonViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolComparisonViewModel.cs
@@ -17,4 +17,5 @@ public class SchoolComparisonViewModel(
     public bool HasDefaultComparatorSet => defaultComparatorSet != null
                                            && (defaultComparatorSet.Building.Any(b => !string.IsNullOrWhiteSpace(b))
                                                || defaultComparatorSet.Pupil.Any(p => !string.IsNullOrWhiteSpace(p)));
+    public Dictionary<string, string> CostCodeMap => new CostCodes(IsPartOfTrust).SubCategoryToCostCodeMap;
 }

--- a/web/src/Web.App/ViewModels/SchoolSpendingViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolSpendingViewModel.cs
@@ -60,6 +60,8 @@ public class CostsViewModel
     public string? Urn { get; init; }
     public bool HasIncompleteData { get; init; }
     public bool IsCustomData { get; set; }
+    public bool IsPartOfTrust { get; set; }
+    public CostCodes CostCodes => new(IsPartOfTrust);
 }
 
 public class RagRatingCommentaryViewModel(string prefix = "Spending is")

--- a/web/src/Web.App/ViewModels/TrustComparisonViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustComparisonViewModel.cs
@@ -13,4 +13,5 @@ public class TrustComparisonViewModel(Trust trust)
         .Select(x => x.Key)
         .OfType<string>()
         .ToArray();
+    public Dictionary<string, string> CostCodeMap => new CostCodes(true).SubCategoryToCostCodeMap;
 }

--- a/web/src/Web.App/Views/LocalAuthorityComparison/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityComparison/Index.cshtml
@@ -19,7 +19,8 @@
     <div id="compare-your-costs"
          data-type="@OrganisationTypes.LocalAuthority"
          data-id="@Model.Code"
-         data-phases="@Model.Phases.ToJson(Formatting.None)">
+         data-phases="@Model.Phases.ToJson(Formatting.None)"
+         data-cost-code-map="@Model.CostCodeMap.ToJson(Formatting.None)">
     </div>    
 }
 

--- a/web/src/Web.App/Views/SchoolComparison/CustomData.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/CustomData.cshtml
@@ -1,4 +1,7 @@
-﻿@model Web.App.ViewModels.SchoolComparisonViewModel
+﻿@using Newtonsoft.Json
+@using Web.App.Extensions
+
+@model Web.App.ViewModels.SchoolComparisonViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.Comparison;
 }
@@ -17,12 +20,14 @@
         id = Model.Urn,
     })
 
-<div 
-    id="compare-your-costs" 
-    data-type="@OrganisationTypes.School" 
-    data-id="@Model.Urn" 
-    data-custom-data-id="@Model.CustomDataId" 
-    data-suppress-negative-or-zero="true"></div>
+<div
+    id="compare-your-costs"
+    data-type="@OrganisationTypes.School"
+    data-id="@Model.Urn"
+    data-custom-data-id="@Model.CustomDataId"
+    data-suppress-negative-or-zero="true"
+    data-cost-code-map="@Model.CostCodeMap.ToJson(Formatting.None)">
+</div>
 
 @await Component.InvokeAsync("CustomDataFinanceTools", new
     {

--- a/web/src/Web.App/Views/SchoolComparison/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/Index.cshtml
@@ -1,4 +1,7 @@
-﻿@model Web.App.ViewModels.SchoolComparisonViewModel
+﻿@using Newtonsoft.Json
+@using Web.App.Extensions
+
+@model Web.App.ViewModels.SchoolComparisonViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.Comparison;
     var hasUserDefinedSet = !string.IsNullOrEmpty(Model.UserDefinedSetId);
@@ -64,7 +67,9 @@
          data-type="@OrganisationTypes.School"
          data-id="@Model.Urn"
          data-suppress-negative-or-zero="true"
-         data-dispatch-event-type="@eventType"></div>
+         data-dispatch-event-type="@eventType"
+         data-cost-code-map="@Model.CostCodeMap.ToJson(Formatting.None)">
+    </div>
 }
 
 @await Component.InvokeAsync("SchoolFinanceTools", new

--- a/web/src/Web.App/Views/SchoolSpending/CustomData.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/CustomData.cshtml
@@ -32,7 +32,8 @@
         Costs = Model.HighPriorityCosts,
         Id = "high-priority",
         Urn = Model.Urn,
-        IsCustomData = true
+        IsCustomData = true,
+        IsPartOfTrust = Model.IsPartOfTrust
             
     })
     
@@ -41,7 +42,8 @@
         Costs = Model.MediumPriorityCosts,
         Id = "medium-priority",
         Urn = Model.Urn,
-        IsCustomData = true
+        IsCustomData = true,
+        IsPartOfTrust = Model.IsPartOfTrust
     })
 }
 
@@ -59,7 +61,8 @@
         Costs = Model.LowPriorityCosts,
         Id = "low-priority",
         Urn = Model.Urn,
-        IsCustomData = true
+        IsCustomData = true,
+        IsPartOfTrust = Model.IsPartOfTrust
     })
 }
 

--- a/web/src/Web.App/Views/SchoolSpending/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/Index.cshtml
@@ -53,14 +53,16 @@
     {
         Costs = Model.HighPriorityCosts,
         Id = "high-priority",
-        Urn = Model.Urn
+        Urn = Model.Urn,
+        IsPartOfTrust = Model.IsPartOfTrust
     })
 
     @await Html.PartialAsync("_Costs", new CostsViewModel
     {
         Costs = Model.MediumPriorityCosts,
         Id = "medium-priority",
-        Urn = Model.Urn
+        Urn = Model.Urn,
+        IsPartOfTrust = Model.IsPartOfTrust
     })
 }
 
@@ -77,6 +79,7 @@
     {
         Costs = Model.LowPriorityCosts,
         Id = "low-priority",
-        Urn = Model.Urn
+        Urn = Model.Urn,
+        IsPartOfTrust = Model.IsPartOfTrust
     })
 }

--- a/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
@@ -57,6 +57,22 @@
                         </div>
                     </div>
                 }
+                
+                @if (category.SubCategories.Any())
+                {
+                    <div class="govuk-grid-column-full">
+                        <ul class="app-cost-code-list">
+                            @foreach(var subCategory in category.SubCategories)
+                            {
+                                var costCode = Model.CostCodes.GetCostCode(subCategory);
+                                if (!string.IsNullOrWhiteSpace(costCode))
+                                {
+                                    <li><strong class="govuk-tag">@costCode</strong></li> 
+                                }   
+                            }
+                        </ul>
+                    </div>
+                }
                 <div class="govuk-grid-column-full">
                     <p
                         class="priority @category.Rating.PriorityTag?.Class govuk-body govuk-!-margin-bottom-0"
@@ -117,7 +133,6 @@
                                 {
                                     subCategory = $"{(category.SubCategories.Length > 1 ? "and " : string.Empty)} {subCategory}.";
                                 }
-
                                 <span>@subCategory</span>
                             }
                         }

--- a/web/src/Web.App/Views/TrustComparison/Index.cshtml
+++ b/web/src/Web.App/Views/TrustComparison/Index.cshtml
@@ -35,7 +35,8 @@
          data-type="@OrganisationTypes.Trust"
          data-id="@Model.CompanyNumber"
          data-phases="@Model.Phases.ToJson(Formatting.None)"
-         data-dispatch-event-type="@eventType">
+         data-dispatch-event-type="@eventType"
+         data-cost-code-map="@Model.CostCodeMap.ToJson(Formatting.None)">
     </div>
 }
 

--- a/web/tests/Web.E2ETests/Pages/School/SpendingCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/SpendingCostsPage.cs
@@ -96,7 +96,6 @@ public partial class SpendingCostsPage(IPage page)
             HasText = "View all utilities"
         });
 
-    private ILocator PriorityTags => page.Locator($"{Selectors.MainContent} {Selectors.GovukTag}");
     private ILocator EducationIctCostCategory => page.Locator(Selectors.EducationIctSpendingCosts);
     private ILocator EducationIctWarningText => page.Locator($"{Selectors.EducationIctSpendingCosts} {Selectors.GovWarning}");
     private ILocator SaveImageTeachingAndTeachingSupportStaff => page.Locator(Selectors.TeachingAndTeachingSupportStaffSaveAsImage);
@@ -128,7 +127,9 @@ public partial class SpendingCostsPage(IPage page)
     {
         var actualOrder = new List<string[]>();
         var chartNames = await GetCategoryNames();
-        var priorityTags = await PriorityTags.AllAsync();
+        var priorityTags = chartNames.Select(
+            chartName => page.GetByTestId(
+                $"{chartName}-rag-commentary").Locator(Selectors.GovukTag)).ToList();
         for (var i = 0; i < chartNames.Count; i++)
         {
             if (i < priorityTags.Count)
@@ -165,7 +166,9 @@ public partial class SpendingCostsPage(IPage page)
         var categorySection = page.Locator($"[id^=spending-priorities-{categoryName.ToSlug()}]");
         await categorySection.IsVisibleAsync();
 
-        var resources = await categorySection.Locator("ul li").AllTextContentsAsync();
+        var resourcesSection = categorySection.Locator(".app-resources");
+
+        var resources = await resourcesSection.Locator("ul li").AllTextContentsAsync();
         Assert.Equal(commercialResources, resources.Select(r => r.Replace("Opens in a new window", string.Empty).Trim()));
     }
 

--- a/web/tests/Web.Tests/Domain/GivenASubCategoryCostCodes.cs
+++ b/web/tests/Web.Tests/Domain/GivenASubCategoryCostCodes.cs
@@ -1,0 +1,22 @@
+﻿using Web.App.Domain;
+using Xunit;
+namespace Web.Tests.Domain;
+
+public class GivenASubCategoryCostCodes
+{
+    [Theory]
+    [InlineData(SubCostCategories.NonEducationalSupportStaff.AuditorsCosts, false, null)]
+    [InlineData(SubCostCategories.NonEducationalSupportStaff.AuditorsCosts, true, "BAE260-T")]
+    [InlineData(SubCostCategories.Other.CommunityFocusedSchoolCosts, false, "E32")]
+    [InlineData(SubCostCategories.Other.CommunityFocusedSchoolCosts, true, null)]
+    [InlineData(SubCostCategories.Other.CommunityFocusedSchoolStaff, false, "E31")]
+    [InlineData(SubCostCategories.Other.CommunityFocusedSchoolStaff, true, null)]
+    public void GetsCorrectCostCode(string subCategory, bool isPartOfTrust, string? expectedCostCode)
+    {
+        var costCodes = new CostCodes(isPartOfTrust);
+
+        var actualCostCode = costCodes.GetCostCode(subCategory);
+
+        Assert.Equal(expectedCostCode, actualCostCode);
+    }
+}


### PR DESCRIPTION
### Context
[AB#242100](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/242100) - [AB#248759](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/248759)

### Change proposed in this pull request
Adds CostCodes class to generate the CFR and AAR cost codes and map them to sub category names
A dictionary is passed to the front-end with these cost codes as part of the dataset for the `CompareYourCosts` element for the benchmark spending pages
For spending prorities the sub categories are used to lookup valid values for display.
Adds unit tests and integration tests
Updates selectors on e2e tests following these changes

Note - added for all versions of school benchmark spending - LA, Trust, Custom Data and default School

### Guidance to review 
A bump to front end will follow
E2E tests will be added for benchmark spending following the package update.
Save as Image will include these codes on benchmark spending with the current implementation but more work is required for spending priorities due to the need to exclude certain elements. This will be addressed in a future PR

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

