### PR TITLE
Added Web proxy for High needs history endpoint

### DIFF
--- a/web/Web.sln.DotSettings
+++ b/web/Web.sln.DotSettings
@@ -40,5 +40,6 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=icfp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=noopener/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=noreferrer/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=outturn/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=precomposed/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=upin/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/web/src/Web.App/Controllers/Api/HighNeedsProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/HighNeedsProxyController.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Web.App.Domain.LocalAuthorities;
+using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Apis.LocalAuthorities;
+using Web.App.Infrastructure.Extensions;
+
+namespace Web.App.Controllers.Api;
+
+[ApiController]
+[Route("api/local-authorities/high-needs")]
+public class HighNeedsProxyController(
+    ILogger<HighNeedsProxyController> logger,
+    ILocalAuthoritiesApi localAuthoritiesApi) : Controller
+{
+    /// <param name="code" example="201"></param>
+    /// <param name="cancellationToken"></param>
+    [HttpGet]
+    [Produces("application/json")]
+    [ProducesResponseType<History<LocalAuthorityHighNeedsYear>>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [Route("history")]
+    public async Task<IActionResult> History([FromQuery] string[]? code, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var query = BuildQuery(code);
+            var result = await localAuthoritiesApi
+                .GetHighNeedsHistory(query, cancellationToken)
+                .GetResultOrThrow<History<LocalAuthorityHighNeedsYear>>();
+
+            return new JsonResult(result);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "An error getting local authority high needs history data: {DisplayUrl}", Request.GetDisplayUrl());
+            return StatusCode(500);
+        }
+    }
+
+    private static ApiQuery BuildQuery(string[]? code)
+    {
+        var query = new ApiQuery();
+        if (code == null)
+        {
+            return query;
+        }
+
+        foreach (var c in code)
+        {
+            query.AddIfNotNull(nameof(code), c);
+        }
+
+        return query;
+    }
+}

--- a/web/src/Web.App/Controllers/Api/Mappers/LocalAuthorityHighNeedsHistoryResponseMapper.cs
+++ b/web/src/Web.App/Controllers/Api/Mappers/LocalAuthorityHighNeedsHistoryResponseMapper.cs
@@ -1,0 +1,70 @@
+using Web.App.Controllers.Api.Responses;
+using Web.App.Domain.LocalAuthorities;
+
+namespace Web.App.Controllers.Api.Mappers;
+
+public static class LocalAuthorityHighNeedsHistoryResponseMapper
+{
+    public static IEnumerable<LocalAuthorityHighNeedsHistoryResponse> MapToApiResponse(this History<LocalAuthorityHighNeedsYear>? history, string code)
+    {
+        if (history?.StartYear == null || history.EndYear == null)
+        {
+            yield break;
+        }
+
+        for (var year = history.StartYear.Value; year <= history.EndYear; year++)
+        {
+            yield return new LocalAuthorityHighNeedsHistoryResponse
+            {
+                Year = year,
+                Term = $"{year - 1} to {year}",
+                Outturn = history.Outturn?.MapToApiResponse(code, year),
+                Budget = history.Budget?.MapToApiResponse(code, year)
+            };
+        }
+    }
+
+    private static LocalAuthorityHighNeedsResponse? MapToApiResponse(this LocalAuthorityHighNeedsYear[]? highNeedsYear, string code, int year)
+    {
+        var item = highNeedsYear?
+            .Where(o => o.Year == year)
+            .SingleOrDefault(o => o.Code == code);
+
+        if (item == null)
+        {
+            return null;
+        }
+
+        return new LocalAuthorityHighNeedsResponse
+        {
+            HighNeedsAmountTotalPlaceFunding = item.HighNeedsAmount?.TotalPlaceFunding,
+            HighNeedsAmountTopUpFundingMaintained = item.HighNeedsAmount?.TopUpFundingMaintained,
+            HighNeedsAmountTopUpFundingNonMaintained = item.HighNeedsAmount?.TopUpFundingNonMaintained,
+            HighNeedsAmountSenServices = item.HighNeedsAmount?.SenServices,
+            HighNeedsAmountAlternativeProvisionServices = item.HighNeedsAmount?.AlternativeProvisionServices,
+            HighNeedsAmountHospitalServices = item.HighNeedsAmount?.HospitalServices,
+            HighNeedsAmountOtherHealthServices = item.HighNeedsAmount?.OtherHealthServices,
+
+            MaintainedEarlyYears = item.Maintained?.EarlyYears,
+            MaintainedPrimary = item.Maintained?.Primary,
+            MaintainedSecondary = item.Maintained?.Secondary,
+            MaintainedSpecial = item.Maintained?.Special,
+            MaintainedAlternativeProvision = item.Maintained?.AlternativeProvision,
+            MaintainedPostSchool = item.Maintained?.PostSchool,
+            MaintainedIncome = item.Maintained?.Income,
+
+            NonMaintainedEarlyYears = item.NonMaintained?.EarlyYears,
+            NonMaintainedPrimary = item.NonMaintained?.Primary,
+            NonMaintainedSecondary = item.NonMaintained?.Secondary,
+            NonMaintainedSpecial = item.NonMaintained?.Special,
+            NonMaintainedAlternativeProvision = item.NonMaintained?.AlternativeProvision,
+            NonMaintainedPostSchool = item.NonMaintained?.PostSchool,
+            NonMaintainedIncome = item.NonMaintained?.Income,
+
+            PlaceFundingPrimary = item.PlaceFunding?.Primary,
+            PlaceFundingSecondary = item.PlaceFunding?.Secondary,
+            PlaceFundingSpecial = item.PlaceFunding?.Special,
+            PlaceFundingAlternativeProvision = item.PlaceFunding?.AlternativeProvision
+        };
+    }
+}

