### PR TITLE
Added Section 251 historical charts to new `<HistoricDataHighNeeds>` view

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -148,7 +148,8 @@
     <svg class="test-element-class" height="100" width="100" xmlns="http://www.w3.org/2000/svg">
       <circle r="45" cx="50" cy="50" fill="purple" />
     </svg> -->
-    <div id="la-national-rank" data-code="201"></div>
+    <!--<div id="la-national-rank" data-code="201"></div>-->
+    <div id="historic-data-high-needs" data-code="201"></div>
     <script type="module" src="/src/main.tsx"></script>
     <script
       type="module"

--- a/front-end-components/src/components/charts/historic-data-section-251-tooltip/component.tsx
+++ b/front-end-components/src/components/charts/historic-data-section-251-tooltip/component.tsx
@@ -1,0 +1,70 @@
+import {
+  NameType,
+  ValueType,
+} from "recharts/types/component/DefaultTooltipContent";
+import { HistoricDataSection251TooltipProps } from "src/components/charts/historic-data-section-251-tooltip";
+import { Section251HistoryValue } from "src/composed/historic-chart-section-251-composed";
+import { ChartDataSeries } from "../types";
+
+export function HistoricDataSection251Tooltip<
+  TData extends ChartDataSeries,
+  TValue extends ValueType,
+  TName extends NameType,
+>({
+  active,
+  payload,
+  valueFormatter,
+  valueUnit,
+}: HistoricDataSection251TooltipProps<TData, TValue, TName>) {
+  if (!active || !payload || !payload.length) {
+    return null;
+  }
+
+  const { term, outturn, budget } = payload[0]
+    .payload as Section251HistoryValue;
+  return (
+    <>
+      <table className="govuk-table govuk-table--small-text-until-tablet tooltip-table">
+        <caption className="govuk-table__caption govuk-table__caption--s">
+          {term}
+        </caption>
+        <thead className="govuk-table__head govuk-visually-hidden">
+          <tr className="govuk-table__row">
+            <th scope="col" className="govuk-table__header">
+              Item
+            </th>
+            <th scope="col" className="govuk-table__header">
+              Value
+            </th>
+          </tr>
+        </thead>
+        <tbody className="govuk-table__body">
+          <tr className="govuk-table__row">
+            <th scope="row" className="govuk-table__header">
+              Actual
+            </th>
+            <td className="govuk-table__cell">
+              {outturn === undefined
+                ? ""
+                : valueFormatter
+                  ? valueFormatter(outturn, { valueUnit })
+                  : String(outturn)}
+            </td>
+          </tr>
+          <tr className="govuk-table__row">
+            <th scope="row" className="govuk-table__header">
+              Planned
+            </th>
+            <td className="govuk-table__cell">
+              {budget === undefined
+                ? ""
+                : valueFormatter
+                  ? valueFormatter(budget, { valueUnit })
+                  : String(budget)}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </>
+  );
+}

--- a/front-end-components/src/components/charts/historic-data-section-251-tooltip/index.tsx
+++ b/front-end-components/src/components/charts/historic-data-section-251-tooltip/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/components/charts/historic-data-section-251-tooltip/types";
+export * from "src/components/charts/historic-data-section-251-tooltip/component";

--- a/front-end-components/src/components/charts/historic-data-section-251-tooltip/types.tsx
+++ b/front-end-components/src/components/charts/historic-data-section-251-tooltip/types.tsx
@@ -1,0 +1,14 @@
+import { TooltipProps } from "recharts";
+import {
+  NameType,
+  ValueType,
+} from "recharts/types/component/DefaultTooltipContent";
+import { ChartDataSeries } from "../types";
+import { LineChartProps } from "../line-chart";
+
+export interface HistoricDataSection251TooltipProps<
+  TData extends ChartDataSeries,
+  TValue extends ValueType,
+  TName extends NameType,
+> extends TooltipProps<TValue, TName>,
+    Pick<LineChartProps<TData>, "valueFormatter" | "valueUnit"> {}

