### PR TITLE
New endpoint in Establishment API to return all Local Authorities, ordered by name

### DIFF
--- a/platform/Platform.sln.DotSettings
+++ b/platform/Platform.sln.DotSettings
@@ -11,4 +11,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=actuals/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=azuresearch/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ipairs/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=orderby/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=outturn/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/platform/src/abstractions/Platform.Sql/DatabaseConnection.cs
+++ b/platform/src/abstractions/Platform.Sql/DatabaseConnection.cs
@@ -53,7 +53,6 @@ public class DatabaseConnection(SqlConnection connection) : IDatabaseConnection,
     public Task<IEnumerable<T>> QueryAsync<T>(PlatformQuery query, CancellationToken cancellationToken = default)
         => connection.QueryAsync<T>(new CommandDefinition(query.QueryTemplate.RawSql, query.QueryTemplate.Parameters, cancellationToken: cancellationToken));
 
-
     public Task<T?> QueryFirstOrDefaultAsync<T>(string sql, object? param = null, CancellationToken cancellationToken = default)
         => connection.QueryFirstOrDefaultAsync<T>(new CommandDefinition(sql, param, cancellationToken: cancellationToken));
 

--- a/platform/src/abstractions/Platform.Sql/QueryBuilders/LocalAuthorityQueries.cs
+++ b/platform/src/abstractions/Platform.Sql/QueryBuilders/LocalAuthorityQueries.cs
@@ -2,5 +2,5 @@
 
 public class LocalAuthorityQuery() : PlatformQuery(Sql)
 {
-    private const string Sql = "SELECT * FROM LocalAuthority /**where**/";
+    private const string Sql = "SELECT * FROM LocalAuthority /**where**/ /**orderby**/";
 }

--- a/platform/src/abstractions/Platform.Sql/QueryBuilders/PlatformQuery.cs
+++ b/platform/src/abstractions/Platform.Sql/QueryBuilders/PlatformQuery.cs
@@ -135,4 +135,14 @@ public abstract class PlatformQuery : SqlBuilder
         Where(sql, parameters);
         return this;
     }
+
+    public PlatformQuery OrderBy(params string[] columns)
+    {
+        foreach (var column in columns)
+        {
+            base.OrderBy(column);
+        }
+
+        return this;
+    }
 }

--- a/platform/src/abstractions/tests/Platform.Sql.Tests/Builders/LocalAuthorityQueryTests.cs
+++ b/platform/src/abstractions/tests/Platform.Sql.Tests/Builders/LocalAuthorityQueryTests.cs
@@ -9,9 +9,8 @@ public class LocalAuthorityQueryTests
     public void ShouldReturnSql()
     {
         var builder = Create();
-        Assert.Equal("SELECT * FROM LocalAuthority ", builder.QueryTemplate.RawSql);
+        Assert.Equal("SELECT * FROM LocalAuthority  ", builder.QueryTemplate.RawSql);
     }
-
 
     private static LocalAuthorityQuery Create() => new();
 }

--- a/platform/src/abstractions/tests/Platform.Sql.Tests/Builders/PlatformQueryTests.cs
+++ b/platform/src/abstractions/tests/Platform.Sql.Tests/Builders/PlatformQueryTests.cs
@@ -227,11 +227,24 @@ public class PlatformQueryTests
         Assert.Equal(expectedSql, builder.QueryTemplate.RawSql);
     }
 
-    private static string BuildExpectedQuery(string wherePart) =>
-        $"{MockPlatformQuery.Sql.Replace("/**where**/", wherePart)}\n";
+    [Fact]
+    public void ShouldAddOrderBy()
+    {
+        const string expectedValue = "Code";
+        var expectedSql = BuildExpectedQuery(string.Empty, "ORDER BY Code");
+
+        var builder = new MockPlatformQuery().OrderBy(expectedValue);
+
+        Assert.Equal(expectedSql, builder.QueryTemplate.RawSql);
+    }
+
+    private static string BuildExpectedQuery(string wherePart, string? orderByPart = null) =>
+        $"{MockPlatformQuery.Sql
+            .Replace("/**where**/", wherePart)
+            .Replace("/**orderby**/", orderByPart)}\n";
 }
 
 public class MockPlatformQuery() : PlatformQuery(Sql)
 {
-    public const string Sql = "SELECT * FROM Mock /**where**/";
+    public const string Sql = "SELECT * FROM Mock /**where**//**orderby**/";
 }

