### PR TITLE
Added High needs target pages and CTAs from High needs landing page

### DIFF
--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -434,10 +434,28 @@ hr.govuk-section-break--print {
 .composed-container {
   min-height: 335px;
 }
+
 .app-cost-code-list {
   display: flex;
   gap: 10px;
   flex-wrap: wrap;
   list-style: none;
   padding: 0;
+}
+
+.govuk-summary-card {
+  .govuk-summary-card__content {
+    .govuk-button {
+      margin-bottom: govuk-spacing(3);
+      @include govuk-media-query($from: tablet) {
+        margin-bottom: govuk-spacing(1);
+      }
+    }
+  }
+
+  .govuk-summary-card__title-wrapper {
+    .govuk-summary-card__title {
+      margin-bottom: govuk-spacing(1);
+    }
+  }
 }

--- a/web/src/Web.App/Constants/DataSourceTypes.cs
+++ b/web/src/Web.App/Constants/DataSourceTypes.cs
@@ -4,4 +4,5 @@ public static class DataSourceTypes
 {
     public const string Spending = "spending";
     public const string Census = "census";
+    public const string HighNeeds = "high-needs";
 }

--- a/web/src/Web.App/Constants/PageTitles.cs
+++ b/web/src/Web.App/Constants/PageTitles.cs
@@ -63,6 +63,9 @@ public static class PageTitles
     public const string LocalAuthorityComparison = "View school spending";
     public const string LocalAuthorityCensus = "View pupil and workforce data";
     public const string LocalAuthorityHighNeeds = "High needs benchmarking";
+    public const string LocalAuthorityHighNeedsStartBenchmarking = "Start high needs benchmarking";
+    public const string LocalAuthorityHighNeedsHistoricData = "High needs historic data";
+    public const string LocalAuthorityHighNeedsNationalRankings = "High needs national rankings";
     public const string TrustSpending = "Spending priorities for this trust";
     public const string TrustComparatorsCreateBy = "How do you want to choose your own set of trusts?";
     public const string TrustComparatorsCreateByName = "Choose trusts to benchmark against";

--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsBenchmarkingController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsBenchmarkingController.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement.Mvc;
+using Web.App.Attributes.RequestTelemetry;
+using Web.App.Domain;
+using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Apis.Establishment;
+using Web.App.Infrastructure.Extensions;
+using Web.App.ViewModels;
+
+namespace Web.App.Controllers;
+
+[Controller]
+[FeatureGate(FeatureFlags.LocalAuthorities, FeatureFlags.HighNeeds)]
+[Route("local-authority/{code}/high-needs/benchmarking")]
+public class LocalAuthorityHighNeedsBenchmarkingController(
+    ILogger<LocalAuthorityHighNeedsBenchmarkingController> logger,
+    IEstablishmentApi establishmentApi)
+    : Controller
+{
+    [HttpGet]
+    [LocalAuthorityRequestTelemetry(TrackedRequestFeature.Home)]
+    public async Task<IActionResult> Index(string code)
+    {
+        using (logger.BeginScope(new
+        {
+            code
+        }))
+        {
+            try
+            {
+                ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.LocalAuthorityHome(code);
+
+                var authority = await LocalAuthority(code);
+                var viewModel = new LocalAuthorityViewModel(authority);
+                return View(viewModel);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "An error displaying local authority high needs benchmarking: {DisplayUrl}", Request.GetDisplayUrl());
+                return e is StatusCodeException s ? StatusCode((int)s.Status) : StatusCode(500);
+            }
+        }
+    }
+
+    private async Task<LocalAuthority> LocalAuthority(string code) => await establishmentApi
+        .GetLocalAuthority(code)
+        .GetResultOrThrow<LocalAuthority>();
+}