--- a/web/src/Web.App/Controllers/Api/Responses/LocalAuthorityHighNeedsHistoryResponse.cs
+++ b/web/src/Web.App/Controllers/Api/Responses/LocalAuthorityHighNeedsHistoryResponse.cs
@@ -1,0 +1,43 @@
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+
+namespace Web.App.Controllers.Api.Responses;
+
+public record LocalAuthorityHighNeedsHistoryResponse
+{
+    public int? Year { get; init; }
+    public string? Term { get; init; }
+    public LocalAuthorityHighNeedsResponse? Outturn { get; init; }
+    public LocalAuthorityHighNeedsResponse? Budget { get; init; }
+}
+
+public record LocalAuthorityHighNeedsResponse
+{
+    public decimal? HighNeedsAmountTotalPlaceFunding { get; init; }
+    public decimal? HighNeedsAmountTopUpFundingMaintained { get; init; }
+    public decimal? HighNeedsAmountTopUpFundingNonMaintained { get; init; }
+    public decimal? HighNeedsAmountSenServices { get; init; }
+    public decimal? HighNeedsAmountAlternativeProvisionServices { get; init; }
+    public decimal? HighNeedsAmountHospitalServices { get; init; }
+    public decimal? HighNeedsAmountOtherHealthServices { get; init; }
+
+    public decimal? MaintainedEarlyYears { get; init; }
+    public decimal? MaintainedPrimary { get; init; }
+    public decimal? MaintainedSecondary { get; init; }
+    public decimal? MaintainedSpecial { get; init; }
+    public decimal? MaintainedAlternativeProvision { get; init; }
+    public decimal? MaintainedPostSchool { get; init; }
+    public decimal? MaintainedIncome { get; init; }
+
+    public decimal? NonMaintainedEarlyYears { get; init; }
+    public decimal? NonMaintainedPrimary { get; init; }
+    public decimal? NonMaintainedSecondary { get; init; }
+    public decimal? NonMaintainedSpecial { get; init; }
+    public decimal? NonMaintainedAlternativeProvision { get; init; }
+    public decimal? NonMaintainedPostSchool { get; init; }
+    public decimal? NonMaintainedIncome { get; init; }
+
+    public decimal? PlaceFundingPrimary { get; init; }
+    public decimal? PlaceFundingSecondary { get; init; }
+    public decimal? PlaceFundingSpecial { get; init; }
+    public decimal? PlaceFundingAlternativeProvision { get; init; }
+}

