### PR TITLE
Set `dbo.UserData.Active` to `0` upon receipt of successful default pipeline finished message

### DIFF
--- a/platform/src/abstractions/Platform.Domain/Messages/PipelineFinish.cs
+++ b/platform/src/abstractions/Platform.Domain/Messages/PipelineFinish.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 
+// ReSharper disable PropertyCanBeMadeInitOnly.Global
 // ReSharper disable ClassNeverInstantiated.Global
 // ReSharper disable UnusedAutoPropertyAccessor.Global
 // ReSharper disable UnusedMember.Global
@@ -12,4 +13,5 @@ public record PipelineFinish
     public string? JobId { get; set; }
     public string? RunId { get; set; }
     public bool Success { get; set; }
+    public string? Error { get; set; }
 }

--- a/platform/src/abstractions/Platform.Domain/Pipeline.cs
+++ b/platform/src/abstractions/Platform.Domain/Pipeline.cs
@@ -34,6 +34,7 @@ public static class Pipeline
     {
         public const string PipelinePendingMessageReceived = nameof(PipelinePendingMessageReceived);
         public const string PipelinePendingMessageOrchestrated = nameof(PipelinePendingMessageOrchestrated);
+        public const string PipelineStatusMessageOrchestrated = nameof(PipelineStatusMessageOrchestrated);
         public const string PipelineStartDefaultMessageReceived = nameof(PipelineStartDefaultMessageReceived);
         public const string PipelineStartCustomMessageReceived = nameof(PipelineStartCustomMessageReceived);
         public const string PipelineFinishedMessageReceived = nameof(PipelineFinishedMessageReceived);

--- a/platform/src/apis/Platform.Orchestrator/Functions/OrchestratorFunctions.cs
+++ b/platform/src/apis/Platform.Orchestrator/Functions/OrchestratorFunctions.cs
@@ -68,7 +68,8 @@ public class OrchestratorFunctions(ILogger<OrchestratorFunctions> logger, ITelem
 
             var runIndexerTask = context.CallActivityAsync(nameof(ActivityTriggerFunctions.RunIndexerTrigger), input);
             var clearCacheTask = context.CallActivityAsync(nameof(ActivityTriggerFunctions.ClearCacheTrigger), input);
-            await Task.WhenAll(runIndexerTask, clearCacheTask);
+            var deactivateUserDataTask = context.CallActivityAsync(nameof(ActivityTriggerFunctions.DeactivateUserDataTrigger), input);
+            await Task.WhenAll(runIndexerTask, clearCacheTask, deactivateUserDataTask);
         }
     }
 

