### PR TITLE
Resolved logic in `getEstablishmentKey()` that may have caused multiple matches when using `name` as collection lookup

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -99,7 +99,7 @@
       data-id="02387916"
       data-phases='["Secondary","Primary","Post-16"]'
     ></div>-->
-    <div id="compare-your-costs" data-type="school" data-id="990332" data-suppress-negative-or-zero="true"></div>
+    <div id="compare-your-costs" data-type="school" data-id="150203" data-suppress-negative-or-zero="true"></div>
     <!--<div id="historic-data" data-type="school" data-id="990095"></div>-->
     <!--<div id="historic-data-2" data-type="school" data-id="123456" data-phase="Primary" data-finance-type="Maintained"></div>-->
     <!--<div
@@ -125,7 +125,7 @@
     <svg id="test-element-id" height="100" width="100" xmlns="http://www.w3.org/2000/svg">
       <circle r="45" cx="50" cy="50" fill="red" />
     </svg> -->
-    <button class="govuk-button" onclick="(function(){const event = new CustomEvent('ready', { detail: true });document.dispatchEvent(event);})();return false;">Ready</button>
+    <!-- <button class="govuk-button" onclick="(function(){const event = new CustomEvent('ready', { detail: true });document.dispatchEvent(event);})();return false;">Ready</button>
     <div data-launch-modal data-modal-name="modal-save-images" data-element-class-name="test-element-class" data-button-label="Save images" data-modal-title="Save images" data-element-title-attr="aria-label" data-save-all="false" data-wait-for-event-type="ready"></div>
     <svg class="test-element-class" aria-label="Red" height="100" width="100" xmlns="http://www.w3.org/2000/svg">
       <circle r="45" cx="50" cy="50" fill="red" />
@@ -147,7 +147,7 @@
     </svg>
     <svg class="test-element-class" height="100" width="100" xmlns="http://www.w3.org/2000/svg">
       <circle r="45" cx="50" cy="50" fill="purple" />
-    </svg>
+    </svg> -->
     <script type="module" src="/src/main.tsx"></script>
     <script
       type="module"

--- a/front-end-components/src/components/charts/establishment-tick/component.tsx
+++ b/front-end-components/src/components/charts/establishment-tick/component.tsx
@@ -20,7 +20,7 @@ export function EstablishmentTick(props: EstablishmentTickProps) {
     href,
     linkToEstablishment,
     onFocused,
-    payload: { value },
+    payload: { value, index },
     specialItemFlags,
     tickFormatter,
     tooltip,
@@ -34,9 +34,9 @@ export function EstablishmentTick(props: EstablishmentTickProps) {
     return (
       linkToEstablishment &&
       establishmentKeyResolver &&
-      establishmentKeyResolver(value)
+      establishmentKeyResolver(value, index)
     );
-  }, [establishmentKeyResolver, linkToEstablishment, value]);
+  }, [establishmentKeyResolver, linkToEstablishment, value, index]);
 
   const partYear = useMemo(() => {
     return (

--- a/front-end-components/src/components/charts/establishment-tick/types.tsx
+++ b/front-end-components/src/components/charts/establishment-tick/types.tsx
@@ -10,7 +10,10 @@ import {
 export interface EstablishmentTickProps
   extends Omit<BaseAxisProps, "scale">,
     Omit<TickProps, "href" | "type" | "onClick" | "ref" | "textAnchor"> {
-  establishmentKeyResolver?: (name: string) => string | undefined;
+  establishmentKeyResolver?: (
+    name: string,
+    index?: number
+  ) => string | undefined;
   highlightedItemKey?: string;
   href: (key: string) => string;
   linkToEstablishment?: boolean;

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -103,16 +103,24 @@ export function HorizontalBarChartWrapper<
       .map((d) => (d as SchoolChartData).urn);
   }, [data.dataPoints, trust]);
 
-  const getEstablishmentKey = (name: string) => {
+  // first attempt to get key by `index` passed to `<EstablishmentTick />`,
+  // otherwise fall back to match by name (which may result in duplicate matched)
+  const getEstablishmentKey = (name: string, index?: number) => {
     if (trust) {
-      return (data.dataPoints as TrustChartData[]).find(
-        (d) => d.trustName === name
-      )?.companyNumber;
+      const trustData = sortedDataPoints as TrustChartData[];
+      if (index != undefined && index < trustData.length) {
+        return trustData[index]?.companyNumber;
+      }
+
+      return trustData.find((d) => d.trustName === name)?.companyNumber;
     }
 
-    return (data.dataPoints as SchoolChartData[]).find(
-      (d) => d.schoolName === name
-    )?.urn;
+    const schoolData = sortedDataPoints as SchoolChartData[];
+    if (index != undefined && index < schoolData.length) {
+      return schoolData[index]?.urn;
+    }
+
+    return schoolData.find((d) => d.schoolName === name)?.urn;
   };
 
   const renderTooltip = (


### PR DESCRIPTION
### Context
[AB#249970](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249970) [AB#249969](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249969)

### Change proposed in this pull request
Prevents incorrect rendering of y-axis establishment name/link/highlight in the case of multiple establishments with the same names being in the source data set.

### Guidance to review 
May be reproduced / validated based on the default benchmarking for the school in the linked work item.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

