### PR TITLE
chore: bump `front-end` to `1.1.65`

### DIFF
--- a/web/src/Web.App/package-lock.json
+++ b/web/src/Web.App/package-lock.json
@@ -1440,9 +1440,9 @@
       }
     },
     "node_modules/front-end": {
-      "version": "1.1.63",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-1.1.63.tgz",
-      "integrity": "sha1-DUfWxmXsuowSmyLWGlK2s9YTUXI=",
+      "version": "1.1.65",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-1.1.65.tgz",
+      "integrity": "sha1-0xX/87gsbHOPYqpFcRh0dJz8+2Y=",
       "dependencies": {
         "accessible-autocomplete": "^3.0.0",
         "classnames": "^2.5.1",


### PR DESCRIPTION
### Context
[AB#249550](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249550) - #2060 

### Change proposed in this pull request
 bump `front-end` to `1.1.65`

### Guidance to review 
n/a

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

