### PR TITLE
feat: use JSON for logging

### DIFF
--- a/data-pipeline/src/pipeline/log.py
+++ b/data-pipeline/src/pipeline/log.py
@@ -1,16 +1,17 @@
 import logging
 import os
 
+from pythonjsonlogger.json import JsonFormatter
 
-def setup_logger(name):
-    formatter = logging.Formatter(
-        fmt="%(asctime)s - %(levelname)s - %(module)s - %(message)s"
-    )
+
+def setup_logger(name: str):
+    logger = logging.getLogger(name)
+
+    logger.setLevel(os.getenv("LOG_LEVEL", logging.DEBUG))
 
     handler = logging.StreamHandler()
+    formatter = JsonFormatter(fmt="%(asctime)s %(levelname)s %(module)s %(message)s")
     handler.setFormatter(formatter)
-
-    logger = logging.getLogger(name)
-    logger.setLevel(logging.DEBUG)
     logger.addHandler(handler)
+
     return logger


### PR DESCRIPTION
### Context

Currently the data-pipeline uses a standard logger. While this is generally okay, messages which span multiple lines (e.g. stacktraces) appear over multiple log entries, not necessarily in the right order.

[AB#243778](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/243778)  

### Change proposed in this pull request

use JSON-formatted log messages throughout, courtesy of [Python JSON Logger](https://nhairs.github.io/python-json-logger/).

### Guidance to review 

Regular log messages now look like:

```txt
{"asctime": "2025-02-13 13:23:09,457", "levelname": "INFO", "module": "database", "message": "Creating temp. table: _NonF…
```

While errors can look like:

```txt
{"asctime": "2025-02-13 13:23:43,917", "levelname": "ERROR", "module": "main", "message": "An exception occurred: KeyError", "exc_info": "Traceback (most recent call last):\n  Fil…
```

Note the `\n` character showing that the entire stacktrace is contained in that single log line.

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~You have reviewed with UX/Design~

