### PR TITLE
chore: add e2e test for cost codes on benchmark spending

### DIFF
--- a/web/tests/Web.E2ETests/Features/School/CompareYourCosts.feature
+++ b/web/tests/Web.E2ETests/Features/School/CompareYourCosts.feature
@@ -326,3 +326,8 @@ Feature: School compare your costs
         Given I am on compare your costs page for school with URN '777042'
         When I click on download data
         Then the file 'comparison-777042.zip' is downloaded
+        
+    Scenario: Cost codes are displayed
+        Given I am on compare your costs page for school with URN '777042'
+        When I click on show all sections
+        Then the cost codes are present

--- a/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
@@ -471,6 +471,22 @@ public class CompareYourCostsPage(IPage page)
         Assert.True(expected.SequenceEqual(actual), $"Test fails on {chartName}. Expected: {string.Join(", ", expected)}, Actual: {string.Join(", ", actual)}");
     }
 
+    public async Task CostCodesArePresent()
+    {
+        var costCodes = await page.Locator(Selectors.CostCodesList).AllAsync();
+        Assert.Equal(42, costCodes.Count);
+
+        var costCodesWithLiChildren = await page.Locator(Selectors.CostCodesList)
+            .Filter(new() { Has = page.Locator("li") })
+            .AllAsync();
+        Assert.Equal(40, costCodesWithLiChildren.Count);
+
+        foreach (var costCodeList in costCodesWithLiChildren)
+        {
+            await costCodeList.IsVisibleAsync();
+        }
+    }
+
     private ILocator ChartTable(ComparisonChartNames chartName)
     {
         var chart = chartName switch

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -195,4 +195,6 @@ public static class Selectors
     public const string AdministrativeSuppliesDimension = "#administrative-supplies-non-educational-dimension";
     public const string CateringServicesDimension = "#total-catering-costs-dimension";
     public const string OtherDimension = "#total-other-costs-dimension";
+
+    public const string CostCodesList = "ul.app-cost-code-list";
 }

--- a/web/tests/Web.E2ETests/Steps/School/CompareYourCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/CompareYourCostsSteps.cs
@@ -398,6 +398,15 @@ public class CompareYourCostsSteps(PageDriver driver)
         Assert.Equal(fileName, downloadedFilePath);
     }
 
+    [Then("the cost codes are present")]
+    public async Task ThenTheCostCodesArePresent()
+    {
+        Assert.NotNull(_comparisonPage);
+
+        await _comparisonPage.CostCodesArePresent();
+    }
+
+
     private void ChartDownloaded(string chartName)
     {
         Assert.NotNull(_download);


### PR DESCRIPTION
### Context
[AB#242100](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/242100) / [AB#249509](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249509)

### Change proposed in this pull request
Adds e2e tests to cover behaviour of displaying cost codes for the benchmark spending page

### Guidance to review 
note spending prioritites in covered under integration tests

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