--- a/web/src/Web.App/Domain/LocalAuthorities/HighNeedsAmount.cs
+++ b/web/src/Web.App/Domain/LocalAuthorities/HighNeedsAmount.cs
@@ -1,0 +1,13 @@
+// ReSharper disable UnusedMember.Global
+namespace Web.App.Domain.LocalAuthorities;
+
+public record HighNeedsAmount
+{
+    public decimal? TotalPlaceFunding { get; set; }
+    public decimal? TopUpFundingMaintained { get; set; }
+    public decimal? TopUpFundingNonMaintained { get; set; }
+    public decimal? SenServices { get; set; }
+    public decimal? AlternativeProvisionServices { get; set; }
+    public decimal? HospitalServices { get; set; }
+    public decimal? OtherHealthServices { get; set; }
+}

--- a/web/src/Web.App/Domain/LocalAuthorities/HighNeedsAmount.cs
+++ b/web/src/Web.App/Domain/LocalAuthorities/HighNeedsAmount.cs
@@ -1,3 +1,5 @@
+// ReSharper disable ClassNeverInstantiated.Global
+// ReSharper disable UnusedAutoPropertyAccessor.Global
 // ReSharper disable UnusedMember.Global
 namespace Web.App.Domain.LocalAuthorities;
 

--- a/web/src/Web.App/Domain/LocalAuthorities/History.cs
+++ b/web/src/Web.App/Domain/LocalAuthorities/History.cs
@@ -1,0 +1,11 @@
+// ReSharper disable ClassNeverInstantiated.Global
+// ReSharper disable UnusedMember.Global
+namespace Web.App.Domain.LocalAuthorities;
+
+public record History<T>
+{
+    public int? StartYear { get; set; }
+    public int? EndYear { get; set; }
+    public T[]? Outturn { get; set; } = [];
+    public T[]? Budget { get; set; } = [];
+}

--- a/web/src/Web.App/Domain/LocalAuthorities/LocalAuthorityHighNeeds.cs
+++ b/web/src/Web.App/Domain/LocalAuthorities/LocalAuthorityHighNeeds.cs
@@ -1,0 +1,17 @@
+// ReSharper disable ClassNeverInstantiated.Global
+// ReSharper disable UnusedMember.Global
+namespace Web.App.Domain.LocalAuthorities;
+
+public record LocalAuthorityHighNeeds
+{
+    public string? Code { get; set; }
+    public HighNeedsAmount HighNeedsAmount { get; set; } = new();
+    public TopFunding Maintained { get; set; } = new();
+    public TopFunding NonMaintained { get; set; } = new();
+    public PlaceFunding PlaceFunding { get; set; } = new();
+}
+
+public record LocalAuthorityHighNeedsYear : LocalAuthorityHighNeeds
+{
+    public int? Year { get; set; }
+}

--- a/web/src/Web.App/Domain/LocalAuthorities/LocalAuthorityHighNeeds.cs
+++ b/web/src/Web.App/Domain/LocalAuthorities/LocalAuthorityHighNeeds.cs
@@ -1,14 +1,16 @@
 // ReSharper disable ClassNeverInstantiated.Global
+// ReSharper disable PropertyCanBeMadeInitOnly.Global
+// ReSharper disable UnusedAutoPropertyAccessor.Global
 // ReSharper disable UnusedMember.Global
 namespace Web.App.Domain.LocalAuthorities;
 
 public record LocalAuthorityHighNeeds
 {
     public string? Code { get; set; }
-    public HighNeedsAmount HighNeedsAmount { get; set; } = new();
-    public TopFunding Maintained { get; set; } = new();
-    public TopFunding NonMaintained { get; set; } = new();
-    public PlaceFunding PlaceFunding { get; set; } = new();
+    public HighNeedsAmount? HighNeedsAmount { get; set; }
+    public TopFunding? Maintained { get; set; }
+    public TopFunding? NonMaintained { get; set; }
+    public PlaceFunding? PlaceFunding { get; set; }
 }
 
 public record LocalAuthorityHighNeedsYear : LocalAuthorityHighNeeds

--- a/web/src/Web.App/Domain/LocalAuthorities/PlaceFunding.cs
+++ b/web/src/Web.App/Domain/LocalAuthorities/PlaceFunding.cs
@@ -1,3 +1,5 @@
+// ReSharper disable ClassNeverInstantiated.Global
+// ReSharper disable UnusedAutoPropertyAccessor.Global
 // ReSharper disable UnusedMember.Global
 namespace Web.App.Domain.LocalAuthorities;
 

