### PR TITLE
chore: bump `front-end` to `1.1.58`

### DIFF
--- a/web/src/Web.App/package-lock.json
+++ b/web/src/Web.App/package-lock.json
@@ -1440,16 +1440,16 @@
       }
     },
     "node_modules/front-end": {
-      "version": "1.1.57",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-1.1.57.tgz",
-      "integrity": "sha1-kDCxRfhjyEhIp2wY6Q3wFqgd41U=",
+      "version": "1.1.58",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-1.1.58.tgz",
+      "integrity": "sha1-TVxEAU6DU2YQkFSNNdPqjkYqauU=",
       "dependencies": {
         "accessible-autocomplete": "^3.0.0",
         "classnames": "^2.5.1",
         "date-fns": "^4.1.0",
         "file-saver": "^2.0.5",
         "govuk-frontend": "^5.6.0",
-        "html-to-image": "^1.11.11",
+        "html-to-image": "1.11.11",
         "jszip": "^3.10.1",
         "punycode": "^2.3.1",
         "react": "^18.2.0",


### PR DESCRIPTION
### Context
bump to `front-end` following #1963 

### Change proposed in this pull request
bump `front-end` to `1.1.58`

### Guidance to review 
Following this charts should display correctly when saved as image

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