--- a/platform/src/apis/Platform.Orchestrator/Functions/PipelineQueueTriggerFunctions.cs
+++ b/platform/src/apis/Platform.Orchestrator/Functions/PipelineQueueTriggerFunctions.cs
@@ -64,7 +64,8 @@ public class PipelineQueueTriggerFunctions(ILogger<PipelineQueueTriggerFunctions
             {
                 telemetryService.TrackEvent(Pipeline.Events.PipelineFinishedMessageReceived, job.JobId, new Dictionary<string, string?>
                 {
-                    { nameof(job.Success), job.Success.ToString() }
+                    { nameof(job.Success), job.Success.ToString() },
+                    { nameof(job.Error), job.Error }
                 });
                 await db.WriteToLog(job.JobId, message);
 

--- a/platform/tests/Platform.Orchestrator.Tests/Functions/ActivityTrigger/WhenRunIndexerTriggered.cs
+++ b/platform/tests/Platform.Orchestrator.Tests/Functions/ActivityTrigger/WhenRunIndexerTriggered.cs
@@ -18,7 +18,7 @@ public class WhenRunIndexerTriggered(ITestOutputHelper testOutputHelper) : Activ
         };
 
         Database?
-            .Setup(d => d.UpdateStatus(status))
+            .Setup(d => d.UpdateUserDataStatus(status))
             .ReturnsAsync(1)
             .Verifiable();
 

--- a/platform/tests/Platform.Orchestrator.Tests/Functions/OrchestrationTrigger/WhenPipelineJobDefaultFinishedTriggered.cs
+++ b/platform/tests/Platform.Orchestrator.Tests/Functions/OrchestrationTrigger/WhenPipelineJobDefaultFinishedTriggered.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.DurableTask;
+using Moq;
+using Platform.Orchestrator.Functions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Platform.Orchestrator.Tests.Functions.OrchestrationTrigger;
+
+public class WhenPipelineJobDefaultFinishedTriggered : OrchestrationTriggerFunctionTest
+{
+    private readonly Mock<TaskOrchestrationContext> _context;
+    private readonly PipelineStatus _input;
+
+    public WhenPipelineJobDefaultFinishedTriggered(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+    {
+        _input = new PipelineStatus
+        {
+            JobId = "jobId",
+            RunId = "2020",
+            Success = true
+        };
+
+        _context = new Mock<TaskOrchestrationContext>();
+        _context
+            .Setup(c => c.GetInput<PipelineStatus>())
+            .Returns(_input);
+    }
+
+    [Fact]
+    public async Task ShouldCallRunIndexerTriggerActivity()
+    {
+        _context
+            .Setup(c => c.CallActivityAsync(
+                nameof(ActivityTriggerFunctions.RunIndexerTrigger),
+                _input,
+                It.IsAny<TaskOptions?>()))
+            .Verifiable();
+
+        await Functions.PipelineJobDefaultFinished(_context.Object);
+
+        _context.Verify();
+    }
+
+    [Fact]
+    public async Task ShouldCallClearCacheTriggerActivity()
+    {
+        _context
+            .Setup(c => c.CallActivityAsync(
+                nameof(ActivityTriggerFunctions.ClearCacheTrigger),
+                _input,
+                It.IsAny<TaskOptions?>()))
+            .Verifiable();
+
+        await Functions.PipelineJobDefaultFinished(_context.Object);
+
+        _context.Verify();
+    }
+
+    [Fact]
+    public async Task ShouldNotCallTriggerActivitiesIfInvalidInput()
+    {
+        _context.Reset();
+        _context
+            .Setup(c => c.CallActivityAsync(It.IsAny<TaskName>(), It.IsAny<object?>(), It.IsAny<TaskOptions?>()))
+            .Verifiable(Times.Never());
+
+        await Functions.PipelineJobDefaultFinished(_context.Object);
+
+        _context.Verify();
+    }
+}

--- a/platform/tests/Platform.Orchestrator.Tests/Functions/OrchestrationTrigger/WhenPipelineJobDefaultFinishedTriggered.cs
+++ b/platform/tests/Platform.Orchestrator.Tests/Functions/OrchestrationTrigger/WhenPipelineJobDefaultFinishedTriggered.cs
@@ -57,6 +57,21 @@ public class WhenPipelineJobDefaultFinishedTriggered : OrchestrationTriggerFunct
     }
 
     [Fact]
+    public async Task ShouldCallDeactivateUserDataTriggerActivity()
+    {
+        _context
+            .Setup(c => c.CallActivityAsync(
+                nameof(ActivityTriggerFunctions.DeactivateUserDataTrigger),
+                _input,
+                It.IsAny<TaskOptions?>()))
+            .Verifiable();
+
+        await Functions.PipelineJobDefaultFinished(_context.Object);
+
+        _context.Verify();
+    }
+
+    [Fact]
     public async Task ShouldNotCallTriggerActivitiesIfInvalidInput()
     {
         _context.Reset();

--- a/platform/tests/Platform.Orchestrator.Tests/Functions/OrchestrationTrigger/WhenPipelineJobOrchestrationTriggeredByDefaultJobType.cs
+++ b/platform/tests/Platform.Orchestrator.Tests/Functions/OrchestrationTrigger/WhenPipelineJobOrchestrationTriggeredByDefaultJobType.cs
@@ -55,7 +55,7 @@ public class WhenPipelineJobOrchestrationTriggeredByDefaultJobType : Orchestrati
     }
 
     [Fact]
-    public async Task ShouldCallRunIndexerTriggerActivity()
+    public async Task ShouldCallSubOrchestrator()
     {
         const bool success = true;
         _context
@@ -63,28 +63,8 @@ public class WhenPipelineJobOrchestrationTriggeredByDefaultJobType : Orchestrati
             .ReturnsAsync(success);
 
         _context
-            .Setup(c => c.CallActivityAsync(
-                nameof(ActivityTriggerFunctions.RunIndexerTrigger),
-                It.Is<PipelineStatus>(p => p.JobId == _input.JobId && p.Success == success),
-                It.IsAny<TaskOptions?>()))
-            .Verifiable();
-
-        await Functions.PipelineJobOrchestrator(_context.Object);
-
-        _context.Verify();
-    }
-
-    [Fact]
-    public async Task ShouldCallClearCacheTriggerActivity()
-    {
-        const bool success = true;
-        _context
-            .Setup(c => c.WaitForExternalEvent<bool>(nameof(PipelineQueueTriggerFunctions.PipelineJobFinished), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(success);
-
-        _context
-            .Setup(c => c.CallActivityAsync(
-                nameof(ActivityTriggerFunctions.ClearCacheTrigger),
+            .Setup(c => c.CallSubOrchestratorAsync(
+                nameof(OrchestratorFunctions.PipelineJobDefaultFinished),
                 It.Is<PipelineStatus>(p => p.JobId == _input.JobId && p.RunId == _input.RunId!.ToString() && p.Success == success),
                 It.IsAny<TaskOptions?>()))
             .Verifiable();

--- a/platform/tests/Platform.Orchestrator.Tests/Sql/WhenPipelineDbDeactivatesUserData.cs
+++ b/platform/tests/Platform.Orchestrator.Tests/Sql/WhenPipelineDbDeactivatesUserData.cs
@@ -1,0 +1,50 @@
+﻿using System.Data;
+using Moq;
+using Platform.Orchestrator.Sql;
+using Platform.Sql;
+using Xunit;
+
+namespace Platform.Orchestrator.Tests.Sql;
+
+public class WhenPipelineDbDeactivatesUserData
+{
+    private readonly Mock<IDatabaseConnection> _connection;
+    private readonly PipelineDb _db;
+    private readonly Mock<IDbTransaction> _transaction;
+
+    public WhenPipelineDbDeactivatesUserData()
+    {
+        _transaction = new Mock<IDbTransaction>();
+
+        _connection = new Mock<IDatabaseConnection>();
+        _connection
+            .Setup(c => c.BeginTransaction())
+            .Returns(_transaction.Object);
+
+        var dbFactory = new Mock<IDatabaseFactory>();
+        dbFactory
+            .Setup(d => d.GetConnection())
+            .ReturnsAsync(_connection.Object);
+
+        _db = new PipelineDb(dbFactory.Object);
+    }
+
+    [Fact]
+    public async Task ShouldDeactivateUserDataInDatabase()
+    {
+        const int rowsAffected = 1;
+
+        string? actualSql = null;
+        _connection
+            .Setup(c => c.ExecuteAsync(It.IsAny<string>(), It.IsAny<object?>(), _transaction.Object, It.IsAny<CancellationToken>()))
+            .Callback<string, object?, IDbTransaction?, CancellationToken>((sql, _, _, _) =>
+            {
+                actualSql = sql;
+            })
+            .ReturnsAsync(rowsAffected);
+
+        var result = await _db.DeactivateUserData();
+        Assert.Equal("UPDATE UserData SET Active = 0", actualSql);
+        Assert.Equal(rowsAffected, result);
+    }
+}

--- a/platform/tests/Platform.Orchestrator.Tests/Sql/WhenPipelineDbUpdatesUserDataStatus.cs
+++ b/platform/tests/Platform.Orchestrator.Tests/Sql/WhenPipelineDbUpdatesUserDataStatus.cs
@@ -7,13 +7,13 @@ using Xunit;
 
 namespace Platform.Orchestrator.Tests.Sql;
 
-public class WhenPipelineDbUpdatesStatus
+public class WhenPipelineDbUpdatesUserDataStatus
 {
     private readonly Mock<IDatabaseConnection> _connection;
     private readonly PipelineDb _db;
     private readonly Mock<IDbTransaction> _transaction;
 
-    public WhenPipelineDbUpdatesStatus()
+    public WhenPipelineDbUpdatesUserDataStatus()
     {
         _transaction = new Mock<IDbTransaction>();
 
@@ -55,7 +55,7 @@ public class WhenPipelineDbUpdatesStatus
             })
             .ReturnsAsync(rowsAffected);
 
-        var result = await _db.UpdateStatus(status);
+        var result = await _db.UpdateUserDataStatus(status);
         Assert.Equal("UPDATE UserData SET Status = @status where Id = @RunId", actualSql);
         Assert.Equal(rowsAffected, result);
         Assert.Equal(runId, actualRunId);

--- a/platform/tests/Platform.Orchestrator.Tests/Telemetry/WhenTelemetryServiceTracksEvent.cs
+++ b/platform/tests/Platform.Orchestrator.Tests/Telemetry/WhenTelemetryServiceTracksEvent.cs
@@ -24,7 +24,9 @@ public class WhenTelemetryServiceTracksEvent
         const string jobId = nameof(jobId);
         var props = new Dictionary<string, string?>
         {
-            { "Key", "Value" }
+            { "Key", "Value" },
+            { "Empty", string.Empty },
+            { "Missing", null }
         };
 
         _service.TrackEvent(eventName, jobId, props);


### PR DESCRIPTION
### Context
[AB#249839](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249839) [AB#249104](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249104)

### Change proposed in this pull request
- Moved post default run completion activity triggers to sub-orchestrator
- Set `dbo.UserData.Active` to `0` from `PipelineJobDefaultFinished` orchestrator upon success message received
- Send error from `PipelineFinish` message with custom event

### Guidance to review 
Deployed and validated in `d12` feature environment.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

