### PR TITLE
Management and persistence of comparator LAs for High needs benchmarking

### DIFF
--- a/web/Web.sln.DotSettings
+++ b/web/Web.sln.DotSettings
@@ -38,6 +38,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=gias/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=govuk/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=icfp/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=nfer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=noopener/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=noreferrer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=outturn/@EntryIndexedValue">True</s:Boolean>

--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -562,3 +562,58 @@ hr.govuk-section-break--print {
     }
   }
 }
+
+table#current-comparators-la {
+  > tbody > tr > td.govuk-table__cell {
+    vertical-align: middle;
+  }
+}
+
+.select-row {
+  display: flex;
+  flex-direction: column;
+  gap: govuk-spacing(3);
+  margin-bottom: govuk-spacing(3);
+
+  @include govuk-media-query($from: tablet) {
+    flex-direction: row;
+    align-items: self-end;
+    gap: govuk-spacing(6);
+  }
+
+  .select-column-two-thirds {
+    @include govuk-media-query($from: tablet) {
+      flex: calc(2 / 3);
+      display: inline-flex;
+    }
+  }
+
+  .select-column-one-third {
+    @include govuk-media-query($from: tablet) {
+      flex: calc(1 / 3);
+      display: inline-flex;
+    }
+  }
+
+  .govuk-form-group {
+    margin-bottom: govuk-spacing(0);
+
+    @include govuk-media-query($from: tablet) {
+      margin-bottom: govuk-spacing(4);
+    }
+
+    &.govuk-form-group--error.govuk-\!-width-full {
+      width: 95% !important;
+
+      @include govuk-media-query($from: tablet) {
+        width: 100% !important;
+      }
+    }
+  }
+
+  .govuk-button {
+    @include govuk-media-query($from: tablet) {
+      margin-bottom: govuk-spacing(4);
+    }
+  }
+}

--- a/web/src/Web.App/Constants/TrackedRequestType.cs
+++ b/web/src/Web.App/Constants/TrackedRequestType.cs
@@ -1,4 +1,5 @@
 ﻿using Web.App.Attributes;
+
 namespace Web.App;
 
 public enum TrackedRequestType
@@ -46,7 +47,9 @@ public enum TrackedRequestFeature
     [StringValue("spending-priorities")]
     SpendingPriorities,
     [StringValue("financial-benchmarking-insights-summary")]
-    FinancialBenchmarkingInsightsSummary
+    FinancialBenchmarkingInsightsSummary,
+    [StringValue("high-needs")]
+    HighNeeds
 }
 
 public enum TrackedRequestRouteParameters

--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsBenchmarkingController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsBenchmarkingController.cs
@@ -1,11 +1,14 @@
 ﻿using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.FeatureManagement.Mvc;
+using Web.App.Attributes;
 using Web.App.Attributes.RequestTelemetry;
 using Web.App.Domain;
+using Web.App.Extensions;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.Establishment;
 using Web.App.Infrastructure.Extensions;
+using Web.App.Services;
 using Web.App.ViewModels;
 
 namespace Web.App.Controllers;