--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsHistoricDataController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsHistoricDataController.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement.Mvc;
+using Web.App.Attributes.RequestTelemetry;
+using Web.App.Domain;
+using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Apis.Establishment;
+using Web.App.Infrastructure.Extensions;
+using Web.App.ViewModels;
+
+namespace Web.App.Controllers;
+
+[Controller]
+[FeatureGate(FeatureFlags.LocalAuthorities, FeatureFlags.HighNeeds)]
+[Route("local-authority/{code}/high-needs/history")]
+public class LocalAuthorityHighNeedsHistoricDataController(
+    ILogger<LocalAuthorityHighNeedsHistoricDataController> logger,
+    IEstablishmentApi establishmentApi)
+    : Controller
+{
+    [HttpGet]
+    [LocalAuthorityRequestTelemetry(TrackedRequestFeature.Home)]
+    public async Task<IActionResult> Index(string code)
+    {
+        using (logger.BeginScope(new
+        {
+            code
+        }))
+        {
+            try
+            {
+                ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.LocalAuthorityHome(code);
+
+                var authority = await LocalAuthority(code);
+                var viewModel = new LocalAuthorityViewModel(authority);
+                return View(viewModel);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "An error displaying local authority high needs history: {DisplayUrl}", Request.GetDisplayUrl());
+                return e is StatusCodeException s ? StatusCode((int)s.Status) : StatusCode(500);
+            }
+        }
+    }
+
+    private async Task<LocalAuthority> LocalAuthority(string code) => await establishmentApi
+        .GetLocalAuthority(code)
+        .GetResultOrThrow<LocalAuthority>();
+}

--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsNationalRankingsController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsNationalRankingsController.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement.Mvc;
+using Web.App.Attributes.RequestTelemetry;
+using Web.App.Domain;
+using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Apis.Establishment;
+using Web.App.Infrastructure.Extensions;
+using Web.App.ViewModels;
+
+namespace Web.App.Controllers;
+
+[Controller]
+[FeatureGate(FeatureFlags.LocalAuthorities, FeatureFlags.HighNeeds)]
+[Route("local-authority/{code}/high-needs/national")]
+public class LocalAuthorityHighNeedsNationalRankingsController(
+    ILogger<LocalAuthorityHighNeedsNationalRankingsController> logger,
+    IEstablishmentApi establishmentApi)
+    : Controller
+{
+    [HttpGet]
+    [LocalAuthorityRequestTelemetry(TrackedRequestFeature.Home)]
+    public async Task<IActionResult> Index(string code)
+    {
+        using (logger.BeginScope(new
+        {
+            code
+        }))
+        {
+            try
+            {
+                ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.LocalAuthorityHome(code);
+
+                var authority = await LocalAuthority(code);
+                var viewModel = new LocalAuthorityViewModel(authority);
+                return View(viewModel);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "An error displaying local authority high needs national rankings: {DisplayUrl}", Request.GetDisplayUrl());
+                return e is StatusCodeException s ? StatusCode((int)s.Status) : StatusCode(500);
+            }
+        }
+    }
+
+    private async Task<LocalAuthority> LocalAuthority(string code) => await establishmentApi
+        .GetLocalAuthority(code)
+        .GetResultOrThrow<LocalAuthority>();
+}

--- a/web/src/Web.App/ViewComponents/DataSourceViewComponent.cs
+++ b/web/src/Web.App/ViewComponents/DataSourceViewComponent.cs
@@ -9,7 +9,7 @@ public class DataSourceViewComponent(IFinanceService financeService) : ViewCompo
     public async Task<IViewComponentResult> InvokeAsync(
         string organisationType,
         string sourceType,
-        bool isPartOfTrust,
+        bool? isPartOfTrust,
         string[]? additionText,
         string wrapperClassName = "govuk-grid-row",
         string className = "govuk-grid-column-full")
@@ -17,11 +17,15 @@ public class DataSourceViewComponent(IFinanceService financeService) : ViewCompo
         var dataSource = sourceType switch
         {
             DataSourceTypes.Spending =>
-                await GetSpendingDataSource(organisationType, isPartOfTrust),
+                await GetSpendingDataSource(organisationType, isPartOfTrust == true),
             DataSourceTypes.Census =>
             [
                 "Workforce data is taken from the workforce census.",
                 "Pupil data is taken from the school census data set in January."
+            ],
+            DataSourceTypes.HighNeeds =>
+            [
+                "Pellentesque vel mattis enim, vel cursus ante."
             ],
             _ => throw new ArgumentOutOfRangeException(nameof(sourceType))
         };

--- a/web/src/Web.App/Views/LocalAuthorityHighNeeds/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeeds/Index.cshtml
@@ -12,6 +12,13 @@
     kind = OrganisationTypes.LocalAuthority
 })
 
