### PR TITLE
Extended Polly logging and alerting

### DIFF
--- a/support-analytics/terraform/README.md
+++ b/support-analytics/terraform/README.md
@@ -84,6 +84,7 @@ No modules.
 | [azurerm_monitor_metric_alert.web_app_error_alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert_v2.failed-finished-pipeline-messages](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert_v2.polly-warnings-429-alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert_v2.polly-warnings-alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_smart_detector_alert_rule.dependency-performance-degradation-detector](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_smart_detector_alert_rule) | resource |
 | [azurerm_monitor_smart_detector_alert_rule.exception-volume-changed-detector](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_smart_detector_alert_rule) | resource |
 | [azurerm_monitor_smart_detector_alert_rule.failure-anomalies-detector](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_smart_detector_alert_rule) | resource |

--- a/support-analytics/terraform/README.md
+++ b/support-analytics/terraform/README.md
@@ -31,6 +31,7 @@ No modules.
 | [azurerm_log_analytics_query_pack_query.feature-requests-by-auth](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_query_pack_query) | resource |
 | [azurerm_log_analytics_query_pack_query.function-app-role-instance-count](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_query_pack_query) | resource |
 | [azurerm_log_analytics_query_pack_query.most-popular-recent-schools](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_query_pack_query) | resource |
+| [azurerm_log_analytics_query_pack_query.polly-warnings](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_query_pack_query) | resource |
 | [azurerm_log_analytics_query_pack_query.popular-commercial-resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_query_pack_query) | resource |
 | [azurerm_log_analytics_query_pack_query.popular-local-authority-requests](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_query_pack_query) | resource |
 | [azurerm_log_analytics_query_pack_query.popular-school-requests](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_query_pack_query) | resource |