--- a/front-end-components/src/components/charts/resolved-stat/component.tsx
+++ b/front-end-components/src/components/charts/resolved-stat/component.tsx
@@ -9,6 +9,7 @@ export function ResolvedStat<TData extends ChartDataSeries>(
   const {
     data,
     displayIndex,
+    seriesFormatter,
     seriesLabel,
     seriesLabelField,
     valueField,
@@ -21,11 +22,23 @@ export function ResolvedStat<TData extends ChartDataSeries>(
       return null;
     }
 
+    let label = seriesLabel || entry[1][seriesLabelField];
+    if (seriesFormatter) {
+      label = seriesFormatter(label);
+    }
+
     return {
-      label: seriesLabel || entry[1][seriesLabelField],
+      label,
       value: entry[1][valueField],
     };
-  }, [data, displayIndex, seriesLabel, seriesLabelField, valueField]);
+  }, [
+    data,
+    displayIndex,
+    seriesFormatter,
+    seriesLabel,
+    seriesLabelField,
+    valueField,
+  ]);
 
   // do not render anything if a match could not be located based on the available data
   if (!entry) {

--- a/front-end-components/src/components/charts/resolved-stat/types.tsx
+++ b/front-end-components/src/components/charts/resolved-stat/types.tsx
@@ -3,7 +3,10 @@ import { StatProps } from "../stat";
 
 export interface ResolvedStatProps<TData extends ChartDataSeries>
   extends Omit<StatProps<TData>, "valueSuffix" | "label" | "value">,
-    Pick<ChartProps<TData>, "data" | "seriesLabel" | "seriesLabelField"> {
+    Pick<
+      ChartProps<TData>,
+      "data" | "seriesFormatter" | "seriesLabel" | "seriesLabelField"
+    > {
   displayIndex: number;
   valueField: keyof TData;
 }

--- a/front-end-components/src/composed/historic-chart-section-251-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-section-251-composed/component.tsx
@@ -12,7 +12,7 @@ import {
 } from "src/components/charts/utils.ts";
 import { useChartModeContext } from "src/contexts";
 import { LocalAuthoritySection251 } from "src/services";
-//import { HistoricDataTooltip } from "src/components/charts/historic-data-tooltip";
+import { HistoricDataSection251Tooltip } from "src/components/charts/historic-data-section-251-tooltip";
 // import { ResolvedStat } from "src/components/charts/resolved-stat";
 import { ShareContent } from "src/components/share-content";
 import "./styles.scss";
@@ -126,17 +126,16 @@ export function HistoricChartSection251<
                 ref={chartRef}
                 onImageCopied={handleImageCopied}
                 onImageLoading={setImageLoading}
-                // tooltip={(t) => (
-                //   <HistoricDataTooltip
-                //     {...t}
-                //     valueFormatter={(v) =>
-                //       shortValueFormatter(v, {
-                //         valueUnit ?? "currency",
-                //       })
-                //     }
-                //     dimension={columnHeading}
-                //   />
-                // )}
+                tooltip={(t) => (
+                  <HistoricDataSection251Tooltip
+                    {...t}
+                    valueFormatter={(v) =>
+                      shortValueFormatter(v, {
+                        valueUnit: valueUnit ?? "currency",
+                      })
+                    }
+                  />
+                )}
                 legend={legend === undefined ? true : legend}
                 legendIconSize={legendIconSize || 24}
                 legendIconType={

--- a/front-end-components/src/composed/historic-chart-section-251-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-section-251-composed/component.tsx
@@ -8,12 +8,15 @@ import { LineChart } from "src/components/charts/line-chart";
 import {
   shortValueFormatter,
   fullValueFormatter,
-  // statValueFormatter,
+  statValueFormatter,
 } from "src/components/charts/utils.ts";
 import { useChartModeContext } from "src/contexts";
 import { LocalAuthoritySection251 } from "src/services";
 import { HistoricDataSection251Tooltip } from "src/components/charts/historic-data-section-251-tooltip";
-// import { ResolvedStat } from "src/components/charts/resolved-stat";
+import {
+  ResolvedStat,
+  ResolvedStatProps,
+} from "src/components/charts/resolved-stat";
 import { ShareContent } from "src/components/share-content";
 import "./styles.scss";
 
@@ -85,6 +88,20 @@ export function HistoricChartSection251<
       setImageCopied(false);
     }, 2000);
   };