+@await Component.InvokeAsync("DataSource", new
+{
+    organisationType = OrganisationTypes.LocalAuthority,
+    sourceType = DataSourceTypes.HighNeeds,
+    additionText = new[] { "Lorem ipsum dolor sit amet, consectetur adipiscing elit." }
+})
+
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <div class="govuk-summary-card">
@@ -74,10 +81,6 @@
         </div>
     </div>
 </div>
-
-
-
-
 
 @await Component.InvokeAsync("LocalAuthorityFinanceTools", new
 {

--- a/web/src/Web.App/Views/LocalAuthorityHighNeeds/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeeds/Index.cshtml
@@ -14,35 +14,70 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-        <p class="govuk-body">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque vel mattis enim, vel cursus ante.
-        </p>
-        <p class="govuk-body">
-            Vivamus tincidunt, justo vel lobortis fringilla, leo nibh efficitur risus, id volutpat magna felis ut eros.
-        </p>
+        <div class="govuk-summary-card">
+            <div class="govuk-summary-card__title-wrapper">
+                <h2 class="govuk-summary-card__title">Benchmark high needs data</h2>
+            </div>
+            <div class="govuk-summary-card__content">
+                <p class="govuk-body">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque vel mattis enim, vel cursus
+                    ante.
+                </p>
+                <a href="@Url.Action("Index", "LocalAuthorityHighNeedsBenchmarking", new
+                         {
+                             code = Model.Code
+                         })" role="button" class="govuk-button govuk-button--primary" data-module="govuk-button">
+                    Start benchmarking
+                </a>
+            </div>
+        </div>
     </div>
 </div>
 
-<a href="@Url.Action("Index", "LocalAuthorityHighNeedsBenchmarking", new
-         {
-             code = Model.Code
-         })" role="button" class="govuk-button govuk-button--primary" data-module="govuk-button">
-    Start benchmarking
-</a>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+        <div class="govuk-summary-card">
+            <div class="govuk-summary-card__title-wrapper">
+                <h2 class="govuk-summary-card__title">National rankings</h2>
+            </div>
+            <div class="govuk-summary-card__content">
+                <p class="govuk-body">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque vel mattis enim, vel cursus
+                    ante.
+                </p>
+                <a href="@Url.Action("Index", "LocalAuthorityHighNeedsNationalRankings", new
+                         {
+                             code = Model.Code
+                         })" role="button" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+                    View national rankings
+                </a>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-column-one-half">
+        <div class="govuk-summary-card">
+            <div class="govuk-summary-card__title-wrapper">
+                <h2 class="govuk-summary-card__title">Historic data</h2>
+            </div>
+            <div class="govuk-summary-card__content">
+                <p class="govuk-body">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque vel mattis enim, vel cursus
+                    ante.
+                </p>
+                <a href="@Url.Action("Index", "LocalAuthorityHighNeedsHistoricData", new
+                         {
+                             code = Model.Code
+                         })" role="button" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+                    View historic data
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
 
-<a href="@Url.Action("Index", "LocalAuthorityHighNeedsNationalRankings", new
-         {
-             code = Model.Code
-         })" role="button" class="govuk-button govuk-button--secondary" data-module="govuk-button">
-    View national rankings
-</a>
 
