### PR TITLE
feat: supplement missing Census/CDC data via GIAS-links

### DIFF
--- a/data-pipeline/src/pipeline/pre_processing/__init__.py
+++ b/data-pipeline/src/pipeline/pre_processing/__init__.py
@@ -10,6 +10,7 @@ from .ancillary import (
     build_bfr_data,
     build_bfr_historical_data,
     build_cfo_data,
+    predecessor_links,
     prepare_cdc_data,
     prepare_census_data,
     prepare_ks2_data,

--- a/data-pipeline/src/pipeline/pre_processing/academies/academies.py
+++ b/data-pipeline/src/pipeline/pre_processing/academies/academies.py
@@ -186,60 +186,6 @@ def prepare_aar_data(aar_path, year: int):
     return aar.set_index(input_schemas.aar_academies_index_col)
 
 
-def _link_data(
-    df: pd.DataFrame,
-    linkable: pd.DataFrame,
-    gias_links: pd.DataFrame,
-) -> pd.DataFrame:
-    """
-    Extend a dataset via GIAS-links.
-
-    - `df`: point of reference, must have `URN`
-    - `linkable`: must have `URN`, an extended version of this
-      `DataFrame` will be returned
-    - `gias_links`: must have `URN` and `LinkURN`, will be used to
-      extend `linkable` with records missing from `df`.
-
-    The data present in `linkable` may be missing URNs present in the
-    `df` data. Where this is the case, we extend those data with
-    additional records referencing the GIAS-link `LinkURN` (i.e. the
-    data will then contain a record for both the GIAS-link `URN` and
-    `LinkURN`).
-
-    - determine which `df` records are missing from the `linkable`
-    - of those missing records, determine which have GIAS-link records
-    - of those GIAS-links, determine which have `linkable` records
-    - supplement the `linkable` records, adding records with the
-      mapped GIAS-links
-    """
-    _df = df.reset_index()[["URN"]]
-    _linkable = linkable.reset_index()
-    _gias_links = gias_links.reset_index()[["URN", "LinkURN"]]
-
-    aar_missing = _df[~_df["URN"].isin(_linkable["URN"])][["URN"]]
-
-    link_urns = _gias_links[
-        (_gias_links["URN"].isin(aar_missing["URN"]))
-        & (_gias_links["LinkURN"].isin(_linkable["URN"]))
-    ][["URN", "LinkURN"]]
-
-    linked = (
-        _linkable[_linkable["URN"].isin(link_urns["LinkURN"])]
-        .merge(
-            link_urns,
-            how="inner",
-            left_on="URN",
-            right_on="LinkURN",
-            suffixes=("_census", "_link"),
-        )
-        .drop(columns=["URN_census", "LinkURN"])
-        .rename(columns={"URN_link": "URN"})
-        .set_index("URN")
-    )
-
-    return pd.concat([linkable, linked])
-
-
 def build_academy_data(
     schools: pd.DataFrame,
     census: pd.DataFrame,
@@ -286,13 +232,13 @@ def build_academy_data(
         aar.reset_index()
         .merge(schools, on="URN")
         .merge(
-            _link_data(aar, census, gias_links),
+            gias.link_data(aar, census, gias_links),
             on="URN",
             how="left",
         )
         .merge(sen, on="URN", how="left")
         .merge(
-            _link_data(aar, cdc, gias_links),
+            gias.link_data(aar, cdc, gias_links),
             on="URN",
             how="left",
         )

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/__init__.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/__init__.py
@@ -3,6 +3,7 @@ from .cdc import prepare_cdc_data
 from .census import prepare_census_data
 from .cfo import build_cfo_data
 from .custom_data import update_custom_data
+from .gias import predecessor_links
 from .ks2 import prepare_ks2_data
 from .ks4 import prepare_ks4_data
 from .schools import prepare_schools_data

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/gias.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/gias.py
@@ -1,12 +1,8 @@
 import pandas as pd
-from pandas._typing import (
-    FilePath,
-    ReadCsvBuffer,
-)
+from pandas._typing import FilePath, ReadCsvBuffer
 
-from pipeline import log
 import pipeline.input_schemas as input_schemas
-
+from pipeline import log
 
 logger = log.setup_logger(__name__)
 

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/gias.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/gias.py
@@ -1,0 +1,37 @@
+import pandas as pd
+from pandas._typing import (
+    FilePath,
+    ReadCsvBuffer,
+)
+
+from pipeline import log
+import pipeline.input_schemas as input_schemas
+
+
+logger = log.setup_logger(__name__)
+
+
+def predecessor_links(
+    filepath_or_buffer: FilePath | ReadCsvBuffer[bytes] | ReadCsvBuffer[str],
+) -> pd.DataFrame:
+    """
+    Read GIAS-links _Predecessor_ data.
+
+    :param base_data_path: source for GIAS-links data
+    :param year: financial year in question
+    """
+    gias_links = pd.read_csv(
+        filepath_or_buffer,
+        encoding="cp1252",
+        index_col=input_schemas.gias_links_index_col,
+        usecols=input_schemas.gias_links.keys(),
+        dtype=input_schemas.gias_links,
+    )
+
+    logger.info(f"Read {len(gias_links.index):,} GIAS-links records.")
+
+    predecessors = gias_links[gias_links["LinkType"] == "Predecessor"]
+
+    logger.info(f"Read {len(predecessors.index):,} predecessor GIAS-links records.")
+
+    return predecessors

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/gias.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/gias.py
@@ -13,8 +13,8 @@ def predecessor_links(
     """
     Read GIAS-links _Predecessor_ data.
 
-    :param base_data_path: source for GIAS-links data
-    :param year: financial year in question
+    :param filepath_or_buffer: source for GIAS-links data
+    :return: GIAS predecessor data
     """
     gias_links = pd.read_csv(
         filepath_or_buffer,
@@ -58,6 +58,11 @@ def link_data(
     - of those GIAS-links, determine which have `linkable` records
     - supplement the `linkable` records, adding records with the
       mapped GIAS-links
+
+    :param df: data source from which to find missing URNs
+    :param linkable: data set which can be linked via GIAS-links
+    :param gias_links: GIAS-links predecessor data
+    :return: extended linkable data set
     """
     _df = df.reset_index()[["URN"]]
     _linkable = linkable.reset_index()

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/gias.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/gias.py
@@ -79,9 +79,10 @@ def link_data(
             right_on="LinkURN",
             suffixes=("_census", "_link"),
         )
-        .drop(columns=["URN_census", "LinkURN"])
         .rename(columns={"URN_link": "URN"})
         .set_index("URN")
+        .drop(columns=["URN_census", "LinkURN"])
+        .drop(columns=["index"], errors="ignore")
     )
 
     return pd.concat([linkable, linked])

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/gias.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/gias.py
@@ -31,3 +31,57 @@ def predecessor_links(
     logger.info(f"Read {len(predecessors.index):,} predecessor GIAS-links records.")
 
     return predecessors
+
+
+def link_data(
+    df: pd.DataFrame,
+    linkable: pd.DataFrame,
+    gias_links: pd.DataFrame,
+) -> pd.DataFrame:
+    """
+    Extend a dataset via GIAS-links.
+
+    - `df`: point of reference, must have `URN`
+    - `linkable`: must have `URN`, an extended version of this
+      `DataFrame` will be returned
+    - `gias_links`: must have `URN` and `LinkURN`, will be used to
+      extend `linkable` with records missing from `df`.
+
+    The data present in `linkable` may be missing URNs present in the
+    `df` data. Where this is the case, we extend those data with
+    additional records referencing the GIAS-link `LinkURN` (i.e. the
+    data will then contain a record for both the GIAS-link `URN` and
+    `LinkURN`).
+
+    - determine which `df` records are missing from the `linkable`
+    - of those missing records, determine which have GIAS-link records
+    - of those GIAS-links, determine which have `linkable` records
+    - supplement the `linkable` records, adding records with the
+      mapped GIAS-links
+    """
+    _df = df.reset_index()[["URN"]]
+    _linkable = linkable.reset_index()
+    _gias_links = gias_links.reset_index()[["URN", "LinkURN"]]
+
+    df_missing = _df[~_df["URN"].isin(_linkable["URN"])][["URN"]]
+
+    link_urns = _gias_links[
+        (_gias_links["URN"].isin(df_missing["URN"]))
+        & (_gias_links["LinkURN"].isin(_linkable["URN"]))
+    ][["URN", "LinkURN"]]
+
+    linked = (
+        _linkable[_linkable["URN"].isin(link_urns["LinkURN"])]
+        .merge(
+            link_urns,
+            how="inner",
+            left_on="URN",
+            right_on="LinkURN",
+            suffixes=("_census", "_link"),
+        )
+        .drop(columns=["URN_census", "LinkURN"])
+        .rename(columns={"URN_link": "URN"})
+        .set_index("URN")
+    )
+
+    return pd.concat([linkable, linked])

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/schools.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/schools.py
@@ -9,7 +9,7 @@ def prepare_schools_data(base_data_path, links_data_path, year: int):
     Prepare school data derived from GIAS and GIAS links.
 
     :param base_data_path: readable source for GIAS
-    :param pupil_census_path: readable source for GIAS links
+    :param links_data_path: readable source for GIAS links
     :param year: financial year in question
     """
     gias = pd.read_csv(

--- a/data-pipeline/tests/unit/pre_processing/test_gias_links.py
+++ b/data-pipeline/tests/unit/pre_processing/test_gias_links.py
@@ -1,0 +1,68 @@
+import pandas as pd
+
+from pipeline.pre_processing.ancillary import gias
+
+
+def test_empty():
+    df = pd.DataFrame({"URN": []})
+    linkable = pd.DataFrame({"URN": []}).set_index("URN")
+    gias_links = pd.DataFrame({"URN": [], "LinkURN": []})
+
+    result = gias.link_data(df, linkable, gias_links)
+
+    assert result.index.name == "URN"
+    assert len(result.index) == 0
+
+
+def test_no_match():
+    df = pd.DataFrame({"URN": [4, 5, 6]})
+    linkable = pd.DataFrame({"URN": [1, 2, 3]}).set_index("URN")
+    gias_links = pd.DataFrame({"URN": [1, 2, 3], "LinkURN": [1, 2, 3]})
+
+    result = gias.link_data(df, linkable, gias_links)
+
+    assert result.index.name == "URN"
+    assert result.index.equals(linkable.index)
+
+
+def test_complete_match():
+    df = pd.DataFrame({"URN": [4, 5, 6]})
+    linkable = pd.DataFrame({"URN": [1, 2, 3]}).set_index("URN")
+    gias_links = pd.DataFrame({"URN": [4, 5, 6], "LinkURN": [1, 2, 3]})
+
+    result = gias.link_data(df, linkable, gias_links)
+
+    assert result.index.name == "URN"
+    assert list(result.index) == [1, 2, 3, 4, 5, 6]
+
+
+def test_partial_match():
+    df = pd.DataFrame({"URN": [4, 5, 6]})
+    linkable = pd.DataFrame({"URN": [3, 4, 5]}).set_index("URN")
+    gias_links = pd.DataFrame({"URN": [4, 5, 6], "LinkURN": [1, 2, 3]})
+
+    result = gias.link_data(df, linkable, gias_links)
+
+    assert result.index.name == "URN"
+    assert list(result.index) == [3, 4, 5, 6]
+
+
+def test_partial_match_data():
+    df = pd.DataFrame({"URN": [4, 5, 6]})
+    linkable = pd.DataFrame(
+        {
+            "URN": [3, 4, 5],
+            "A": ["3", "4", "5"],
+            "B": ["3", "4", "5"],
+            "C": ["3", "4", "5"],
+        }
+    ).set_index("URN")
+    gias_links = pd.DataFrame({"URN": [4, 5, 6], "LinkURN": [1, 2, 3]})
+
+    result = gias.link_data(df, linkable, gias_links)
+
+    assert result.index.name == "URN"
+    assert list(result.index) == [3, 4, 5, 6]
+    assert result.loc[6, "A"] == "3"
+    assert result.loc[6, "B"] == "3"
+    assert result.loc[6, "C"] == "3"

--- a/data-pipeline/tests/unit/pre_processing/test_gias_links.py
+++ b/data-pipeline/tests/unit/pre_processing/test_gias_links.py
@@ -48,6 +48,11 @@ def test_partial_match():
 
 
 def test_partial_match_data():
+    """
+    - 3 and 4 are present in `df` and `linkable`, 6 is missing
+    - GIAS links 3 and 6
+    - `linkable` should be extended to include 6 with the data from 3
+    """
     df = pd.DataFrame({"URN": [4, 5, 6]})
     linkable = pd.DataFrame(
         {
@@ -61,8 +66,35 @@ def test_partial_match_data():
 
     result = gias.link_data(df, linkable, gias_links)
 
+    assert list(result.columns) == ["A", "B", "C"]
     assert result.index.name == "URN"
     assert list(result.index) == [3, 4, 5, 6]
-    assert result.loc[6, "A"] == "3"
-    assert result.loc[6, "B"] == "3"
-    assert result.loc[6, "C"] == "3"
+    assert result.loc[6].to_dict() == {"A": "3", "B": "3", "C": "3"}
+
+
+def test_original_data_prioritised():
+    """
+    - 4 and 5 are present in `df` and `linkable`, 6 is missing
+    - GIAS links 3 and 4, 4 and 5, 5 and 6
+    - `linkable` should be extended to include 6 with the data from 5
+    - the data for 4 and 5, despite the GIAS links, must not be changed
+    """
+    df = pd.DataFrame({"URN": [4, 5, 6]})
+    linkable = pd.DataFrame(
+        {
+            "URN": [3, 4, 5],
+            "A": ["3", "4", "5"],
+            "B": ["3", "4", "5"],
+            "C": ["3", "4", "5"],
+        }
+    ).set_index("URN")
+    gias_links = pd.DataFrame({"URN": [4, 5, 6], "LinkURN": [3, 4, 5]})
+
+    result = gias.link_data(df, linkable, gias_links)
+
+    assert result.index.name == "URN"
+    assert list(result.columns) == ["A", "B", "C"]
+    assert list(result.index) == [3, 4, 5, 6]
+    assert result.loc[4].to_dict() == {"A": "4", "B": "4", "C": "4"}
+    assert result.loc[5].to_dict() == {"A": "5", "B": "5", "C": "5"}
+    assert result.loc[6].to_dict() == {"A": "5", "B": "5", "C": "5"}


### PR DESCRIPTION
### Context

Some Academies in the 2024 data are missing pupil and/or floor-area data, leading to missing data, apportionment issues, etc.

### Change proposed in this pull request

Extend the Census data:

- AAR URNs may be missing from the Census data
- for those missing URNs, check for GIAS `Predecessor` links
- for those links, check for Census data via the `LinkURN`
- for those with Census data, duplicate those data for the GIAS-links' `URN` and `LinkURN` values

…and as per the above CDC/GIAS-links processing:

- refactor this to supplement _any_ dataset via GIAS-links
- pass the CDC data to this function

[AB#250420](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/250420)  

### Guidance to review 

Ran locally and the URNs flagged initially now have `TotalPupils` and `TotalInternalFloorArea` populated as expected.

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~You have reviewed with UX/Design~

