### PR TITLE
E2E tests for Send 2 tab High Needs Historic Data page

### DIFF
--- a/front-end-components/src/composed/historic-chart-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/component.tsx
@@ -106,7 +106,7 @@ export function HistoricChart<TData extends ChartDataSeries>({
       ) : (
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-three-quarters">
-            <table className="govuk-table">
+            <table className="govuk-table" data-testid={`${chartTitle}-table`}>
               <thead className="govuk-table__head">
                 <tr className="govuk-table__row">
                   <th className="govuk-table__header govuk-!-width-one-half">

--- a/front-end-components/src/views/historic-data-high-needs/partials/send-2-section.tsx
+++ b/front-end-components/src/views/historic-data-high-needs/partials/send-2-section.tsx
@@ -94,14 +94,14 @@ export const Send2Section: React.FC<HistoricDataHighNeedsProps> = ({
             <h2 className="govuk-accordion__section-heading">
               <span
                 className="govuk-accordion__section-button"
-                id="accordion-send-2-heading"
+                id="accordion-send-2-heading-1"
               >
                 {send2AccordionSection.heading}
               </span>
             </h2>
           </div>
           <div
-            id={"accordion-send-2-content"}
+            id={"accordion-send-2-content-1"}
             className="govuk-accordion__section-content"
           >
             {data &&

--- a/front-end-components/src/views/historic-data-high-needs/partials/send-2-section.tsx
+++ b/front-end-components/src/views/historic-data-high-needs/partials/send-2-section.tsx
@@ -120,7 +120,7 @@ export const Send2Section: React.FC<HistoricDataHighNeedsProps> = ({
                     valueField={chart.field}
                     columnHeading="Amount"
                   >
-                    <h2 className="govuk-heading-m">{chart.name}</h2>
+                    <h3 className="govuk-heading-m">{chart.name}</h3>
                   </HistoricChart>
                 </section>
               ))}

--- a/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsHistoricData.feature
+++ b/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsHistoricData.feature
@@ -53,6 +53,7 @@
         Examples:
           | tab         | charts |
           | section 251 | 25     |
+          | send 2      | 8      |
 
     @HighNeedsFlagEnabled
     Scenario Outline: Change all charts to table view
@@ -64,9 +65,10 @@
         Examples:
           | tab         |
           | section 251 |
+          | send 2      |
 
     @HighNeedsFlagEnabled
-    Scenario: Hide single section
+    Scenario: Hide single section section 251
         Given I am on 'section 251' high needs history page for local authority with code '201'
         And all sections are shown on 'section 251'
         When I click section link for 'place funding'
@@ -83,7 +85,7 @@
           | section 251 | Total place funding for special schools and AP/PRUs | actual, planned |
 
     @HighNeedsFlagEnabled
-    Scenario: Viewing data in table view
+    Scenario: Viewing data in table view section 251
         Given I am on 'section 251' high needs history page for local authority with code '201'
         And all sections are shown on 'section 251'
         When I click on view as table on 'section 251' tab
@@ -93,3 +95,38 @@
           | 2021 to 2022 | £1,002,044 | £1,102,044 |
           | 2022 to 2023 | £1,002,045 | £1,102,045 |
           | 2023 to 2024 | £1,002,046 | £1,102,046 |
+
+    @HighNeedsFlagEnabled
+    Scenario: Show all should expand all sections on Send 2 tab
+        Given I am on 'send 2' high needs history page for local authority with code '201'
+        When I click on show all sections on 'send 2'
+        Then all sections on 'send 2' tab are expanded
+        And the show all text changes to hide all sections on 'send 2'
+        And the expected sub categories should be displayed on 'send 2':
+          | Sub category                                                     |
+          | Mainstream schools or academies                                  |
+          | Resourced provision or SEN units                                 |
+          | Maintained special schools or special academies                  |
+          | NMSS or independent schools                                      |
+          | Hospital schools or alternative provisions                       |
+          | Post 16                                                          |
+          | Other                                                            |
+          
+    @HighNeedsFlagEnabled
+    Scenario: Hide single section send 2
+        Given I am on 'send 2' high needs history page for local authority with code '201'
+        And all sections are shown on 'send 2'
+        When I click section link for 'Placement of pupils aged up to 25 with SEN statement or EHC plan (per 1000 2 to 18 population)'
+        Then the section 'Placement of pupils aged up to 25 with SEN statement or EHC plan (per 1000 2 to 18 population)' is hidden
+        
+    @HighNeedsFlagEnabled
+    Scenario: Viewing data in table view send 2
+        Given I am on 'send 2' high needs history page for local authority with code '201'
+        When I click on view as table on 'send 2' tab
+        Then the table on the 'send 2' tab 'Number aged up to 25 with SEN statement or EHC plan' chart contains:
+          | Year         | Amount |
+          | 2019 to 2020 | 52     |
+          | 2020 to 2021 | 59     |
+          | 2021 to 2022 | 66     |
+          | 2022 to 2023 | 65     |
+          | 2023 to 2024 | 47     |

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsHistoricDataPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsHistoricDataPage.cs
@@ -11,9 +11,10 @@ public enum HighNeedsHistoryTabs
     Send2
 }
 
-public enum Section251CategoriesNames
+public enum HistoricDataCategoryNames
 {
-    PlaceFunding
+    PlaceFunding,
+    PlacementOfPupils
 }
 
 public class HighNeedsHistoricDataPage(IPage page)
@@ -25,13 +26,26 @@ public class HighNeedsHistoricDataPage(IPage page)
     private ILocator Section251Sections => page.Locator($"{Selectors.Section251Tab} {Selectors.GovAccordionSection}");
     private ILocator Section251Accordion => page.Locator(Selectors.Section251Accordions);
     private ILocator Section251SubCategories => Section251Accordion.Locator($"{Selectors.H3}");
-    private ILocator ShowHideAllSectionsLink => page.Locator(Selectors.GovShowAllLinkText);
+    private ILocator Section251ShowHideAllSectionsLink => Section251TabContent.Locator(Selectors.GovShowAllLinkText);
+    private ILocator Send2ShowHideAllSectionsLink => Send2TabContent.Locator(Selectors.GovShowAllLinkText);
     private ILocator Section251ModeTable => page.Locator(Selectors.Section251ModeTable);
     private ILocator Section251ModeChart => page.Locator(Selectors.Section251ModeChart);
     private ILocator AllSection251Charts => Section251TabContent.Locator(Selectors.Charts);
     private ILocator Section251ChartsStats => Section251TabContent.Locator(Selectors.LineChartStats);
     private ILocator Section251TableView => page.Locator(Selectors.Section251TableMode);
     private ILocator Section251PlaceFundingAccordionContent => page.Locator(Selectors.Section251AccordionContent1);
+    private ILocator Send2TabContent => page.Locator(Selectors.Send2Panel);
+    private ILocator Send2CategoryHeadings => Send2TabContent.Locator($"{Selectors.H2} {Selectors.AccordionHeadingText}");
+    private ILocator Send2Sections => page.Locator($"{Selectors.Send2Tab} {Selectors.GovAccordionSection}");
+    private ILocator Send2Accordion => page.Locator(Selectors.Send2Accordions);
+    private ILocator Send2SubCategories => Send2Accordion.Locator($"{Selectors.H3}");
+    private ILocator Send2ModeTable => page.Locator(Selectors.Send2ModeTable);
+    private ILocator Send2ModeChart => page.Locator(Selectors.Send2ModeChart);
+    private ILocator AllSend2Charts => Send2TabContent.Locator(Selectors.Charts);
+    private ILocator Send2ChartsStats => Send2TabContent.Locator(Selectors.LineChartStats);
+    private ILocator Send2TableView => page.Locator(Selectors.Send2ModeTable);
+    private ILocator Send2PlaceFundingAccordionContent => page.Locator(Selectors.Section251AccordionContent1);
+    private ILocator Send2AccordionContent => page.Locator(Selectors.Send2AccordionContent1);
     private ILocator SaveAsImageButtons(string elementId)
     {
         return page.Locator($"#{elementId}").Locator(".share-button--save");
@@ -45,11 +59,14 @@ public class HighNeedsHistoricDataPage(IPage page)
         switch (selectedTab)
         {
             case HighNeedsHistoryTabs.Section251:
-                await ShowHideAllSectionsLink.First.ShouldBeVisible();
+                await Section251ShowHideAllSectionsLink.First.ShouldBeVisible();
                 await Section251ModeTable.ShouldBeVisible().ShouldBeChecked(false);
                 await Section251ModeChart.ShouldBeVisible().ShouldBeChecked();
                 break;
             case HighNeedsHistoryTabs.Send2:
+                await Send2ShowHideAllSectionsLink.First.ShouldBeVisible();
+                await Send2ModeTable.ShouldBeVisible().ShouldBeChecked(false);
+                await Send2ModeChart.ShouldBeVisible().ShouldBeChecked();
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(tab));
@@ -60,7 +77,8 @@ public class HighNeedsHistoricDataPage(IPage page)
     {
         var showAllSectionsLink = tab switch
         {
-            HighNeedsHistoryTabs.Section251 => ShowHideAllSectionsLink.First,
+            HighNeedsHistoryTabs.Section251 => Section251ShowHideAllSectionsLink.First,
+            HighNeedsHistoryTabs.Send2 => Send2ShowHideAllSectionsLink.First,
             _ => throw new ArgumentOutOfRangeException(nameof(tab))
         };
 
@@ -77,6 +95,7 @@ public class HighNeedsHistoricDataPage(IPage page)
         var tabSections = tab switch
         {
             HighNeedsHistoryTabs.Section251 => Section251Sections,
+            HighNeedsHistoryTabs.Send2 => Send2Sections,
             _ => throw new ArgumentOutOfRangeException(nameof(tab))
         };
 
@@ -91,7 +110,8 @@ public class HighNeedsHistoricDataPage(IPage page)
     {
         var showAllSectionsLink = tab switch
         {
-            HighNeedsHistoryTabs.Section251 => ShowHideAllSectionsLink.First,
+            HighNeedsHistoryTabs.Section251 => Section251ShowHideAllSectionsLink.First,
+            HighNeedsHistoryTabs.Send2 => Send2ShowHideAllSectionsLink.First,
             _ => throw new ArgumentOutOfRangeException(nameof(tab))
         };
         await showAllSectionsLink.TextEqual(expectedText);
@@ -102,6 +122,7 @@ public class HighNeedsHistoricDataPage(IPage page)
         var expectedSubCategories = tab switch
         {
             HighNeedsHistoryTabs.Section251 => subCategories,
+            HighNeedsHistoryTabs.Send2 => subCategories,
             _ => throw new ArgumentOutOfRangeException(nameof(tab))
         };
         await AreChartStatsVisible(tab);
@@ -114,6 +135,7 @@ public class HighNeedsHistoricDataPage(IPage page)
         var charts = tab switch
         {
             HighNeedsHistoryTabs.Section251 => AllSection251Charts,
+            HighNeedsHistoryTabs.Send2 => AllSend2Charts,
             _ => throw new ArgumentOutOfRangeException(nameof(tab))
         };
 
@@ -125,6 +147,7 @@ public class HighNeedsHistoricDataPage(IPage page)
         var sections = tab switch
         {
             HighNeedsHistoryTabs.Section251 => Section251TabContent.Locator(Tables),
+            HighNeedsHistoryTabs.Send2 => Send2TabContent.Locator(Tables),
             _ => throw new ArgumentOutOfRangeException(nameof(tab))
         };
 
@@ -140,20 +163,21 @@ public class HighNeedsHistoricDataPage(IPage page)
         var viewAsTableRadio = tab switch
         {
             HighNeedsHistoryTabs.Section251 => Section251TableView,
+            HighNeedsHistoryTabs.Send2 => Send2TableView,
             _ => throw new ArgumentOutOfRangeException(nameof(tab))
         };
 
         await viewAsTableRadio.Click();
     }
 
-    public async Task ClickSectionLink(Section251CategoriesNames categoryName)
+    public async Task ClickSectionLink(HistoricDataCategoryNames categoryName)
     {
         var link = SectionLink(categoryName);
 
         await link.Locator(Selectors.ToggleSectionText).First.ClickAsync();
     }
 
-    public async Task IsSectionVisible(Section251CategoriesNames categoryName, bool visibility, string text,
+    public async Task IsSectionVisible(HistoricDataCategoryNames categoryName, bool visibility, string text,
         string chartMode)
     {
         var link = SectionLink(categoryName);
@@ -225,17 +249,19 @@ public class HighNeedsHistoricDataPage(IPage page)
                 await AssertCategoryNames(categories, tab);
                 break;
             case HighNeedsHistoryTabs.Send2:
+                await AssertCategoryNames(categories, tab);
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(tab));
         }
     }
 
-    private async Task IsSectionContentVisible(Section251CategoriesNames categoryName, bool visibility, string chartMode)
+    private async Task IsSectionContentVisible(HistoricDataCategoryNames categoryName, bool visibility, string chartMode)
     {
         var contentLocator = categoryName switch
         {
-            Section251CategoriesNames.PlaceFunding => Section251PlaceFundingAccordionContent,
+            HistoricDataCategoryNames.PlaceFunding => Section251PlaceFundingAccordionContent,
+            HistoricDataCategoryNames.PlacementOfPupils => Send2AccordionContent,
             _ => throw new ArgumentOutOfRangeException(nameof(categoryName))
         };
         foreach (var locator in await contentLocator.Locator(chartMode).AllAsync())
@@ -251,11 +277,12 @@ public class HighNeedsHistoricDataPage(IPage page)
         }
     }
 
-    private ILocator SectionLink(Section251CategoriesNames categoryName)
+    private ILocator SectionLink(HistoricDataCategoryNames categoryName)
     {
         var link = categoryName switch
         {
-            Section251CategoriesNames.PlaceFunding => SectionLink(Selectors.Section251AccordionHeading1),
+            HistoricDataCategoryNames.PlaceFunding => SectionLink(Selectors.Section251AccordionHeading1),
+            HistoricDataCategoryNames.PlacementOfPupils => SectionLink(Selectors.Send2AccordionHeading1),
             _ => throw new ArgumentOutOfRangeException(nameof(categoryName))
         };
         return link;
@@ -276,6 +303,7 @@ public class HighNeedsHistoricDataPage(IPage page)
         var subCategories = tab switch
         {
             HighNeedsHistoryTabs.Section251 => await Section251SubCategories.AllAsync(),
+            HighNeedsHistoryTabs.Send2 => await Send2SubCategories.AllAsync(),
             _ => throw new ArgumentOutOfRangeException(nameof(tab))
         };
 
@@ -295,6 +323,7 @@ public class HighNeedsHistoricDataPage(IPage page)
         var categories = tab switch
         {
             HighNeedsHistoryTabs.Section251 => await Section251CategoryHeadings.AllTextContentsAsync(),
+            HighNeedsHistoryTabs.Send2 => await Send2CategoryHeadings.AllTextContentsAsync(),
             _ => throw new ArgumentOutOfRangeException(nameof(tab))
         };
         foreach (var expectedHeading in expected)
@@ -308,6 +337,7 @@ public class HighNeedsHistoricDataPage(IPage page)
         var sections = tab switch
         {
             HighNeedsHistoryTabs.Section251 => Section251ChartsStats,
+            HighNeedsHistoryTabs.Send2 => Send2ChartsStats,
             _ => throw new ArgumentOutOfRangeException(nameof(tab))
         };
         await CheckVisibility(sections);
@@ -318,6 +348,7 @@ public class HighNeedsHistoricDataPage(IPage page)
         var sections = tab switch
         {
             HighNeedsHistoryTabs.Section251 => AllSection251Charts,
+            HighNeedsHistoryTabs.Send2 => AllSend2Charts,
             _ => throw new ArgumentOutOfRangeException(nameof(tab))
         };
         await CheckVisibility(sections);
@@ -337,6 +368,7 @@ public class HighNeedsHistoricDataPage(IPage page)
         var elementId = tab switch
         {
             HighNeedsHistoryTabs.Section251 => "section-251",
+            HighNeedsHistoryTabs.Send2 => "send-2",
             _ => throw new ArgumentOutOfRangeException(nameof(tab))
         };
 

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -129,6 +129,9 @@ public static class Selectors
     public const string Section251Tab = "#tab_section-251";
     public const string Section251ModeTable = "#section-251-mode-table";
     public const string Section251ModeChart = "#section-251-mode-chart";
+    public const string Send2Tab = "#tab_send-2";
+    public const string Send2ModeTable = "#send-2-mode-table";
+    public const string Send2ModeChart = "#send-2-mode-chart";
 
     public const string IncomeDimension = "#income-dimension";
     public const string BalanceDimension = "#balance-dimension";
@@ -138,6 +141,7 @@ public static class Selectors
     public const string SpendingAccordions = "#accordion-expenditure";
     public const string IncomeAccordions = "#accordion-income";
     public const string Section251Accordions = "#accordion-section-251";
+    public const string Send2Accordions = "#accordion-send-2";
     public const string SpendingTableMode = "#expenditure-mode-table";
     public const string IncomeTableMode = "#income-mode-table";
     public const string BalanceTableMode = "#balance-mode-table";
@@ -148,11 +152,14 @@ public static class Selectors
     public const string BalancePanel = "#balance";
     public const string CensusPanel = "#census";
     public const string Section251Panel = "#section-251";
+    public const string Send2Panel = "#send-2";
 
     public const string SpendingAccordionHeading2 = "#accordion-expenditure-heading-2";
     public const string SpendingAccordionContent2 = "#accordion-expenditure-content-2";
     public const string Section251AccordionHeading1 = "#accordion-section-251-heading-1";
     public const string Section251AccordionContent1 = "#accordion-section-251-content-1";
+    public const string Send2AccordionHeading1 = "#accordion-send-2-heading-1";
+    public const string Send2AccordionContent1 = "#accordion-send-2-content-1";
 
     public const string LineChartStats = ".chart-stat-line-chart";
 

--- a/web/tests/Web.E2ETests/Steps/LocalAuthority/HighNeedsHistoricDataSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/LocalAuthority/HighNeedsHistoricDataSteps.cs
@@ -88,14 +88,14 @@ public class HighNeedsHistoricDataSteps(PageDriver driver)
     public async Task WhenIClickSectionLinkFor(string chartName)
     {
         Assert.NotNull(_highNeedsHistoricDataPage);
-        await _highNeedsHistoricDataPage.ClickSectionLink(Section251CategoryFromFriendlyName(chartName));
+        await _highNeedsHistoricDataPage.ClickSectionLink(HistoricDataCategoryFromFriendlyName(chartName));
     }
 
     [Then("the section '(.*)' is hidden")]
     public async Task ThenTheSectionIsHidden(string chartName)
     {
         Assert.NotNull(_highNeedsHistoricDataPage);
-        await _highNeedsHistoricDataPage.IsSectionVisible(Section251CategoryFromFriendlyName(chartName), false, "Show", "chart");
+        await _highNeedsHistoricDataPage.IsSectionVisible(HistoricDataCategoryFromFriendlyName(chartName), false, "Show", "chart");
     }
 
     [Then("the '(.*)' tab '(.*)' chart shows the legend '(.*)' using separator '(.*)'")]
@@ -112,11 +112,12 @@ public class HighNeedsHistoricDataSteps(PageDriver driver)
         await _highNeedsHistoricDataPage.ChartTableContains(chartName, table);
     }
 
-    private static Section251CategoriesNames Section251CategoryFromFriendlyName(string chartName)
+    private static HistoricDataCategoryNames HistoricDataCategoryFromFriendlyName(string chartName)
     {
         return chartName switch
         {
-            "place funding" => Section251CategoriesNames.PlaceFunding,
+            "place funding" => HistoricDataCategoryNames.PlaceFunding,
+            "Placement of pupils aged up to 25 with SEN statement or EHC plan (per 1000 2 to 18 population)" => HistoricDataCategoryNames.PlacementOfPupils,
             _ => throw new ArgumentOutOfRangeException(nameof(chartName))
         };
     }
@@ -131,6 +132,7 @@ public class HighNeedsHistoricDataSteps(PageDriver driver)
         return tab switch
         {
             "section 251" => HighNeedsHistoryTabs.Section251,
+            "send 2" => HighNeedsHistoryTabs.Send2,
             _ => throw new ArgumentOutOfRangeException(nameof(tab))
         };
     }


### PR DESCRIPTION
### Context
AB#249550 - AB#251210

Also addresses some accessibility issues identified

### Change proposed in this pull request
adds e2e tests to cover behaviour of the send 2 tab of this page
fixes issue for ids for the accordion not aligning for aria-controls
fixes headings for charts. They were h2 inside the accordion, changed to h3
adds a test id for tables in the `HistoricChart` component

### Guidance to review 
Is anything additonal required?
To test locally you can copy assets from front-end-components and then running web locally all tests should pass

A bump to `front-end` will be required following this PR

### Checklist (add/remove as appropriate)
- [ ] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally

