### PR TITLE
LA high needs history endpoint with stubbed data

### DIFF
--- a/platform/src/abstractions/Platform.Functions/Extensions/NameValueCollectionExtensions.cs
+++ b/platform/src/abstractions/Platform.Functions/Extensions/NameValueCollectionExtensions.cs
@@ -1,0 +1,19 @@
+using System.Collections.Specialized;
+
+namespace Platform.Functions.Extensions;
+
+public static class NameValueCollectionExtensions
+{
+    public static string[] ToStringArray(this NameValueCollection query, string parameterName)
+    {
+        return query[parameterName]?
+            .Split(",", StringSplitOptions.TrimEntries)
+            .Where(x => !string.IsNullOrEmpty(x))
+            .ToArray() ?? [];
+    }
+
+    public static bool ToBool(this NameValueCollection query, string parameterName)
+    {
+        return bool.TryParse(query[parameterName], out var val) && val;
+    }
+}

--- a/platform/src/abstractions/Platform.Functions/Extensions/QueryCollectionExtensions.cs
+++ b/platform/src/abstractions/Platform.Functions/Extensions/QueryCollectionExtensions.cs
@@ -6,6 +6,7 @@ namespace Platform.Functions.Extensions;
 [ExcludeFromCodeCoverage]
 public static class QueryCollectionExtensions
 {
+    [Obsolete("Switch over to NameValueCollection and use ToStringArray(this NameValueCollection query, string parameterName) instead")]
     public static string[] ToStringArray(this IQueryCollection query, string parameterName)
     {
         return query[parameterName].ToString()
@@ -14,6 +15,7 @@ public static class QueryCollectionExtensions
             .ToArray();
     }
 
+    [Obsolete("Switch over to NameValueCollection and use ToBool(this NameValueCollection query, string parameterName) instead")]
     public static bool ToBool(this IQueryCollection query, string parameterName)
     {
         return bool.TryParse(query[parameterName].ToString(), out var val) && val;

--- a/platform/src/abstractions/Platform.Functions/QueryParameters.cs
+++ b/platform/src/abstractions/Platform.Functions/QueryParameters.cs
@@ -8,9 +8,9 @@ namespace Platform.Functions;
 [ExcludeFromCodeCoverage]
 public abstract record QueryParameters
 {
+    [Obsolete("Use SetValues(NameValueCollection query) overload instead")]
     public virtual void SetValues(IQueryCollection query)
     {
-        throw new NotImplementedException();
     }
 
     public virtual void SetValues(NameValueCollection query)

--- a/platform/src/abstractions/tests/Platform.Functions.Tests/Extensions/WhenNameValueCollectionExtensionsConvertsFromQuery.cs
+++ b/platform/src/abstractions/tests/Platform.Functions.Tests/Extensions/WhenNameValueCollectionExtensionsConvertsFromQuery.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
+using Platform.Functions.Extensions;
+using Xunit;
+
+namespace Platform.Functions.Tests.Extensions;
+
+[SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments")]
+public class WhenNameValueCollectionExtensionsConvertsFromQuery
+{
+    [Theory]
+    [InlineData(null, new string[] { })]
+    [InlineData("", new string[] { })]
+    [InlineData("value", new[] { "value" })]
+    [InlineData("value1, value2", new[] { "value1", "value2" })]
+    [InlineData("value1, , value2", new[] { "value1", "value2" })]
+    public void ShouldConvertQueryParameterToArray(string? value, string[] expected)
+    {
+        const string name = nameof(name);
+
+        var collection = new NameValueCollection
+        {
+            { name, value }
+        };
+
+        var actual = collection.ToStringArray(name);
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData("true", true)]
+    [InlineData("false", false)]
+    [InlineData("invalid", false)]
+    public void ShouldConvertQueryParameterToBoolean(string? value, bool expected)
+    {
+        const string name = nameof(name);
+
+        var collection = new NameValueCollection
+        {
+            { name, value }
+        };
+
+        var actual = collection.ToBool(name);
+        Assert.Equal(expected, actual);
+    }
+}

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Configuration/Services.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Configuration/Services.cs
@@ -1,9 +1,13 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using FluentValidation;
 using Microsoft.ApplicationInsights.DependencyCollector;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.DependencyInjection;
+using Platform.Api.LocalAuthorityFinances.Features.HighNeeds;
+using Platform.Api.LocalAuthorityFinances.Features.HighNeeds.Parameters;
+using Platform.Api.LocalAuthorityFinances.Features.Validators;
 using Platform.Functions;
 using Platform.Json;
 using Platform.Sql;
@@ -19,6 +23,9 @@ internal static class Services
     {
         serviceCollection
             .AddSingleton<IFunctionContextDataProvider, FunctionContextDataProvider>();
+
+        serviceCollection
+            .AddTransient<IValidator<HighNeedsHistoryParameters>, HighNeedsHistoryParametersValidator>();
 
         serviceCollection
             .AddTelemetry()
@@ -59,5 +66,6 @@ internal static class Services
     private static IServiceCollection AddPlatformServices(this IServiceCollection serviceCollection) => serviceCollection
         .AddPlatformSql();
 
-    private static IServiceCollection AddFeatures(this IServiceCollection serviceCollection) => serviceCollection;
+    private static IServiceCollection AddFeatures(this IServiceCollection serviceCollection) => serviceCollection
+        .AddHighNeedsFeature();
 }

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Configuration/Services.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Configuration/Services.cs
@@ -1,13 +1,10 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
-using FluentValidation;
 using Microsoft.ApplicationInsights.DependencyCollector;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.DependencyInjection;
 using Platform.Api.LocalAuthorityFinances.Features.HighNeeds;
-using Platform.Api.LocalAuthorityFinances.Features.HighNeeds.Parameters;
-using Platform.Api.LocalAuthorityFinances.Features.Validators;
 using Platform.Functions;
 using Platform.Json;
 using Platform.Sql;
@@ -23,9 +20,6 @@ internal static class Services
     {
         serviceCollection
             .AddSingleton<IFunctionContextDataProvider, FunctionContextDataProvider>();
-
-        serviceCollection
-            .AddTransient<IValidator<HighNeedsHistoryParameters>, HighNeedsHistoryParametersValidator>();
 
         serviceCollection
             .AddTelemetry()

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Constants.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Constants.cs
@@ -10,5 +10,6 @@ public static class Constants
     public static class Features
     {
         public const string HealthCheck = "Health Check";
+        public const string HighNeeds = "High Needs";
     }
 }

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/GetHighNeedsHistoryFunction.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/GetHighNeedsHistoryFunction.cs
@@ -1,0 +1,43 @@
+﻿using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentValidation;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.OpenApi.Models;
+using Platform.Api.LocalAuthorityFinances.Features.HighNeeds.Models;
+using Platform.Api.LocalAuthorityFinances.Features.HighNeeds.Parameters;
+using Platform.Api.LocalAuthorityFinances.Features.HighNeeds.Services;
+using Platform.Functions;
+using Platform.Functions.Extensions;
+using Platform.Functions.OpenApi;
+
+namespace Platform.Api.LocalAuthorityFinances.Features.HighNeeds;
+
+public class GetHighNeedsHistoryFunction(IHighNeedsHistoryService service, IValidator<HighNeedsHistoryParameters> validator)
+{
+    [Function(nameof(GetHighNeedsHistoryFunction))]
+    [OpenApiSecurityHeader]
+    [OpenApiOperation(nameof(GetHighNeedsHistoryFunction), Constants.Features.HighNeeds)]
+    [OpenApiParameter("code", In = ParameterLocation.Query, Type = typeof(string[]), Required = true)]
+    [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(History<LocalAuthorityHighNeedsYear>))]
+    [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
+    public async Task<HttpResponseData> RunAsync(
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.HighNeedsHistory)] HttpRequestData req,
+        CancellationToken token)
+    {
+        var queryParams = req.GetParameters<HighNeedsHistoryParameters>();
+
+        var validationResult = await validator.ValidateAsync(queryParams, token);
+        if (!validationResult.IsValid)
+        {
+            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+        }
+
+        var history = await service.GetHistory(queryParams.Codes, token);
+        return history == null
+            ? req.CreateNotFoundResponse()
+            : await req.CreateJsonResponseAsync(history);
+    }
+}

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/HighNeedsFeature.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/HighNeedsFeature.cs
@@ -1,6 +1,9 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
+using Platform.Api.LocalAuthorityFinances.Features.HighNeeds.Parameters;
 using Platform.Api.LocalAuthorityFinances.Features.HighNeeds.Services;
+using Platform.Api.LocalAuthorityFinances.Features.Validators;
 
 namespace Platform.Api.LocalAuthorityFinances.Features.HighNeeds;
 
@@ -11,6 +14,9 @@ public static class HighNeedsFeature
     {
         serviceCollection
             .AddSingleton<IHighNeedsHistoryService, HighNeedsHistoryStubService>();
+
+        serviceCollection
+            .AddTransient<IValidator<HighNeedsHistoryParameters>, HighNeedsHistoryParametersValidator>();
 
         return serviceCollection;
     }

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/HighNeedsFeature.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/HighNeedsFeature.cs
@@ -1,0 +1,17 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.DependencyInjection;
+using Platform.Api.LocalAuthorityFinances.Features.HighNeeds.Services;
+
+namespace Platform.Api.LocalAuthorityFinances.Features.HighNeeds;
+
+[ExcludeFromCodeCoverage]
+public static class HighNeedsFeature
+{
+    public static IServiceCollection AddHighNeedsFeature(this IServiceCollection serviceCollection)
+    {
+        serviceCollection
+            .AddSingleton<IHighNeedsHistoryService, HighNeedsHistoryStubService>();
+
+        return serviceCollection;
+    }
+}

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/Models/History.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/Models/History.cs
@@ -1,0 +1,54 @@
+﻿// ReSharper disable UnusedAutoPropertyAccessor.Global
+namespace Platform.Api.LocalAuthorityFinances.Features.HighNeeds.Models;
+
+public record History<T>
+{
+    public int? StartYear { get; set; }
+    public int? EndYear { get; set; }
+    public T[]? Outturn { get; set; } = [];
+    public T[]? Budget { get; set; } = [];
+}
+
+public record LocalAuthorityHighNeedsYear : LocalAuthorityHighNeeds
+{
+    public int? Year { get; set; }
+}
+
+public record LocalAuthorityHighNeeds
+{
+    public string? Code { get; set; }
+    public HighNeedsAmount HighNeedsAmount { get; set; } = new();
+    public TopFunding Maintained { get; set; } = new();
+    public TopFunding NonMaintained { get; set; } = new();
+    public PlaceFunding PlaceFunding { get; set; } = new();
+}
+
+public record HighNeedsAmount
+{
+    public decimal? TotalPlaceFunding { get; set; }
+    public decimal? TopUpFundingMaintained { get; set; }
+    public decimal? TopUpFundingNonMaintained { get; set; }
+    public decimal? SenServices { get; set; }
+    public decimal? AlternativeProvisionServices { get; set; }
+    public decimal? HospitalServices { get; set; }
+    public decimal? OtherHealthServices { get; set; }
+}
+
+public record TopFunding
+{
+    public decimal? EarlyYears { get; set; }
+    public decimal? Primary { get; set; }
+    public decimal? Secondary { get; set; }
+    public decimal? Special { get; set; }
+    public decimal? AlternativeProvision { get; set; }
+    public decimal? PostSchool { get; set; }
+    public decimal? Income { get; set; }
+}
+
+public record PlaceFunding
+{
+    public decimal? Primary { get; set; }
+    public decimal? Secondary { get; set; }
+    public decimal? Special { get; set; }
+    public decimal? AlternativeProvision { get; set; }
+}

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/Parameters/HighNeedsHistoryParameters.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/Parameters/HighNeedsHistoryParameters.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using System.Collections.Specialized;
 using Platform.Functions;
 using Platform.Functions.Extensions;
 
@@ -6,9 +6,9 @@ namespace Platform.Api.LocalAuthorityFinances.Features.HighNeeds.Parameters;
 
 public record HighNeedsHistoryParameters : QueryParameters
 {
-    public string[] Codes { get; internal set; } = [];
+    public string[] Codes { get; private set; } = [];
 
-    public override void SetValues(IQueryCollection query)
+    public override void SetValues(NameValueCollection query)
     {
         Codes = query.ToStringArray("code");
     }

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/Parameters/HighNeedsHistoryParameters.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/Parameters/HighNeedsHistoryParameters.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Http;
+using Platform.Functions;
+using Platform.Functions.Extensions;
+
+namespace Platform.Api.LocalAuthorityFinances.Features.HighNeeds.Parameters;
+
+public record HighNeedsHistoryParameters : QueryParameters
+{
+    public string[] Codes { get; internal set; } = [];
+
+    public override void SetValues(IQueryCollection query)
+    {
+        Codes = query.ToStringArray("code");
+    }
+}

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/Routes.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/Routes.cs
@@ -1,0 +1,6 @@
+﻿namespace Platform.Api.LocalAuthorityFinances.Features.HighNeeds;
+
+public static class Routes
+{
+    public const string HighNeedsHistory = "high-needs/history";
+}

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/Services/HighNeedsHistoryService.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/Services/HighNeedsHistoryService.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Platform.Api.LocalAuthorityFinances.Features.HighNeeds.Models;
+
+namespace Platform.Api.LocalAuthorityFinances.Features.HighNeeds.Services;
+
+public interface IHighNeedsHistoryService
+{
+    Task<History<LocalAuthorityHighNeedsYear>?> GetHistory(string[] codes, CancellationToken cancellationToken = default);
+}

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/Services/HighNeedsHistoryStubService.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/Services/HighNeedsHistoryStubService.cs
@@ -1,0 +1,88 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Platform.Api.LocalAuthorityFinances.Features.HighNeeds.Models;
+
+namespace Platform.Api.LocalAuthorityFinances.Features.HighNeeds.Services;
+
+// stubbed, untested implementation until backend ready
+[ExcludeFromCodeCoverage]
+public class HighNeedsHistoryStubService : IHighNeedsHistoryService
+{
+    public Task<History<LocalAuthorityHighNeedsYear>?> GetHistory(string[] codes, CancellationToken cancellationToken = default)
+    {
+        var code = codes.First();
+        const int startYear = 2021;
+        const int endYear = 2024;
+        var history = new History<LocalAuthorityHighNeedsYear>
+        {
+            StartYear = startYear,
+            EndYear = endYear,
+            Budget = GetBudget(code, startYear, endYear).ToArray(),
+            Outturn = GetOutturn(code, startYear, endYear).ToArray()
+        };
+
+        return Task.FromResult<History<LocalAuthorityHighNeedsYear>?>(history);
+    }
+
+    private static IEnumerable<LocalAuthorityHighNeedsYear> GetBudget(string code, int startYear, int endYear)
+    {
+        for (var year = startYear; year <= endYear; year++)
+        {
+            yield return GetStubbedRow(code, year, 1_100_000);
+        }
+    }
+
+    private static IEnumerable<LocalAuthorityHighNeedsYear> GetOutturn(string code, int startYear, int endYear)
+    {
+        for (var year = startYear; year <= endYear; year++)
+        {
+            yield return GetStubbedRow(code, year, 1_000_000);
+        }
+    }
+
+    private static LocalAuthorityHighNeedsYear GetStubbedRow(string code, int year, decimal baseValue) => new()
+    {
+        Code = code,
+        Year = year,
+        HighNeedsAmount = new HighNeedsAmount
+        {
+            TotalPlaceFunding = baseValue + 1 + year,
+            TopUpFundingMaintained = baseValue + 2 + year,
+            TopUpFundingNonMaintained = baseValue + 3 + year,
+            SenServices = baseValue + 4 + year,
+            AlternativeProvisionServices = baseValue + 5 + year,
+            HospitalServices = baseValue + 6 + year,
+            OtherHealthServices = baseValue + 7 + year
+        },
+        Maintained = new TopFunding
+        {
+            EarlyYears = baseValue + 8 + year,
+            Primary = baseValue + 9 + year,
+            Secondary = baseValue + 10 + year,
+            Special = baseValue + 11 + year,
+            AlternativeProvision = baseValue + 12 + year,
+            PostSchool = baseValue + 13 + year,
+            Income = baseValue + 14 + year
+        },
+        NonMaintained = new TopFunding
+        {
+            EarlyYears = baseValue + 15 + year,
+            Primary = baseValue + 16 + year,
+            Secondary = baseValue + 17 + year,
+            Special = baseValue + 18 + year,
+            AlternativeProvision = baseValue + 19 + year,
+            PostSchool = baseValue + 20 + year,
+            Income = baseValue + 21 + year
+        },
+        PlaceFunding = new PlaceFunding
+        {
+            Primary = baseValue + 22 + year,
+            Secondary = baseValue + 23 + year,
+            Special = baseValue + 24 + year,
+            AlternativeProvision = baseValue + 25 + year
+        }
+    };
+}

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/Validators/HighNeedsHistoryParametersValidator.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/Validators/HighNeedsHistoryParametersValidator.cs
@@ -1,0 +1,15 @@
+﻿using FluentValidation;
+using Platform.Api.LocalAuthorityFinances.Features.HighNeeds.Parameters;
+
+namespace Platform.Api.LocalAuthorityFinances.Features.Validators;
+
+public class HighNeedsHistoryParametersValidator : AbstractValidator<HighNeedsHistoryParameters>
+{
+    public HighNeedsHistoryParametersValidator()
+    {
+        RuleFor(x => x.Codes)
+            .NotEmpty()
+            .Must(c => c.Length <= 10)
+            .WithMessage("One or more local authority codes must be supplied");
+    }
+}

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Program.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Program.cs
@@ -1,7 +1,10 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Extensions;
 using Microsoft.Extensions.Hosting;
 using Platform.Api.LocalAuthorityFinances.Configuration;
+
+[assembly: InternalsVisibleTo("Platform.LocalAuthorityFinances.Tests")]
 
 var hostBuilder = new HostBuilder()
     .ConfigureFunctionsWorkerDefaults(Worker.Configure, Worker.Options)

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Program.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Program.cs
@@ -1,10 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Extensions;
 using Microsoft.Extensions.Hosting;
 using Platform.Api.LocalAuthorityFinances.Configuration;
-
-[assembly: InternalsVisibleTo("Platform.LocalAuthorityFinances.Tests")]
 
 var hostBuilder = new HostBuilder()
     .ConfigureFunctionsWorkerDefaults(Worker.Configure, Worker.Options)

--- a/platform/tests/Platform.ApiTests/Features/LocalAuthoritiesHighNeeds.feature
+++ b/platform/tests/Platform.ApiTests/Features/LocalAuthoritiesHighNeeds.feature
@@ -1,0 +1,119 @@
+Feature: Local authorities high needs endpoints
+# todo: replace stubbed values with real
+
+    Scenario: Sending a valid high needs request returns the expected outturn values
+        Given a valid high needs request with LA codes '201'
+        When I submit the high needs request
+        Then the high needs result should be ok and have the following values:
+          | Start year | End year |
+          | 2021       | 2024     |
+        And the high needs result should contain the following outturn values for '2021':
+          | Field | Value |
+          | Year  | 2021  |
+          | Code  | 201   |
+        And the high needs result should contain the following outturn values for '2022':
+          | Field | Value |
+          | Year  | 2022  |
+          | Code  | 201   |
+        And the high needs result should contain the following outturn values for '2023':
+          | Field | Value |
+          | Year  | 2023  |
+          | Code  | 201   |
+        And the high needs result should contain the following outturn values for '2024':
+          | Field | Value |
+          | Year  | 2024  |
+          | Code  | 201   |
+        And the high needs result should contain the following outturn high needs amount values for '2021':
+          | Field                        | Value   |
+          | TotalPlaceFunding            | 1002022 |
+          | TopUpFundingMaintained       | 1002023 |
+          | TopUpFundingNonMaintained    | 1002024 |
+          | SenServices                  | 1002025 |
+          | AlternativeProvisionServices | 1002026 |
+          | HospitalServices             | 1002027 |
+          | OtherHealthServices          | 1002028 |
+        And the high needs result should contain the following outturn maintained values for '2021':
+          | Field                | Value   |
+          | EarlyYears           | 1002029 |
+          | Primary              | 1002030 |
+          | Secondary            | 1002031 |
+          | Special              | 1002032 |
+          | AlternativeProvision | 1002033 |
+          | PostSchool           | 1002034 |
+          | Income               | 1002035 |
+        And the high needs result should contain the following outturn non maintained values for '2021':
+          | Field                | Value   |
+          | EarlyYears           | 1002036 |
+          | Primary              | 1002037 |
+          | Secondary            | 1002038 |
+          | Special              | 1002039 |
+          | AlternativeProvision | 1002040 |
+          | PostSchool           | 1002041 |
+          | Income               | 1002042 |
+        And the high needs result should contain the following outturn place funding values for '2021':
+          | Field                | Value   |
+          | Primary              | 1002043 |
+          | Secondary            | 1002044 |
+          | Special              | 1002045 |
+          | AlternativeProvision | 1002046 |
+
+    Scenario: Sending a valid high needs request returns the expected budget values
+        Given a valid high needs request with LA codes '201'
+        When I submit the high needs request
+        Then the high needs result should be ok and have the following values:
+          | Start year | End year |
+          | 2021       | 2024     |
+        And the high needs result should contain the following budget values for '2021':
+          | Field | Value |
+          | Year  | 2021  |
+          | Code  | 201   |
+        And the high needs result should contain the following budget values for '2022':
+          | Field | Value |
+          | Year  | 2022  |
+          | Code  | 201   |
+        And the high needs result should contain the following budget values for '2023':
+          | Field | Value |
+          | Year  | 2023  |
+          | Code  | 201   |
+        And the high needs result should contain the following budget values for '2024':
+          | Field | Value |
+          | Year  | 2024  |
+          | Code  | 201   |
+        And the high needs result should contain the following budget high needs amount values for '2021':
+          | Field                        | Value   |
+          | TotalPlaceFunding            | 1102022 |
+          | TopUpFundingMaintained       | 1102023 |
+          | TopUpFundingNonMaintained    | 1102024 |
+          | SenServices                  | 1102025 |
+          | AlternativeProvisionServices | 1102026 |
+          | HospitalServices             | 1102027 |
+          | OtherHealthServices          | 1102028 |
+        And the high needs result should contain the following budget maintained values for '2021':
+          | Field                | Value   |
+          | EarlyYears           | 1102029 |
+          | Primary              | 1102030 |
+          | Secondary            | 1102031 |
+          | Special              | 1102032 |
+          | AlternativeProvision | 1102033 |
+          | PostSchool           | 1102034 |
+          | Income               | 1102035 |
+        And the high needs result should contain the following budget non maintained values for '2021':
+          | Field                | Value   |
+          | EarlyYears           | 1102036 |
+          | Primary              | 1102037 |
+          | Secondary            | 1102038 |
+          | Special              | 1102039 |
+          | AlternativeProvision | 1102040 |
+          | PostSchool           | 1102041 |
+          | Income               | 1102042 |
+        And the high needs result should contain the following budget place funding values for '2021':
+          | Field                | Value   |
+          | Primary              | 1102043 |
+          | Secondary            | 1102044 |
+          | Special              | 1102045 |
+          | AlternativeProvision | 1102046 |
+
+    Scenario: Sending an invalid high needs request
+        Given an invalid high needs request
+        When I submit the high needs request
+        Then the high needs result should be bad request

--- a/platform/tests/Platform.ApiTests/Steps/LocalAuthoritiesHighNeedsSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/LocalAuthoritiesHighNeedsSteps.cs
@@ -1,0 +1,157 @@
+﻿using System.Net;
+using FluentAssertions;
+using Platform.Api.LocalAuthorityFinances.Features.HighNeeds.Models;
+using Platform.ApiTests.Drivers;
+using Platform.Json;
+using Xunit;
+
+namespace Platform.ApiTests.Steps;
+
+[Binding]
+[Scope(Feature = "Local authorities high needs endpoints")]
+public class LocalAuthoritiesHighNeedsSteps(LocalAuthorityFinancesApiDriver api)
+{
+    private const string HistoryKey = "history";
+    private History<LocalAuthorityHighNeedsYear>? _result;
+
+    [Given("a valid high needs request with LA codes '(.*)'")]
+    public void GivenAValidHighNeedsRequestWithLaCodes(string codes)
+    {
+        api.CreateRequest(HistoryKey, new HttpRequestMessage
+        {
+            RequestUri = new Uri($"/api/high-needs/history?code={string.Join("&code=", codes.Split(","))}", UriKind.Relative),
+            Method = HttpMethod.Get
+        });
+    }
+
+    [Given("an invalid high needs request")]
+    public void GivenAnInvalidHighNeedsRequest()
+    {
+        api.CreateRequest(HistoryKey, new HttpRequestMessage
+        {
+            RequestUri = new Uri("/api/high-needs/history", UriKind.Relative),
+            Method = HttpMethod.Get
+        });
+    }
+
+    [When("I submit the high needs request")]
+    public async Task WhenISubmitTheHighNeedsRequest()
+    {
+        await api.Send();
+    }
+
+    [Then("the high needs result should be ok and have the following values:")]
+    public async Task ThenTheHighNeedsResultShouldBeOkAndHaveTheFollowingValues(DataTable table)
+    {
+        var response = api[HistoryKey].Response;
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsByteArrayAsync();
+        _result = content.FromJson<History<LocalAuthorityHighNeedsYear>>();
+        var startYear = table.Rows.First()["Start year"];
+        var endYear = table.Rows.First()["End year"];
+
+        Assert.Equal(startYear, _result.StartYear.ToString());
+        Assert.Equal(endYear, _result.EndYear.ToString());
+    }
+
+    [Then("the high needs result should contain the following outturn values for '(.*)':")]
+    public void ThenTheHighNeedsResultShouldContainTheFollowingOutturnValuesFor(string year, DataTable table)
+    {
+        var outturn = OutturnResultForYear(year);
+        Assert.NotNull(outturn);
+        table.CompareToInstance(outturn);
+    }
+
+    [Then("the high needs result should contain the following outturn high needs amount values for '(.*)':")]
+    public void ThenTheHighNeedsResultShouldContainTheFollowingOutturnHighNeedsAmountValuesFor(string year, DataTable table)
+    {
+        var highNeedsAmount = OutturnResultForYear(year)?.HighNeedsAmount;
+        Assert.NotNull(highNeedsAmount);
+        table.CompareToInstance(highNeedsAmount);
+    }
+
+    [Then("the high needs result should contain the following outturn maintained values for '(.*)':")]
+    public void ThenTheHighNeedsResultShouldContainTheFollowingOutturnMaintainedValuesFor(string year, DataTable table)
+    {
+        var maintained = OutturnResultForYear(year)?.Maintained;
+        Assert.NotNull(maintained);
+        table.CompareToInstance(maintained);
+    }
+
+    [Then("the high needs result should contain the following outturn non maintained values for '(.*)':")]
+    public void ThenTheHighNeedsResultShouldContainTheFollowingOutturnNonMaintainedValuesFor(string year, DataTable table)
+    {
+        var nonMaintained = OutturnResultForYear(year)?.NonMaintained;
+        Assert.NotNull(nonMaintained);
+        table.CompareToInstance(nonMaintained);
+    }
+
+    [Then("the high needs result should contain the following outturn place funding values for '(.*)':")]
+    public void ThenTheHighNeedsResultShouldContainTheFollowingOutturnPlaceFundingValuesFor(string year, DataTable table)
+    {
+        var placeFunding = OutturnResultForYear(year)?.PlaceFunding;
+        Assert.NotNull(placeFunding);
+        table.CompareToInstance(placeFunding);
+    }
+
+    [Then("the high needs result should contain the following budget values for '(.*)':")]
+    public void ThenTheHighNeedsResultShouldContainTheFollowingBudgetValuesFor(string year, DataTable table)
+    {
+        var budget = BudgetResultForYear(year);
+        Assert.NotNull(budget);
+        table.CompareToInstance(budget);
+    }
+
+    [Then("the high needs result should contain the following budget high needs amount values for '(.*)':")]
+    public void ThenTheHighNeedsResultShouldContainTheFollowingBudgetHighNeedsAmountValuesFor(string year, DataTable table)
+    {
+        var highNeedsAmount = BudgetResultForYear(year)?.HighNeedsAmount;
+        Assert.NotNull(highNeedsAmount);
+        table.CompareToInstance(highNeedsAmount);
+    }
+
+    [Then("the high needs result should contain the following budget maintained values for '(.*)':")]
+    public void ThenTheHighNeedsResultShouldContainTheFollowingBudgetMaintainedValuesFor(string year, DataTable table)
+    {
+        var maintained = BudgetResultForYear(year)?.Maintained;
+        Assert.NotNull(maintained);
+        table.CompareToInstance(maintained);
+    }
+
+    [Then("the high needs result should contain the following budget non maintained values for '(.*)':")]
+    public void ThenTheHighNeedsResultShouldContainTheFollowingBudgetNonMaintainedValuesFor(string year, DataTable table)
+    {
+        var nonMaintained = BudgetResultForYear(year)?.NonMaintained;
+        Assert.NotNull(nonMaintained);
+        table.CompareToInstance(nonMaintained);
+    }
+
+    [Then("the high needs result should contain the following budget place funding values for '(.*)':")]
+    public void ThenTheHighNeedsResultShouldContainTheFollowingBudgetPlaceFundingValuesFor(string year, DataTable table)
+    {
+        var placeFunding = BudgetResultForYear(year)?.PlaceFunding;
+        Assert.NotNull(placeFunding);
+        table.CompareToInstance(placeFunding);
+    }
+
+    [Then("the high needs result should be bad request")]
+    public void ThenTheHighNeedsResultShouldBeBadRequest()
+    {
+        var response = api[HistoryKey].Response;
+
+        response.Should().NotBeNull();
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    private LocalAuthorityHighNeedsYear? OutturnResultForYear(string year)
+    {
+        return _result?.Outturn?.SingleOrDefault(o => o.Year.ToString() == year);
+    }
+
+    private LocalAuthorityHighNeedsYear? BudgetResultForYear(string year)
+    {
+        return _result?.Budget?.SingleOrDefault(o => o.Year.ToString() == year);
+    }
+}

--- a/platform/tests/Platform.LocalAuthorityFinances.Tests/HighNeeds/HighNeedsHistoryParametersTests.cs
+++ b/platform/tests/Platform.LocalAuthorityFinances.Tests/HighNeeds/HighNeedsHistoryParametersTests.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Specialized;
+using Platform.Api.LocalAuthorityFinances.Features.HighNeeds.Parameters;
+using Xunit;
+
+namespace Platform.LocalAuthorityFinances.Tests.HighNeeds;
+
+public class HighNeedsHistoryParametersTests
+{
+    [Fact]
+    public void ShouldSetValuesFromQuery()
+    {
+        var values = new NameValueCollection
+        {
+            { "code", "code1" },
+            { "code", "code2" },
+            { "code", "code3" }
+        };
+
+        var parameters = new HighNeedsHistoryParameters();
+        parameters.SetValues(values);
+
+        Assert.Equal(["code1", "code2", "code3"], parameters.Codes);
+    }
+}

--- a/platform/tests/Platform.LocalAuthorityFinances.Tests/Validators/WhenHighNeedsHistoryParametersValidatorValidates.cs
+++ b/platform/tests/Platform.LocalAuthorityFinances.Tests/Validators/WhenHighNeedsHistoryParametersValidatorValidates.cs
@@ -1,4 +1,5 @@
-﻿using Platform.Api.LocalAuthorityFinances.Features.HighNeeds.Parameters;
+﻿using System.Collections.Specialized;
+using Platform.Api.LocalAuthorityFinances.Features.HighNeeds.Parameters;
 using Platform.Api.LocalAuthorityFinances.Features.Validators;
 using Xunit;
 
@@ -14,10 +15,11 @@ public class WhenHighNeedsHistoryParametersValidatorValidates
     [InlineData("code1,code2,code3,code4,code5,code6,code7,code9,code9,code10")]
     public async Task ShouldValidateAndEvaluateGoodParametersAsValid(string codes)
     {
-        var parameters = new HighNeedsHistoryParameters
+        var parameters = new HighNeedsHistoryParameters();
+        parameters.SetValues(new NameValueCollection
         {
-            Codes = codes.Split(",")
-        };
+            { "code", codes }
+        });
 
         var actual = await _validator.ValidateAsync(parameters);
         Assert.True(actual.IsValid);
@@ -29,10 +31,11 @@ public class WhenHighNeedsHistoryParametersValidatorValidates
     [InlineData("code1,code2,code3,code4,code5,code6,code7,code9,code9,code10,code11")]
     public async Task ShouldValidateAndEvaluateBadParametersAsInvalid(string codes)
     {
-        var parameters = new HighNeedsHistoryParameters
+        var parameters = new HighNeedsHistoryParameters();
+        parameters.SetValues(new NameValueCollection
         {
-            Codes = codes.Split(",", StringSplitOptions.RemoveEmptyEntries)
-        };
+            { "code", codes }
+        });
 
         var actual = await _validator.ValidateAsync(parameters);
         Assert.False(actual.IsValid);

--- a/platform/tests/Platform.LocalAuthorityFinances.Tests/Validators/WhenHighNeedsHistoryParametersValidatorValidates.cs
+++ b/platform/tests/Platform.LocalAuthorityFinances.Tests/Validators/WhenHighNeedsHistoryParametersValidatorValidates.cs
@@ -1,0 +1,41 @@
+﻿using Platform.Api.LocalAuthorityFinances.Features.HighNeeds.Parameters;
+using Platform.Api.LocalAuthorityFinances.Features.Validators;
+using Xunit;
+
+namespace Platform.LocalAuthorityFinances.Tests.Validators;
+
+public class WhenHighNeedsHistoryParametersValidatorValidates
+{
+    private readonly HighNeedsHistoryParametersValidator _validator = new();
+
+    [Theory]
+    [InlineData("code1")]
+    [InlineData("code1,code2,code3")]
+    [InlineData("code1,code2,code3,code4,code5,code6,code7,code9,code9,code10")]
+    public async Task ShouldValidateAndEvaluateGoodParametersAsValid(string codes)
+    {
+        var parameters = new HighNeedsHistoryParameters
+        {
+            Codes = codes.Split(",")
+        };
+
+        var actual = await _validator.ValidateAsync(parameters);
+        Assert.True(actual.IsValid);
+        Assert.Empty(actual.Errors);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("code1,code2,code3,code4,code5,code6,code7,code9,code9,code10,code11")]
+    public async Task ShouldValidateAndEvaluateBadParametersAsInvalid(string codes)
+    {
+        var parameters = new HighNeedsHistoryParameters
+        {
+            Codes = codes.Split(",", StringSplitOptions.RemoveEmptyEntries)
+        };
+
+        var actual = await _validator.ValidateAsync(parameters);
+        Assert.False(actual.IsValid);
+        Assert.NotEmpty(actual.Errors);
+    }
+}


### PR DESCRIPTION
### Context
[AB#251204](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/251204) [AB#249550](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249550)

### Change proposed in this pull request
- New endpoint with API test coverage over stubbed data
- Marked `QueryParameters.SetValues(IQueryCollection query)` as obsolete

### Guidance to review 
To validate locally, debug the `LocalAuthorities` function app and run Swagger UI: `http://localhost:7074/api/swagger/ui#/High%20Needs/GetHighNeedsHistoryFunction`

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

