### PR TITLE
feat: add debug logging for SQL logging

### DIFF
--- a/data-pipeline/src/pipeline/database.py
+++ b/data-pipeline/src/pipeline/database.py
@@ -41,7 +41,15 @@ def get_engine() -> sqlalchemy.engine.Engine:
         query={"driver": "ODBC Driver 18 for SQL Server"} | args,
     )
 
-    return create_engine(connection_url, fast_executemany=True)
+    engine = create_engine(connection_url, fast_executemany=True)
+
+    @event.listens_for(engine, "before_cursor_execute")
+    def receive_before_cursor_execute(
+        conn, cursor, statement, params, context, executemany
+    ):
+        logger.debug(str(statement))
+
+    return engine
 
 
 @dataclass


### PR DESCRIPTION
### Context

Currently, we've little insight into the actual queries being made to the DB (some of which are obfuscated by Pandas' `to_sql()` calls).

### Change proposed in this pull request

Log (at a `DEBUG` level) every query to the database: as queries are now batched, this should be minimal but may highlight instances where this is _not_ occuring.

### Guidance to review 

Similar to the previous use of `fast_executemany`, this will trigger before each DB-cursor use.

Note: this logs the _statement_ only, not any params. passed.

By way of evidence:

```sh
{"asctime": "2025-02-27 08:51:46,443", "levelname": "DEBUG", "module": "database", "message": "DROP TABLE _Financial_2021_1740646300_temp;"}
{"asctime": "2025-02-27 08:51:46,452", "levelname": "INFO", "module": "database", "message": "Wrote 22,420 rows to Financial:2021 in 1 seconds."}
{"asctime": "2025-02-27 08:51:46,458", "levelname": "INFO", "module": "database", "message": "Creating temp. table: _TrustFinancial_2021_1740646306_temp."}
{"asctime": "2025-02-27 08:51:46,471", "levelname": "DEBUG", "module": "database", "message": "SELECT *\n  INTO _TrustFinancial_2021_1740646306_temp\n  FROM TrustFinancial\n WHERE 1=0\n;"}
```

### Checklist (add/remove as appropriate)

- [ ] ~Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)~
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~You have reviewed with UX/Design~