--- a/web/src/Web.App/Domain/LocalAuthorities/PlaceFunding.cs
+++ b/web/src/Web.App/Domain/LocalAuthorities/PlaceFunding.cs
@@ -1,0 +1,10 @@
+// ReSharper disable UnusedMember.Global
+namespace Web.App.Domain.LocalAuthorities;
+
+public record PlaceFunding
+{
+    public decimal? Primary { get; set; }
+    public decimal? Secondary { get; set; }
+    public decimal? Special { get; set; }
+    public decimal? AlternativeProvision { get; set; }
+}

--- a/web/src/Web.App/Domain/LocalAuthorities/TopFunding.cs
+++ b/web/src/Web.App/Domain/LocalAuthorities/TopFunding.cs
@@ -1,3 +1,5 @@
+// ReSharper disable ClassNeverInstantiated.Global
+// ReSharper disable UnusedAutoPropertyAccessor.Global
 // ReSharper disable UnusedMember.Global
 namespace Web.App.Domain.LocalAuthorities;
 

--- a/web/src/Web.App/Domain/LocalAuthorities/TopFunding.cs
+++ b/web/src/Web.App/Domain/LocalAuthorities/TopFunding.cs
@@ -1,0 +1,13 @@
+// ReSharper disable UnusedMember.Global
+namespace Web.App.Domain.LocalAuthorities;
+
+public record TopFunding
+{
+    public decimal? EarlyYears { get; set; }
+    public decimal? Primary { get; set; }
+    public decimal? Secondary { get; set; }
+    public decimal? Special { get; set; }
+    public decimal? AlternativeProvision { get; set; }
+    public decimal? PostSchool { get; set; }
+    public decimal? Income { get; set; }
+}

--- a/web/src/Web.App/Extensions/ServiceCollectionExtensions.cs
+++ b/web/src/Web.App/Extensions/ServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.Benchmark;
 using Web.App.Infrastructure.Apis.Establishment;
 using Web.App.Infrastructure.Apis.Insight;
+using Web.App.Infrastructure.Apis.LocalAuthorities;
 using Web.App.Infrastructure.Storage;
 using Web.App.Services;
 
@@ -88,6 +89,7 @@ public static class ServiceCollectionExtensions
         const string section = "Apis:LocalAuthorityFinances";
 
         services.AddHttpClient<IHealthApi, HealthApi>(section).Configure<HealthApi>(section);
+        services.AddHttpClient<ILocalAuthoritiesApi, LocalAuthoritiesApi>().Configure<LocalAuthoritiesApi>(section);
 
         return services;
     }

--- a/web/src/Web.App/Infrastructure/Apis/LocalAuthorities/Api.cs
+++ b/web/src/Web.App/Infrastructure/Apis/LocalAuthorities/Api.cs
@@ -1,0 +1,9 @@
+﻿namespace Web.App.Infrastructure.Apis.LocalAuthorities;
+
+public static class Api
+{
+    public static class LocalAuthorities
+    {
+        public static string HighNeedsHistory => "api/high-needs/history";
+    }
+}

--- a/web/src/Web.App/Infrastructure/Apis/LocalAuthorities/LocalAuthoritiesApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/LocalAuthorities/LocalAuthoritiesApi.cs
@@ -1,0 +1,14 @@
+namespace Web.App.Infrastructure.Apis.LocalAuthorities;
+
+public class LocalAuthoritiesApi(HttpClient httpClient, string? key = default) : ApiBase(httpClient, key), ILocalAuthoritiesApi
+{
+    public Task<ApiResult> GetHighNeedsHistory(ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return GetAsync($"{Api.LocalAuthorities.HighNeedsHistory}{query?.ToQueryString()}", cancellationToken);
+    }
+}
+
+public interface ILocalAuthoritiesApi
+{
+    Task<ApiResult> GetHighNeedsHistory(ApiQuery? query = null, CancellationToken cancellationToken = default);
+}

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -106,6 +106,8 @@ public static class Paths
     public static string ApiExpenditureUserDefined(string? type, string? id, string dimension, string? category) => $"api/expenditure/user-defined?type={type}&id={id}&dimension={dimension}&category={category}";
     public static string ApiCensus(string id, string type, string category, string dimension) => $"api/census?id={id}&type={type}&category={category}&dimension={dimension}";
     public static string ApiCensusHistoryComparison(string id, string dimension, string? phase, string? financeType) => $"api/census/history/comparison?id={id}&dimension={dimension}&phase={phase}&financeType={financeType}";