@@ -15,16 +18,20 @@ namespace Web.App.Controllers;
 [Route("local-authority/{code}/high-needs/benchmarking")]
 public class LocalAuthorityHighNeedsBenchmarkingController(
     ILogger<LocalAuthorityHighNeedsBenchmarkingController> logger,
-    IEstablishmentApi establishmentApi)
+    IEstablishmentApi establishmentApi,
+    ILocalAuthorityComparatorSetService localAuthorityComparatorSetService)
     : Controller
 {
     [HttpGet]
     [LocalAuthorityRequestTelemetry(TrackedRequestFeature.Home)]
-    public async Task<IActionResult> Index(string code)
+    [ImportModelState]
+    public async Task<IActionResult> Index(string code, [FromQuery] string[]? la = null, [FromQuery] bool? updated = false)
     {
         using (logger.BeginScope(new
         {
-            code
+            code,
+            la,
+            updated
         }))
         {
             try
@@ -32,13 +39,81 @@ public class LocalAuthorityHighNeedsBenchmarkingController(
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.LocalAuthorityHome(code);
 
                 var neighbours = await LocalAuthorityStatisticalNeighbours(code);
-                var viewModel = new LocalAuthorityStatisticalNeighboursViewModel(neighbours);
+                var viewModel = new LocalAuthorityHighNeedsBenchmarkingViewModel(
+                    neighbours,
+                    la ?? (updated == true ? [] : localAuthorityComparatorSetService.ReadUserDefinedComparatorSetFromSession(code).Set));
                 return View(viewModel);
             }
             catch (Exception e)
             {
                 logger.LogError(e, "An error displaying local authority high needs benchmarking: {DisplayUrl}", Request.GetDisplayUrl());
                 return e is StatusCodeException s ? StatusCode((int)s.Status) : StatusCode(500);
+            }
+        }
+    }
+
+    [HttpPost]
+    [ExportModelState]
+    [Route("update")]
+    public IActionResult UpdateComparators([FromRoute] string code, [FromForm] LocalAuthorityComparatorViewModel viewModel)
+    {
+        using (logger.BeginScope(new
+        {
+            code,
+            viewModel
+        }))
+        {
+            try
+            {
+                var comparators = new List<string>(viewModel.Selected);
+                var action = viewModel.Action ?? string.Empty;
+
+                switch (action)
+                {
+                    case FormAction.Reset:
+                        return RedirectToAction("Index", "LocalAuthorityHighNeeds", new { code });
+                    case FormAction.Add when string.IsNullOrWhiteSpace(viewModel.LaInput):
+                        ModelState.AddModelError(nameof(viewModel.LaInput), "Select a local authority");
+                        break;
+                    case FormAction.Add when comparators.Count >= 9:
+                        ModelState.AddModelError(nameof(viewModel.LaInput), "Select up to 9 comparator local authorities");
+                        break;
+                    case FormAction.Add:
+                        comparators.Add(viewModel.LaInput);
+                        break;
+                    case FormAction.Continue when comparators.Count is < 1 or > 9:
+                        ModelState.AddModelError(nameof(viewModel.LaInput), "Select between 1 and 9 comparator local authorities");
+                        break;
+                }
+
+                if (action.StartsWith(FormAction.Remove))
+                {
+                    var laCode = action[(FormAction.Remove.Length + 1)..];
+                    comparators.Remove(laCode);
+                }
+
+                if (!ModelState.IsValid)
+                {
+                    logger.LogDebug("Posted local authorities comparators failed validation: {ModelState}",
+                        ModelState.Where(m => m.Value != null && m.Value.Errors.Any()).ToJson());
+                }
+                else if (action == FormAction.Continue)
+                {
+                    localAuthorityComparatorSetService.SetUserDefinedComparatorSetInSession(code, new UserDefinedLocalAuthorityComparatorSet { Set = comparators.ToArray() });
+                    return RedirectToAction("Index", "LocalAuthorityHighNeeds", new { code });
+                }
+
+                return RedirectToAction("Index", new
+                {
+                    code,
+                    la = comparators,
+                    updated = true
+                });
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "An error occurred managing local authority comparators: {DisplayUrl}", Request.GetDisplayUrl());
+                return StatusCode(StatusCodes.Status400BadRequest);
             }
         }
     }

