### PR TITLE
Fix chart heading for historic data high needs send 2 lead chart

### DIFF
--- a/front-end-components/src/views/historic-data-high-needs/partials/index.tsx
+++ b/front-end-components/src/views/historic-data-high-needs/partials/index.tsx
@@ -147,7 +147,7 @@ export const send2LeadSection: HistoricChartSend2Section<LocalAuthorityEducation
   {
     charts: [
       {
-        name: "Number aged up to 25 with SEN statement or EHC plan",
+        name: "Number aged up to 25 with SEN statement or EHC plan (per 1000 2 to 18 population)",
         field: "total",
       },
     ],

--- a/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsHistoricData.feature
+++ b/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsHistoricData.feature
@@ -123,7 +123,7 @@
     Scenario: Viewing data in table view send 2
         Given I am on 'send 2' high needs history page for local authority with code '201'
         When I click on view as table on 'send 2' tab
-        Then the table on the 'send 2' tab 'Number aged up to 25 with SEN statement or EHC plan' chart contains:
+        Then the table on the 'send 2' tab 'Number aged up to 25 with SEN statement or EHC plan (per 1000 2 to 18 population)' chart contains:
           | Year         | Amount |
           | 2019 to 2020 | 52     |
           | 2020 to 2021 | 59     |


### PR DESCRIPTION
### Context
[AB#249550](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249550)
incorrect chart title flagged in QA

### Change proposed in this pull request
Corrects chart name
Updates E2E tests (for table values assertion)

### Guidance to review 
Running locally with Vite or copying front end to web should now show the correct chart heading on the send 2 tab lead chart

Was Number aged up to 25 with SEN statement or EHC plan (per 1000 2 to 18 population)
Now Number aged up to 25 with SEN statement or EHC plan

Will require a bump to front end following this PR

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