@@ -63,6 +64,7 @@ No modules.
 | [azurerm_log_analytics_saved_search.get-users](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_saved_search.get-waf-blocked-requests](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_log_analytics_saved_search.get-waf-logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
+| [azurerm_log_analytics_saved_search.get-web-warnings](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_saved_search) | resource |
 | [azurerm_logic_app_action_custom.initialise-affected-resource-ids](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
 | [azurerm_logic_app_action_custom.initialise-alert-id](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
 | [azurerm_logic_app_action_custom.initialise-fired-timestamp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
@@ -98,6 +100,7 @@ No modules.
 | [random_uuid.feature-requests-id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [random_uuid.function-app-role-instance-count-id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [random_uuid.most-popular-recent-schools-id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
+| [random_uuid.polly-warnings-id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [random_uuid.popular-commercial-resources-id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [random_uuid.popular-local-authority-requests-id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [random_uuid.popular-school-requests-id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |

--- a/support-analytics/terraform/README.md
+++ b/support-analytics/terraform/README.md
@@ -83,6 +83,7 @@ No modules.
 | [azurerm_monitor_metric_alert.non_financial_api_error_alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.web_app_error_alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert_v2.failed-finished-pipeline-messages](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert_v2.polly-warnings-429-alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_smart_detector_alert_rule.dependency-performance-degradation-detector](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_smart_detector_alert_rule) | resource |
 | [azurerm_monitor_smart_detector_alert_rule.exception-volume-changed-detector](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_smart_detector_alert_rule) | resource |
 | [azurerm_monitor_smart_detector_alert_rule.failure-anomalies-detector](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_smart_detector_alert_rule) | resource |

--- a/support-analytics/terraform/queries.tf
+++ b/support-analytics/terraform/queries.tf
@@ -521,3 +521,27 @@ resource "azurerm_log_analytics_query_pack_query" "most-popular-recent-schools" 
 
   body = file("${path.module}/queries/most-popular-recent-schools.kql")
 }
+
+resource "azurerm_log_analytics_saved_search" "get-web-warnings" {
+  name                       = "GetWebWarnings"
+  log_analytics_workspace_id = data.azurerm_log_analytics_workspace.application-insights-workspace.id
+  category                   = "Function"
+  display_name               = "GetWebWarnings"
+  function_alias             = "GetWebWarnings"
+  tags                       = local.query-tags
+
+  query = file("${path.module}/queries/functions/get-web-warnings.kql")
+}
+
+resource "random_uuid" "polly-warnings-id" {}
+
+resource "azurerm_log_analytics_query_pack_query" "polly-warnings" {
+  name          = random_uuid.polly-warnings-id.result
+  query_pack_id = azurerm_log_analytics_query_pack.query-pack.id
+  display_name  = "Polly warning messages"
+  description   = "Warning messages from the Polly policy handler in the Web project"
+  categories    = ["applications"]
+  tags          = local.query-tags
+
+  body = file("${path.module}/queries/polly-warnings.kql")
+}

--- a/support-analytics/terraform/queries/functions/get-web-warnings.kql
+++ b/support-analytics/terraform/queries/functions/get-web-warnings.kql
@@ -7,7 +7,7 @@ AppTraces
 | where 
     isempty(SyntheticSource)
 | where
-    SeverityLevel <= 2
+    SeverityLevel == 2
 | where
     isempty(AppRoleName) or AppRoleName matches regex "s198[ptd]\\d{2}-education-benchmarking"
 | project

--- a/support-analytics/terraform/queries/functions/get-web-warnings.kql
+++ b/support-analytics/terraform/queries/functions/get-web-warnings.kql
@@ -1,0 +1,20 @@
+AppTraces
+| extend
+    RetryAttempt = tostring(Properties["RetryAttempt"]),
+    Source = tostring(Properties["Source"]),
+    StatusCode = tostring(Properties["StatusCode"]),
+    Uri = tostring(Properties["Uri"])
+| where 
+    isempty(SyntheticSource)
+| where
+    SeverityLevel <= 2
+| where
+    isempty(AppRoleName) or AppRoleName matches regex "s198[ptd]\\d{2}-education-benchmarking"
+| project
+    TimeGenerated,
+    SeverityLevel,
+    Message,
+    Source,
+    StatusCode,
+    RetryAttempt,
+    Uri

--- a/support-analytics/terraform/queries/polly-warnings.kql
+++ b/support-analytics/terraform/queries/polly-warnings.kql
@@ -1,0 +1,2 @@
+GetWebWarnings
+| where Source == "Polly"

--- a/web/src/Web.App/Properties/launchSettings.json
+++ b/web/src/Web.App/Properties/launchSettings.json
@@ -6,7 +6,9 @@
       "launchBrowser": false,
       "applicationUrl": "https://localhost:7095",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "APPINSIGHTS_INSTRUMENTATIONKEY": "00000000-0000-0000-0000-000000000000",
+        "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westeurope-1.in.applicationinsights.azure.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.com/;ApplicationId=00000000-0000-0000-0000-000000000000"
       }
     },
     "https:test": {

--- a/web/src/Web.App/appsettings.Development.json
+++ b/web/src/Web.App/appsettings.Development.json
@@ -44,7 +44,8 @@
   },
   "Serilog": {
     "Using": [
-      "Serilog.Sinks.Console"
+      "Serilog.Sinks.Console",
+      "Serilog.Sinks.ApplicationInsights"
     ],
     "MinimumLevel": {
       "Default": "Debug"
@@ -52,6 +53,13 @@
     "WriteTo": [
       {
         "Name": "Console"
+      },
+      {
+        "Name": "ApplicationInsights",
+        "Args": {
+          "telemetryConverter": "Serilog.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights",
+          "restrictedToMinimumLevel": "Warning"
+        }
       }
     ],
     "Enrich": [


### PR DESCRIPTION
### Context
[AB#252424](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/252424) [AB#249246](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249246)

### Change proposed in this pull request
- Extended structured logging for Polly and created query to return warnings from `AppTraces`
- Log query alert rule for excessive `429` status codes from logged Polly warnings
- Log query alert rule for excessive Polly warnings over previous 24 hours

### Guidance to review 
Deployed to `d18`, along with sample endpoint that returns `429`. To test, GET `.../api/429`. Alerts should be sent to the Development Teams channel, e.g.:

![image](https://github.com/user-attachments/assets/45476c80-9920-4664-9f0d-779c076befa7)

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

