### PR TITLE
Displayed statistical neighbours on High needs Start benchmarking page

### DIFF
--- a/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/Services/LocalAuthoritiesService.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/Services/LocalAuthoritiesService.cs
@@ -86,7 +86,7 @@ public class LocalAuthoritiesService(
             {
                 Code = stubbedCode,
                 Name = $"Local authority {stubbedCode}",
-                Order = i
+                Order = i + 1
             };
 
             neighbours.Add(value);

--- a/platform/tests/Platform.ApiTests/Features/EstablishmentLocalAuthorities.feature
+++ b/platform/tests/Platform.ApiTests/Features/EstablishmentLocalAuthorities.feature
@@ -228,13 +228,13 @@ Feature: Establishment local authorities endpoints
           | Name  | City of London |
         And the local authorities statistical neighbours result should contain the following neighbours:
           | Code | Name                | Order |
-          | 200  | Local authority 200 | 0     |
-          | 201  | Local authority 201 | 1     |
-          | 202  | Local authority 202 | 2     |
-          | 203  | Local authority 203 | 3     |
-          | 204  | Local authority 204 | 4     |
-          | 205  | Local authority 205 | 5     |
-          | 206  | Local authority 206 | 6     |
-          | 207  | Local authority 207 | 7     |
-          | 208  | Local authority 208 | 8     |
-          | 209  | Local authority 209 | 9     |
+          | 200  | Local authority 200 | 1     |
+          | 201  | Local authority 201 | 2     |
+          | 202  | Local authority 202 | 3     |
+          | 203  | Local authority 203 | 4     |
+          | 204  | Local authority 204 | 5     |
+          | 205  | Local authority 205 | 6     |
+          | 206  | Local authority 206 | 7     |
+          | 207  | Local authority 207 | 8     |
+          | 208  | Local authority 208 | 9     |
+          | 209  | Local authority 209 | 10    |

--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -554,3 +554,11 @@ hr.govuk-section-break--print {
     vertical-align: text-bottom;
   }
 }
+
+.govuk-inset-text {
+  > .govuk-list {
+    &.govuk-list--number {
+      padding-left: govuk-spacing(6);
+    }
+  }
+}

--- a/web/src/Web.App/Constants/PageTitles.cs
+++ b/web/src/Web.App/Constants/PageTitles.cs
@@ -63,7 +63,7 @@ public static class PageTitles
     public const string LocalAuthorityComparison = "View school spending";
     public const string LocalAuthorityCensus = "View pupil and workforce data";
     public const string LocalAuthorityHighNeeds = "High needs benchmarking";
-    public const string LocalAuthorityHighNeedsStartBenchmarking = "Start high needs benchmarking";
+    public const string LocalAuthorityHighNeedsStartBenchmarking = "Choose local authorities to benchmark against";
     public const string LocalAuthorityHighNeedsHistoricData = "High needs historic data";
     public const string LocalAuthorityHighNeedsNationalRankings = "High needs national rankings";
     public const string TrustSpending = "Spending priorities for this trust";

--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsBenchmarkingController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsBenchmarkingController.cs
@@ -31,8 +31,8 @@ public class LocalAuthorityHighNeedsBenchmarkingController(
             {
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.LocalAuthorityHome(code);
 
-                var authority = await LocalAuthority(code);
-                var viewModel = new LocalAuthorityViewModel(authority);
+                var neighbours = await LocalAuthorityStatisticalNeighbours(code);
+                var viewModel = new LocalAuthorityStatisticalNeighboursViewModel(neighbours);
                 return View(viewModel);
             }
             catch (Exception e)
@@ -43,7 +43,10 @@ public class LocalAuthorityHighNeedsBenchmarkingController(
         }
     }
 
-    private async Task<LocalAuthority> LocalAuthority(string code) => await establishmentApi
-        .GetLocalAuthority(code)
-        .GetResultOrThrow<LocalAuthority>();
+    private async Task<LocalAuthorityStatisticalNeighbours> LocalAuthorityStatisticalNeighbours(string code)
+    {
+        return await establishmentApi
+            .GetLocalAuthorityStatisticalNeighbours(code)
+            .GetResultOrThrow<LocalAuthorityStatisticalNeighbours>();
+    }
 }

--- a/web/src/Web.App/Domain/Establishment/LocalAuthorityStatisticalNeighbours.cs
+++ b/web/src/Web.App/Domain/Establishment/LocalAuthorityStatisticalNeighbours.cs
@@ -1,0 +1,23 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+// ReSharper disable ClassNeverInstantiated.Global
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+// ReSharper disable AutoPropertyCanBeMadeGetOnly.Global
+
+namespace Web.App.Domain;
+
+[ExcludeFromCodeCoverage]
+public record LocalAuthorityStatisticalNeighbours
+{
+    public string? Code { get; set; }
+    public string? Name { get; set; }
+    public IEnumerable<LocalAuthorityStatisticalNeighbour>? StatisticalNeighbours { get; set; }
+}
+
+[ExcludeFromCodeCoverage]
+public record LocalAuthorityStatisticalNeighbour
+{
+    public string? Code { get; set; }
+    public string? Name { get; set; }
+    public int? Order { get; set; }
+}