--- a/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/GetLocalAuthoritiesFunction.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/GetLocalAuthoritiesFunction.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
@@ -19,16 +18,10 @@ public class GetLocalAuthoritiesFunction(ILocalAuthoritiesService service)
     [OpenApiSecurityHeader]
     [OpenApiOperation(nameof(GetLocalAuthoritiesFunction), Constants.Features.LocalAuthorities)]
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(IEnumerable<LocalAuthority>))]
-    [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.LocalAuthorities)] HttpRequestData req)
     {
         var response = await service.GetAllAsync();
-        if (!response.Any())
-        {
-            return req.CreateNotFoundResponse();
-        }
-
         return await req.CreateJsonResponseAsync(response);
     }
 }

--- a/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/GetLocalAuthoritiesFunction.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/GetLocalAuthoritiesFunction.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
@@ -11,20 +13,18 @@ using Platform.Functions.OpenApi;
 
 namespace Platform.Api.Establishment.Features.LocalAuthorities;
 
-public class GetLocalAuthorityStatisticalNeighboursFunction(ILocalAuthoritiesService service)
+public class GetLocalAuthoritiesFunction(ILocalAuthoritiesService service)
 {
-    [Function(nameof(GetLocalAuthorityStatisticalNeighboursFunction))]
+    [Function(nameof(GetLocalAuthoritiesFunction))]
     [OpenApiSecurityHeader]
-    [OpenApiOperation(nameof(GetLocalAuthorityStatisticalNeighboursFunction), Constants.Features.LocalAuthorities)]
-    [OpenApiParameter("identifier", Type = typeof(string), Required = true)]
-    [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(LocalAuthorityStatisticalNeighbours))]
+    [OpenApiOperation(nameof(GetLocalAuthoritiesFunction), Constants.Features.LocalAuthorities)]
+    [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(IEnumerable<LocalAuthority>))]
     [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.LocalAuthorityStatisticalNeighbours)] HttpRequestData req,
