### PR TITLE
feat: add content to `Send2Section` component

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -150,6 +150,7 @@
     </svg> -->
     <!--<div id="la-national-rank" data-code="201"></div>-->
     <div id="historic-data-high-needs" data-code="201"></div>
+    <!-- <div id="historic-data" data-type="school" data-id="114504"></div> -->
     <script type="module" src="/src/main.tsx"></script>
     <script
       type="module"

--- a/front-end-components/src/services/education-health-care-plans-api.tsx
+++ b/front-end-components/src/services/education-health-care-plans-api.tsx
@@ -1,0 +1,33 @@
+import { LocalAuthoritySend2History } from "src/services/types";
+import { v4 as uuidv4 } from "uuid";
+
+export class EducationHealthCarePlanApi {
+  static async history(
+    code: string,
+    signals?: AbortSignal[]
+  ): Promise<LocalAuthoritySend2History[]> {
+    const params = new URLSearchParams({
+      code,
+    });
+
+    const response = await fetch(
+      "/api/local-authorities/education-health-care-plans/history?" + params,
+      {
+        redirect: "manual",
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Correlation-ID": uuidv4(),
+        },
+        signal: signals?.length ? AbortSignal.any(signals) : undefined,
+      }
+    );
+
+    const json = await response.json();
+    if (json.error) {
+      throw json.error;
+    }
+
+    return json;
+  }
+}

--- a/front-end-components/src/services/types.tsx
+++ b/front-end-components/src/services/types.tsx
@@ -446,3 +446,17 @@ export type LocalAuthoritySection251 = {
   placeFundingSpecial?: number;
   placeFundingAlternativeProvision?: number;
 };
+
+export type LocalAuthorityEducationHealthCarePlan = {
+  total?: number;
+  mainstream?: number;
+  resourced?: number;
+  special?: number;
+  independent?: number;
+  hospital?: number;
+  post16?: number;
+  other?: number;
+};
+
+export type LocalAuthoritySend2History = HistoryBase &
+  LocalAuthorityEducationHealthCarePlan;

--- a/front-end-components/src/views/historic-data-high-needs/partials/index.tsx
+++ b/front-end-components/src/views/historic-data-high-needs/partials/index.tsx
@@ -1,5 +1,11 @@
-import { LocalAuthoritySection251 } from "src/services";
-import { HistoricChartSection251Section } from "../types";
+import {
+  LocalAuthoritySection251,
+  LocalAuthorityEducationHealthCarePlan,
+} from "src/services";
+import {
+  HistoricChartSection251Section,
+  HistoricChartSend2Section,
+} from "../types";
 
 /* eslint-disable react-refresh/only-export-components */
 export * from "src/views/historic-data-high-needs/partials/section-251-section.tsx";
@@ -136,3 +142,48 @@ export const section251Sections: HistoricChartSection251Section<LocalAuthoritySe
       ],
     },
   ];
+
+export const send2LeadSection: HistoricChartSend2Section<LocalAuthorityEducationHealthCarePlan> =
+  {
+    charts: [
+      {
+        name: "Number aged up to 25 with SEN statement or EHC plan",
+        field: "total",
+      },
+    ],
+  };
+export const send2AccordionSection: HistoricChartSend2Section<LocalAuthorityEducationHealthCarePlan> =
+  {
+    heading:
+      "Placement of pupils aged up to 25 with SEN statement or EHC plan (per 1000 2 to 18 population)",
+    charts: [
+      {
+        name: "Mainstream schools or academies",
+        field: "mainstream",
+      },
+      {
+        name: "Resourced provision or SEN units",
+        field: "resourced",
+      },
+      {
+        name: "Maintained special schools or special academies",
+        field: "special",
+      },
+      {
+        name: "NMSS or independent schools",
+        field: "independent",
+      },
+      {
+        name: "Hospital schools or alternative provisions",
+        field: "hospital",
+      },
+      {
+        name: "Post 16",
+        field: "post16",
+      },
+      {
+        name: "Other",
+        field: "other",
+      },
+    ],
+  };

--- a/front-end-components/src/views/historic-data-high-needs/partials/send-2-section.tsx
+++ b/front-end-components/src/views/historic-data-high-needs/partials/send-2-section.tsx
@@ -1,5 +1,128 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { ChartMode } from "src/components";
+import { LocalAuthoritySend2History } from "src/services";
+import { useChartModeContext } from "src/contexts";
+import { Loading } from "src/components/loading";
 import { HistoricDataHighNeedsProps } from "../types";
