### PR TITLE
Reinstate `APPINSIGHTS_INSTRUMENTATIONKEY` alongside `APPLICATIONINSIGHTS_CONNECTION_STRING` in web app service

### DIFF
--- a/web/terraform/app-service.tf
+++ b/web/terraform/app-service.tf
@@ -64,6 +64,7 @@ resource "azurerm_windows_web_app" "education-benchmarking-as" {
 
   app_settings = {
     "ASPNETCORE_ENVIRONMENT"                                  = "Production"
+    "APPINSIGHTS_INSTRUMENTATIONKEY"                          = data.azurerm_application_insights.application-insights.instrumentation_key
     "APPLICATIONINSIGHTS_CONNECTION_STRING"                   = data.azurerm_application_insights.application-insights.connection_string
     "FeatureManagement__CurriculumFinancialPlanning"          = var.configuration[var.environment].features.CurriculumFinancialPlanning
     "FeatureManagement__CustomData"                           = var.configuration[var.environment].features.CustomData


### PR DESCRIPTION
### Context
[AB#249878](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249878) [AB#246758](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/246758) #1893 

### Change proposed in this pull request
Included both App Insights configuration settings to allow release annotations to be set during web app service deployment due to [this issue](https://github.com/microsoft/azure-pipelines-tasks/issues/20857).

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~~Your code builds clean without any errors or warnings~~
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [ ] ~~You have tested by running locally~~
- [ ] ~~You have reviewed with UX/Design~~