-        string identifier)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.LocalAuthorities)] HttpRequestData req)
     {
-        var response = await service.GetStatisticalNeighboursAsync(identifier);
-        if (response == null)
+        var response = await service.GetAllAsync();
+        if (!response.Any())
         {
             return req.CreateNotFoundResponse();
         }

--- a/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/Routes.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/Routes.cs
@@ -2,6 +2,7 @@
 
 public static class Routes
 {
+    public const string LocalAuthorities = "local-authorities";
     public const string LocalAuthoritiesSuggest = "local-authorities/suggest";
     public const string LocalAuthoritiesNationalRank = "local-authorities/national-rank";
     public const string LocalAuthority = "local-authority/{identifier}";

--- a/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/Services/LocalAuthoritiesService.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/Services/LocalAuthoritiesService.cs
@@ -17,7 +17,8 @@ public interface ILocalAuthoritiesService
 {
     Task<SuggestResponse<LocalAuthority>> SuggestAsync(LocalAuthoritySuggestRequest request);
     Task<LocalAuthority?> GetAsync(string code);
-    Task<LocalAuthorityStatisticalNeighbours?> GetStatisticalNeighbours(string identifier);
+    Task<LocalAuthorityStatisticalNeighbours?> GetStatisticalNeighboursAsync(string identifier);
+    Task<IEnumerable<LocalAuthority>> GetAllAsync();
 }
 
 [ExcludeFromCodeCoverage]
@@ -66,7 +67,7 @@ public class LocalAuthoritiesService(
     }
 
     // stubbed implementation for the time being
-    public async Task<LocalAuthorityStatisticalNeighbours?> GetStatisticalNeighbours(string code)
+    public async Task<LocalAuthorityStatisticalNeighbours?> GetStatisticalNeighboursAsync(string code)
     {
         var laBuilder = new LocalAuthorityQuery()
             .WhereCodeEqual(code);
@@ -98,5 +99,15 @@ public class LocalAuthoritiesService(
             Name = localAuthority.Name,
             StatisticalNeighbours = neighbours
         };
+    }
+
+    public async Task<IEnumerable<LocalAuthority>> GetAllAsync()
+    {
+        var laBuilder = new LocalAuthorityQuery()
+            .OrderBy(nameof(LocalAuthority.Name));
+
+        using var conn = await dbFactory.GetConnection();
+        var localAuthorities = await conn.QueryAsync<LocalAuthority>(laBuilder);
+        return localAuthorities;
     }
 }

--- a/platform/tests/Platform.ApiTests/Features/EstablishmentLocalAuthorities.feature
+++ b/platform/tests/Platform.ApiTests/Features/EstablishmentLocalAuthorities.feature
@@ -238,3 +238,163 @@ Feature: Establishment local authorities endpoints
           | 207  | Local authority 207 | 8     |
           | 208  | Local authority 208 | 9     |
           | 209  | Local authority 209 | 10    |
+
+    Scenario: Sending a valid local authorities request
+        Given a valid local authorities request
+        When I submit the local authorities request
+        Then the local authorities result should be ok and have the following values:
+          | Code | Name                              |
+          | 301  | Barking and Dagenham              |
+          | 302  | Barnet                            |
+          | 370  | Barnsley                          |
+          | 800  | Bath and North East Somerset      |
+          | 822  | Bedford                           |
+          | 303  | Bexley                            |
+          | 330  | Birmingham                        |
+          | 889  | Blackburn with Darwen             |
+          | 890  | Blackpool                         |
+          | 350  | Bolton                            |
+          | 839  | Bournemouth, Christchurch & Poole |
+          | 867  | Bracknell Forest                  |
+          | 380  | Bradford                          |
+          | 304  | Brent                             |
+          | 846  | Brighton and Hove                 |
+          | 801  | Bristol                           |
+          | 305  | Bromley                           |
+          | 825  | Buckinghamshire                   |
+          | 351  | Bury                              |
+          | 381  | Calderdale                        |
+          | 873  | Cambridgeshire                    |
+          | 202  | Camden                            |
+          | 823  | Central Bedfordshire              |
+          | 895  | Cheshire East                     |
+          | 896  | Cheshire West & Chester           |
+          | 201  | City of London                    |
+          | 908  | Cornwall                          |
+          | 840  | County Durham                     |
+          | 331  | Coventry                          |
+          | 306  | Croydon                           |
+          | 942  | Cumberland                        |
+          | 841  | Darlington                        |
+          | 831  | Derby                             |
+          | 830  | Derbyshire                        |
+          | 878  | Devon                             |
+          | 371  | Doncaster                         |
+          | 838  | Dorset                            |
+          | 332  | Dudley                            |
+          | 307  | Ealing                            |
+          | 811  | East Riding of Yorkshire          |
+          | 845  | East Sussex                       |
+          | 308  | Enfield                           |
+          | 881  | Essex                             |
+          | 390  | Gateshead                         |
+          | 916  | Gloucestershire                   |
+          | 203  | Greenwich                         |
+          | 204  | Hackney                           |
+          | 876  | Halton                            |
+          | 205  | Hammersmith and Fulham            |
+          | 850  | Hampshire                         |
+          | 309  | Haringey                          |
+          | 310  | Harrow                            |
+          | 805  | Hartlepool                        |
+          | 311  | Havering                          |
+          | 884  | Herefordshire                     |
+          | 919  | Hertfordshire                     |
+          | 312  | Hillingdon                        |
+          | 313  | Hounslow                          |
+          | 921  | Isle of Wight                     |
+          | 420  | Isles of Scilly                   |
+          | 206  | Islington                         |
+          | 207  | Kensington and Chelsea            |
+          | 886  | Kent                              |
+          | 810  | Kingston Upon Hull                |
+          | 314  | Kingston upon Thames              |
+          | 382  | Kirklees                          |
+          | 340  | Knowsley                          |
+          | 208  | Lambeth                           |
+          | 888  | Lancashire                        |
+          | 383  | Leeds                             |
+          | 856  | Leicester                         |
+          | 855  | Leicestershire                    |
+          | 209  | Lewisham                          |
+          | 925  | Lincolnshire                      |
+          | 341  | Liverpool                         |
+          | 821  | Luton                             |
+          | 352  | Manchester                        |
+          | 887  | Medway                            |
+          | 315  | Merton                            |
+          | 806  | Middlesbrough                     |
+          | 826  | Milton Keynes                     |
+          | 391  | Newcastle upon Tyne               |
+          | 316  | Newham                            |
+          | 926  | Norfolk                           |
+          | 812  | North East Lincolnshire           |
+          | 813  | North Lincolnshire                |
+          | 940  | North Northamptonshire            |
+          | 802  | North Somerset                    |
+          | 392  | North Tyneside                    |
+          | 815  | North Yorkshire                   |
+          | 929  | Northumberland                    |
+          | 892  | Nottingham                        |
+          | 891  | Nottinghamshire                   |
+          | 353  | Oldham                            |
+          | 931  | Oxfordshire                       |
+          | 874  | Peterborough                      |
+          | 879  | Plymouth                          |
+          | 851  | Portsmouth                        |
+          | 870  | Reading                           |
+          | 317  | Redbridge                         |
+          | 807  | Redcar and Cleveland              |
+          | 318  | Richmond upon Thames              |
+          | 354  | Rochdale                          |
+          | 372  | Rotherham                         |
+          | 857  | Rutland                           |
+          | 355  | Salford                           |
+          | 333  | Sandwell                          |
+          | 343  | Sefton                            |
+          | 373  | Sheffield                         |
+          | 893  | Shropshire                        |
+          | 871  | Slough                            |
+          | 334  | Solihull                          |
+          | 933  | Somerset                          |
+          | 803  | South Gloucestershire             |
+          | 393  | South Tyneside                    |
+          | 852  | Southampton                       |
+          | 882  | Southend-on-Sea                   |
+          | 210  | Southwark                         |
+          | 342  | St. Helens                        |
+          | 860  | Staffordshire                     |
+          | 356  | Stockport                         |
+          | 808  | Stockton-on-Tees                  |
+          | 861  | Stoke-on-Trent                    |
+          | 935  | Suffolk                           |
+          | 394  | Sunderland                        |
+          | 936  | Surrey                            |
+          | 319  | Sutton                            |
+          | 866  | Swindon                           |
+          | 357  | Tameside                          |
+          | 894  | Telford and Wrekin                |
+          | 006  | Test Local Authority              |
+          | 883  | Thurrock                          |
+          | 880  | Torbay                            |
+          | 211  | Tower Hamlets                     |
+          | 358  | Trafford                          |
+          | 384  | Wakefield                         |
+          | 335  | Walsall                           |
+          | 320  | Waltham Forest                    |
+          | 212  | Wandsworth                        |
+          | 877  | Warrington                        |
+          | 937  | Warwickshire                      |
+          | 869  | West Berkshire                    |
+          | 941  | West Northamptonshire             |
+          | 938  | West Sussex                       |
+          | 213  | Westminster                       |
+          | 943  | Westmorland and Furness           |
+          | 359  | Wigan                             |
+          | 865  | Wiltshire                         |
+          | 868  | Windsor and Maidenhead            |
+          | 344  | Wirral                            |
+          | 872  | Wokingham                         |
+          | 336  | Wolverhampton                     |
+          | 885  | Worcestershire                    |
+          | 816  | York                              |

--- a/platform/tests/Platform.ApiTests/Steps/EstablishmentLocalAuthoritiesSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/EstablishmentLocalAuthoritiesSteps.cs
@@ -13,6 +13,7 @@ namespace Platform.ApiTests.Steps;
 public class EstablishmentLocalAuthoritiesSteps(EstablishmentApiDriver api)
 {
     private const string RequestKey = "get-local-authority";
+    private const string GetAllKey = "get-local-authorities";
     private const string NationalRankRequestKey = "get-local-authority-national-rank";
     private const string SuggestRequestKey = "suggest-local-authority";
     private const string StatisticalNeighboursRequestKey = "get-local-authority-statistical-neighbours";
@@ -87,6 +88,16 @@ public class EstablishmentLocalAuthoritiesSteps(EstablishmentApiDriver api)
         api.CreateRequest(NationalRankRequestKey, new HttpRequestMessage
         {
             RequestUri = new Uri($"/api/local-authorities/national-rank?sort={sort}", UriKind.Relative),
+            Method = HttpMethod.Get
+        });
+    }
+
+    [Given("a valid local authorities request")]
+    private void GivenAValidLocalAuthoritiesRequest()
+    {
+        api.CreateRequest(GetAllKey, new HttpRequestMessage
+        {
+            RequestUri = new Uri("/api/local-authorities", UriKind.Relative),
             Method = HttpMethod.Get
         });
     }
@@ -245,6 +256,23 @@ public class EstablishmentLocalAuthoritiesSteps(EstablishmentApiDriver api)
             s.Code,
             s.Name,
             s.Order
+        }).ToList();
+
+        table.CompareToSet(set);
+    }
+
+    [Then("the local authorities result should be ok and have the following values:")]
+    private async Task ThenTheLocalAuthoritiesResultShouldBeOkAndHaveTheFollowingValues(DataTable table)
+    {
+        var response = api[GetAllKey].Response;
+        AssertHttpResponse.IsOk(response);
+
+        var content = await response.Content.ReadAsByteArrayAsync();
+        var result = content.FromJson<IEnumerable<LocalAuthority>>();
+        var set = result.Select(s => new
+        {
+            s.Code,
+            s.Name
         }).ToList();
 
         table.CompareToSet(set);

--- a/platform/tests/Platform.Establishment.Tests/LocalAuthorities/GetLocalAuthoritiesFunctionTests.cs
+++ b/platform/tests/Platform.Establishment.Tests/LocalAuthorities/GetLocalAuthoritiesFunctionTests.cs
@@ -45,17 +45,4 @@ public class GetLocalAuthoritiesFunctionTests : FunctionsTestBase
         Assert.NotNull(body);
         Assert.Equivalent(_localAuthorities, body);
     }
