### PR TITLE
Moved Trust comparators dimension drop down for Balance tab above both charts

### DIFF
--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -31,6 +31,7 @@ import {
 import { SchoolExpenditure } from "src/services";
 import { ShareContentByElement } from "src/components/share-content-by-element";
 import { v4 as uuidv4 } from "uuid";
+import "./styles.scss";
 
 export function HorizontalBarChartWrapper<
   TData extends SchoolChartData | TrustChartData,
@@ -170,7 +171,7 @@ export function HorizontalBarChartWrapper<
   const uuid = uuidv4();
 
   return (
-    <>
+    <div className="horizontal-bar-chart-wrapper">
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">{children}</div>
         {chartMode == ChartModeChart && (
@@ -259,6 +260,6 @@ export function HorizontalBarChartWrapper<
           )}
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/styles.scss
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/styles.scss
@@ -1,0 +1,3 @@
+.horizontal-bar-chart-wrapper:not(:last-child) {
+    margin-bottom: govuk-spacing(4);
+}

--- a/front-end-components/src/views/compare-your-trust/partials/balance-section.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/balance-section.tsx
@@ -1,17 +1,41 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   BalanceSectionProps,
   Balance,
 } from "src/views/compare-your-trust/partials";
-import { ChartMode } from "src/components";
+import {
+  ChartDimensions,
+  ChartMode,
+  CostCategories,
+  PoundsPerPupil,
+} from "src/components";
 import { useChartModeContext } from "src/contexts";
 
 export const BalanceSection: React.FC<BalanceSectionProps> = ({ id }) => {
+  const defaultDimension = PoundsPerPupil;
   const { chartMode, setChartMode } = useChartModeContext();
+  const [dimension, setDimension] = useState(defaultDimension);
+
+  const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
+    event
+  ) => {
+    const dimension =
+      CostCategories.find((x) => x.value === event.target.value) ??
+      defaultDimension;
+    setDimension(dimension);
+  };
 
   return (
     <>
       <div className="chart-options trust-options">
+        <div>
+          <ChartDimensions
+            dimensions={CostCategories}
+            handleChange={handleSelectChange}
+            elementId="balance"
+            value={dimension.value}
+          />
+        </div>
         <div>
           <ChartMode
             chartMode={chartMode}
@@ -20,8 +44,9 @@ export const BalanceSection: React.FC<BalanceSectionProps> = ({ id }) => {
           />
         </div>
       </div>
+      <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-0" />
       <div>
-        <Balance id={id} />
+        <Balance dimension={dimension} id={id} />
       </div>
     </>
   );

--- a/front-end-components/src/views/compare-your-trust/partials/balance.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/balance.tsx
@@ -1,14 +1,17 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { BalanceData } from "src/views/compare-your-trust/partials";
-import { CostCategories, PoundsPerPupil } from "src/components";
-import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
+import { Dimension } from "src/components";
+import {
+  HorizontalBarChartWrapper,
+  HorizontalBarChartWrapperData,
+} from "src/composed/horizontal-bar-chart-wrapper";
 import { BalanceApi, TrustBalance } from "src/services";
-import { DimensionedChart } from "src/composed/dimensioned-chart";
+import { ChartDimensionContext } from "src/contexts";
 
 export const Balance: React.FC<{
   id: string;
-}> = ({ id }) => {
-  const [dimension, setDimension] = useState(PoundsPerPupil);
+  dimension: Dimension;
+}> = ({ id, dimension }) => {
   const [data, setData] = useState<TrustBalance[] | null>();
   const getData = useCallback(async () => {
     setData(null);
@@ -68,28 +71,24 @@ export const Balance: React.FC<{
       };
     }, [dimension, data]);
 
-  const handleDimensionChange = (value: string) => {
-    const dimension =
-      CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
-    setDimension(dimension);
-  };
-
   return (
-    <DimensionedChart
-      charts={[
-        { data: inYearBalanceChartData, title: "In-year balance" },
-        {
-          data: revenueReserveChartData,
-          title: "Revenue reserve",
-          selector: true,
-        },
-      ]}
-      dimension={dimension}
-      dimensions={CostCategories}
-      handleDimensionChange={handleDimensionChange}
-      showCopyImageButton
-      topLevel
-      trust
-    />
+    <ChartDimensionContext.Provider value={dimension}>
+      <HorizontalBarChartWrapper
+        chartTitle="In-year balance"
+        data={inYearBalanceChartData}
+        showCopyImageButton
+        trust
+      >
+        <h2 className="govuk-heading-m">In-year balance</h2>
+      </HorizontalBarChartWrapper>
+      <HorizontalBarChartWrapper
+        chartTitle="Revenue reserve"
+        data={revenueReserveChartData}
+        showCopyImageButton
+        trust
+      >
+        <h2 className="govuk-heading-m">Revenue reserve</h2>
+      </HorizontalBarChartWrapper>
+    </ChartDimensionContext.Provider>
   );
 };


### PR DESCRIPTION
### Context
[AB#249738](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249738) [AB#249206](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249206)

### Change proposed in this pull request
- Fixed dimensions on balance view

### Guidance to review 
`front-end` should be built and copied to `Web` to ensure E2E test run completes successfully. This will be bumped in a follow-up PR.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

