### PR TITLE
Added and wired up Budget vs spend (historical view) dashboard content to new `Total` field on `LocalAuthorityHighNeeds`

### DIFF
--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/Models/History.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/Models/History.cs
@@ -18,6 +18,7 @@ public record LocalAuthorityHighNeedsYear : LocalAuthorityHighNeeds
 public record LocalAuthorityHighNeeds
 {
     public string? Code { get; set; }
+    public decimal? Total { get; set; }
     public HighNeedsAmount HighNeedsAmount { get; set; } = new();
     public TopFunding Maintained { get; set; } = new();
     public TopFunding NonMaintained { get; set; } = new();

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/Services/HighNeedsHistoryStubService.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/Services/HighNeedsHistoryStubService.cs
@@ -47,6 +47,7 @@ public class HighNeedsHistoryStubService : IHighNeedsHistoryService
     {
         Code = code,
         Year = year,
+        Total = baseValue + 10_000 + year,
         HighNeedsAmount = new HighNeedsAmount
         {
             TotalPlaceFunding = baseValue + 1 + year,

--- a/platform/tests/Platform.ApiTests/Features/LocalAuthoritiesHighNeeds.feature
+++ b/platform/tests/Platform.ApiTests/Features/LocalAuthoritiesHighNeeds.feature
@@ -8,21 +8,25 @@ Feature: Local authorities high needs endpoints
           | Start year | End year |
           | 2021       | 2024     |
         And the high needs result should contain the following outturn values for '2021':
-          | Field | Value |
-          | Year  | 2021  |
-          | Code  | 201   |
+          | Field | Value   |
+          | Year  | 2021    |
+          | Code  | 201     |
+          | Total | 1012021 |
         And the high needs result should contain the following outturn values for '2022':
-          | Field | Value |
-          | Year  | 2022  |
-          | Code  | 201   |
+          | Field | Value   |
+          | Year  | 2022    |
+          | Code  | 201     |
+          | Total | 1012022 |
         And the high needs result should contain the following outturn values for '2023':
-          | Field | Value |
-          | Year  | 2023  |
-          | Code  | 201   |
+          | Field | Value   |
+          | Year  | 2023    |
+          | Code  | 201     |
+          | Total | 1012023 |
         And the high needs result should contain the following outturn values for '2024':
-          | Field | Value |
-          | Year  | 2024  |
-          | Code  | 201   |
+          | Field | Value   |
+          | Year  | 2024    |
+          | Code  | 201     |
+          | Total | 1012024 |
         And the high needs result should contain the following outturn high needs amount values for '2021':
           | Field                        | Value   |
           | TotalPlaceFunding            | 1002022 |
@@ -64,21 +68,25 @@ Feature: Local authorities high needs endpoints
           | Start year | End year |
           | 2021       | 2024     |
         And the high needs result should contain the following budget values for '2021':
-          | Field | Value |
-          | Year  | 2021  |
-          | Code  | 201   |
+          | Field | Value   |
+          | Year  | 2021    |
+          | Code  | 201     |
+          | Total | 1112021 |
         And the high needs result should contain the following budget values for '2022':
-          | Field | Value |
-          | Year  | 2022  |
-          | Code  | 201   |
+          | Field | Value   |
+          | Year  | 2022    |
+          | Code  | 201     |
+          | Total | 1112022 |
         And the high needs result should contain the following budget values for '2023':
-          | Field | Value |
-          | Year  | 2023  |
-          | Code  | 201   |
+          | Field | Value   |
+          | Year  | 2023    |
+          | Code  | 201     |
+          | Total | 1112023 |
         And the high needs result should contain the following budget values for '2024':
-          | Field | Value |
-          | Year  | 2024  |
-          | Code  | 201   |
+          | Field | Value   |
+          | Year  | 2024    |
+          | Code  | 201     |
+          | Total | 1112024 |
         And the high needs result should contain the following budget high needs amount values for '2021':
           | Field                        | Value   |
           | TotalPlaceFunding            | 1102022 |

--- a/web/src/Web.App/Controllers/Api/Mappers/LocalAuthorityHighNeedsHistoryResponseMapper.cs
+++ b/web/src/Web.App/Controllers/Api/Mappers/LocalAuthorityHighNeedsHistoryResponseMapper.cs
@@ -95,16 +95,9 @@ public static class LocalAuthorityHighNeedsHistoryResponseMapper
 
     private static decimal? MapToTotal(this LocalAuthorityHighNeedsYear[]? highNeedsYear, string code, int year)
     {
-        var item = highNeedsYear?
+        return highNeedsYear?
             .Where(o => o.Year == year)
-            .SingleOrDefault(o => o.Code == code);
-
-        if (item == null)
-        {
-            return null;
-        }
-
-        // todo: clarify data point/calculation to use
-        return item.HighNeedsAmount?.TotalPlaceFunding;
+            .SingleOrDefault(o => o.Code == code)
+            ?.Total;
     }
 }

--- a/web/src/Web.App/Domain/LocalAuthorities/LocalAuthorityHighNeeds.cs
+++ b/web/src/Web.App/Domain/LocalAuthorities/LocalAuthorityHighNeeds.cs
@@ -7,6 +7,7 @@ namespace Web.App.Domain.LocalAuthorities;
 public record LocalAuthorityHighNeeds
 {
     public string? Code { get; set; }
+    public decimal? Total { get; set; }
     public HighNeedsAmount? HighNeedsAmount { get; set; }
     public TopFunding? Maintained { get; set; }
     public TopFunding? NonMaintained { get; set; }

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeeds.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeeds.cs
@@ -225,10 +225,10 @@ public class WhenViewingHighNeeds(SchoolBenchmarkingWebAppClient client) : PageB
             {
                 var outturn = history.Outturn.Single(o => o.Year == year);
                 var budget = history.Budget.Single(o => o.Year == year);
-                var outrunValue = outturn.HighNeedsAmount?.TotalPlaceFunding;
-                var budgetValue = budget.HighNeedsAmount?.TotalPlaceFunding;
-                var balanceValue = budgetValue - outrunValue;
-                DocumentAssert.AssertNodeText(bodyRows.ElementAt(i), $"{year}  Spend:\n                        {outrunValue?.ToString("C0")}\n                    \n                    \n                        Budget:\n                        {budgetValue?.ToString("C0")}  {balanceValue?.ToString("C0")}");
+                var outturnValue = outturn.Total;
+                var budgetValue = budget.Total;
+                var balanceValue = budgetValue - outturnValue;
+                DocumentAssert.AssertNodeText(bodyRows.ElementAt(i), $"{year}  Spend:\n                        {outturnValue?.ToString("C0")}\n                    \n                    \n                        Budget:\n                        {budgetValue?.ToString("C0")}  {balanceValue?.ToString("C0")}");
                 year++;
             }
         }

--- a/web/tests/Web.Integration.Tests/packages.lock.json
+++ b/web/tests/Web.Integration.Tests/packages.lock.json
@@ -2295,7 +2295,7 @@
       },
       "Swashbuckle.AspNetCore": {
         "type": "CentralTransitive",
-        "requested": "[7.3.0, )",
+        "requested": "[7.3.1, )",
         "resolved": "7.3.1",
         "contentHash": "6u8w+UXp/sF89xQjfydWw6znQrUpbpFOmEIs8ODE+S0bV+mCQ9dNP4mk+HRsGHylpDaP5KSYSCEfFSgluLXHsA==",
         "dependencies": {

--- a/web/tests/Web.Tests/Controllers/Api/Mappers/WhenLocalAuthorityHighNeedsHistoryResponseMapperMapsToDashboardWithCode.cs
+++ b/web/tests/Web.Tests/Controllers/Api/Mappers/WhenLocalAuthorityHighNeedsHistoryResponseMapperMapsToDashboardWithCode.cs
@@ -14,14 +14,14 @@ public class WhenLocalAuthorityHighNeedsHistoryResponseMapperMapsToDashboardWith
 
         var startYearResponse = actual.FirstOrDefault();
         Assert.NotNull(startYearResponse);
-        Assert.Equal(OutturnStartYear.HighNeedsAmount?.TotalPlaceFunding, startYearResponse.Outturn);
-        Assert.Equal(BudgetStartYear.HighNeedsAmount?.TotalPlaceFunding, startYearResponse.Budget);
-        Assert.Equal(BudgetStartYear.HighNeedsAmount?.TotalPlaceFunding - OutturnStartYear.HighNeedsAmount?.TotalPlaceFunding, startYearResponse.Balance);
+        Assert.Equal(OutturnStartYear.Total, startYearResponse.Outturn);
+        Assert.Equal(BudgetStartYear.Total, startYearResponse.Budget);
+        Assert.Equal(BudgetStartYear.Total - OutturnStartYear.Total, startYearResponse.Balance);
 
         var endYearResponse = actual.LastOrDefault();
         Assert.NotNull(endYearResponse);
-        Assert.Equal(OutturnEndYear.HighNeedsAmount?.TotalPlaceFunding, endYearResponse.Outturn);
-        Assert.Equal(BudgetEndYear.HighNeedsAmount?.TotalPlaceFunding, endYearResponse.Budget);
-        Assert.Equal(BudgetEndYear.HighNeedsAmount?.TotalPlaceFunding - OutturnEndYear.HighNeedsAmount?.TotalPlaceFunding, endYearResponse.Balance);
+        Assert.Equal(OutturnEndYear.Total, endYearResponse.Outturn);
+        Assert.Equal(BudgetEndYear.Total, endYearResponse.Budget);
+        Assert.Equal(BudgetEndYear.Total - OutturnEndYear.Total, endYearResponse.Balance);
     }
 }

--- a/web/tests/Web.Tests/packages.lock.json
+++ b/web/tests/Web.Tests/packages.lock.json
@@ -2090,7 +2090,7 @@
       },
       "Swashbuckle.AspNetCore": {
         "type": "CentralTransitive",
-        "requested": "[7.3.0, )",
+        "requested": "[7.3.1, )",
         "resolved": "7.3.1",
         "contentHash": "6u8w+UXp/sF89xQjfydWw6znQrUpbpFOmEIs8ODE+S0bV+mCQ9dNP4mk+HRsGHylpDaP5KSYSCEfFSgluLXHsA==",
         "dependencies": {


### PR DESCRIPTION
### Context
[AB#251922](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/251922) [AB#249540](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249540)

### Change proposed in this pull request
- Added new `Total` property to source model in Platform
- Stubbed `Total` value in the short term
- Mapped `Total` property in Web
- Updated affected tests

### Guidance to review 
Deployed to `d18` for validation

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] You have reviewed with UX/Design