-<a href="@Url.Action("Index", "LocalAuthorityHighNeedsHistoricData", new
-         {
-             code = Model.Code
-         })" role="button" class="govuk-button govuk-button--secondary" data-module="govuk-button">
-    View historic data
-</a>
+
+
 
 @await Component.InvokeAsync("LocalAuthorityFinanceTools", new
 {

--- a/web/src/Web.App/Views/LocalAuthorityHighNeeds/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeeds/Index.cshtml
@@ -23,6 +23,27 @@
     </div>
 </div>
 
+<a href="@Url.Action("Index", "LocalAuthorityHighNeedsBenchmarking", new
+         {
+             code = Model.Code
+         })" role="button" class="govuk-button govuk-button--primary" data-module="govuk-button">
+    Start benchmarking
+</a>
+
+<a href="@Url.Action("Index", "LocalAuthorityHighNeedsNationalRankings", new
+         {
+             code = Model.Code
+         })" role="button" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+    View national rankings
+</a>
+
+<a href="@Url.Action("Index", "LocalAuthorityHighNeedsHistoricData", new
+         {
+             code = Model.Code
+         })" role="button" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+    View historic data
+</a>
+
 @await Component.InvokeAsync("LocalAuthorityFinanceTools", new
 {
     identifier = Model.Code,

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsBenchmarking/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsBenchmarking/Index.cshtml
@@ -1,0 +1,12 @@
+@model Web.App.ViewModels.LocalAuthorityViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.LocalAuthorityHighNeedsStartBenchmarking;
+}
+
+@await Component.InvokeAsync("EstablishmentHeading", new
+{
+    title = ViewData[ViewDataKeys.Title],
+    name = Model.Name,
+    id = Model.Code,
+    kind = OrganisationTypes.LocalAuthority
+})

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsHistoricData/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsHistoricData/Index.cshtml
@@ -1,0 +1,12 @@
+@model Web.App.ViewModels.LocalAuthorityViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.LocalAuthorityHighNeedsHistoricData;
+}
+
+@await Component.InvokeAsync("EstablishmentHeading", new
+{
+    title = ViewData[ViewDataKeys.Title],
+    name = Model.Name,
+    id = Model.Code,
+    kind = OrganisationTypes.LocalAuthority
+})

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsNationalRankings/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsNationalRankings/Index.cshtml
@@ -1,0 +1,12 @@
+@model Web.App.ViewModels.LocalAuthorityViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.LocalAuthorityHighNeedsNationalRankings;
+}
+
+@await Component.InvokeAsync("EstablishmentHeading", new
+{
+    title = ViewData[ViewDataKeys.Title],
+    name = Model.Name,
+    id = Model.Code,
+    kind = OrganisationTypes.LocalAuthority
+})

--- a/web/src/Web.App/Views/Shared/Components/LocalAuthorityFinanceTools/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/LocalAuthorityFinanceTools/Default.cshtml
@@ -47,8 +47,9 @@
                                     <a href="@Url.Action("Index", "LocalAuthorityHighNeeds", new
                                              {
                                                  code = Model.Identifier
-                                             })" class="govuk-link govuk-link--no-visited-state">High needs
-                                        benchmarking</a>
+                                             })" class="govuk-link govuk-link--no-visited-state">
+                                        High needs benchmarking
+                                    </a>
                                 </h3>
                                 <p class="govuk-body">
                                     Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/web/tests/Web.A11yTests/Pages/LocalAuthority/WhenViewingHighNeedsHistoricData.cs
+++ b/web/tests/Web.A11yTests/Pages/LocalAuthority/WhenViewingHighNeedsHistoricData.cs
@@ -1,0 +1,21 @@
+using Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Web.A11yTests.Pages.LocalAuthority;
+
+[Trait("Category", "HighNeedsFlagEnabled")]
+public class WhenViewingHighNeedsHistoricData(
+    ITestOutputHelper testOutputHelper,
+    WebDriver webDriver)
+    : PageBase(testOutputHelper, webDriver)
+{
+    protected override string PageUrl => $"/local-authority/{TestConfiguration.LocalAuthority}/high-needs/history";
+
+    [Fact]
+    public async Task ThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await EvaluatePage();
+    }
+}

--- a/web/tests/Web.A11yTests/Pages/LocalAuthority/WhenViewingHighNeedsNationalRankings.cs
+++ b/web/tests/Web.A11yTests/Pages/LocalAuthority/WhenViewingHighNeedsNationalRankings.cs
@@ -1,0 +1,21 @@
+using Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Web.A11yTests.Pages.LocalAuthority;
+
+[Trait("Category", "HighNeedsFlagEnabled")]
+public class WhenViewingHighNeedsNationalRankings(
+    ITestOutputHelper testOutputHelper,
+    WebDriver webDriver)
+    : PageBase(testOutputHelper, webDriver)
+{
+    protected override string PageUrl => $"/local-authority/{TestConfiguration.LocalAuthority}/high-needs/national";
+
+    [Fact]
+    public async Task ThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await EvaluatePage();
+    }
+}

