### PR TITLE
Replaced `WaitForDownloadAsync` with `RunAndWaitForDownloadAsync` in E2E tests

### DIFF
--- a/web/tests/Web.E2ETests/Extensions/PageExtensions.cs
+++ b/web/tests/Web.E2ETests/Extensions/PageExtensions.cs
@@ -16,7 +16,7 @@ public static class PageExtensions
         return response;
     }
 
-    public static Task<IDownload> WaitForDownloadAsync(this IPage page, TimeSpan timeout) => page.WaitForDownloadAsync(new PageWaitForDownloadOptions
+    public static Task<IDownload> RunAndWaitForDownloadAsync(this IPage page, Func<Task> action, TimeSpan timeout) => page.RunAndWaitForDownloadAsync(action, new PageRunAndWaitForDownloadOptions
     {
         Timeout = Convert.ToSingle(timeout.TotalMilliseconds)
     });

--- a/web/tests/Web.E2ETests/Steps/LocalAuthority/BenchmarkCensusSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/LocalAuthority/BenchmarkCensusSteps.cs
@@ -26,11 +26,7 @@ public class BenchmarkCensusSteps(PageDriver driver)
     {
         Assert.NotNull(_censusPage);
         var page = await driver.Current;
-        var downloadTask = page.WaitForDownloadAsync();
-
-        await _censusPage.ClickSaveAsImage(ChartNameFromFriendlyName(chartName));
-
-        _download = await downloadTask;
+        _download = await page.RunAndWaitForDownloadAsync(() => _censusPage.ClickSaveAsImage(ChartNameFromFriendlyName(chartName)));
     }
 
     [Then("the '(.*)' chart image is downloaded")]

--- a/web/tests/Web.E2ETests/Steps/LocalAuthority/CompareYourCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/LocalAuthority/CompareYourCostsSteps.cs
@@ -30,11 +30,7 @@ public class CompareYourCostsSteps(PageDriver driver)
     {
         Assert.NotNull(_comparisonPage);
         var page = await driver.Current;
-        var downloadTask = page.WaitForDownloadAsync();
-
-        await _comparisonPage.ClickSaveAsImage(ChartNameFromFriendlyName(chartName));
-
-        _download = await downloadTask;
+        _download = await page.RunAndWaitForDownloadAsync(() => _comparisonPage.ClickSaveAsImage(ChartNameFromFriendlyName(chartName)));
     }
 
     [Then("the '(.*)' chart image is downloaded")]

--- a/web/tests/Web.E2ETests/Steps/SaveImagesModalSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/SaveImagesModalSteps.cs
@@ -42,9 +42,7 @@ public class SaveImagesModalSteps(PageDriver driver)
     {
         Assert.NotNull(_spendingCostsPage);
         var page = await driver.Current;
-        var downloadTask = page.WaitForDownloadAsync(new TimeSpan(0, 1, 0));
-        await _spendingCostsPage.ClickSaveImagesModalOkButton();
-        _download = await downloadTask;
+        _download = await page.RunAndWaitForDownloadAsync(() => _spendingCostsPage.ClickSaveImagesModalOkButton(), new TimeSpan(0, 2, 0));
     }
 
     [When("I click the start button without any items selected")]

--- a/web/tests/Web.E2ETests/Steps/School/BenchmarkCensusSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/BenchmarkCensusSteps.cs
@@ -32,11 +32,7 @@ public class BenchmarkCensusSteps(PageDriver driver)
     {
         Assert.NotNull(_censusPage);
         var page = await driver.Current;
-        var downloadTask = page.WaitForDownloadAsync();
-
-        await _censusPage.ClickSaveAsImage(ChartNameFromFriendlyName(chartName));
-
-        _download = await downloadTask;
+        _download = await page.RunAndWaitForDownloadAsync(() => _censusPage.ClickSaveAsImage(ChartNameFromFriendlyName(chartName)));
     }
 
     [Then("the '(.*)' chart image is downloaded")]
@@ -165,11 +161,7 @@ public class BenchmarkCensusSteps(PageDriver driver)
     {
         Assert.NotNull(_censusPage);
         var page = await driver.Current;
-        var downloadTask = page.WaitForDownloadAsync();
-
-        await _censusPage.ClickDownloadDataButton();
-
-        _download = await downloadTask;
+        _download = await page.RunAndWaitForDownloadAsync(() => _censusPage.ClickDownloadDataButton());
     }
 
     [Then("the file '(.*)' is downloaded")]

--- a/web/tests/Web.E2ETests/Steps/School/CompareYourCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/CompareYourCostsSteps.cs
@@ -53,11 +53,7 @@ public class CompareYourCostsSteps(PageDriver driver)
     {
         Assert.NotNull(_comparisonPage);
         var page = await driver.Current;
-        var downloadTask = page.WaitForDownloadAsync();
-
-        await _comparisonPage.ClickSaveAsImage(ChartNameFromFriendlyName(chartName));
-
-        _download = await downloadTask;
+        _download = await page.RunAndWaitForDownloadAsync(() => _comparisonPage.ClickSaveAsImage(ChartNameFromFriendlyName(chartName)));
     }
 
     [Then("the '(.*)' chart image is downloaded")]

--- a/web/tests/Web.E2ETests/Steps/Trust/BenchmarkCensusSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/Trust/BenchmarkCensusSteps.cs
@@ -26,11 +26,7 @@ public class BenchmarkCensusSteps(PageDriver driver)
     {
         Assert.NotNull(_censusPage);
         var page = await driver.Current;
-        var downloadTask = page.WaitForDownloadAsync();
-
-        await _censusPage.ClickSaveAsImage(ChartNameFromFriendlyName(chartName));
-
-        _download = await downloadTask;
+        _download = await page.RunAndWaitForDownloadAsync(() => _censusPage.ClickSaveAsImage(ChartNameFromFriendlyName(chartName)));
     }
 
     [Then("the '(.*)' chart image is downloaded")]

--- a/web/tests/Web.E2ETests/Steps/Trust/CompareYourCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/Trust/CompareYourCostsSteps.cs
@@ -30,11 +30,7 @@ public class CompareYourCostsSteps(PageDriver driver)
     {
         Assert.NotNull(_comparisonPage);
         var page = await driver.Current;
-        var downloadTask = page.WaitForDownloadAsync();
-
-        await _comparisonPage.ClickSaveAsImage(ChartNameFromFriendlyName(chartName));
-
-        _download = await downloadTask;
+        _download = await page.RunAndWaitForDownloadAsync(() => _comparisonPage.ClickSaveAsImage(ChartNameFromFriendlyName(chartName)));
     }
 
     [Then("the '(.*)' chart image is downloaded")]


### PR DESCRIPTION
### Context
[AB#250717](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/250717) [AB#242097](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/242097) #2014

### Change proposed in this pull request
Attempt to resolve flaky E2E tests around file downloads.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~


