### PR TITLE
chore: pin `html-to-image` to `1.11.11`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,7 +36,6 @@
         - dependency-name: "@types/react-dom"
           versions: ["19.*"]
         - dependency-name: "html-to-image"
-          versions: [">1.11.11"]
 
     - package-ecosystem: "terraform"
       directory: "/platform/terraform"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,9 @@
       open-pull-requests-limit: 10
       # React v18 to v19 major version upgrade affects other packages as at 
       # Feb 2025 due to broken peer dependencies. Ignore for the time being.
+      # Feb 2025 html-to-image versions after 1.11.11 cause issues for
+      # the styling of front-end-components charts in images. 
+      # Ignore until resolved.
       ignore:
         - dependency-name: "react"
           versions: ["19.*"]
@@ -32,6 +35,8 @@
           versions: ["19.*"]
         - dependency-name: "@types/react-dom"
           versions: ["19.*"]
+        - dependency-name: "html-to-image"
+          versions: [">1.11.11"]
 
     - package-ecosystem: "terraform"
       directory: "/platform/terraform"

--- a/front-end-components/package-lock.json
+++ b/front-end-components/package-lock.json
@@ -13,7 +13,7 @@
         "date-fns": "^4.1.0",
         "file-saver": "^2.0.5",
         "govuk-frontend": "^5.6.0",
-        "html-to-image": "^1.11.11",
+        "html-to-image": "1.11.11",
         "jszip": "^3.10.1",
         "punycode": "^2.3.1",
         "react": "^18.2.0",
@@ -5704,9 +5704,10 @@
       "dev": true
     },
     "node_modules/html-to-image": {
-      "version": "1.11.13",
-      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
-      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg=="
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
+      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA==",
+      "license": "MIT"
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",

--- a/front-end-components/package.json
+++ b/front-end-components/package.json
@@ -22,7 +22,7 @@
     "date-fns": "^4.1.0",
     "file-saver": "^2.0.5",
     "govuk-frontend": "^5.6.0",
-    "html-to-image": "^1.11.11",
+    "html-to-image": "1.11.11",
     "jszip": "^3.10.1",
     "punycode": "^2.3.1",
     "react": "^18.2.0",


### PR DESCRIPTION
### Context
[AB#248372](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/248372) - [AB#249983](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249983)

See the description in task 249983. In newer versions of this package a change has been introduced where the styling for the charts is not being resolved correctly resulting in the charts displaying incorrectly as images. Worth noting `1.11.11` is the most popular version.

See below comment from @WolfyUK  for likely source.

### Change proposed in this pull request
pin the version for `html-to-image` to `1.11.11`

### Guidance to review 
front-end component can be built locally and using that for the Web app the charts should display correctly when saved. Worth clearing broswer cache as that can preserve styles if you have generated images previously.

A bump to `front-end` will follow

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