-
-    [Fact]
-    public async Task ShouldReturn404OnInvalidRequest()
-    {
-        _service
-            .Setup(d => d.GetAllAsync())
-            .ReturnsAsync(Array.Empty<LocalAuthority>());
-
-        var result = await _function.RunAsync(CreateHttpRequestData());
-
-        Assert.NotNull(result);
-        Assert.Equal(HttpStatusCode.NotFound, result.StatusCode);
-    }
 }

--- a/platform/tests/Platform.Establishment.Tests/LocalAuthorities/GetLocalAuthoritiesFunctionTests.cs
+++ b/platform/tests/Platform.Establishment.Tests/LocalAuthorities/GetLocalAuthoritiesFunctionTests.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using AutoFixture;
+using Moq;
+using Platform.Api.Establishment.Features.LocalAuthorities;
+using Platform.Api.Establishment.Features.LocalAuthorities.Models;
+using Platform.Api.Establishment.Features.LocalAuthorities.Services;
+using Platform.Functions;
+using Platform.Test;
+using Platform.Test.Extensions;
+using Xunit;
+
+namespace Platform.Establishment.Tests.LocalAuthorities;
+
+public class GetLocalAuthoritiesFunctionTests : FunctionsTestBase
+{
+    private readonly GetLocalAuthoritiesFunction _function;
+    private readonly IEnumerable<LocalAuthority> _localAuthorities;
+    private readonly Mock<ILocalAuthoritiesService> _service;
+
+    public GetLocalAuthoritiesFunctionTests()
+    {
+        _service = new Mock<ILocalAuthoritiesService>();
+        _function = new GetLocalAuthoritiesFunction(_service.Object);
+
+        var fixture = new Fixture();
+        _localAuthorities = fixture
+            .Build<LocalAuthority>()
+            .CreateMany();
+    }
+
+    [Fact]
+    public async Task ShouldReturn200OnValidRequest()
+    {
+        _service
+            .Setup(d => d.GetAllAsync())
+            .ReturnsAsync(_localAuthorities);
+
+        var result = await _function.RunAsync(CreateHttpRequestData());
+
+        Assert.NotNull(result);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal(ContentType.ApplicationJson, result.ContentType());
+
+        var body = await result.ReadAsJsonAsync<IEnumerable<LocalAuthority>>();
+        Assert.NotNull(body);
+        Assert.Equivalent(_localAuthorities, body);
+    }
+
+    [Fact]
+    public async Task ShouldReturn404OnInvalidRequest()
+    {
+        _service
+            .Setup(d => d.GetAllAsync())
+            .ReturnsAsync(Array.Empty<LocalAuthority>());
+
+        var result = await _function.RunAsync(CreateHttpRequestData());
+
+        Assert.NotNull(result);
+        Assert.Equal(HttpStatusCode.NotFound, result.StatusCode);
+    }
+}