+    public static string ApiNationalRank(string? sort) => $"api/local-authorities/national-rank?sort={sort}";
+    public static string ApiHighNeedsHistory(string code) => $"api/local-authorities/high-needs/history?code={code}";
     public static string LocalAuthorityHome(string? code) => $"/local-authority/{code}";
     public static string LocalAuthorityResources(string? code) => $"/local-authority/{code}/find-ways-to-spend-less";
     public static string LocalAuthorityHighNeeds(string? code) => $"/local-authority/{code}/high-needs";

--- a/web/tests/Web.Integration.Tests/Proxy/WhenRequestingHighNeedsHistory.cs
+++ b/web/tests/Web.Integration.Tests/Proxy/WhenRequestingHighNeedsHistory.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using AutoFixture;
 using Newtonsoft.Json;
+using Web.App.Controllers.Api.Responses;
 using Web.App.Domain.LocalAuthorities;
 using Xunit;
 
@@ -13,7 +14,11 @@ public class WhenRequestingHighNeedsHistory(SchoolBenchmarkingWebAppClient clien
     [Fact]
     public async Task CanReturnCorrectResponse()
     {
-        var history = Fixture.Create<History<LocalAuthorityHighNeedsYear>>();
+        var history = Fixture
+            .Build<History<LocalAuthorityHighNeedsYear>>()
+            .With(h => h.StartYear, 2021)
+            .With(h => h.EndYear, 2022)
+            .Create();
         const string sort = nameof(sort);
         var response = await client
             .SetupHighNeedsHistory(history)
@@ -23,8 +28,15 @@ public class WhenRequestingHighNeedsHistory(SchoolBenchmarkingWebAppClient clien
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         var resultContent = await response.Content.ReadAsStringAsync();
-        var actual = JsonConvert.DeserializeObject<History<LocalAuthorityHighNeedsYear>>(resultContent);
-        Assert.Equivalent(history, actual);
+        var actual = JsonConvert.DeserializeObject<LocalAuthorityHighNeedsHistoryResponse[]>(resultContent);
+
+        Assert.NotNull(actual);
+
+        var startYear = actual.FirstOrDefault(y => y.Year == history.StartYear);
+        Assert.NotNull(startYear);
+
+        var endYear = actual.FirstOrDefault(y => y.Year == history.EndYear);
+        Assert.NotNull(endYear);
     }
 
     [Fact]

--- a/web/tests/Web.Integration.Tests/Proxy/WhenRequestingHighNeedsHistory.cs
+++ b/web/tests/Web.Integration.Tests/Proxy/WhenRequestingHighNeedsHistory.cs
@@ -1,0 +1,40 @@
+using System.Net;
+using AutoFixture;
+using Newtonsoft.Json;
+using Web.App.Domain.LocalAuthorities;
+using Xunit;
+
+namespace Web.Integration.Tests.Proxy;
+
+public class WhenRequestingHighNeedsHistory(SchoolBenchmarkingWebAppClient client) : IClassFixture<SchoolBenchmarkingWebAppClient>
+{
+    private static readonly Fixture Fixture = new();
+
+    [Fact]
+    public async Task CanReturnCorrectResponse()
+    {
+        var history = Fixture.Create<History<LocalAuthorityHighNeedsYear>>();
+        const string sort = nameof(sort);
+        var response = await client
+            .SetupHighNeedsHistory(history)
+            .Get(Paths.ApiHighNeedsHistory(sort));
+
+        Assert.IsType<HttpResponseMessage>(response);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var resultContent = await response.Content.ReadAsStringAsync();
+        var actual = JsonConvert.DeserializeObject<History<LocalAuthorityHighNeedsYear>>(resultContent);
+        Assert.Equivalent(history, actual);
+    }
+
+    [Fact]
+    public async Task CanReturnInternalServerError()
+    {
+        const string sort = nameof(sort);
+        var response = await client
+            .SetupLocalAuthoritiesWithException()
+            .Get(Paths.ApiHighNeedsHistory(sort));
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+}

--- a/web/tests/Web.Integration.Tests/Proxy/WhenRequestingNationalRanking.cs
+++ b/web/tests/Web.Integration.Tests/Proxy/WhenRequestingNationalRanking.cs
@@ -1,0 +1,40 @@
+using System.Net;
+using AutoFixture;
+using Newtonsoft.Json;
+using Web.App.Domain;
+using Xunit;
+
+namespace Web.Integration.Tests.Proxy;
+
+public class WhenRequestingNationalRanking(SchoolBenchmarkingWebAppClient client) : IClassFixture<SchoolBenchmarkingWebAppClient>
+{
+    private static readonly Fixture Fixture = new();
+
+    [Fact]
+    public async Task CanReturnCorrectResponse()
+    {
+        var ranking = Fixture.Create<LocalAuthorityRanking>();
+        const string sort = nameof(sort);
+        var response = await client
+            .SetupLocalAuthoritiesNationalRank(ranking)
+            .Get(Paths.ApiNationalRank(sort));
+
+        Assert.IsType<HttpResponseMessage>(response);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var resultContent = await response.Content.ReadAsStringAsync();
+        var actual = JsonConvert.DeserializeObject<LocalAuthorityRanking>(resultContent);
+        Assert.Equivalent(ranking, actual);
+    }
+
+    [Fact]
+    public async Task CanReturnInternalServerError()
+    {
+        const string sort = nameof(sort);
+        var response = await client
+            .SetupEstablishmentWithException()
+            .Get(Paths.ApiNationalRank(sort));
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+}

--- a/web/tests/Web.Tests/Controllers/Api/Mappers/WhenLocalAuthorityHighNeedsHistoryResponseMapperMapsWithCode.cs
+++ b/web/tests/Web.Tests/Controllers/Api/Mappers/WhenLocalAuthorityHighNeedsHistoryResponseMapperMapsWithCode.cs
@@ -1,0 +1,124 @@
+using AutoFixture;
+using Web.App.Controllers.Api.Mappers;
+using Web.App.Controllers.Api.Responses;
+using Web.App.Domain.LocalAuthorities;
+using Xunit;
+
+namespace Web.Tests.Controllers.Api.Mappers;
+
+public class WhenLocalAuthorityHighNeedsHistoryResponseMapperMapsWithCode
+{
+    private static readonly Fixture Fixture = new();
+
+    [Fact]
+    public void ShouldMapToLocalAuthorityHighNeedsHistoryResponses()
+    {
+        const string code = nameof(code);
+        const int startYear = 2021;
+        const int endYear = 2024;
+
+        var outturnStartYear = Fixture
+            .Build<LocalAuthorityHighNeedsYear>()
+            .With(o => o.Year, startYear)
+            .With(o => o.Code, code)
+            .Create();
+
+        var outturnEndYear = Fixture
+            .Build<LocalAuthorityHighNeedsYear>()
+            .With(o => o.Year, endYear)
+            .With(o => o.Code, code)
+            .Create();
+
+        var budgetStartYear = Fixture
+            .Build<LocalAuthorityHighNeedsYear>()
+            .With(o => o.Year, startYear)
+            .With(o => o.Code, code)
+            .Create();
+
+        var budgetEndYear = Fixture
+            .Build<LocalAuthorityHighNeedsYear>()
+            .With(o => o.Year, endYear)
+            .With(o => o.Code, code)
+            .Create();
+
+        var history = new History<LocalAuthorityHighNeedsYear>
+        {
+            StartYear = startYear,
+            EndYear = endYear,
+            Outturn =
+            [
+                outturnStartYear,
+                outturnEndYear,
+                new LocalAuthorityHighNeedsYear
+                {
+                    Year = endYear,
+                },
+                new LocalAuthorityHighNeedsYear
+                {
+                    Code = code
+                }
+            ],
+            Budget =
+            [
+                budgetStartYear,
+                budgetEndYear,
+                new LocalAuthorityHighNeedsYear
+                {
+                    Year = endYear,
+                },
+                new LocalAuthorityHighNeedsYear
+                {
+                    Code = code
+                }
+            ]
+        };
+
+        var actual = history.MapToApiResponse(code).ToArray();
+
+        Assert.Equal(endYear - startYear + 1, actual.Length);
+
+        var startYearResponse = actual.FirstOrDefault();
+        Assert.NotNull(startYearResponse);
+        Assert.Equal("2020 to 2021", startYearResponse.Term);
+        AssertFieldsMapped(outturnStartYear, startYearResponse.Outturn);
+        AssertFieldsMapped(budgetStartYear, startYearResponse.Budget);
+
+        var endYearResponse = actual.LastOrDefault();
+        Assert.NotNull(endYearResponse);
+        Assert.Equal("2023 to 2024", endYearResponse.Term);
+        AssertFieldsMapped(outturnEndYear, endYearResponse.Outturn);
+        AssertFieldsMapped(budgetEndYear, endYearResponse.Budget);
+    }
+
+    private static void AssertFieldsMapped(LocalAuthorityHighNeedsYear? expected, LocalAuthorityHighNeedsResponse? actual)
+    {
+        Assert.Equal(expected?.HighNeedsAmount?.TotalPlaceFunding, actual?.HighNeedsAmountTotalPlaceFunding);
+        Assert.Equal(expected?.HighNeedsAmount?.TopUpFundingMaintained, actual?.HighNeedsAmountTopUpFundingMaintained);
+        Assert.Equal(expected?.HighNeedsAmount?.TopUpFundingNonMaintained, actual?.HighNeedsAmountTopUpFundingNonMaintained);
+        Assert.Equal(expected?.HighNeedsAmount?.SenServices, actual?.HighNeedsAmountSenServices);
+        Assert.Equal(expected?.HighNeedsAmount?.AlternativeProvisionServices, actual?.HighNeedsAmountAlternativeProvisionServices);
+        Assert.Equal(expected?.HighNeedsAmount?.HospitalServices, actual?.HighNeedsAmountHospitalServices);
+        Assert.Equal(expected?.HighNeedsAmount?.OtherHealthServices, actual?.HighNeedsAmountOtherHealthServices);
+
+        Assert.Equal(expected?.Maintained?.EarlyYears, actual?.MaintainedEarlyYears);
+        Assert.Equal(expected?.Maintained?.Primary, actual?.MaintainedPrimary);
+        Assert.Equal(expected?.Maintained?.Secondary, actual?.MaintainedSecondary);
+        Assert.Equal(expected?.Maintained?.Special, actual?.MaintainedSpecial);
+        Assert.Equal(expected?.Maintained?.AlternativeProvision, actual?.MaintainedAlternativeProvision);
+        Assert.Equal(expected?.Maintained?.PostSchool, actual?.MaintainedPostSchool);
+        Assert.Equal(expected?.Maintained?.Income, actual?.MaintainedIncome);
+
+        Assert.Equal(expected?.NonMaintained?.EarlyYears, actual?.NonMaintainedEarlyYears);
+        Assert.Equal(expected?.NonMaintained?.Primary, actual?.NonMaintainedPrimary);
+        Assert.Equal(expected?.NonMaintained?.Secondary, actual?.NonMaintainedSecondary);
+        Assert.Equal(expected?.NonMaintained?.Special, actual?.NonMaintainedSpecial);
+        Assert.Equal(expected?.NonMaintained?.AlternativeProvision, actual?.NonMaintainedAlternativeProvision);
+        Assert.Equal(expected?.NonMaintained?.PostSchool, actual?.NonMaintainedPostSchool);
+        Assert.Equal(expected?.NonMaintained?.Income, actual?.NonMaintainedIncome);
+
+        Assert.Equal(expected?.PlaceFunding?.Primary, actual?.PlaceFundingPrimary);
+        Assert.Equal(expected?.PlaceFunding?.Secondary, actual?.PlaceFundingSecondary);
+        Assert.Equal(expected?.PlaceFunding?.Special, actual?.PlaceFundingSpecial);
+        Assert.Equal(expected?.PlaceFunding?.AlternativeProvision, actual?.PlaceFundingAlternativeProvision);
+    }
+}


### PR DESCRIPTION
### Context
[AB#251206](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/251206) [AB#249550](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249550) #2030

### Change proposed in this pull request
Proxy endpoint and integration test coverage. Includes mapping API response to flattened type expected by consuming charts/tables.

### Guidance to review 
Dependent on #2030. May be validated locally from `https://localhost:7095/swagger/index.html#operations-tag-HighNeedsProxy`

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