--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsController.cs
@@ -19,7 +19,7 @@ public class LocalAuthorityHighNeedsController(
     : Controller
 {
     [HttpGet]
-    [LocalAuthorityRequestTelemetry(TrackedRequestFeature.Home)]
+    [LocalAuthorityRequestTelemetry(TrackedRequestFeature.HighNeeds)]
     public async Task<IActionResult> Index(string code)
     {
         using (logger.BeginScope(new

--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsHistoricDataController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsHistoricDataController.cs
@@ -19,7 +19,7 @@ public class LocalAuthorityHighNeedsHistoricDataController(
     : Controller
 {
     [HttpGet]
-    [LocalAuthorityRequestTelemetry(TrackedRequestFeature.Home)]
+    [LocalAuthorityRequestTelemetry(TrackedRequestFeature.HighNeeds)]
     public async Task<IActionResult> Index(string code)
     {
         using (logger.BeginScope(new

--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsNationalRankingsController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsNationalRankingsController.cs
@@ -19,7 +19,7 @@ public class LocalAuthorityHighNeedsNationalRankingsController(
     : Controller
 {
     [HttpGet]
-    [LocalAuthorityRequestTelemetry(TrackedRequestFeature.Home)]
+    [LocalAuthorityRequestTelemetry(TrackedRequestFeature.HighNeeds)]
     public async Task<IActionResult> Index(string code)
     {
         using (logger.BeginScope(new

--- a/web/src/Web.App/Infrastructure/Apis/Establishment/Api.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Establishment/Api.cs
@@ -7,6 +7,7 @@ public static class Api
         public static string Schools => "api/schools";
         public static string SchoolSuggest => "api/schools/suggest";
         public static string TrustSuggest => "api/trusts/suggest";
+        public static string LocalAuthorities => "api/local-authorities";
         public static string LocalAuthoritySuggest => "api/local-authorities/suggest";
         public static string LocalAuthorityNationalRank => "api/local-authorities/national-rank";
         public static string School(string? identifier)

--- a/web/src/Web.App/Infrastructure/Apis/Establishment/EstablishmentApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Establishment/EstablishmentApi.cs
@@ -27,6 +27,11 @@ public class EstablishmentApi(HttpClient httpClient, string? key = default) : Ap
         return GetAsync($"{Api.Establishment.LocalAuthorityNationalRank}{query?.ToQueryString()}", cancellationToken);
     }
 
+    public Task<ApiResult> GetLocalAuthorities()
+    {
+        return GetAsync(Api.Establishment.LocalAuthorities);
+    }
+
     public Task<ApiResult> SuggestSchools(string search, string[]? exclude = null)
     {
         return SendAsync(new HttpRequestMessage
@@ -65,6 +70,7 @@ public interface IEstablishmentApi
     Task<ApiResult> GetLocalAuthority(string? identifier);
     Task<ApiResult> GetLocalAuthorityStatisticalNeighbours(string? identifier);
     Task<ApiResult> GetLocalAuthoritiesNationalRank(ApiQuery? query = null, CancellationToken cancellationToken = default);
+    Task<ApiResult> GetLocalAuthorities();
     Task<ApiResult> SuggestSchools(string search, string[]? exclude = null);
     Task<ApiResult> SuggestTrusts(string search, string[]? exclude = null);
     Task<ApiResult> SuggestLocalAuthorities(string search, string[]? exclude = null);

--- a/web/src/Web.App/ViewComponents/LocalAuthorityComparatorsViewComponent.cs
+++ b/web/src/Web.App/ViewComponents/LocalAuthorityComparatorsViewComponent.cs
@@ -10,14 +10,9 @@ public class LocalAuthorityComparatorsViewComponent(IEstablishmentApi establishm
 {
     public async Task<IViewComponentResult> InvokeAsync(string code, string[] comparators)
     {
-        var localAuthorities = await LocalAuthorities();
-        return View(new LocalAuthorityComparatorsViewModel(code, localAuthorities, comparators));
-    }
-
-    private async Task<IEnumerable<LocalAuthority>> LocalAuthorities()
-    {
-        return await establishmentApi
+        var localAuthorities = await establishmentApi
             .GetLocalAuthorities()
             .GetResultOrThrow<IEnumerable<LocalAuthority>>();
+        return View(new LocalAuthorityComparatorsViewModel(code, localAuthorities, comparators));
     }
 }

--- a/web/src/Web.App/ViewComponents/LocalAuthorityComparatorsViewComponent.cs
+++ b/web/src/Web.App/ViewComponents/LocalAuthorityComparatorsViewComponent.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Web.App.Domain;
+using Web.App.Infrastructure.Apis.Establishment;
+using Web.App.Infrastructure.Extensions;
+using Web.App.ViewModels.Components;
+
+namespace Web.App.ViewComponents;
+
+public class LocalAuthorityComparatorsViewComponent(IEstablishmentApi establishmentApi) : ViewComponent
+{
+    public async Task<IViewComponentResult> InvokeAsync(string code, string[] comparators)
+    {
+        var localAuthorities = await LocalAuthorities();
+        return View(new LocalAuthorityComparatorsViewModel(code, localAuthorities, comparators));
+    }
+
+    private async Task<IEnumerable<LocalAuthority>> LocalAuthorities()
+    {
+        return await establishmentApi
+            .GetLocalAuthorities()
+            .GetResultOrThrow<IEnumerable<LocalAuthority>>();
+    }
+}

--- a/web/src/Web.App/ViewModels/Components/LocalAuthorityComparatorsViewModel.cs
+++ b/web/src/Web.App/ViewModels/Components/LocalAuthorityComparatorsViewModel.cs
@@ -1,0 +1,21 @@
+﻿using Web.App.Domain;
+
+namespace Web.App.ViewModels.Components;
+
+public class LocalAuthorityComparatorsViewModel(
+    string code,
+    IEnumerable<LocalAuthority> localAuthorities,
+    string[] comparators)
+{
+    public string Code => code;
+
+    public LocalAuthority[] AvailableLocalAuthorities => localAuthorities
+        .Where(l => l.Code != code)
+        .Where(l => !comparators.Contains(l.Code))
+        .ToArray();
+
+    public LocalAuthority[] SelectedLocalAuthorities => comparators
+        .Join(localAuthorities, c => c, l => l.Code, (_, localAuthority) => localAuthority)
+        .OrderBy(l => l.Name)
+        .ToArray();
+}

--- a/web/src/Web.App/ViewModels/LocalAuthorityComparatorViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityComparatorViewModel.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+// ReSharper disable PropertyCanBeMadeInitOnly.Global
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+
+namespace Web.App.ViewModels;
+
+public class LocalAuthorityComparatorViewModel
+{
+    [Required]
+    public string? Action { get; set; }
+
+    public string? LaInput { get; set; }
+
+    public string[] Selected { get; set; } = [];
+}

--- a/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsBenchmarkingViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsBenchmarkingViewModel.cs
@@ -2,7 +2,7 @@ using Web.App.Domain;
 
 namespace Web.App.ViewModels;
 
-public class LocalAuthorityStatisticalNeighboursViewModel(LocalAuthorityStatisticalNeighbours localAuthority)
+public class LocalAuthorityHighNeedsBenchmarkingViewModel(LocalAuthorityStatisticalNeighbours localAuthority, string[] comparators)
 {
     public string? Code => localAuthority.Code;
     public string? Name => localAuthority.Name;
@@ -14,4 +14,9 @@ public class LocalAuthorityStatisticalNeighboursViewModel(LocalAuthorityStatisti
         .Select(n => n.Name)
         .Cast<string>()
         .ToArray() ?? [];
+
+    public string[] Comparators => comparators
+        .Where(c => c != Code)
+        .Distinct()
+        .ToArray();
 }

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsBenchmarking/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsBenchmarking/Index.cshtml
@@ -1,4 +1,4 @@
-@model Web.App.ViewModels.LocalAuthorityStatisticalNeighboursViewModel
+@model Web.App.ViewModels.LocalAuthorityHighNeedsBenchmarkingViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.LocalAuthorityHighNeedsStartBenchmarking;
 }
@@ -10,6 +10,8 @@
     id = Model.Code,
     kind = OrganisationTypes.LocalAuthority
 })
+
+@await Html.PartialAsync("_ErrorSummary")
 
 <div class="govuk-inset-text">
     <p class="govuk-body">
@@ -35,3 +37,9 @@
         elit.
     </div>
 </details>
+
+@await Component.InvokeAsync("LocalAuthorityComparators", new
+{
+    Model.Code,
+    Model.Comparators
+})

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsBenchmarking/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsBenchmarking/Index.cshtml
@@ -1,3 +1,5 @@
+@using Microsoft.AspNetCore.Mvc.TagHelpers
+@using Web.App.Domain
 @model Web.App.ViewModels.LocalAuthorityHighNeedsBenchmarkingViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.LocalAuthorityHighNeedsStartBenchmarking;
@@ -13,33 +15,65 @@
 
 @await Html.PartialAsync("_ErrorSummary")
 
-<div class="govuk-inset-text">
-    <p class="govuk-body">
-        These local authorities are your ten closest statistical neighbours which are deemed to have similar
-        characteristics:
-    </p>
-    <ol class="govuk-list govuk-list--number">
-        @foreach (var neighbour in Model.StatisticalNeighbours)
-        {
-            <li>@neighbour</li>
-        }
-    </ol>
-</div>
-
-<details class="govuk-details">
-    <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-            More about statistical neighbours
-        </span>
-    </summary>
-    <div class="govuk-details__text">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing
-        elit.
-    </div>
-</details>
-
-@await Component.InvokeAsync("LocalAuthorityComparators", new
+@if (Model.StatisticalNeighbours.Any())
 {
-    Model.Code,
-    Model.Comparators
-})
+    <div class="govuk-inset-text">
+        <p class="govuk-body">
+            These local authorities are your ten closest statistical neighbours which are deemed to have similar
+            characteristics:
+        </p>
+        <ol class="govuk-list govuk-list--number">
+            @foreach (var neighbour in Model.StatisticalNeighbours)
+            {
+                <li>@neighbour</li>
+            }
+        </ol>
+    </div>
+
+    <details class="govuk-details">
+        <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+                More about statistical neighbours
+            </span>
+        </summary>
+        <div class="govuk-details__text">
+            <p class="govuk-body-s">
+                Statistical neighbours provide suggestions for local authorities to compare against.
+            </p>
+            <p class="govuk-body-s">
+                For each local authority, 10 local authorities are listed which are deemed to have
+                similar characteristics. These designated local authorities are known as statistical
+                neighbours and are listed in order from the statistically closest (top) to least close
+                (bottom).
+            </p>
+            <p class="govuk-body-s">
+                The National Foundation for Educational Research (NFER) was commissioned in
+                2007 by the Department for Education (DfE) to identify and group similar local
+                authorities in terms of the socio-economic characteristic.
+            </p>
+        </div>
+    </details>
+}
+
+<h2 class="govuk-heading-m">
+    Add local authorities
+</h2>
+
+<form action="@Url.Action("Index", "LocalAuthorityHighNeedsBenchmarking", new { Model.Code })" method="post">
+    @await Component.InvokeAsync("LocalAuthorityComparators", new
+    {
+        Model.Code,
+        Model.Comparators
+    })
+
+    <div class="govuk-button-group">
+        <button type="submit" class="govuk-button" data-module="govuk-button" name="action"
+                value="@FormAction.Continue">
+            Save and continue
+        </button>
+        <a class="govuk-button govuk-button--secondary" data-module="govuk-button"
+           href="@Url.Action("Index", "LocalAuthorityHighNeeds", new { Model.Code })">
+            Cancel
+        </a>
+    </div>
+</form>

--- a/web/src/Web.App/Views/Shared/Components/LocalAuthorityComparators/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/LocalAuthorityComparators/Default.cshtml
@@ -7,95 +7,79 @@
     var hasLaInputError = ViewData.ModelState.HasError(nameof(LocalAuthorityComparatorViewModel.LaInput));
 }
 
-<form
-    action="@Url.Action("UpdateComparators", "LocalAuthorityHighNeedsBenchmarking", new { Model.Code })"
-    method="post">
-    <h2 class="govuk-heading-m">
-        Add local authorities
-    </h2>
-
-    <div class="select-row">
-        <div class="select-column-two-thirds">
-            <div
-                class="govuk-form-group govuk-!-width-full@(hasLaInputError ? " govuk-form-group--error" : string.Empty)">
-                <label class="govuk-label govuk-visually-hidden"
-                       for="@nameof(LocalAuthorityComparatorViewModel.LaInput)">
-                    Local authority
-                </label>
+<div class="select-row">
+    <div class="select-column-two-thirds">
+        <div
+            class="govuk-form-group govuk-!-width-full@(hasLaInputError ? " govuk-form-group--error" : string.Empty)">
+            <label class="govuk-label govuk-visually-hidden"
+                   for="@nameof(LocalAuthorityComparatorViewModel.LaInput)">
+                Local authority
+            </label>
+            @if (hasLaInputError)
+            {
                 <p id="@nameof(LocalAuthorityComparatorViewModel.LaInput)-error" class="govuk-error-message">
                     <span class="govuk-visually-hidden">Error:</span>
                     @ViewData.ModelState[nameof(LocalAuthorityComparatorViewModel.LaInput)]?.Errors.First().ErrorMessage
                 </p>
-                <select
-                    class="govuk-select govuk-!-width-full@(hasLaInputError ? " govuk-select--error" : string.Empty)"
-                    id="@nameof(LocalAuthorityComparatorViewModel.LaInput)"
-                    name="@nameof(LocalAuthorityComparatorViewModel.LaInput)">
-                    <option value="">Choose local authority</option>
-                    @foreach (var localAuthority in Model.AvailableLocalAuthorities)
-                    {
-                        <option value="@localAuthority.Code">@localAuthority.Name</option>
-                    }
-                </select>
-            </div>
-        </div>
-        <div class="select-column-one-third">
-            <button
-                type="submit"
-                class="govuk-button govuk-button--secondary"
-                data-module="govuk-button"
-                name="action" value="@FormAction.Add">
-                Add
-            </button>
-        </div>
-    </div>
-
-    @if (Model.SelectedLocalAuthorities.Any())
-    {
-        <h3 class="govuk-heading-s">
-            Comparators added
-        </h3>
-
-        <table class="govuk-table" id="current-comparators-la">
-            <caption class="govuk-table__caption govuk-visually-hidden">Currently selected comparator local
-                authorities
-            </caption>
-            <thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-                <th scope="col" class="govuk-table__header govuk-!-width-two-thirds">Local authority</th>
-                <th scope="col" class="govuk-table__header govuk-!-width-one-third"></th>
-            </tr>
-            </thead>
-            <tbody class="govuk-table__body">
-            @foreach (var selected in Model.SelectedLocalAuthorities)
-            {
-                <tr class="govuk-table__row">
-                    <td class="govuk-table__cell">@selected.Name</td>
-                    <td class="govuk-table__cell">
-                        <input
-                            type="hidden" name="@nameof(LocalAuthorityComparatorViewModel.Selected)"
-                            value="@selected.Code"/>
-                        <button
-                            type="submit"
-                            class="govuk-button govuk-button--warning govuk-!-margin-bottom-0"
-                            data-module="govuk-button"
-                            name="action" value="@FormAction.Remove-@selected.Code">
-                            Remove
-                        </button>
-                    </td>
-                </tr>
             }
-            </tbody>
-        </table>
-    }
-
-    <div class="govuk-button-group">
-        <button type="submit" class="govuk-button" data-module="govuk-button" name="action"
-                value="@FormAction.Continue">
-            Save and continue
-        </button>
-        <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button" name="action"
-                value="@FormAction.Reset">
-            Cancel
+            <select
+                class="govuk-select govuk-!-width-full@(hasLaInputError ? " govuk-select--error" : string.Empty)"
+                id="@nameof(LocalAuthorityComparatorViewModel.LaInput)"
+                name="@nameof(LocalAuthorityComparatorViewModel.LaInput)">
+                <option value="">Choose local authority</option>
+                @foreach (var localAuthority in Model.AvailableLocalAuthorities)
+                {
+                    <option value="@localAuthority.Code">@localAuthority.Name</option>
+                }
+            </select>
+        </div>
+    </div>
+    <div class="select-column-one-third">
+        <button
+            type="submit"
+            class="govuk-button govuk-button--secondary"
+            data-module="govuk-button"
+            name="action" value="@FormAction.Add">
+            Add
         </button>
     </div>
-</form>
+</div>
+
+@if (Model.SelectedLocalAuthorities.Any())
+{
+    <h3 class="govuk-heading-s">
+        Comparators added
+    </h3>
+
+    <table class="govuk-table" id="current-comparators-la">
+        <caption class="govuk-table__caption govuk-visually-hidden">Currently selected comparator local
+            authorities
+        </caption>
+        <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header govuk-!-width-two-thirds">Local authority</th>
+            <th scope="col" class="govuk-table__header govuk-!-width-one-third"></th>
+        </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        @foreach (var selected in Model.SelectedLocalAuthorities)
+        {
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell">@selected.Name</td>
+                <td class="govuk-table__cell">
+                    <input
+                        type="hidden" name="@nameof(LocalAuthorityComparatorViewModel.Selected)"
+                        value="@selected.Code"/>
+                    <button
+                        type="submit"
+                        class="govuk-button govuk-button--warning govuk-!-margin-bottom-0"
+                        data-module="govuk-button"
+                        name="action" value="@FormAction.Remove-@selected.Code">
+                        Remove
+                    </button>
+                </td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}

--- a/web/src/Web.App/Views/Shared/Components/LocalAuthorityComparators/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/LocalAuthorityComparators/Default.cshtml
@@ -22,9 +22,9 @@
                        for="@nameof(LocalAuthorityComparatorViewModel.LaInput)">
                     Local authority
                 </label>
-                <p id="location-error" class="govuk-error-message">
-                    <span
-                        class="govuk-visually-hidden">Error:</span> @ViewData.ModelState[nameof(LocalAuthorityComparatorViewModel.LaInput)]?.Errors.First().ErrorMessage
+                <p id="@nameof(LocalAuthorityComparatorViewModel.LaInput)-error" class="govuk-error-message">
+                    <span class="govuk-visually-hidden">Error:</span>
+                    @ViewData.ModelState[nameof(LocalAuthorityComparatorViewModel.LaInput)]?.Errors.First().ErrorMessage
                 </p>
                 <select
                     class="govuk-select govuk-!-width-full@(hasLaInputError ? " govuk-select--error" : string.Empty)"

--- a/web/src/Web.App/Views/Shared/Components/LocalAuthorityComparators/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/LocalAuthorityComparators/Default.cshtml
@@ -1,0 +1,101 @@
+﻿@using Microsoft.AspNetCore.Mvc.TagHelpers
+@using Web.App.Domain
+@using Web.App.Extensions
+@using Web.App.ViewModels
+@model Web.App.ViewModels.Components.LocalAuthorityComparatorsViewModel
+@{
+    var hasLaInputError = ViewData.ModelState.HasError(nameof(LocalAuthorityComparatorViewModel.LaInput));
+}
+
+<form
+    action="@Url.Action("UpdateComparators", "LocalAuthorityHighNeedsBenchmarking", new { Model.Code })"
+    method="post">
+    <h2 class="govuk-heading-m">
+        Add local authorities
+    </h2>
+
+    <div class="select-row">
+        <div class="select-column-two-thirds">
+            <div
+                class="govuk-form-group govuk-!-width-full@(hasLaInputError ? " govuk-form-group--error" : string.Empty)">
+                <label class="govuk-label govuk-visually-hidden"
+                       for="@nameof(LocalAuthorityComparatorViewModel.LaInput)">
+                    Local authority
+                </label>
+                <p id="location-error" class="govuk-error-message">
+                    <span
+                        class="govuk-visually-hidden">Error:</span> @ViewData.ModelState[nameof(LocalAuthorityComparatorViewModel.LaInput)]?.Errors.First().ErrorMessage
+                </p>
+                <select
+                    class="govuk-select govuk-!-width-full@(hasLaInputError ? " govuk-select--error" : string.Empty)"
+                    id="@nameof(LocalAuthorityComparatorViewModel.LaInput)"
+                    name="@nameof(LocalAuthorityComparatorViewModel.LaInput)">
+                    <option value="">Choose local authority</option>
+                    @foreach (var localAuthority in Model.AvailableLocalAuthorities)
+                    {
+                        <option value="@localAuthority.Code">@localAuthority.Name</option>
+                    }
+                </select>
+            </div>
+        </div>
+        <div class="select-column-one-third">
+            <button
+                type="submit"
+                class="govuk-button govuk-button--secondary"
+                data-module="govuk-button"
+                name="action" value="@FormAction.Add">
+                Add
+            </button>
+        </div>
+    </div>
+
+    @if (Model.SelectedLocalAuthorities.Any())
+    {
+        <h3 class="govuk-heading-s">
+            Comparators added
+        </h3>
+
+        <table class="govuk-table" id="current-comparators-la">
+            <caption class="govuk-table__caption govuk-visually-hidden">Currently selected comparator local
+                authorities
+            </caption>
+            <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header govuk-!-width-two-thirds">Local authority</th>
+                <th scope="col" class="govuk-table__header govuk-!-width-one-third"></th>
+            </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+            @foreach (var selected in Model.SelectedLocalAuthorities)
+            {
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">@selected.Name</td>
+                    <td class="govuk-table__cell">
+                        <input
+                            type="hidden" name="@nameof(LocalAuthorityComparatorViewModel.Selected)"
+                            value="@selected.Code"/>
+                        <button
+                            type="submit"
+                            class="govuk-button govuk-button--warning govuk-!-margin-bottom-0"
+                            data-module="govuk-button"
+                            name="action" value="@FormAction.Remove-@selected.Code">
+                            Remove
+                        </button>
+                    </td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    }
+
+    <div class="govuk-button-group">
+        <button type="submit" class="govuk-button" data-module="govuk-button" name="action"
+                value="@FormAction.Continue">
+            Save and continue
+        </button>
+        <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button" name="action"
+                value="@FormAction.Reset">
+            Cancel
+        </button>
+    </div>
+</form>

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -185,18 +185,25 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         return this;
     }
 
-    public BenchmarkingWebAppClient SetupEstablishment(LocalAuthority authority, LocalAuthorityRanking ranking, LocalAuthorityStatisticalNeighbours statisticalNeighbours)
+    public BenchmarkingWebAppClient SetupEstablishment(
+        LocalAuthority authority,
+        LocalAuthorityRanking ranking,
+        LocalAuthorityStatisticalNeighbours statisticalNeighbours,
+        LocalAuthority[] authorities)
     {
         SetupEstablishment(authority, []);
         EstablishmentApi.Setup(api => api.GetLocalAuthoritiesNationalRank(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(ranking));
         EstablishmentApi.Setup(api => api.GetLocalAuthorityStatisticalNeighbours(authority.Code)).ReturnsAsync(ApiResult.Ok(statisticalNeighbours));
+        EstablishmentApi.Setup(api => api.GetLocalAuthorities()).ReturnsAsync(ApiResult.Ok(authorities));
         return this;
     }
 
-    public BenchmarkingWebAppClient SetupEstablishment(LocalAuthorityStatisticalNeighbours authority)
+    public BenchmarkingWebAppClient SetupEstablishment(LocalAuthorityStatisticalNeighbours authority, LocalAuthority[] authorities)
     {
         EstablishmentApi.Reset();
         EstablishmentApi.Setup(api => api.GetLocalAuthorityStatisticalNeighbours(authority.Code)).ReturnsAsync(ApiResult.Ok(authority));
+        EstablishmentApi.Setup(api => api.GetLocalAuthorities()).ReturnsAsync(ApiResult.Ok(authorities));
+        EstablishmentApi.Setup(api => api.GetLocalAuthority(It.IsAny<string>())).ReturnsAsync(ApiResult.Ok(authorities.First()));
         return this;
     }
 
@@ -217,6 +224,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         EstablishmentApi.Setup(api => api.GetTrust(It.IsAny<string>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.GetLocalAuthority(It.IsAny<string>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.GetLocalAuthorityStatisticalNeighbours(It.IsAny<string>())).Throws(new Exception());
+        EstablishmentApi.Setup(api => api.GetLocalAuthorities()).Throws(new Exception());
         EstablishmentApi.Setup(api => api.SuggestSchools(It.IsAny<string>(), It.IsAny<string[]?>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.SuggestTrusts(It.IsAny<string>(), It.IsAny<string[]?>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.SuggestLocalAuthorities(It.IsAny<string>(), It.IsAny<string[]?>())).Throws(new Exception());

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeeds.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeeds.cs
@@ -142,8 +142,9 @@ public class WhenViewingHighNeeds(SchoolBenchmarkingWebAppClient client) : PageB
         Assert.NotNull(authority.Name);
 
         var statisticalNeighbours = Fixture.Build<LocalAuthorityStatisticalNeighbours>().Create();
+        var authorities = Fixture.Build<LocalAuthority>().CreateMany().ToArray();
 
-        var page = await Client.SetupEstablishment(authority, ranking, statisticalNeighbours)
+        var page = await Client.SetupEstablishment(authority, ranking, statisticalNeighbours, authorities)
             .SetupHighNeedsHistory(history)
             .SetupInsights()
             .Navigate(Paths.LocalAuthorityHighNeeds(authority.Code));

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsStartBenchmarking.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsStartBenchmarking.cs
@@ -101,6 +101,9 @@ public class WhenViewingHighNeedsStartBenchmarking(SchoolBenchmarkingWebAppClien
             {
                 {
                     "LaInput", code
+                },
+                {
+                    "Selected", code
                 }
             });
         });
@@ -129,11 +132,10 @@ public class WhenViewingHighNeedsStartBenchmarking(SchoolBenchmarkingWebAppClien
     {
         var (page, authority, _) = await SetupNavigateInitPage();
 
-        var cancelButton = page.QuerySelector("button[name='action'][value='reset']");
+        var cancelButton = page.QuerySelector("a.govuk-button--secondary") as IHtmlAnchorElement;
         Assert.NotNull(cancelButton);
 
-        page = await Client.SubmitForm(page.Forms[0], cancelButton);
-
+        page = await client.Follow(cancelButton);
         DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeeds(authority.Code).ToAbsolute());
     }
 
@@ -147,7 +149,10 @@ public class WhenViewingHighNeedsStartBenchmarking(SchoolBenchmarkingWebAppClien
             .ToArray();
 
         authority.StatisticalNeighbours = statisticalNeighbours;
-        var authorities = Fixture.Build<LocalAuthority>().CreateMany().ToArray();
+        var authorities = Fixture.Build<LocalAuthority>()
+            .With(l => l.Code, () => Fixture.Create<string>().Replace("-", string.Empty))
+            .CreateMany()
+            .ToArray();
 
         var page = await Client.SetupEstablishment(authority, authorities)
             .SetupInsights()
@@ -190,7 +195,7 @@ public class WhenViewingHighNeedsStartBenchmarking(SchoolBenchmarkingWebAppClien
         var continueButton = page.QuerySelector("button[name='action'][value='continue']");
         Assert.NotNull(continueButton);
 
-        var cancelButton = page.QuerySelector("button[name='action'][value='reset']");
+        var cancelButton = page.QuerySelector("a.govuk-button--secondary");
         Assert.NotNull(cancelButton);
     }
 }


### PR DESCRIPTION
### Context
[AB#252038](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/252038) [AB#249552](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249552)

### Change proposed in this pull request
- Select/add/remove LAs (via `<select>` only in current iteration)
- Validation for selection and min/max items
- Save to session or cancel
- Integration tests

### Guidance to review 
Deployed to `d18` feature environment for validation. Progressive enhancement to follow as part of future work. Copy review as part of future work (especially around validation messages).

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

