### PR TITLE
Added `LocalAuthorityComparatorSetService` for persisting comparators to session

### DIFF
--- a/web/src/Web.App/Constants/SessionKeys.cs
+++ b/web/src/Web.App/Constants/SessionKeys.cs
@@ -11,4 +11,5 @@ public static class SessionKeys
     public static string TrustComparatorSetCharacteristic(string urn) => $"trust-comparator-set-characteristic-{urn}";
     public static string TrustComparatorSetUserDefined(string companyNumber) => $"trust-comparator-set-user-defined-{companyNumber}";
     public static string TrustComparatorSetUserDefined(string companyNumber, string identifier) => $"trust-comparator-set-user-defined-{companyNumber}-{identifier}";
+    public static string LocalAuthorityComparatorSetUserDefined(string code) => $"local-authority-comparator-set-user-defined-{code}";
 }

--- a/web/src/Web.App/Domain/Benchmark/LocalAuthorityComparatorSet.cs
+++ b/web/src/Web.App/Domain/Benchmark/LocalAuthorityComparatorSet.cs
@@ -1,0 +1,6 @@
+namespace Web.App.Domain;
+
+public record UserDefinedLocalAuthorityComparatorSet
+{
+    public string[] Set { get; set; } = [];
+}

--- a/web/src/Web.App/Program.cs
+++ b/web/src/Web.App/Program.cs
@@ -44,6 +44,7 @@ builder.Services
     .AddScoped<ICustomDataService, CustomDataService>()
     .AddScoped<IUserDataService, UserDataService>()
     .AddScoped<IClaimsIdentifierService, ClaimsIdentifierService>()
+    .AddScoped<ILocalAuthorityComparatorSetService, LocalAuthorityComparatorSetService>()
     .AddActionResults();
 
 builder.Services.AddHealthChecks()

--- a/web/src/Web.App/Services/LocalAuthorityComparatorSetService.cs
+++ b/web/src/Web.App/Services/LocalAuthorityComparatorSetService.cs
@@ -1,0 +1,40 @@
+using Web.App.Domain;
+using Web.App.Extensions;
+
+namespace Web.App.Services;
+
+public interface ILocalAuthorityComparatorSetService
+{
+    UserDefinedLocalAuthorityComparatorSet ReadUserDefinedComparatorSetFromSession(string code);
+    UserDefinedLocalAuthorityComparatorSet SetUserDefinedComparatorSetInSession(string code, UserDefinedLocalAuthorityComparatorSet set);
+    void ClearUserDefinedComparatorSetFromSession(string code);
+}
+
+public class LocalAuthorityComparatorSetService(IHttpContextAccessor httpContextAccessor) : ILocalAuthorityComparatorSetService
+{
+    public UserDefinedLocalAuthorityComparatorSet ReadUserDefinedComparatorSetFromSession(string code)
+    {
+        var key = SessionKeys.LocalAuthorityComparatorSetUserDefined(code);
+        var context = httpContextAccessor.HttpContext;
+
+        var set = context?.Session.Get<UserDefinedLocalAuthorityComparatorSet>(key);
+        return set ?? SetUserDefinedComparatorSetInSession(code, new UserDefinedLocalAuthorityComparatorSet());
+    }
+
+    public void ClearUserDefinedComparatorSetFromSession(string code)
+    {
+        var key = SessionKeys.LocalAuthorityComparatorSetUserDefined(code);
+        var context = httpContextAccessor.HttpContext;
+
+        context?.Session.Remove(key);
+    }
+
+    public UserDefinedLocalAuthorityComparatorSet SetUserDefinedComparatorSetInSession(string code, UserDefinedLocalAuthorityComparatorSet set)
+    {
+        var key = SessionKeys.LocalAuthorityComparatorSetUserDefined(code);
+        var context = httpContextAccessor.HttpContext;
+
+        context?.Session.Set(key, set);
+        return set;
+    }
+}