--- a/web/src/Web.App/Infrastructure/Apis/Establishment/Api.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Establishment/Api.cs
@@ -9,8 +9,21 @@ public static class Api
         public static string TrustSuggest => "api/trusts/suggest";
         public static string LocalAuthoritySuggest => "api/local-authorities/suggest";
         public static string LocalAuthorityNationalRank => "api/local-authorities/national-rank";
-        public static string School(string? identifier) => $"api/school/{identifier}";
-        public static string Trust(string? identifier) => $"api/trust/{identifier}";
-        public static string LocalAuthority(string? identifier) => $"api/local-authority/{identifier}";
+        public static string School(string? identifier)
+        {
+            return $"api/school/{identifier}";
+        }
+        public static string Trust(string? identifier)
+        {
+            return $"api/trust/{identifier}";
+        }
+        public static string LocalAuthority(string? identifier)
+        {
+            return $"api/local-authority/{identifier}";
+        }
+        public static string LocalAuthorityStatisticalNeighbours(string? identifier)
+        {
+            return $"api/local-authority/{identifier}/statistical-neighbours";
+        }
     }
 }

--- a/web/src/Web.App/Infrastructure/Apis/Establishment/EstablishmentApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Establishment/EstablishmentApi.cs
@@ -17,6 +17,11 @@ public class EstablishmentApi(HttpClient httpClient, string? key = default) : Ap
         return GetAsync(Api.Establishment.LocalAuthority(identifier));
     }
 
+    public Task<ApiResult> GetLocalAuthorityStatisticalNeighbours(string? identifier)
+    {
+        return GetAsync(Api.Establishment.LocalAuthorityStatisticalNeighbours(identifier));
+    }
+
     public Task<ApiResult> GetLocalAuthoritiesNationalRank(ApiQuery? query = null, CancellationToken cancellationToken = default)
     {
         return GetAsync($"{Api.Establishment.LocalAuthorityNationalRank}{query?.ToQueryString()}", cancellationToken);
@@ -58,6 +63,7 @@ public interface IEstablishmentApi
     Task<ApiResult> GetSchool(string? identifier);
     Task<ApiResult> GetTrust(string? identifier);
     Task<ApiResult> GetLocalAuthority(string? identifier);
+    Task<ApiResult> GetLocalAuthorityStatisticalNeighbours(string? identifier);
     Task<ApiResult> GetLocalAuthoritiesNationalRank(ApiQuery? query = null, CancellationToken cancellationToken = default);
     Task<ApiResult> SuggestSchools(string search, string[]? exclude = null);
     Task<ApiResult> SuggestTrusts(string search, string[]? exclude = null);

--- a/web/src/Web.App/ViewModels/LocalAuthorityStatisticalNeighboursViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityStatisticalNeighboursViewModel.cs
@@ -1,0 +1,16 @@
+using Web.App.Domain;
+
+namespace Web.App.ViewModels;
+
+public class LocalAuthorityStatisticalNeighboursViewModel(LocalAuthorityStatisticalNeighbours localAuthority)
+{
+    public string? Code => localAuthority.Code;
+    public string? Name => localAuthority.Name;
+
+    public string[] StatisticalNeighbours => localAuthority.StatisticalNeighbours?
+        .OrderBy(n => n.Name)
+        .Where(n => !string.IsNullOrWhiteSpace(n.Name))
+        .Select(n => n.Name)
+        .Cast<string>()
+        .ToArray() ?? [];
+}

--- a/web/src/Web.App/ViewModels/LocalAuthorityStatisticalNeighboursViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityStatisticalNeighboursViewModel.cs
@@ -8,7 +8,8 @@ public class LocalAuthorityStatisticalNeighboursViewModel(LocalAuthorityStatisti
     public string? Name => localAuthority.Name;
 
     public string[] StatisticalNeighbours => localAuthority.StatisticalNeighbours?
-        .OrderBy(n => n.Name)
+        .OrderBy(n => n.Order)
+        .ThenBy(n => n.Name)
         .Where(n => !string.IsNullOrWhiteSpace(n.Name))
         .Select(n => n.Name)
         .Cast<string>()

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsBenchmarking/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsBenchmarking/Index.cshtml
@@ -1,4 +1,4 @@
-@model Web.App.ViewModels.LocalAuthorityViewModel
+@model Web.App.ViewModels.LocalAuthorityStatisticalNeighboursViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.LocalAuthorityHighNeedsStartBenchmarking;
 }
@@ -10,3 +10,28 @@
     id = Model.Code,
     kind = OrganisationTypes.LocalAuthority
 })
