### PR TITLE
feat: include cost code list in saved image for spending priorities

### DIFF
--- a/front-end-components/src/components/element-selector/component.tsx
+++ b/front-end-components/src/components/element-selector/component.tsx
@@ -1,4 +1,4 @@
-import { ElementAndTitle } from "src/hooks/useDownloadImage";
+import { ElementAndAttributes } from "src/hooks/useDownloadImage";
 import { ElementSelectorProps } from "./types";
 import "./styles.scss";
 import classNames from "classnames";
@@ -9,7 +9,7 @@ export function ElementSelector({
   selected,
   showValidationError,
 }: ElementSelectorProps) {
-  const handleChange = (element: ElementAndTitle, checked: boolean) => {
+  const handleChange = (element: ElementAndAttributes, checked: boolean) => {
     const selectedElements = [...selected.filter((e) => e !== element)];
     if (checked) {
       selectedElements.push(element);

--- a/front-end-components/src/components/element-selector/types.tsx
+++ b/front-end-components/src/components/element-selector/types.tsx
@@ -1,8 +1,8 @@
-import { ElementAndTitle } from "src/hooks/useDownloadImage";
+import { ElementAndAttributes } from "src/hooks/useDownloadImage";
 
 export type ElementSelectorProps = {
-  elements: ElementAndTitle[];
-  onChange: (selected: ElementAndTitle[]) => void;
-  selected: ElementAndTitle[];
+  elements: ElementAndAttributes[];
+  onChange: (selected: ElementAndAttributes[]) => void;
+  selected: ElementAndAttributes[];
   showValidationError?: boolean;
 };

--- a/front-end-components/src/components/modals/modal-save-images/modal-save-images-modal/component.tsx
+++ b/front-end-components/src/components/modals/modal-save-images/modal-save-images-modal/component.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Modal, ModalHandler } from "../../modal";
 import { ModalSaveImagesModalProps } from "./types";
 import {
-  ElementAndTitle,
+  ElementAndAttributes,
   useDownloadPngImages,
 } from "src/hooks/useDownloadImage";
 import { ElementSelector } from "src/components/element-selector";
@@ -12,6 +12,7 @@ export function ModalSaveImagesModal({
   all,
   elementClassName,
   elementTitleAttr,
+  costCodesAttr,
   fileName,
   modalTitle,
   onCloseModal,
@@ -27,10 +28,10 @@ export function ModalSaveImagesModal({
   );
   const [cancelMode, setCancelMode] = useState(false);
   const modalRef = useRef<ModalHandler>(null);
-  const [allElements, setAllElements] = useState<ElementAndTitle[]>([]);
-  const [selectedElements, setSelectedElements] = useState<ElementAndTitle[]>(
-    []
-  );
+  const [allElements, setAllElements] = useState<ElementAndAttributes[]>([]);
+  const [selectedElements, setSelectedElements] = useState<
+    ElementAndAttributes[]
+  >([]);
   const autoCloseTimeout = useRef<NodeJS.Timeout | null>(null);
   const progressId = "save-progress";
   const [showValidationError, setShowValidationError] =
@@ -58,12 +59,19 @@ export function ModalSaveImagesModal({
       const title = elementTitleAttr
         ? element.getAttribute(elementTitleAttr) || undefined
         : undefined;
-      results.push({ element, title });
+      const rawCostCodes = costCodesAttr
+        ? element.getAttribute(costCodesAttr)
+        : undefined;
+
+      const costCodes = rawCostCodes
+        ? (JSON.parse(rawCostCodes) as string[])
+        : undefined;
+      results.push({ element, title, costCodes });
     }
 
     setAllElements(results);
     setSelectedElements(results);
-  }, [elementClassName, elementTitleAttr]);
+  }, [elementClassName, elementTitleAttr, costCodesAttr]);
 
   const handleCloseModal = useCallback(
     (abort: boolean) => {

--- a/front-end-components/src/components/modals/modal-save-images/modal-save-images-modal/types.tsx
+++ b/front-end-components/src/components/modals/modal-save-images/modal-save-images-modal/types.tsx
@@ -4,6 +4,7 @@ export type ModalSaveImagesModalProps = ModalCommonProps & {
   all?: boolean;
   elementClassName: string;
   elementTitleAttr?: string;
+  costCodesAttr?: string;
   fileName?: string;
   modalTitle: string;
   onCloseModal: () => void;

--- a/front-end-components/src/components/share-content-by-element/component.tsx
+++ b/front-end-components/src/components/share-content-by-element/component.tsx
@@ -8,6 +8,7 @@ export const ShareContentByElement: React.FC<ShareContentByElementProps> = ({
   elementSelector,
   title,
   showTitle,
+  costCodes,
   ...props
 }) => {
   const [imageLoading, setImageLoading] = useState<boolean>();
@@ -26,6 +27,7 @@ export const ShareContentByElement: React.FC<ShareContentByElementProps> = ({
     onLoading: setImageLoading,
     title,
     showTitle,
+    costCodes,
   });
 
   return (

--- a/front-end-components/src/components/share-content/types.tsx
+++ b/front-end-components/src/components/share-content/types.tsx
@@ -14,4 +14,5 @@ export type ShareContentProps = Pick<
   saveEventId?: string;
   showCopy?: boolean;
   showSave?: boolean;
+  costCodes?: string[];
 };

--- a/front-end-components/src/hooks/useDownloadImage.ts
+++ b/front-end-components/src/hooks/useDownloadImage.ts
@@ -34,7 +34,7 @@ export type DownloadPngImagesOptions = {
 const imageTitleHeight = 50;
 const type = "image/png";
 const backgroundColor = "#fff";
-const CostCodesListHeight = 50;
+const costCodesListHeight = 50;
 
 export function useDownloadPngImage<T>({
   elementSelector,
@@ -255,7 +255,7 @@ const getImageOptions = (
     height += imageTitleHeight;
   }
   if (costCodes) {
-    height += CostCodesListHeight;
+    height += costCodesListHeight;
   }
 
   const onCloned = (node: HTMLElement): void => {

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -886,10 +886,13 @@ const shareContentByElementIdElements = document.querySelectorAll<HTMLElement>(
 
 if (shareContentByElementIdElements) {
   shareContentByElementIdElements.forEach((element) => {
-    const { copyEventId, elementId, saveEventId, showTitle, title } =
+    const { copyEventId, elementId, saveEventId, showTitle, title, costCodes } =
       element.dataset;
     if (elementId && title) {
       const el = document.getElementById(elementId);
+      const parsedCostCodes = costCodes
+        ? (JSON.parse(costCodes) as string[])
+        : undefined;
       if (el) {
         const root = ReactDOM.createRoot(element);
         root.render(
@@ -904,6 +907,7 @@ if (shareContentByElementIdElements) {
               showCopy
               showSave
               showTitle={showTitle === "true"}
+              costCodes={parsedCostCodes}
             />
           </React.StrictMode>
         );
@@ -922,6 +926,7 @@ if (launchModalElements) {
       buttonLabel,
       elementClassName,
       elementTitleAttr,
+      costCodesAttr,
       fileName,
       mainContentId,
       modalName,
@@ -953,6 +958,7 @@ if (launchModalElements) {
               buttonLabel={buttonLabel || "Save"}
               elementClassName={elementClassName as string}
               elementTitleAttr={elementTitleAttr}
+              costCodesAttr={costCodesAttr}
               fileName={fileName}
               modalTitle={modalTitle || "Save all images"}
               overlayContentId={mainContentId}

--- a/web/src/Web.App/ViewComponents/PageActionsViewComponent.cs
+++ b/web/src/Web.App/ViewComponents/PageActionsViewComponent.cs
@@ -11,6 +11,7 @@ public class PageActionsViewComponent : ViewComponent
         string? saveClassName,
         string? saveFileName,
         string? saveTitleAttr,
+        string? costCodesAttr,
         string? waitForEventType,
         string? downloadLink)
         => View(new PageActionsViewModel(
@@ -19,6 +20,7 @@ public class PageActionsViewComponent : ViewComponent
             saveClassName,
             saveFileName,
             saveTitleAttr,
+            costCodesAttr,
             waitForEventType,
             downloadLink));
 }

--- a/web/src/Web.App/ViewModels/Components/PageActionsViewModel.cs
+++ b/web/src/Web.App/ViewModels/Components/PageActionsViewModel.cs
@@ -9,6 +9,7 @@ public class PageActionsViewModel(
     string? saveClassName,
     string? saveFileName,
     string? saveTitleAttr,
+    string? costCodesAttr,
     string? waitForEventType,
     string? downloadLink)
 {
@@ -18,6 +19,7 @@ public class PageActionsViewModel(
     public string SaveClassName { get; init; } = saveClassName ?? "chart-wrapper";
     public string SaveFileName { get; init; } = saveFileName ?? "charts.zip";
     public string SaveTitleAttr { get; init; } = saveTitleAttr ?? "aria-label";
+    public string CostCodesAttr { get; init; } = costCodesAttr ?? "";
 
     public string WaitForEventType { get; init; } = waitForEventType ?? "";
 

--- a/web/src/Web.App/Views/SchoolSpending/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/Index.cshtml
@@ -11,7 +11,9 @@
         saveButtonVisible = true,
         saveClassName = "costs-chart-wrapper",
         saveFileName = $"spending-priorities-{Model.Urn}.zip",
-        saveTitleAttr = "data-title"
+        saveTitleAttribute = "data-title",
+        saveTitleAttr = "data-title",
+        costCodesAttr = "data-cost-codes"    
     })
 }
 

--- a/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
@@ -36,6 +36,11 @@
                 urn = Model.Urn
             });
 
+        var costCodes = category.SubCategories
+            .Select(c => Model.CostCodes.GetCostCode(c))
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .ToList();
+
         var uuid = Guid.NewGuid();
 
         <section id="spending-priorities-@category.Rating.CostCategoryAnchorId">
@@ -53,22 +58,19 @@
                             data-title="@categoryHeading"
                             data-show-title="true"
                             data-copy-event-id="copy-chart-as-image"
-                            data-save-event-id="save-chart-as-image">
+                            data-save-event-id="save-chart-as-image"
+                            data-cost-codes="@costCodes.ToJson(Formatting.None)">
                         </div>
                     </div>
                 }
                 
-                @if (category.SubCategories.Any())
+                @if (costCodes.Any())
                 {
                     <div class="govuk-grid-column-full">
                         <ul class="app-cost-code-list">
-                            @foreach(var subCategory in category.SubCategories)
-                            {
-                                var costCode = Model.CostCodes.GetCostCode(subCategory);
-                                if (!string.IsNullOrWhiteSpace(costCode))
-                                {
-                                    <li><strong class="govuk-tag">@costCode</strong></li> 
-                                }   
+                            @foreach(var costCode in costCodes)
+                            { 
+                                <li><strong class="govuk-tag">@costCode</strong></li> 
                             }
                         </ul>
                     </div>
@@ -111,7 +113,8 @@
                              data-sort-direction="asc"
                              data-stats="@SchoolSpendingViewModel.Stats(category.Rating).ToJson(Formatting.None)"
                              data-has-incomplete-data="@Model.HasIncompleteData"
-                             data-title="@categoryHeading">
+                             data-title="@categoryHeading"
+                             data-cost-codes="@costCodes.ToJson(Formatting.None)">
                         </div>
                     </div>
 

--- a/web/src/Web.App/Views/Shared/Components/PageActions/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/PageActions/Default.cshtml
@@ -11,6 +11,7 @@
                 data-button-label="Save chart images"
                 data-modal-title="Save chart images"
                 data-element-title-attr="@Model.SaveTitleAttr"
+                data-cost-codes-attr="@Model.CostCodesAttr"
                 data-show-titles="true"
                 data-show-progress="true"
                 data-file-name="@Model.SaveFileName"


### PR DESCRIPTION
### Context
[AB#242100](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/242100) - [AB#249508](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249508)

### Change proposed in this pull request
Similar to how we create the chart titles for the spending priorities page the we pass the cost codes through the `html-dataset` so that they can be used in `onCloned` to create the required elements for the image and set styles.
Slight refactor around `onCloned` as it is too busy with the addition of creating cost codes as well but previous behaviour should be preserved.

### Guidance to review 
Is there a better way to achieve this?

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