--- a/web/tests/Web.A11yTests/Pages/LocalAuthority/WhenViewingHighNeedsStartBenchmarking.cs
+++ b/web/tests/Web.A11yTests/Pages/LocalAuthority/WhenViewingHighNeedsStartBenchmarking.cs
@@ -1,0 +1,21 @@
+using Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Web.A11yTests.Pages.LocalAuthority;
+
+[Trait("Category", "HighNeedsFlagEnabled")]
+public class WhenViewingHighNeedsStartBenchmarking(
+    ITestOutputHelper testOutputHelper,
+    WebDriver webDriver)
+    : PageBase(testOutputHelper, webDriver)
+{
+    protected override string PageUrl => $"/local-authority/{TestConfiguration.LocalAuthority}/high-needs/benchmarking";
+
+    [Fact]
+    public async Task ThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await EvaluatePage();
+    }
+}

--- a/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsBenchmarking.feature
+++ b/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsBenchmarking.feature
@@ -1,5 +1,19 @@
 ﻿Feature: Local Authority high needs benchmarking
 
     @HighNeedsFlagEnabled
-    Scenario: TODO: do something on high needs benchmarking page
+    Scenario: Go to start benchmarking page
         Given I am on local authority high needs benchmarking for local authority with code '204'
+        When I click on start benchmarking
+        Then the start benchmarking page is displayed
+
+    @HighNeedsFlagEnabled
+    Scenario: Go to view national rankings
+        Given I am on local authority high needs benchmarking for local authority with code '204'
+        When I click on view national rankings
+        Then the national rankings page is displayed
+
+    @HighNeedsFlagEnabled
+    Scenario: Go to view historic data
+        Given I am on local authority high needs benchmarking for local authority with code '204'
+        When I click on view historic data
+        Then the historic data page is displayed

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsBenchmarkingPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsBenchmarkingPage.cs
@@ -5,9 +5,39 @@ namespace Web.E2ETests.Pages.LocalAuthority;
 public class HighNeedsBenchmarkingPage(IPage page)
 {
     private ILocator PageH1Heading => page.Locator($"main {Selectors.H1}");
+    private ILocator StartBenchmarkingButton => page.Locator(Selectors.CtaButton, new PageLocatorOptions
+    {
+        HasText = "Start benchmarking"
+    });
+    private ILocator ViewNationalRankingsButton => page.Locator(Selectors.CtaButton, new PageLocatorOptions
+    {
+        HasText = "View national rankings"
+    });
+    private ILocator ViewHistoricDataButton => page.Locator(Selectors.CtaButton, new PageLocatorOptions
+    {
+        HasText = "View historic data"
+    });
 
     public async Task IsDisplayed()
     {
         await PageH1Heading.ShouldBeVisible();
+    }
+
+    public async Task<HighNeedsStartBenchmarkingPage> ClickStartBenchmarking()
+    {
+        await StartBenchmarkingButton.Click();
+        return new HighNeedsStartBenchmarkingPage(page);
+    }
+
+    public async Task<HighNeedsNationalRankingsPage> ClickViewNationalRankings()
+    {
+        await ViewNationalRankingsButton.Click();
+        return new HighNeedsNationalRankingsPage(page);
+    }
+
+    public async Task<HighNeedsHistoricDataPage> ClickViewHistoricData()
+    {
+        await ViewHistoricDataButton.Click();
+        return new HighNeedsHistoricDataPage(page);
     }
 }

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsBenchmarkingPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsBenchmarkingPage.cs
@@ -17,10 +17,34 @@ public class HighNeedsBenchmarkingPage(IPage page)
     {
         HasText = "View historic data"
     });