+
+<div class="govuk-inset-text">
+    <p class="govuk-body">
+        These local authorities are your ten closest statistical neighbours which are deemed to have similar
+        characteristics:
+    </p>
+    <ol class="govuk-list govuk-list--number">
+        @foreach (var neighbour in Model.StatisticalNeighbours)
+        {
+            <li>@neighbour</li>
+        }
+    </ol>
+</div>
+
+<details class="govuk-details">
+    <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+            More about statistical neighbours
+        </span>
+    </summary>
+    <div class="govuk-details__text">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing
+        elit.
+    </div>
+</details>

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -185,10 +185,18 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         return this;
     }
 
-    public BenchmarkingWebAppClient SetupEstablishment(LocalAuthority authority, LocalAuthorityRanking ranking)
+    public BenchmarkingWebAppClient SetupEstablishment(LocalAuthority authority, LocalAuthorityRanking ranking, LocalAuthorityStatisticalNeighbours statisticalNeighbours)
     {
         SetupEstablishment(authority, []);
         EstablishmentApi.Setup(api => api.GetLocalAuthoritiesNationalRank(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(ranking));
+        EstablishmentApi.Setup(api => api.GetLocalAuthorityStatisticalNeighbours(authority.Code)).ReturnsAsync(ApiResult.Ok(statisticalNeighbours));
+        return this;
+    }
+
+    public BenchmarkingWebAppClient SetupEstablishment(LocalAuthorityStatisticalNeighbours authority)
+    {
+        EstablishmentApi.Reset();
+        EstablishmentApi.Setup(api => api.GetLocalAuthorityStatisticalNeighbours(authority.Code)).ReturnsAsync(ApiResult.Ok(authority));
         return this;
     }
 
@@ -198,6 +206,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         EstablishmentApi.Setup(api => api.GetSchool(It.IsAny<string>())).ReturnsAsync(ApiResult.NotFound);
         EstablishmentApi.Setup(api => api.GetTrust(It.IsAny<string>())).ReturnsAsync(ApiResult.NotFound);
         EstablishmentApi.Setup(api => api.GetLocalAuthority(It.IsAny<string>())).ReturnsAsync(ApiResult.NotFound);
+        EstablishmentApi.Setup(api => api.GetLocalAuthorityStatisticalNeighbours(It.IsAny<string>())).ReturnsAsync(ApiResult.NotFound);
         return this;
     }
 
