### PR TITLE
feat: extract fields from data-pipeline logs

### DIFF
--- a/support-analytics/terraform/queries/pipeline-runs-custom.kql
+++ b/support-analytics/terraform/queries/pipeline-runs-custom.kql
@@ -1,11 +1,22 @@
 ContainerAppConsoleLogs_CL
+| extend
+    LogData = parse_json(Log_s)
+| extend
+    TimeGenerated = todatetime(replace_string(tostring(LogData.asctime), ",", ".")),
+    Message = tostring(LogData.message),
+    Level = tostring(LogData.levelname)
 | where 
     RevisionName_s matches regex "s198[ptd]\\d{2}-ebis-pipeline-custom"
 | where 
     TimeGenerated between (ago(1d)..now())
 | project 
-    TimeGenerated, 
-    ContainerId_s, 
+    TimeGenerated,
+    Level,
+    Message,
+    ContainerImage_s,
+    ContainerId_s,
+    ContainerAppName_s,
+    Type,
     Log_s
 | order by 
     TimeGenerated desc,

--- a/support-analytics/terraform/queries/pipeline-runs-default.kql
+++ b/support-analytics/terraform/queries/pipeline-runs-default.kql
@@ -1,11 +1,22 @@
 ContainerAppConsoleLogs_CL
+| extend
+    LogData = parse_json(Log_s)
+| extend
+    TimeGenerated = todatetime(replace_string(tostring(LogData.asctime), ",", ".")),
+    Message = tostring(LogData.message),
+    Level = tostring(LogData.levelname)
 | where 
     RevisionName_s matches regex "s198[ptd]\\d{2}-ebis-pipeline-default"
 | where 
     TimeGenerated between (ago(1d)..now())
 | project 
-    TimeGenerated, 
-    ContainerId_s, 
+    TimeGenerated,
+    Level,
+    Message,
+    ContainerImage_s,
+    ContainerId_s,
+    ContainerAppName_s,
+    Type,
     Log_s
 | order by 
     TimeGenerated desc,


### PR DESCRIPTION
### Context

The data-pipeline now uses JSON for logging, allowing us to make better use of the data therein.

[AB#243778](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/243778)  

### Change proposed in this pull request

Following changes to format data-pipeline logs as JSON (#1944), update existing KQL queries to extract relevant fields.

### Guidance to review 

Unabashedly stolen from @WolfyUK's suggestion.
 
I've run these against `d01` and the queries/output appear as expected.

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~You have reviewed with UX/Design~