+import classNames from "classnames";
+import { DataWarning } from "src/components/charts/data-warning";
+import { EducationHealthCarePlanApi } from "src/services/education-health-care-plans-api";
+import { HistoricChart } from "src/composed/historic-chart-composed";
+import { send2LeadSection, send2AccordionSection } from ".";
 
-export const Send2Section: React.FC<HistoricDataHighNeedsProps> = () => {
-  return <p className="govuk-body">TODO</p>;
+export const Send2Section: React.FC<HistoricDataHighNeedsProps> = ({
+  code,
+  load,
+  fetchTimeout,
+}) => {
+  const { chartMode, setChartMode } = useChartModeContext();
+  const [data, setData] = useState<LocalAuthoritySend2History[] | undefined>();
+  const [loadError, setLoadError] = useState<string>();
+
+  const getData = useCallback(async () => {
+    if (!load) {
+      return undefined;
+    }
+
+    setLoadError(undefined);
+    setData(undefined);
+    return await EducationHealthCarePlanApi.history(
+      code,
+      fetchTimeout ? [AbortSignal.timeout(fetchTimeout)] : undefined
+    );
+  }, [code, load, fetchTimeout]);
+
+  useEffect(() => {
+    getData()
+      .then((result) => {
+        setData(result);
+      })
+      .catch((e: Error) => {
+        setData([]);
+
+        if (e.name !== "AbortError") {
+          setLoadError("Unable to load historical send 2 data");
+        }
+      });
+  }, [getData]);
+
+  return (
+    <>
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-two-thirds">&nbsp;</div>
+        <div className="govuk-grid-column-one-third">
+          <ChartMode
+            chartMode={chartMode}
+            handleChange={setChartMode}
+            prefix="send-2"
+          />
+        </div>
+      </div>
+      {loadError ? (
+        <DataWarning>{loadError}</DataWarning>
+      ) : (
+        !data && <Loading />
+      )}
+      {data &&
+        send2LeadSection.charts.map((chart, index) => (
+          <HistoricChart
+            key={index}
+            chartTitle={chart.name}
+            data={data}
+            seriesConfig={{
+              [chart.field]: {
+                visible: true,
+              },
+            }}
+            valueField={chart.field}
+            columnHeading="Amount"
+          >
+            <h2 className="govuk-heading-m">{chart.name}</h2>
+          </HistoricChart>
+        ))}
+      <div
+        className={classNames("govuk-accordion", {
+          "govuk-visually-hidden": !data?.length,
+        })}
+        data-module="govuk-accordion"
+        id="accordion-section-251"
+      >
+        <div className="govuk-accordion__section">
+          <div className="govuk-accordion__section-header">
+            <h2 className="govuk-accordion__section-heading">
+              <span
+                className="govuk-accordion__section-button"
+                id="accordion-send-2-heading"
+              >
+                {send2AccordionSection.heading}
+              </span>
+            </h2>
+          </div>
+          <div
+            id={"accordion-send-2-content"}
+            className="govuk-accordion__section-content"
+          >
+            {data &&
+              send2AccordionSection.charts.map((chart, index) => (
+                <HistoricChart
+                  key={index}
+                  chartTitle={chart.name}
+                  data={data}
+                  seriesConfig={{
+                    [chart.field]: {
+                      label: chart.name,
+                      visible: true,
+                    },
+                  }}
+                  valueField={chart.field}
+                  columnHeading="Amount"
+                >
+                  <h2 className="govuk-heading-m">{chart.name}</h2>
+                </HistoricChart>
+              ))}
+          </div>
+        </div>
+      </div>
+    </>
+  );
 };

--- a/front-end-components/src/views/historic-data-high-needs/partials/send-2-section.tsx
+++ b/front-end-components/src/views/historic-data-high-needs/partials/send-2-section.tsx
@@ -64,28 +64,30 @@ export const Send2Section: React.FC<HistoricDataHighNeedsProps> = ({
         !data && <Loading />
       )}
       {data &&
-        send2LeadSection.charts.map((chart, index) => (
-          <HistoricChart
-            key={index}
-            chartTitle={chart.name}
-            data={data}
-            seriesConfig={{
-              [chart.field]: {
-                visible: true,
-              },
-            }}
-            valueField={chart.field}
-            columnHeading="Amount"
-          >
-            <h2 className="govuk-heading-m">{chart.name}</h2>
-          </HistoricChart>
+        data.length > 0 &&
+        send2LeadSection.charts.map((chart) => (
+          <section key={chart.field}>
+            <HistoricChart
+              chartTitle={chart.name}
+              data={data}
+              seriesConfig={{
+                [chart.field]: {
+                  visible: true,
+                },
+              }}
+              valueField={chart.field}
+              columnHeading="Amount"
+            >
+              <h2 className="govuk-heading-m">{chart.name}</h2>
+            </HistoricChart>
+          </section>
         ))}
       <div
         className={classNames("govuk-accordion", {
           "govuk-visually-hidden": !data?.length,
         })}
         data-module="govuk-accordion"
-        id="accordion-section-251"
+        id="accordion-send-2"
       >
         <div className="govuk-accordion__section">
           <div className="govuk-accordion__section-header">
@@ -103,22 +105,24 @@ export const Send2Section: React.FC<HistoricDataHighNeedsProps> = ({
             className="govuk-accordion__section-content"
           >
             {data &&
-              send2AccordionSection.charts.map((chart, index) => (
-                <HistoricChart
-                  key={index}
-                  chartTitle={chart.name}
-                  data={data}
-                  seriesConfig={{
-                    [chart.field]: {
-                      label: chart.name,
-                      visible: true,
-                    },
-                  }}
-                  valueField={chart.field}
-                  columnHeading="Amount"
-                >
-                  <h2 className="govuk-heading-m">{chart.name}</h2>
-                </HistoricChart>
+              data.length > 0 &&
+              send2AccordionSection.charts.map((chart) => (
+                <section key={chart.field}>
+                  <HistoricChart
+                    chartTitle={chart.name}
+                    data={data}
+                    seriesConfig={{
+                      [chart.field]: {
+                        label: chart.name,
+                        visible: true,
+                      },
+                    }}
+                    valueField={chart.field}
+                    columnHeading="Amount"
+                  >
+                    <h2 className="govuk-heading-m">{chart.name}</h2>
+                  </HistoricChart>
+                </section>
               ))}
           </div>
         </div>

--- a/front-end-components/src/views/historic-data-high-needs/types.tsx
+++ b/front-end-components/src/views/historic-data-high-needs/types.tsx
@@ -1,7 +1,10 @@
 import { ReactNode } from "react";
 import { ResolvedStatProps } from "src/components/charts/resolved-stat";
 import { HistoricChartSection251Props } from "src/composed/historic-chart-section-251-composed";
-import { LocalAuthoritySection251 } from "src/services";
+import {
+  LocalAuthoritySection251,
+  LocalAuthorityEducationHealthCarePlan,
+} from "src/services";
 
 export type HistoricDataHighNeedsProps = {
   code: string;
@@ -29,6 +32,24 @@ export type HistoricChartSection251Section<
 export type HistoricDataHighNeedsSection251Chart<
   TData extends LocalAuthoritySection251,
 > = Pick<HistoricChartSection251Props<TData>, "valueUnit" | "axisLabel"> & {
+  name: string;
+  field: ResolvedStatProps<TData>["valueField"];
+  details?: {
+    label: string;
+    content: ReactNode;
+  };
+};
+
+export type HistoricChartSend2Section<
+  TData extends LocalAuthorityEducationHealthCarePlan,
+> = {
+  heading?: string;
+  charts: HistoricDataHighNeedsSend2Chart<TData>[];
+};
+
+export type HistoricDataHighNeedsSend2Chart<
+  TData extends LocalAuthorityEducationHealthCarePlan,
+> = {
   name: string;
   field: ResolvedStatProps<TData>["valueField"];
   details?: {


### PR DESCRIPTION
### Context
[AB#249550](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249550) - [AB#251208](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/251208)

### Change proposed in this pull request
- using existing `HistoricChart` component. 
- `EducationHealthCarePlanApi` created to support this.

### Guidance to review 
Currently `axisLabel` is not included but can be added quickly if later required.
Can run locally using Vite or copy and build `front-end` to Web to verify.

Will require a bump to `front-end` and then can be deployed to `d18`

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