--- a/web/tests/Web.Tests/Services/WhenLocalAuthorityComparatorSetServiceIsCalled.cs
+++ b/web/tests/Web.Tests/Services/WhenLocalAuthorityComparatorSetServiceIsCalled.cs
@@ -1,0 +1,100 @@
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Web.App;
+using Web.App.Domain;
+using Web.App.Extensions;
+using Web.App.Services;
+using Web.Tests.Stubs;
+using Xunit;
+
+namespace Web.Tests.Services;
+
+public class WhenLocalAuthorityComparatorSetServiceIsCalled
+{
+    private readonly LocalAuthorityComparatorSetService _service;
+    private readonly Mock<IHttpContextAccessor> _httpContextAccessor = new();
+    private readonly SessionStub _session = new();
+
+    public WhenLocalAuthorityComparatorSetServiceIsCalled()
+    {
+        var context = new DefaultHttpContext
+        {
+            Session = _session
+        };
+
+        _httpContextAccessor.Setup(a => a.HttpContext).Returns(context);
+        _service = new LocalAuthorityComparatorSetService(_httpContextAccessor.Object);
+    }
+
+    [Fact]
+    public void ShouldReadComparatorSetFromSessionIfPresent()
+    {
+        const string code = nameof(code);
+        var key = SessionKeys.LocalAuthorityComparatorSetUserDefined(code);
+        var set = new UserDefinedLocalAuthorityComparatorSet
+        {
+            Set = ["123", "456", "789"]
+        };
+        _session.Set(key, GetBytes(set));
+
+        var result = _service.ReadUserDefinedComparatorSetFromSession(code);
+
+        Assert.NotNull(result);
+        Assert.Equivalent(set, result);
+    }
+
+    [Fact]
+    public void ShouldSetAndReturnNewComparatorSetFromSessionIfNotPresent()
+    {
+        const string code = nameof(code);
+
+        var result = _service.ReadUserDefinedComparatorSetFromSession(code);
+
+        Assert.NotNull(result);
+        Assert.Equivalent(new UserDefinedLocalAuthorityComparatorSet(), result);
+        Assert.Single(_session.Keys);
+        Assert.Equal(SessionKeys.LocalAuthorityComparatorSetUserDefined(code), _session.Keys.Single());
+    }
+
+    [Fact]
+    public void ShouldSetComparatorSetInSession()
+    {
+        const string code = nameof(code);
+        var set = new UserDefinedLocalAuthorityComparatorSet
+        {
+            Set = ["123", "456", "789"]
+        };
+
+        var result = _service.SetUserDefinedComparatorSetInSession(code, set);
+
+        Assert.NotNull(result);
+        Assert.Equivalent(set, result);
+        Assert.Single(_session.Keys);
+        Assert.Equal(SessionKeys.LocalAuthorityComparatorSetUserDefined(code), _session.Keys.Single());
+    }
+
+    [Fact]
+    public void ShouldClearComparatorSetFromSession()
+    {
+        const string code = nameof(code);
+        var key1 = SessionKeys.LocalAuthorityComparatorSetUserDefined(code);
+        var key2 = SessionKeys.LocalAuthorityComparatorSetUserDefined(code + code);
+        var set = new UserDefinedLocalAuthorityComparatorSet
+        {
+            Set = ["123", "456", "789"]
+        };
+        _session.Set(key1, GetBytes(set));
+        _session.Set(key2, GetBytes(set));
+
+        _service.ClearUserDefinedComparatorSetFromSession(code);
+
+        Assert.Single(_session.Keys);
+        Assert.Equal(key2, _session.Keys.Single());
+    }
+
+    private static byte[] GetBytes(UserDefinedLocalAuthorityComparatorSet value)
+    {
+        return Encoding.UTF8.GetBytes(value.ToJson());
+    }
+}

--- a/web/tests/Web.Tests/Stubs/SessionStub.cs
+++ b/web/tests/Web.Tests/Stubs/SessionStub.cs
@@ -1,0 +1,37 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Http;
+
+namespace Web.Tests.Stubs;
+
+public class SessionStub(ConcurrentDictionary<string, byte[]>? items = null) : ISession
+{
+    private readonly ConcurrentDictionary<string, byte[]> _items = items ?? new ConcurrentDictionary<string, byte[]>();
+
+    public Task LoadAsync(CancellationToken cancellationToken = new()) => throw new NotImplementedException();
+
+    public Task CommitAsync(CancellationToken cancellationToken = new()) => throw new NotImplementedException();
+
+    public bool TryGetValue(string key, [MaybeNullWhen(false)] out byte[] value) => _items.TryGetValue(key, out value);
+
+    public void Set(string key, byte[] value)
+    {
+        _items[key] = value;
+    }
+
+    public void Remove(string key)
+    {
+        _items.Remove(key, out _);
+    }
+
+    public void Clear()
+    {
+        _items.Clear();
+    }
+
+    public bool IsAvailable => true;
+
+    public string Id => nameof(SessionStub);
+
+    public IEnumerable<string> Keys => _items.Keys;
+}


### PR DESCRIPTION
### Context
[AB#252037](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/252037) [AB#249552](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249552)

### Change proposed in this pull request
- New service to persist comparator set to session
- Unit test coverage

### Guidance to review 
To be consumed as part of future work on this story.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