@@ -207,6 +216,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         EstablishmentApi.Setup(api => api.GetSchool(It.IsAny<string>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.GetTrust(It.IsAny<string>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.GetLocalAuthority(It.IsAny<string>())).Throws(new Exception());
+        EstablishmentApi.Setup(api => api.GetLocalAuthorityStatisticalNeighbours(It.IsAny<string>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.SuggestSchools(It.IsAny<string>(), It.IsAny<string[]?>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.SuggestTrusts(It.IsAny<string>(), It.IsAny<string[]?>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.SuggestLocalAuthorities(It.IsAny<string>(), It.IsAny<string[]?>())).Throws(new Exception());
@@ -607,11 +617,20 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     {
         private readonly ConcurrentDictionary<string, byte[]> _items = items ?? new ConcurrentDictionary<string, byte[]>();
 
-        public Task LoadAsync(CancellationToken cancellationToken = new()) => throw new NotImplementedException();
+        public Task LoadAsync(CancellationToken cancellationToken = new())
+        {
+            throw new NotImplementedException();
+        }
 
-        public Task CommitAsync(CancellationToken cancellationToken = new()) => throw new NotImplementedException();
+        public Task CommitAsync(CancellationToken cancellationToken = new())
+        {
+            throw new NotImplementedException();
+        }
 
-        public bool TryGetValue(string key, [MaybeNullWhen(false)] out byte[] value) => _items.TryGetValue(key, out value);
+        public bool TryGetValue(string key, [MaybeNullWhen(false)] out byte[] value)
+        {
+            return _items.TryGetValue(key, out value);
+        }
 
         public void Set(string key, byte[] value)
         {

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeeds.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeeds.cs
@@ -141,7 +141,9 @@ public class WhenViewingHighNeeds(SchoolBenchmarkingWebAppClient client) : PageB
 
         Assert.NotNull(authority.Name);
 
-        var page = await Client.SetupEstablishment(authority, ranking)
+        var statisticalNeighbours = Fixture.Build<LocalAuthorityStatisticalNeighbours>().Create();
+
+        var page = await Client.SetupEstablishment(authority, ranking, statisticalNeighbours)
             .SetupHighNeedsHistory(history)
             .SetupInsights()
             .Navigate(Paths.LocalAuthorityHighNeeds(authority.Code));

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsStartBenchmarking.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsStartBenchmarking.cs
@@ -1,0 +1,81 @@
+﻿using System.Net;
+using AngleSharp.Html.Dom;
+using AutoFixture;
+using Web.App.Domain;
+using Xunit;
+
+namespace Web.Integration.Tests.Pages.LocalAuthorities;
+
+public class WhenViewingHighNeedsStartBenchmarking(SchoolBenchmarkingWebAppClient client) : PageBase<SchoolBenchmarkingWebAppClient>(client)
+{
+    [Fact]
+    public async Task CanDisplay()
+    {
+        var (page, authority) = await SetupNavigateInitPage();
+
+        AssertPageLayout(page, authority);
+    }
+
+    [Fact]
+    public async Task CanDisplayProblemWithService()
+    {
+        const string code = "123";
+        var page = await Client.SetupEstablishmentWithException()
+            .Navigate(Paths.LocalAuthorityHome(code));
+
+        PageAssert.IsProblemPage(page);
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHome(code).ToAbsolute(), HttpStatusCode.InternalServerError);
+    }
+
+    [Fact]
+    public async Task CanDisplayNotFound()
+    {
+        const string code = "123";
+        var page = await Client.SetupEstablishmentWithNotFound()
+            .Navigate(Paths.LocalAuthorityHome(code));
+
+        PageAssert.IsNotFoundPage(page);
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHome(code).ToAbsolute(), HttpStatusCode.NotFound);
+    }
+
+    private async Task<(IHtmlDocument page, LocalAuthorityStatisticalNeighbours authority)> SetupNavigateInitPage()
+    {
+        var authority = Fixture.Build<LocalAuthorityStatisticalNeighbours>()
+            .Create();
+
+        var statisticalNeighbours = Fixture.Build<LocalAuthorityStatisticalNeighbour>()
+            .CreateMany()
+            .ToArray();
+
+        authority.StatisticalNeighbours = statisticalNeighbours;
+
+        var page = await Client.SetupEstablishment(authority)
+            .SetupInsights()
+            .Navigate(Paths.LocalAuthorityHighNeedsStartBenchmarking(authority.Code));
+
+        return (page, authority);
+    }
+
+    private static void AssertPageLayout(
+        IHtmlDocument page,
+        LocalAuthorityStatisticalNeighbours authority)
+    {
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeedsStartBenchmarking(authority.Code).ToAbsolute());
+
+        var expectedBreadcrumbs = new[] { ("Home", Paths.ServiceHome.ToAbsolute()) };
+        DocumentAssert.Breadcrumbs(page, expectedBreadcrumbs);
+
+        Assert.NotNull(authority.Name);
+        DocumentAssert.TitleAndH1(page, "Choose local authorities to benchmark against - Financial Benchmarking and Insights Tool - GOV.UK", "Choose local authorities to benchmark against");
+
+        var orderedList = page.QuerySelector(".govuk-inset-text > ol.govuk-list--number");
+        Assert.NotNull(orderedList);
+        var listItems = orderedList.QuerySelectorAll("li").Select(q => q.TextContent).ToArray();
+        var expectedListItems = authority.StatisticalNeighbours?
+            .OrderBy(n => n.Order)
+            .ThenBy(n => n.Name)
+            .Select(n => n.Name)
+            .ToArray();
+        Assert.Equal(expectedListItems, listItems);
+    }
+}

--- a/web/tests/Web.Tests/Infrastructure/GivenAnEstablishmentApi.cs
+++ b/web/tests/Web.Tests/Infrastructure/GivenAnEstablishmentApi.cs
@@ -110,4 +110,15 @@ public class GivenAnEstablishmentApi(ITestOutputHelper testOutputHelper) : ApiCl
 
         VerifyCall(HttpMethod.Get, expected);
     }
+
+    [Fact]
+    public async Task GetLocalAuthorityStatisticalNeighboursShouldCallCorrectUrl()
+    {
+        var api = new EstablishmentApi(HttpClient);
+        const string identifier = nameof(identifier);
+
+        await api.GetLocalAuthorityStatisticalNeighbours(identifier);
+
+        VerifyCall(HttpMethod.Get, $"api/local-authority/{identifier}/statistical-neighbours");
+    }
 }


### PR DESCRIPTION
### Context
[AB#252040](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/252040) [AB#249552](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249552)

### Change proposed in this pull request
- List of statistical neighbours for LA using stubbed endpoint
- Integration tests for ordered list on benchmarking page

### Guidance to review 
Deployed to `d18` for validation.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

