### PR TITLE
fix: include suppress negative and zero warning text and cost codes in save all images for page

### DIFF
--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -204,7 +204,11 @@ export function HorizontalBarChartWrapper<
         )}
       </div>
       <div className="govuk-grid-row">
-        <div className="govuk-grid-column-full" data-chart-uuid={uuid}>
+        <div
+          className="govuk-grid-column-full costs-chart-wrapper"
+          data-chart-uuid={uuid}
+          data-title={chartTitle}
+        >
           {hasData ? (
             <>
               <CostCodesList category={chartTitle} />

--- a/web/src/Web.App/Views/SchoolComparison/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/Index.cshtml
@@ -21,6 +21,8 @@
     {
         saveButtonVisible = true,
         downloadButtonVisible = true,
+        saveClassName = "costs-chart-wrapper",
+        saveTitleAttr = "data-title",
         saveFileName = $"benchmark-spending-{Model.Urn}.zip",
         waitForEventType = eventType,
         downloadLink = Url.ActionLink("Download", "SchoolComparison", new

--- a/web/src/Web.App/Views/SchoolSpending/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/Index.cshtml
@@ -11,7 +11,6 @@
         saveButtonVisible = true,
         saveClassName = "costs-chart-wrapper",
         saveFileName = $"spending-priorities-{Model.Urn}.zip",
-        saveTitleAttribute = "data-title",
         saveTitleAttr = "data-title",
         costCodesAttr = "data-cost-codes"    
     })

--- a/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/_Costs.cshtml
@@ -93,7 +93,7 @@
 
             <div class="govuk-grid-row govuk-!-margin-bottom-4">
                 <div class="govuk-grid-column-two-thirds">
-                    <div id="@uuid">
+                    <div id="@uuid" class="costs-chart-wrapper" data-title="@categoryHeading" data-cost-codes="@costCodes.ToJson(Formatting.None)">
                         @if (hasNegativeOrZeroValues)
                         {
                             <div class="govuk-warning-text">
@@ -105,7 +105,7 @@
                             </div>
                         }
 
-                        <div class="govuk-!-margin-bottom-2 composed-container costs-chart-wrapper"
+                        <div class="govuk-!-margin-bottom-2 composed-container"
                              data-spending-and-costs-composed
                              data-json="@filteredData.ToJson(Formatting.None)"
                              data-highlight="@Model.Urn"
@@ -113,8 +113,7 @@
                              data-sort-direction="asc"
                              data-stats="@SchoolSpendingViewModel.Stats(category.Rating).ToJson(Formatting.None)"
                              data-has-incomplete-data="@Model.HasIncompleteData"
-                             data-title="@categoryHeading"
-                             data-cost-codes="@costCodes.ToJson(Formatting.None)">
+                             >
                         </div>
                     </div>
 

--- a/web/src/Web.App/Views/TrustComparison/Index.cshtml
+++ b/web/src/Web.App/Views/TrustComparison/Index.cshtml
@@ -10,6 +10,8 @@
 {
     saveButtonVisible = true,
     saveFileName = $"benchmark-spending-{Model.CompanyNumber}.zip",
+    saveClassName = "costs-chart-wrapper",
+    saveTitleAttr = "data-title",
     waitForEventType = eventType
 })
 


### PR DESCRIPTION
### Context
[AB#242100](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/242100) - [AB#250518](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/250518)

### Change proposed in this pull request
use `costs-chart-wrapper` class so the correct element is targeted for the "save chart images" (all) for the page.
data atrributes moved to that element so they are used for title and cost codes.

### Guidance to review 
will require a bump to front end.
to test locally can build and copy front-end for use in web app

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

