### PR TITLE
Warning message on High need dashboard if High needs history could not be loaded

### DIFF
--- a/web/src/Web.App/Domain/LocalAuthorities/History.cs
+++ b/web/src/Web.App/Domain/LocalAuthorities/History.cs
@@ -6,6 +6,6 @@ public record HighNeedsHistory<T>
 {
     public int? StartYear { get; set; }
     public int? EndYear { get; set; }
-    public T[]? Outturn { get; set; } = [];
-    public T[]? Budget { get; set; } = [];
+    public T[]? Outturn { get; set; }
+    public T[]? Budget { get; set; }
 }

--- a/web/src/Web.App/ViewComponents/LocalAuthorityHighNeedsHistoryViewComponent.cs
+++ b/web/src/Web.App/ViewComponents/LocalAuthorityHighNeedsHistoryViewComponent.cs
@@ -7,7 +7,9 @@ using Web.App.ViewModels.Components;
 
 namespace Web.App.ViewComponents;
 
-public class LocalAuthorityHighNeedsHistoryViewComponent(ILocalAuthoritiesApi localAuthoritiesApi) : ViewComponent
+public class LocalAuthorityHighNeedsHistoryViewComponent(
+    ILocalAuthoritiesApi localAuthoritiesApi,
+    ILogger<LocalAuthorityHighNeedsNationalRankingsViewComponent> logger) : ViewComponent
 {
     public async Task<IViewComponentResult> InvokeAsync(string identifier, CancellationToken cancellationToken = default)
     {
@@ -16,7 +18,13 @@ public class LocalAuthorityHighNeedsHistoryViewComponent(ILocalAuthoritiesApi lo
             .GetHighNeedsHistory(query, cancellationToken)
             .GetResultOrDefault<HighNeedsHistory<LocalAuthorityHighNeedsYear>>();
 
-        return View(new LocalAuthorityHighNeedsHistoryViewModel(identifier, history));
+        if (history is { Outturn.Length: > 0, Budget.Length: > 0 })
+        {
+            return View(new LocalAuthorityHighNeedsHistoryViewModel(identifier, history));
+        }
+
+        logger.LogWarning("Local authority high needs history could not be displayed for {Code}", identifier);
+        return View("MissingData");
     }
 
     private static ApiQuery BuildQuery(params string[] code)

--- a/web/src/Web.App/Views/LocalAuthorityHighNeeds/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeeds/Index.cshtml
@@ -65,12 +65,6 @@
                 {
                     identifier = Model.Code
                 })
-                <a href="@Url.Action("Index", "LocalAuthorityHighNeedsHistoricData", new
-                         {
-                             code = Model.Code
-                         })" role="button" class="govuk-button govuk-button--secondary" data-module="govuk-button">
-                    View historic data
-                </a>
             </div>
         </div>
     </div>

--- a/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsHistory/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsHistory/Default.cshtml
@@ -41,3 +41,9 @@
     }
     </tbody>
 </table>
+
+<a
+    href="@Url.Action("Index", "LocalAuthorityHighNeedsHistoricData", new { code = Model.Code })"
+    role="button"
+    class="govuk-button govuk-button--secondary"
+    data-module="govuk-button">View historic data</a>

--- a/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsHistory/MissingData.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsHistory/MissingData.cshtml
@@ -1,0 +1,7 @@
+<div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+        <span class="govuk-visually-hidden">Warning</span>
+        Budget vs spend (historical view) could not be displayed.
+    </strong>
+</div>


### PR DESCRIPTION
### Context
[AB#251214](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/251214) [AB#249539](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249539)

### Change proposed in this pull request
- Added warning message with integration test coverage
- Conditionally rendered High needs history CTA based on successful retrieval of underlying data

### Guidance to review 
Published to `d18` feature environment for validation.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] You have reviewed with UX/Design