--- a/platform/tests/Platform.Establishment.Tests/LocalAuthorities/GetLocalAuthorityStatisticalNeighboursFunctionTests.cs
+++ b/platform/tests/Platform.Establishment.Tests/LocalAuthorities/GetLocalAuthorityStatisticalNeighboursFunctionTests.cs
@@ -35,7 +35,7 @@ public class GetLocalAuthorityStatisticalNeighboursFunctionTests : FunctionsTest
     public async Task ShouldReturn200OnValidRequest()
     {
         _service
-            .Setup(d => d.GetStatisticalNeighbours(_laCode))
+            .Setup(d => d.GetStatisticalNeighboursAsync(_laCode))
             .ReturnsAsync(_neighbours);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), _laCode);

--- a/platform/tests/Platform.Establishment.Tests/LocalAuthorities/WhenLocalAuthoritiesServiceQueriesAsync.cs
+++ b/platform/tests/Platform.Establishment.Tests/LocalAuthorities/WhenLocalAuthoritiesServiceQueriesAsync.cs
@@ -1,0 +1,50 @@
+﻿using Moq;
+using Platform.Api.Establishment.Features.LocalAuthorities.Models;
+using Platform.Api.Establishment.Features.LocalAuthorities.Services;
+using Platform.Search;
+using Platform.Sql;
+using Platform.Sql.QueryBuilders;
+using Xunit;
+
+namespace Platform.Establishment.Tests.LocalAuthorities;
+
+public class WhenLocalAuthoritiesServiceQueriesAsync
+{
+    private readonly Mock<IDatabaseConnection> _connection;
+    private readonly LocalAuthoritiesService _service;
+
+    public WhenLocalAuthoritiesServiceQueriesAsync()
+    {
+        _connection = new Mock<IDatabaseConnection>();
+
+        var dbFactory = new Mock<IDatabaseFactory>();
+        dbFactory.Setup(d => d.GetConnection()).ReturnsAsync(_connection.Object);
+
+        var indexClient = new Mock<IIndexClient>();
+
+        _service = new LocalAuthoritiesService(indexClient.Object, dbFactory.Object);
+    }
+
+    [Fact]
+    public async Task ShouldQueryAsyncWhenGetAll()
+    {
+        // arrange
+        LocalAuthority[] results = [new()];
+        string? actualSql = null;
+
+        _connection
+            .Setup(c => c.QueryAsync<LocalAuthority>(It.IsAny<PlatformQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<PlatformQuery, CancellationToken>((query, _) =>
+            {
+                actualSql = query.QueryTemplate.RawSql.Trim();
+            })
+            .ReturnsAsync(results);
+
+        // act
+        var actual = await _service.GetAllAsync();
+
+        // assert
+        Assert.Equal(results, actual);
+        Assert.Equal("SELECT * FROM LocalAuthority  ORDER BY Name", actualSql);
+    }
+}


### PR DESCRIPTION
### Context
[AB#252078](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/252078) [AB#249552](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249552)

### Change proposed in this pull request
- New endpoint that returns an array of all LA Code/Names only
- Unit test coverage
- API test coverage

### Guidance to review 
Maybe validated locally in Swagger UI, e.g.: `http://localhost:7073/api/swagger/ui#/Local%20Authorities/GetLocalAuthoritiesFunction`

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] You have reviewed with UX/Design