+    private ILocator BenchmarkHighNeedsCard => page.Locator(Selectors.GovSummaryCard, new PageLocatorOptions
+    {
+        Has = page.Locator(Selectors.GovSummaryCardTitle, new PageLocatorOptions
+        {
+            HasText = "Benchmark high needs data"
+        })
+    });
+    private ILocator NationalRankingsCard => page.Locator(Selectors.GovSummaryCard, new PageLocatorOptions
+    {
+        Has = page.Locator(Selectors.GovSummaryCardTitle, new PageLocatorOptions
+        {
+            HasText = "National rankings"
+        })
+    });
+    private ILocator HistoricDataCard => page.Locator(Selectors.GovSummaryCard, new PageLocatorOptions
+    {
+        Has = page.Locator(Selectors.GovSummaryCardTitle, new PageLocatorOptions
+        {
+            HasText = "Historic data"
+        })
+    });
 
     public async Task IsDisplayed()
     {
         await PageH1Heading.ShouldBeVisible();
+        await BenchmarkHighNeedsCard.ShouldBeVisible();
+        await NationalRankingsCard.ShouldBeVisible();
+        await HistoricDataCard.ShouldBeVisible();
     }
 
     public async Task<HighNeedsStartBenchmarkingPage> ClickStartBenchmarking()

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsHistoricDataPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsHistoricDataPage.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Playwright;
+
+namespace Web.E2ETests.Pages.LocalAuthority;
+
+public class HighNeedsHistoricDataPage(IPage page)
+{
+    private ILocator PageH1Heading => page.Locator($"main {Selectors.H1}");
+
+    public async Task IsDisplayed()
+    {
+        await PageH1Heading.ShouldBeVisible();
+    }
+}

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsNationalRankingsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsNationalRankingsPage.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Playwright;
+
+namespace Web.E2ETests.Pages.LocalAuthority;
+
+public class HighNeedsNationalRankingsPage(IPage page)
+{
+    private ILocator PageH1Heading => page.Locator($"main {Selectors.H1}");
+
+    public async Task IsDisplayed()
+    {
+        await PageH1Heading.ShouldBeVisible();
+    }
+}

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsStartBenchmarkingPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsStartBenchmarkingPage.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Playwright;
+
+namespace Web.E2ETests.Pages.LocalAuthority;
+
+public class HighNeedsStartBenchmarkingPage(IPage page)
+{
+    private ILocator PageH1Heading => page.Locator($"main {Selectors.H1}");
+
+    public async Task IsDisplayed()
+    {
+        await PageH1Heading.ShouldBeVisible();
+    }
+}

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -63,6 +63,7 @@ public static class Selectors
     public const string Aside = "aside";
     public const string Modal = "div.modal";
     public const string ModalButton = $"{Modal} {Button}";
+    public const string CtaButton = "[role='button'][class*='govuk-button']";
 
     public const string ComparisonChartsAndTables = "#compare-your-costs";
     public const string ComparisonTables = "#compare-your-costs table.govuk-table";

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -22,6 +22,8 @@ public static class Selectors
     public const string GovWarning = ".govuk-warning-text";
     public const string GovFooterLink = "footer .govuk-footer__link";
     public const string GovErrorSummary = ".govuk-error-summary";
+    public const string GovSummaryCard = ".govuk-summary-card";
+    public const string GovSummaryCardTitle = ".govuk-summary-card__title";
 
     public const string ChangeSchoolLink = ":text('Change school')";
     public const string ModeChart = "#mode-chart";

--- a/web/tests/Web.E2ETests/Steps/LocalAuthority/HighNeedsBenchmarkingSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/LocalAuthority/HighNeedsBenchmarkingSteps.cs
@@ -1,5 +1,6 @@
 using Web.E2ETests.Drivers;
 using Web.E2ETests.Pages.LocalAuthority;
+using Xunit;
 
 namespace Web.E2ETests.Steps.LocalAuthority;
 