+
+  const statProps = (
+    label: string
+  ): Omit<ResolvedStatProps<Section251HistoryValue>, "valueField"> => ({
+    chartTitle: `${label} ${chartTitle.toLowerCase()}`,
+    className: "chart-stat-line-chart",
+    compactValue: true,
+    data: mergedData || [],
+    displayIndex: (mergedData?.length || 0) - 1,
+    seriesFormatter: (s) => `${s} ${label.toLowerCase()}`,
+    seriesLabelField: "term",
+    valueFormatter: statValueFormatter,
+    valueUnit: valueUnit ?? "currency",
+  });
 
   return (
     <>
@@ -165,17 +182,8 @@ export function HistoricChartSection251<
             </div>
           </div>
           <aside className="govuk-grid-column-one-quarter">
-            {/* <ResolvedStat
-              chartTitle={`Most recent ${chartTitle.toLowerCase()}`}
-              className="chart-stat-line-chart"
-              compactValue
-              data={data.school || []}
-              displayIndex={(data.school?.length || 0) - 1}
-              seriesLabelField="term"
-              valueField={valueField}
-              valueFormatter={statValueFormatter}
-              valueUnit={valueUnit ?? "currency"}
-            /> */}
+            <ResolvedStat valueField="outturn" {...statProps("Actual")} />
+            <ResolvedStat valueField="budget" {...statProps("Planned")} />
           </aside>
         </div>
       ) : (

--- a/front-end-components/src/composed/historic-chart-section-251-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-section-251-composed/component.tsx
@@ -1,0 +1,238 @@
+import { useMemo, useRef, useState } from "react";
+import { ChartModeChart, ChartHandler, ChartProps } from "src/components";
+import {
+  HistoricChartSection251Props,
+  Section251HistoryValue,
+} from "src/composed/historic-chart-section-251-composed";
+import { LineChart } from "src/components/charts/line-chart";
+import {
+  shortValueFormatter,
+  fullValueFormatter,
+  // statValueFormatter,
+} from "src/components/charts/utils.ts";
+import { useChartModeContext } from "src/contexts";
+import { LocalAuthoritySection251 } from "src/services";
+//import { HistoricDataTooltip } from "src/components/charts/historic-data-tooltip";
+// import { ResolvedStat } from "src/components/charts/resolved-stat";
+import { ShareContent } from "src/components/share-content";
+import "./styles.scss";
+
+export function HistoricChartSection251<
+  TData extends LocalAuthoritySection251,
+>({
+  axisLabel,
+  chartTitle,
+  children,
+  data,
+  legend,
+  legendHorizontalAlign,
+  legendIconSize,
+  legendIconType,
+  legendVerticalAlign,
+  legendWrapperStyle,
+  showCopyImageButton,
+  valueField,
+  valueUnit,
+}: HistoricChartSection251Props<TData>) {
+  const { chartMode } = useChartModeContext();
+  const chartRef = useRef<ChartHandler>(null);
+  const [imageLoading, setImageLoading] = useState<boolean>();
+  const [imageCopied, setImageCopied] = useState<boolean>();
+
+  const mergedData = useMemo(() => {
+    const result: Section251HistoryValue[] = [];
+
+    data?.forEach((s) => {
+      const year = s.year;
+      const outturnValue = s.outturn && (s.outturn[valueField] as number);
+      const budgetValue = s.budget && (s.budget[valueField] as number);
+
+      result.push({
+        year,
+        term: s.term,
+        outturn:
+          outturnValue === undefined ||
+          outturnValue === null ||
+          isNaN(outturnValue)
+            ? undefined
+            : outturnValue,
+        budget:
+          budgetValue === undefined ||
+          budgetValue === null ||
+          isNaN(budgetValue)
+            ? undefined
+            : budgetValue,
+      });
+    });
+
+    return result;
+  }, [data, valueField]);
+
+  const seriesConfig: ChartProps<Section251HistoryValue>["seriesConfig"] = {
+    outturn: {
+      label: "actual",
+      visible: true,
+    },
+    budget: {
+      label: "planned",
+      visible: true,
+    },
+  };
+
+  const handleImageCopied = () => {
+    setImageCopied(true);
+    setTimeout(() => {
+      setImageCopied(false);
+    }, 2000);
+  };
+
+  return (
+    <>
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-three-quarters">{children}</div>
+        {chartMode == ChartModeChart && (
+          <div className="govuk-grid-column-one-quarter">
+            <ShareContent
+              copied={imageCopied}
+              disabled={imageLoading}
+              onCopyClick={() => chartRef.current?.download("copy")}
+              onSaveClick={() => chartRef.current?.download("save")}
+              copyEventId="copy-chart-as-image"
+              saveEventId="save-chart-as-image"
+              showCopy={showCopyImageButton}
+              showSave
+              title={chartTitle}
+            />
+          </div>
+        )}
+      </div>
+      {chartMode == ChartModeChart ? (
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-three-quarters">
+            <div style={{ height: 200 }}>
+              <LineChart
+                chartTitle={chartTitle}
+                className="historic-chart-high-needs"
+                data={mergedData}
+                grid
+                highlightActive
+                keyField="term"
+                margin={20}
+                seriesConfig={seriesConfig}
+                seriesLabel={axisLabel}
+                seriesLabelField="term"
+                valueFormatter={shortValueFormatter}
+                valueUnit={valueUnit ?? "currency"}
+                ref={chartRef}
+                onImageCopied={handleImageCopied}
+                onImageLoading={setImageLoading}
+                // tooltip={(t) => (
+                //   <HistoricDataTooltip
+                //     {...t}
+                //     valueFormatter={(v) =>
+                //       shortValueFormatter(v, {
+                //         valueUnit ?? "currency",
+                //       })
+                //     }
+                //     dimension={columnHeading}
+                //   />
+                // )}
+                legend={legend === undefined ? true : legend}
+                legendIconSize={legendIconSize || 24}
+                legendIconType={
+                  legend === undefined ? "default" : legendIconType
+                }
+                legendHorizontalAlign={
+                  legendHorizontalAlign === undefined
+                    ? "center"
+                    : legendHorizontalAlign
+                }
+                legendVerticalAlign={
+                  legendVerticalAlign === undefined
+                    ? "bottom"
+                    : legendVerticalAlign
+                }
+                legendWrapperStyle={
+                  (legendWrapperStyle ?? legendVerticalAlign === undefined)
+                    ? {
+                        position: "relative",
+                        left: "inherit",
+                        bottom: "inherit",
+                        marginTop: -40,
+                      }
+                    : undefined
+                }
+              />
+            </div>
+          </div>
+          <aside className="govuk-grid-column-one-quarter">
+            {/* <ResolvedStat
+              chartTitle={`Most recent ${chartTitle.toLowerCase()}`}
+              className="chart-stat-line-chart"
+              compactValue
+              data={data.school || []}
+              displayIndex={(data.school?.length || 0) - 1}
+              seriesLabelField="term"
+              valueField={valueField}
+              valueFormatter={statValueFormatter}
+              valueUnit={valueUnit ?? "currency"}
+            /> */}
+          </aside>
+        </div>
+      ) : (
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-full">
+            <table className="govuk-table" data-testid={`${chartTitle}-table`}>
+              <thead className="govuk-table__head">
+                <tr className="govuk-table__row">
+                  <th className="govuk-table__header govuk-!-width-one-quarter">
+                    Year
+                  </th>
+                  <th className="govuk-table__header govuk-!-width-one-quarter">
+                    Actual
+                  </th>
+                  <th className="govuk-table__header govuk-!-width-one-quarter">
+                    Planned
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="govuk-table__body">
+                {mergedData?.map(({ year, term, outturn, budget }) => {
+                  return (
+                    <tr className="govuk-table__row" key={year}>
+                      <td className="govuk-table__cell">{String(term)}</td>
+                      <td className="govuk-table__cell">
+                        {fullValueFormatter(
+                          outturn === undefined ||
+                            outturn === null ||
+                            isNaN(outturn as number)
+                            ? undefined
+                            : outturn,
+                          {
+                            valueUnit: valueUnit ?? "currency",
+                          }
+                        )}
+                      </td>
+                      <td className="govuk-table__cell">
+                        {fullValueFormatter(
+                          budget === undefined ||
+                            budget === null ||
+                            isNaN(budget as number)
+                            ? undefined
+                            : budget,
+                          {
+                            valueUnit: valueUnit ?? "currency",
+                          }
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/front-end-components/src/composed/historic-chart-section-251-composed/index.tsx
+++ b/front-end-components/src/composed/historic-chart-section-251-composed/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/composed/historic-chart-section-251-composed/types";
+export * from "src/composed/historic-chart-section-251-composed/component";

--- a/front-end-components/src/composed/historic-chart-section-251-composed/styles.scss
+++ b/front-end-components/src/composed/historic-chart-section-251-composed/styles.scss
@@ -1,0 +1,44 @@
+$historic-chart-high-needs-series-0-colour: #156082;
+$historic-chart-high-needs-series-1-colour: #e97132;
+
+.recharts-wrapper.historic-chart-high-needs {
+
+  .chart-line.chart-line-series-0 path,
+  .chart-line.chart-line-series-0 .recharts-line-dot,
+  .recharts-default-legend .legend-item-0 path {
+    stroke: $historic-chart-high-needs-series-0-colour;
+  }
+
+  .chart-line.chart-line-series-0 path,
+  .chart-line.chart-line-series-1 path {
+    stroke-opacity: 75%;
+  }
+
+  .chart-line.chart-line-series-1 path,
+  .chart-line.chart-line-series-1 .recharts-line-dot,
+  .recharts-default-legend .legend-item-1 path {
+    stroke: $historic-chart-high-needs-series-1-colour;
+  }
+
+  .recharts-default-legend {
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: center;
+  }
+
+  .recharts-default-legend .recharts-legend-item {
+    white-space: nowrap;
+  }
+
+  .chart-active-dot.chart-active-dot-series-0,
+  .recharts-label-list .chart-label-series-0,
+  .recharts-default-legend .legend-item-0 path {
+    fill: $historic-chart-high-needs-series-0-colour;
+  }
+
+  .chart-active-dot.chart-active-dot-series-1,
+  .recharts-label-list .chart-label-series-1,
+  .recharts-default-legend .legend-item-1 path {
+    fill: $historic-chart-high-needs-series-1-colour;
+  }
+}

--- a/front-end-components/src/composed/historic-chart-section-251-composed/types.tsx
+++ b/front-end-components/src/composed/historic-chart-section-251-composed/types.tsx
@@ -1,0 +1,37 @@
+import { ReactNode } from "react";
+import {
+  ChartSeriesValue,
+  ChartSeriesValueUnit,
+} from "src/components/charts/types";
+import { ResolvedStatProps } from "src/components/charts/resolved-stat";
+import {
+  HistoryBase,
+  LocalAuthoritySection251,
+  LocalAuthoritySection251History,
+} from "src/services";
+import { LineChartProps } from "src/components/charts/line-chart";
+
+export interface HistoricChartSection251Props<
+  TData extends LocalAuthoritySection251,
+> extends Pick<
+    LineChartProps<TData>,
+    | "legend"
+    | "legendIconSize"
+    | "legendIconType"
+    | "legendHorizontalAlign"
+    | "legendVerticalAlign"
+    | "legendWrapperStyle"
+    | "showCopyImageButton"
+  > {
+  chartTitle: string;
+  data: LocalAuthoritySection251History<TData>[] | undefined;
+  valueField: ResolvedStatProps<TData>["valueField"];
+  children?: ReactNode;
+  valueUnit?: ChartSeriesValueUnit;
+  axisLabel?: string;
+}
+
+export type Section251HistoryValue = HistoryBase & {
+  outturn?: ChartSeriesValue;
+  budget?: ChartSeriesValue;
+};

--- a/front-end-components/src/constants.tsx
+++ b/front-end-components/src/constants.tsx
@@ -22,3 +22,4 @@ export const BudgetForecastReturnsElementId = "budget-forecast-returns";
 export const ShareContentByElementIdDataAttr = "share-content-by-element-id";
 export const LaunchModalDataAttr = "launch-modal";
 export const LaNationalRankViewElementId = "la-national-rank";
+export const HistoricDataHighNeedsElementId = "historic-data-high-needs";

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -34,6 +34,7 @@ import {
   ShareContentByElementIdDataAttr,
   LaunchModalDataAttr,
   LaNationalRankViewElementId,
+  HistoricDataHighNeedsElementId,
 } from "src/constants";
 import { HorizontalBarChart } from "./components/charts/horizontal-bar-chart";
 import { VerticalBarChart } from "./components/charts/vertical-bar-chart";
@@ -63,6 +64,10 @@ import { TrustChartData } from "./components/charts/table-chart";
 import { BudgetForecastReturns } from "./views/budget-forecast-returns";
 import { ShareContentByElement } from "./components/share-content-by-element";
 import { ModalSaveImages } from "./components/modals/modal-save-images";
+import {
+  HistoricDataHighNeeds,
+  HistoricDataHighNeedsSectionName,
+} from "./views/historic-data-high-needs";
 
 const historicDataElement = document.getElementById(HistoricDataElementId);
 if (historicDataElement) {
@@ -992,6 +997,28 @@ if (laNationalRankViewElement) {
     root.render(
       <React.StrictMode>
         <LaNationalRankView code={code} />
+      </React.StrictMode>
+    );
+  }
+}
+
+const historicDataHighNeedsElement = document.getElementById(
+  HistoricDataHighNeedsElementId
+);
+if (historicDataHighNeedsElement) {
+  const { code } = historicDataHighNeedsElement.dataset;
+  if (code) {
+    const root = ReactDOM.createRoot(historicDataHighNeedsElement);
+    const hash = window?.location.hash.replace("#", "");
+    root.render(
+      <React.StrictMode>
+        <HistoricDataHighNeeds
+          code={code}
+          preLoadSections={
+            hash ? [hash as HistoricDataHighNeedsSectionName] : undefined
+          }
+          fetchTimeout={30_000}
+        />
       </React.StrictMode>
     );
   }

--- a/front-end-components/src/services/high-needs-api.tsx
+++ b/front-end-components/src/services/high-needs-api.tsx
@@ -1,0 +1,36 @@
+import {
+  LocalAuthoritySection251,
+  LocalAuthoritySection251History,
+} from "src/services/types";
+import { v4 as uuidv4 } from "uuid";
+
+export class HighNeedsApi {
+  static async history(
+    code: string,
+    signals?: AbortSignal[]
+  ): Promise<LocalAuthoritySection251History<LocalAuthoritySection251>[]> {
+    const params = new URLSearchParams({
+      code,
+    });
+
+    const response = await fetch(
+      "/api/local-authorities/high-needs/history?" + params,
+      {
+        redirect: "manual",
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Correlation-ID": uuidv4(),
+        },
+        signal: signals?.length ? AbortSignal.any(signals) : undefined,
+      }
+    );
+
+    const json = await response.json();
+    if (json.error) {
+      throw json.error;
+    }
+
+    return json;
+  }
+}

--- a/front-end-components/src/services/types.tsx
+++ b/front-end-components/src/services/types.tsx
@@ -408,3 +408,41 @@ export type LocalAuthorityRank = {
   value?: number;
   rank: number;
 };
+
+export type LocalAuthoritySection251History<
+  T extends LocalAuthoritySection251,
+> = HistoryBase & {
+  outturn?: T;
+  budget?: T;
+};
+
+export type LocalAuthoritySection251 = {
+  highNeedsAmountTotalPlaceFunding?: number;
+  highNeedsAmountTopUpFundingMaintained?: number;
+  highNeedsAmountTopUpFundingNonMaintained?: number;
+  highNeedsAmountSenServices?: number;
+  highNeedsAmountAlternativeProvisionServices?: number;
+  highNeedsAmountHospitalServices?: number;
+  highNeedsAmountOtherHealthServices?: number;
+
+  maintainedEarlyYears?: number;
+  maintainedPrimary?: number;
+  maintainedSecondary?: number;
+  maintainedSpecial?: number;
+  maintainedAlternativeProvision?: number;
+  maintainedPostSchool?: number;
+  maintainedIncome?: number;
+
+  nonMaintainedEarlyYears?: number;
+  nonMaintainedPrimary?: number;
+  nonMaintainedSecondary?: number;
+  nonMaintainedSpecial?: number;
+  nonMaintainedAlternativeProvision?: number;
+  nonMaintainedPostSchool?: number;
+  nonMaintainedIncome?: number;
+
+  placeFundingPrimary?: number;
+  placeFundingSecondary?: number;
+  placeFundingSpecial?: number;
+  placeFundingAlternativeProvision?: number;
+};

--- a/front-end-components/src/views/historic-data-high-needs/index.tsx
+++ b/front-end-components/src/views/historic-data-high-needs/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/views/historic-data-high-needs/types";
+export * from "src/views/historic-data-high-needs/view";

--- a/front-end-components/src/views/historic-data-high-needs/partials/index.tsx
+++ b/front-end-components/src/views/historic-data-high-needs/partials/index.tsx
@@ -1,0 +1,19 @@
+import { LocalAuthoritySection251 } from "src/services";
+import { HistoricChartSection251Section } from "../types";
+
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/views/historic-data-high-needs/partials/section-251-section.tsx";
+export * from "src/views/historic-data-high-needs/partials/send-2-section.tsx";
+
+export const section251Sections: HistoricChartSection251Section<LocalAuthoritySection251>[] =
+  [
+    {
+      heading: "High needs amount per head 2-18 population",
+      charts: [
+        {
+          name: "Total place funding for special schools and AP/PRUs",
+          field: "highNeedsAmountTotalPlaceFunding",
+        },
+      ],
+    },
+  ];

--- a/front-end-components/src/views/historic-data-high-needs/partials/index.tsx
+++ b/front-end-components/src/views/historic-data-high-needs/partials/index.tsx
@@ -5,6 +5,9 @@ import { HistoricChartSection251Section } from "../types";
 export * from "src/views/historic-data-high-needs/partials/section-251-section.tsx";
 export * from "src/views/historic-data-high-needs/partials/send-2-section.tsx";
 
+const summary =
+  "Split by phase (for mainstream) and type of institution (specialist provision)";
+
 export const section251Sections: HistoricChartSection251Section<LocalAuthoritySection251>[] =
   [
     {
@@ -13,6 +16,122 @@ export const section251Sections: HistoricChartSection251Section<LocalAuthoritySe
         {
           name: "Total place funding for special schools and AP/PRUs",
           field: "highNeedsAmountTotalPlaceFunding",
+        },
+        {
+          name: "Top up funding (maintained schools, academies, free schools and colleges)",
+          field: "highNeedsAmountTopUpFundingMaintained",
+        },
+        {
+          name: "Top up funding (non-maintained and independent schools and colleges)",
+          field: "highNeedsAmountTopUpFundingNonMaintained",
+        },
+        {
+          name: "SEN support and inclusion services",
+          field: "highNeedsAmountSenServices",
+        },
+        {
+          name: "Alternative provision services",
+          field: "highNeedsAmountAlternativeProvisionServices",
+        },
+        {
+          name: "Hospital education services",
+          field: "highNeedsAmountHospitalServices",
+        },
+        {
+          name: "Therapies and other health related services",
+          field: "highNeedsAmountOtherHealthServices",
+        },
+      ],
+    },
+    {
+      heading: "Place funding",
+      summary,
+      charts: [
+        {
+          name: "Primary place funding per head 2-18 population",
+          field: "placeFundingPrimary",
+        },
+        {
+          name: "Secondary place funding per head 2-18 population",
+          field: "placeFundingSecondary",
+        },
+        {
+          name: "Special place funding per head 2-18 population",
+          field: "placeFundingSpecial",
+        },
+        {
+          name: "Alternative provision place funding per head 2-18 population",
+          field: "placeFundingAlternativeProvision",
+        },
+      ],
+    },
+    {
+      heading:
+        "Top up funding (maintained schools, academies, free schools and colleges)",
+      summary,
+      charts: [
+        {
+          name: "Early years top up funding per head 2-18 population (maintained)",
+          field: "maintainedEarlyYears",
+        },
+        {
+          name: "Primary top up funding per head 2-18 population (maintained)",
+          field: "maintainedPrimary",
+        },
+        {
+          name: "Secondary top up funding per head 2-18 population (maintained)",
+          field: "maintainedSecondary",
+        },
+        {
+          name: "Special top up funding per head 2-18 population (maintained)",
+          field: "maintainedSpecial",
+        },
+        {
+          name: "Alternative provision top up funding per head 2-18 population (maintained)",
+          field: "maintainedAlternativeProvision",
+        },
+        {
+          name: "Post-school top up funding per head 2-18 population (maintained)",
+          field: "maintainedPostSchool",
+        },
+        {
+          name: "Top up funding income per head 2-18 population (maintained)",
+          field: "maintainedIncome",
+        },
+      ],
+    },
+    {
+      heading:
+        "Top up funding (non-maintained schools, and independent schools and colleges)",
+      summary,
+      charts: [
+        {
+          name: "Early years top up funding per head 2-18 population (non-maintained)",
+          field: "nonMaintainedEarlyYears",
+        },
+        {
+          name: "Primary top up funding per head 2-18 population (non-maintained)",
+          field: "nonMaintainedPrimary",
+        },
+        {
+          name: "Secondary top up funding per head 2-18 population (non-maintained)",
+          field: "nonMaintainedSecondary",
+        },
+        {
+          name: "Special top up funding per head 2-18 population (non-maintained)",
+          field: "nonMaintainedSpecial",
+        },
+        {
+          name: "Alternative provision top up funding per head 2-18 population (non-maintained)",
+          field: "nonMaintainedAlternativeProvision",
+        },
+        {
+          name: "Post-school top up funding per head 2-18 population (non-maintained)",
+          field: "nonMaintainedPostSchool",
+        },
+        {
+          name: "Top up funding income per head 2-18 population (non-maintained)",
+          field: "nonMaintainedIncome",
         },
       ],
     },

--- a/front-end-components/src/views/historic-data-high-needs/partials/section-251-section.tsx
+++ b/front-end-components/src/views/historic-data-high-needs/partials/section-251-section.tsx
@@ -63,7 +63,6 @@ export const Section251Section: React.FC<HistoricDataHighNeedsProps> = ({
           />
         </div>
       </div>
-      <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-0" />
       {loadError ? (
         <DataWarning>{loadError}</DataWarning>
       ) : (
@@ -87,6 +86,14 @@ export const Section251Section: React.FC<HistoricDataHighNeedsProps> = ({
                   {section.heading}
                 </span>
               </h2>
+              {section.summary && (
+                <div
+                  className="govuk-accordion__section-summary govuk-body"
+                  id={`accordion-with-summary-sections-summary-${index + 1}`}
+                >
+                  {section.summary}
+                </div>
+              )}
             </div>
             <div
               id={`accordion-expenditure-content-${index + 1}`}

--- a/front-end-components/src/views/historic-data-high-needs/partials/section-251-section.tsx
+++ b/front-end-components/src/views/historic-data-high-needs/partials/section-251-section.tsx
@@ -73,7 +73,7 @@ export const Section251Section: React.FC<HistoricDataHighNeedsProps> = ({
           "govuk-visually-hidden": !data?.length,
         })}
         data-module="govuk-accordion"
-        id="accordion-expenditure"
+        id="accordion-section-251"
       >
         {section251Sections.map((section, index) => (
           <div className="govuk-accordion__section" key={index}>
@@ -81,7 +81,7 @@ export const Section251Section: React.FC<HistoricDataHighNeedsProps> = ({
               <h2 className="govuk-accordion__section-heading">
                 <span
                   className="govuk-accordion__section-button"
-                  id={`accordion-expenditure-heading-${index + 1}`}
+                  id={`accordion-section-251-heading-${index + 1}`}
                 >
                   {section.heading}
                 </span>
@@ -96,7 +96,7 @@ export const Section251Section: React.FC<HistoricDataHighNeedsProps> = ({
               )}
             </div>
             <div
-              id={`accordion-expenditure-content-${index + 1}`}
+              id={`accordion-section-251-content-${index + 1}`}
               className="govuk-accordion__section-content"
             >
               {section.charts.map((chart) => (

--- a/front-end-components/src/views/historic-data-high-needs/partials/section-251-section.tsx
+++ b/front-end-components/src/views/historic-data-high-needs/partials/section-251-section.tsx
@@ -1,0 +1,112 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { ChartMode } from "src/components";
+import {
+  LocalAuthoritySection251,
+  LocalAuthoritySection251History,
+} from "src/services";
+import { useChartModeContext } from "src/contexts";
+import { Loading } from "src/components/loading";
+import { HistoricDataHighNeedsProps } from "../types";
+import { section251Sections } from ".";
+import classNames from "classnames";
+import { DataWarning } from "src/components/charts/data-warning";
+import { HighNeedsApi } from "src/services/high-needs-api";
+import { HistoricChartSection251 } from "src/composed/historic-chart-section-251-composed";
+
+export const Section251Section: React.FC<HistoricDataHighNeedsProps> = ({
+  code,
+  load,
+  fetchTimeout,
+}) => {
+  const { chartMode, setChartMode } = useChartModeContext();
+  const [data, setData] = useState<
+    LocalAuthoritySection251History<LocalAuthoritySection251>[] | undefined
+  >();
+  const [loadError, setLoadError] = useState<string>();
+
+  const getData = useCallback(async () => {
+    if (!load) {
+      return undefined;
+    }
+
+    setLoadError(undefined);
+    setData(undefined);
+    return await HighNeedsApi.history(
+      code,
+      fetchTimeout ? [AbortSignal.timeout(fetchTimeout)] : undefined
+    );
+  }, [code, load, fetchTimeout]);
+
+  useEffect(() => {
+    getData()
+      .then((result) => {
+        setData(result);
+      })
+      .catch((e: Error) => {
+        setData([]);
+
+        if (e.name !== "AbortError") {
+          setLoadError("Unable to load historical section 251 data");
+        }
+      });
+  }, [getData]);
+
+  return (
+    <>
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-two-thirds">&nbsp;</div>
+        <div className="govuk-grid-column-one-third">
+          <ChartMode
+            chartMode={chartMode}
+            handleChange={setChartMode}
+            prefix="section-251"
+          />
+        </div>
+      </div>
+      <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-0" />
+      {loadError ? (
+        <DataWarning>{loadError}</DataWarning>
+      ) : (
+        !data && <Loading />
+      )}
+      <div
+        className={classNames("govuk-accordion", {
+          "govuk-visually-hidden": !data?.length,
+        })}
+        data-module="govuk-accordion"
+        id="accordion-expenditure"
+      >
+        {section251Sections.map((section, index) => (
+          <div className="govuk-accordion__section" key={index}>
+            <div className="govuk-accordion__section-header">
+              <h2 className="govuk-accordion__section-heading">
+                <span
+                  className="govuk-accordion__section-button"
+                  id={`accordion-expenditure-heading-${index + 1}`}
+                >
+                  {section.heading}
+                </span>
+              </h2>
+            </div>
+            <div
+              id={`accordion-expenditure-content-${index + 1}`}
+              className="govuk-accordion__section-content"
+            >
+              {section.charts.map((chart) => (
+                <section key={chart.field}>
+                  <HistoricChartSection251
+                    chartTitle={chart.name}
+                    data={data}
+                    valueField={chart.field}
+                  >
+                    <h3 className="govuk-heading-s">{chart.name}</h3>
+                  </HistoricChartSection251>
+                </section>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+};

--- a/front-end-components/src/views/historic-data-high-needs/partials/send-2-section.tsx
+++ b/front-end-components/src/views/historic-data-high-needs/partials/send-2-section.tsx
@@ -1,0 +1,5 @@
+import { HistoricDataHighNeedsProps } from "../types";
+
+export const Send2Section: React.FC<HistoricDataHighNeedsProps> = () => {
+  return <p className="govuk-body">TODO</p>;
+};

--- a/front-end-components/src/views/historic-data-high-needs/types.tsx
+++ b/front-end-components/src/views/historic-data-high-needs/types.tsx
@@ -22,6 +22,7 @@ export type HistoricChartSection251Section<
   TData extends LocalAuthoritySection251,
 > = {
   heading: string;
+  summary?: string;
   charts: HistoricDataHighNeedsSection251Chart<TData>[];
 };
 

--- a/front-end-components/src/views/historic-data-high-needs/types.tsx
+++ b/front-end-components/src/views/historic-data-high-needs/types.tsx
@@ -1,0 +1,37 @@
+import { ReactNode } from "react";
+import { ResolvedStatProps } from "src/components/charts/resolved-stat";
+import { HistoricChartSection251Props } from "src/composed/historic-chart-section-251-composed";
+import { LocalAuthoritySection251 } from "src/services";
+
+export type HistoricDataHighNeedsProps = {
+  code: string;
+  load?: boolean;
+  fetchTimeout?: number;
+};
+
+export type HistoricDataHighNeedsViewProps = Omit<
+  HistoricDataHighNeedsProps,
+  "load"
+> & {
+  preLoadSections?: HistoricDataHighNeedsSectionName[];
+};
+
+export type HistoricDataHighNeedsSectionName = "section-251" | "send-2";
+
+export type HistoricChartSection251Section<
+  TData extends LocalAuthoritySection251,
+> = {
+  heading: string;
+  charts: HistoricDataHighNeedsSection251Chart<TData>[];
+};
+
+export type HistoricDataHighNeedsSection251Chart<
+  TData extends LocalAuthoritySection251,
+> = Pick<HistoricChartSection251Props<TData>, "valueUnit" | "axisLabel"> & {
+  name: string;
+  field: ResolvedStatProps<TData>["valueField"];
+  details?: {
+    label: string;
+    content: ReactNode;
+  };
+};

--- a/front-end-components/src/views/historic-data-high-needs/view.tsx
+++ b/front-end-components/src/views/historic-data-high-needs/view.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import {
+  HistoricDataHighNeedsSectionName,
+  HistoricDataHighNeedsViewProps,
+} from "src/views/historic-data-high-needs/types";
+import { useGovUk } from "src/hooks/useGovUk";
+import { ChartModeChart } from "src/components";
+import { ChartModeProvider } from "src/contexts";
+import {
+  Section251Section,
+  Send2Section,
+} from "src/views/historic-data-high-needs/partials";
+
+export const HistoricDataHighNeeds: React.FC<
+  HistoricDataHighNeedsViewProps
+> = ({ preLoadSections, ...props }) => {
+  const [loadedSections, setLoadedSections] = useState<
+    HistoricDataHighNeedsSectionName[]
+  >(preLoadSections ?? ["section-251"]);
+  useGovUk();
+
+  const handleSectionLoad = (section: HistoricDataHighNeedsSectionName) => {
+    if (loadedSections.includes(section)) {
+      return;
+    }
+
+    setLoadedSections([...loadedSections, section]);
+  };
+
+  return (
+    <div className="govuk-tabs" data-module="govuk-tabs">
+      <ul className="govuk-tabs__list">
+        <li className="govuk-tabs__list-item govuk-tabs__list-item--selected">
+          <a
+            className="govuk-tabs__tab"
+            href="#section-251"
+            onClick={() => handleSectionLoad("section-251")}
+          >
+            Section 251
+          </a>
+        </li>
+        <li className="govuk-tabs__list-item">
+          <a
+            className="govuk-tabs__tab"
+            href="#send-2"
+            onClick={() => handleSectionLoad("send-2")}
+          >
+            SEND 2
+          </a>
+        </li>
+      </ul>
+      <ChartModeProvider initialValue={ChartModeChart}>
+        <div className="govuk-tabs__panel" id="section-251">
+          <Section251Section
+            {...props}
+            load={loadedSections.includes("section-251")}
+          />
+        </div>
+        <div
+          className="govuk-tabs__panel govuk-tabs__panel--hidden"
+          id="send-2"
+        >
+          <Send2Section {...props} load={loadedSections.includes("send-2")} />
+        </div>
+      </ChartModeProvider>
+    </div>
+  );
+};


### PR DESCRIPTION
### Context
[AB#251207](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/251207) [AB#249550](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249550)

### Change proposed in this pull request
- Created new view containing two tabs
- Implemented Section 251 tab, leaving SEND 2 tab empty for now
- Added chart section and multi-series configuration
- Mapped to charts and tables from API response
- Added tooltips and stats to charts (subject to design crit)
- Added explicit error logging and correlation ID to underlying function app

### Guidance to review 
May be validated locally using Vite dev server with the stubbed data from the API. e.g.:

![image](https://github.com/user-attachments/assets/b595af81-c0fd-4950-a571-e769a9d34b14)

![image](https://github.com/user-attachments/assets/b0378612-301d-4733-a8de-ea5a514eea44)

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

