### PR TITLE
fix: use chunksize for df.to_sql

### DIFF
--- a/data-pipeline/src/pipeline/database.py
+++ b/data-pipeline/src/pipeline/database.py
@@ -192,6 +192,7 @@ def _write_data(
         con=engine,
         if_exists="append",
         index=df.index.name is not None,
+        chunksize=int(os.getenv("SQL_CHUNKSIZE", 10_000)),
     )
     logger.info(
         f"Wrote {len(df.index):,} rows to {temp_table} in {int(time.time() - start):,} seconds."


### PR DESCRIPTION
### Context

Writing of `MetricRAG` to the temp. table is taking 60 minutes+.

[AB#250420](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/250420)  

### Change proposed in this pull request

Use the [`chunksize` parameter](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_sql.html) of Pandas' `to_sql()` method to reduce the batch size (configurable by an environment variable but with a default of 10,000).

### Guidance to review 

Verified locally that data are still correctly written to the DB.

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~You have reviewed with UX/Design~