@@ -8,6 +9,9 @@ namespace Web.E2ETests.Steps.LocalAuthority;
 public class HighNeedsBenchmarkingSteps(PageDriver driver)
 {
     private HighNeedsBenchmarkingPage? _highNeedsBenchmarkingPage;
+    private HighNeedsHistoricDataPage? _highNeedsHistoricDataPage;
+    private HighNeedsNationalRankingsPage? _highNeedsNationalRankingsPage;
+    private HighNeedsStartBenchmarkingPage? _highNeedsStartBenchmarkingPage;
 
     [Given("I am on local authority high needs benchmarking for local authority with code '(.*)'")]
     public async Task GivenIAmOnLocalAuthorityHighNeedsBenchmarkingForLocalAuthorityWithCode(string laCode)
@@ -18,6 +22,48 @@ public class HighNeedsBenchmarkingSteps(PageDriver driver)
 
         _highNeedsBenchmarkingPage = new HighNeedsBenchmarkingPage(page);
         await _highNeedsBenchmarkingPage.IsDisplayed();
+    }
+
+    [When("I click on start benchmarking")]
+    public async Task WhenIClickOnStartBenchmarking()
+    {
+        Assert.NotNull(_highNeedsBenchmarkingPage);
+        _highNeedsStartBenchmarkingPage = await _highNeedsBenchmarkingPage.ClickStartBenchmarking();
+    }
+
+    [When("I click on view national rankings")]
+    public async Task WhenIClickOnViewNationalRankings()
+    {
+        Assert.NotNull(_highNeedsBenchmarkingPage);
+        _highNeedsNationalRankingsPage = await _highNeedsBenchmarkingPage.ClickViewNationalRankings();
+    }
+
+    [When("I click on view historic data")]
+    public async Task WhenIClickOnViewHistoricData()
+    {
+        Assert.NotNull(_highNeedsBenchmarkingPage);
+        _highNeedsHistoricDataPage = await _highNeedsBenchmarkingPage.ClickViewHistoricData();
+    }
+
+    [Then("the start benchmarking page is displayed")]
+    public async Task ThenTheStartBenchmarkingPageIsDisplayed()
+    {
+        Assert.NotNull(_highNeedsStartBenchmarkingPage);
+        await _highNeedsStartBenchmarkingPage.IsDisplayed();
+    }
+
+    [Then("the national rankings page is displayed")]
+    public async Task ThenTheNationalRankingsPageIsDisplayed()
+    {
+        Assert.NotNull(_highNeedsNationalRankingsPage);
+        await _highNeedsNationalRankingsPage.IsDisplayed();
+    }
+
+    [Then("the historic data page is displayed")]
+    public async Task ThenTheHistoricDataPageIsDisplayed()
+    {
+        Assert.NotNull(_highNeedsHistoricDataPage);
+        await _highNeedsHistoricDataPage.IsDisplayed();
     }
 
     private static string LocalAuthorityHighNeedsBenchmarkingUrl(string laCode) => $"{TestConfiguration.ServiceUrl}/local-authority/{laCode}/high-needs";

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeeds.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeeds.cs
@@ -1,0 +1,101 @@
+﻿using System.Net;
+using AngleSharp.Html.Dom;
+using AutoFixture;
+using Web.App.Domain;
+using Xunit;
+
+namespace Web.Integration.Tests.Pages.LocalAuthorities;
+
+public class WhenViewingHighNeeds(SchoolBenchmarkingWebAppClient client) : PageBase<SchoolBenchmarkingWebAppClient>(client)
+{
+    [Fact]
+    public async Task CanDisplay()
+    {
+        var (page, authority) = await SetupNavigateInitPage();
+
+        AssertPageLayout(page, authority);
+    }
+
+    [Fact]
+    public async Task CanNavigateToStartBenchmarking()
+    {
+        var (page, authority) = await SetupNavigateInitPage();
+
+        var anchor = page.QuerySelectorAll("a").FirstOrDefault(x => x.TextContent.Trim() == "Start benchmarking");
+        Assert.NotNull(anchor);
+
+        page = await Client.Follow(anchor);
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeedsStartBenchmarking(authority.Code).ToAbsolute());
+    }
+
+    [Fact]
+    public async Task CanNavigateToNationalRankings()
+    {
+        var (page, authority) = await SetupNavigateInitPage();
+
+        var anchor = page.QuerySelectorAll("a").FirstOrDefault(x => x.TextContent.Trim() == "View national rankings");
+        Assert.NotNull(anchor);
+
+        page = await Client.Follow(anchor);
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeedsNationalRankings(authority.Code).ToAbsolute());
+    }
+
+    [Fact]
+    public async Task CanNavigateToHistoricData()
+    {
+        var (page, authority) = await SetupNavigateInitPage();
+
+        var anchor = page.QuerySelectorAll("a").FirstOrDefault(x => x.TextContent.Trim() == "View historic data");
+        Assert.NotNull(anchor);
+
+        page = await Client.Follow(anchor);
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeedsHistoricData(authority.Code).ToAbsolute());
+    }
+
+    [Fact]
+    public async Task CanDisplayNotFound()
+    {
+        const string code = "123";
+        var page = await Client.SetupEstablishmentWithNotFound()
+            .Navigate(Paths.LocalAuthorityHome(code));
+
+        PageAssert.IsNotFoundPage(page);
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHome(code).ToAbsolute(), HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task CanDisplayProblemWithService()
+    {
+        const string code = "123";
+        var page = await Client.SetupEstablishmentWithException()
+            .Navigate(Paths.LocalAuthorityHome(code));
+
+        PageAssert.IsProblemPage(page);
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHome(code).ToAbsolute(), HttpStatusCode.InternalServerError);
+    }
+
+    private async Task<(IHtmlDocument page, LocalAuthority authority)> SetupNavigateInitPage()
+    {
+        var authority = Fixture.Build<LocalAuthority>()
+            .Create();
+
+        Assert.NotNull(authority.Name);
+
+        var page = await Client.SetupEstablishment(authority, [])
+            .SetupInsights()
+            .Navigate(Paths.LocalAuthorityHighNeeds(authority.Code));
+
+        return (page, authority);
+    }
+
+    private static void AssertPageLayout(IHtmlDocument page, LocalAuthority authority)
+    {
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeeds(authority.Code).ToAbsolute());
+
+        var expectedBreadcrumbs = new[] { ("Home", Paths.ServiceHome.ToAbsolute()) };
+        DocumentAssert.Breadcrumbs(page, expectedBreadcrumbs);
+
+        Assert.NotNull(authority.Name);
+        DocumentAssert.TitleAndH1(page, "High needs benchmarking - Financial Benchmarking and Insights Tool - GOV.UK", "High needs benchmarking");
+    }
+}

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHome.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHome.cs
@@ -50,6 +50,18 @@ public class WhenViewingHome(SchoolBenchmarkingWebAppClient client) : PageBase<S
         DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityResources(authority.Code).ToAbsolute());
     }
 
