### PR TITLE
Warning message on High need dashboard if national ranking could not be loaded

### DIFF
--- a/web/src/Web.App/ViewComponents/LocalAuthorityHighNeedsNationalRankingsViewComponent.cs
+++ b/web/src/Web.App/ViewComponents/LocalAuthorityHighNeedsNationalRankingsViewComponent.cs
@@ -7,7 +7,9 @@ using Web.App.ViewModels.Components;
 
 namespace Web.App.ViewComponents;
 
-public class LocalAuthorityHighNeedsNationalRankingsViewComponent(IEstablishmentApi establishmentApi) : ViewComponent
+public class LocalAuthorityHighNeedsNationalRankingsViewComponent(
+    IEstablishmentApi establishmentApi,
+    ILogger<LocalAuthorityHighNeedsNationalRankingsViewComponent> logger) : ViewComponent
 {
     public async Task<IViewComponentResult> InvokeAsync(string identifier, string sort = "asc", int count = 5, CancellationToken cancellationToken = default)
     {
@@ -16,7 +18,13 @@ public class LocalAuthorityHighNeedsNationalRankingsViewComponent(IEstablishment
             .GetLocalAuthoritiesNationalRank(query, cancellationToken)
             .GetResultOrDefault<LocalAuthorityRanking>();
 
-        return View(new LocalAuthorityHighNeedsNationalRankingsViewModel(identifier, result, count));
+        if (result?.Ranking is { Length: > 0 })
+        {
+            return View(new LocalAuthorityHighNeedsNationalRankingsViewModel(identifier, result, count));
+        }
+
+        logger.LogWarning("Local authority national rankings could not be displayed for {Code}", identifier);
+        return View("MissingData");
     }
 
     private static ApiQuery BuildQuery(string? sort)

--- a/web/src/Web.App/Views/LocalAuthorityHighNeeds/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeeds/Index.cshtml
@@ -52,12 +52,6 @@
                 {
                     identifier = Model.Code
                 })
-                <a href="@Url.Action("Index", "LocalAuthorityHighNeedsNationalRankings", new
-                         {
-                             code = Model.Code
-                         })" role="button" class="govuk-button govuk-button--secondary" data-module="govuk-button">
-                    View national rankings
-                </a>
             </div>
         </div>
     </div>

--- a/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsNationalRankings/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsNationalRankings/Default.cshtml
@@ -29,3 +29,9 @@
     }
     </tbody>
 </table>
+
+<a
+    href="@Url.Action("Index", "LocalAuthorityHighNeedsNationalRankings", new { code = Model.Code })"
+    role="button"
+    class="govuk-button govuk-button--secondary"
+    data-module="govuk-button">View national rankings</a>

--- a/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsNationalRankings/MissingData.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsNationalRankings/MissingData.cshtml
@@ -1,0 +1,7 @@
+<div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+        <span class="govuk-visually-hidden">Warning</span>
+        National Ranking could not be displayed.
+    </strong>
+</div>


### PR DESCRIPTION
### Context
[AB#251215](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/251215) [AB#249550](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249550) #2038

### Change proposed in this pull request
- Added warning message with integration test coverage
- Conditionally rendered national rankings CTA based on successful retrieval of underlying data

### Guidance to review 
Dependent on #2038. Published to `d18` feature environment for validation.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] You have reviewed with UX/Design