+    [Fact]
+    public async Task CanNavigateToHighNeeds()
+    {
+        var (page, authority, _) = await SetupNavigateInitPage();
+
+        var anchor = page.QuerySelectorAll("a").FirstOrDefault(x => x.TextContent.Trim() == "High needs benchmarking");
+        Assert.NotNull(anchor);
+
+        page = await Client.Follow(anchor);
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeeds(authority.Code).ToAbsolute());
+    }
+
     // TODO: review for public beta
     //[Fact]
     //public async Task CanNavigateToServiceHelp()
@@ -136,10 +148,7 @@ public class WhenViewingHome(SchoolBenchmarkingWebAppClient client) : PageBase<S
     {
         DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHome(authority.Code).ToAbsolute());
 
-        var expectedBreadcrumbs = new[]
-        {
-            ("Home", Paths.ServiceHome.ToAbsolute())
-        };
+        var expectedBreadcrumbs = new[] { ("Home", Paths.ServiceHome.ToAbsolute()) };
         DocumentAssert.Breadcrumbs(page, expectedBreadcrumbs);
 
         Assert.NotNull(authority.Name);

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -109,6 +109,9 @@ public static class Paths
     public static string LocalAuthorityHome(string? code) => $"/local-authority/{code}";
     public static string LocalAuthorityResources(string? code) => $"/local-authority/{code}/find-ways-to-spend-less";
     public static string LocalAuthorityHighNeeds(string? code) => $"/local-authority/{code}/high-needs";
+    public static string LocalAuthorityHighNeedsStartBenchmarking(string? code) => $"/local-authority/{code}/high-needs/benchmarking";
+    public static string LocalAuthorityHighNeedsNationalRankings(string? code) => $"/local-authority/{code}/high-needs/national";
+    public static string LocalAuthorityHighNeedsHistoricData(string? code) => $"/local-authority/{code}/high-needs/history";
     public static string SchoolResources(string? urn) => $"/school/{urn}/find-ways-to-spend-less";
     public static string ToAbsolute(this string path) => $"https://localhost{path}";
 }


### PR DESCRIPTION
### Context
[AB#250675](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/250675) [AB#249538](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249538) #2011

### Change proposed in this pull request
- New High needs target pages and links from High needs landing page
- Added summary card layout to High needs landing page
- Added placeholder data source content to High needs page
- E2E, a11y and integration tests

### Guidance to review 
Dependency on #2011. Deployed to `d18` feature environment.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

