### PR TITLE
Created front-end view for Benchmarking High needs data

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -149,7 +149,8 @@
       <circle r="45" cx="50" cy="50" fill="purple" />
     </svg> -->
     <!--<div id="la-national-rank" data-code="201"></div>-->
-    <div id="historic-data-high-needs" data-code="201"></div>
+    <!-- <div id="historic-data-high-needs" data-code="201"></div> -->
+    <div id="benchmark-data-high-needs" data-code="201"></div>
     <!-- <div id="historic-data" data-type="school" data-id="114504"></div> -->
     <script type="module" src="/src/main.tsx"></script>
     <script

--- a/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
@@ -57,7 +57,10 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
 ) {
   const {
     barCategoryGap,
+    barGap,
+    barHeight,
     chartTitle,
+    className,
     data,
     grid,
     hideXAxis,
@@ -68,6 +71,8 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
     labelListSeriesName,
     labels,
     legend,
+    legendHorizontalAlign,
+    legendVerticalAlign,
     margin: _margin,
     onImageCopied,
     onImageLoading,
@@ -246,6 +251,8 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
     );
   }
 
+  const legendHeight = 30;
+
   return (
     // a11y: https://github.com/recharts/recharts/issues/3816
     <>
@@ -253,7 +260,14 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
         isRendered={suppressNegativeOrZero && filteredData.length < data.length}
         message={message}
       />
-      <div style={{ height: 22 * filteredData.length + 75 }}>
+      <div
+        style={{
+          height:
+            (barHeight ?? 22) * filteredData.length +
+            75 +
+            (legend ? legendHeight : 0),
+        }}
+      >
         <div
           aria-label={chartTitle}
           className="govuk-body-s govuk-!-font-size-14 full-height-width chart-wrapper"
@@ -262,6 +276,7 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
           <ResponsiveContainer>
             <BarChart
               barCategoryGap={barCategoryGap}
+              barGap={barGap}
               data={filteredData}
               layout="vertical"
               margin={{
@@ -275,7 +290,7 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
                 // https://github.com/recharts/recharts/issues/2665
                 rechartsRef as never
               }
-              className="recharts-wrapper-horizontal-bar-chart"
+              className={className ?? "recharts-wrapper-horizontal-bar-chart"}
             >
               {grid && <CartesianGrid />}
               {!!tooltip && <Tooltip content={tooltip} />}
@@ -347,12 +362,12 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
               )}
               {legend && (
                 <Legend
-                  align="right"
-                  verticalAlign="top"
+                  align={legendHorizontalAlign ?? "right"}
+                  verticalAlign={legendVerticalAlign ?? "top"}
                   formatter={(value) =>
                     (seriesConfig && seriesConfig[value]?.label) || value
                   }
-                  height={30}
+                  height={legendHeight}
                 />
               )}
             </BarChart>

--- a/front-end-components/src/components/charts/table-chart/component.tsx
+++ b/front-end-components/src/components/charts/table-chart/component.tsx
@@ -89,7 +89,7 @@ export const TableChart: React.FC<
               const { laName, schoolType, totalPupils, urn, value } = schoolRow;
               const { totalValue, schoolValue, centralValue, companyNumber } =
                 trustRow;
-              const { laCode } = laRow;
+              const { budget, laCode } = laRow;
               const additionalData = schoolRow.urn
                 ? {
                     laName,
@@ -141,6 +141,21 @@ export const TableChart: React.FC<
                             </td>
                           </>
                         )}
+                    </>
+                  ) : localAuthority ? (
+                    <>
+                      <td className="govuk-table__cell table-cell-value">
+                        {fullValueFormatter(value, {
+                          valueUnit,
+                        })}
+                      </td>
+                      {budget !== undefined && (
+                        <td className="govuk-table__cell table-cell-value">
+                          {fullValueFormatter(budget, {
+                            valueUnit,
+                          })}
+                        </td>
+                      )}
                     </>
                   ) : (
                     <td className="govuk-table__cell table-cell-value">

--- a/front-end-components/src/components/charts/table-chart/types.tsx
+++ b/front-end-components/src/components/charts/table-chart/types.tsx
@@ -35,4 +35,6 @@ export type LaChartData = {
   laCode: string;
   laName: string;
   value?: number;
+  budget?: number;
+  outturn?: number;
 };

--- a/front-end-components/src/components/charts/types.tsx
+++ b/front-end-components/src/components/charts/types.tsx
@@ -16,6 +16,8 @@ import { DownloadMode } from "src/services";
 export interface ChartProps<TData extends ChartDataSeries>
   extends ValueFormatterProps {
   barCategoryGap?: string | number;
+  barGap?: string | number;
+  barHeight?: number;
   chartTitle: string;
   className?: string;
   data: TData[];

--- a/front-end-components/src/composed/benchmark-chart-section-251/component.tsx
+++ b/front-end-components/src/composed/benchmark-chart-section-251/component.tsx
@@ -1,0 +1,73 @@
+import { useMemo } from "react";
+import { BenchmarkChartSection251Props } from "src/composed/benchmark-chart-section-251";
+import { LocalAuthoritySection251 } from "src/services";
+import { HorizontalBarChartMultiSeries } from "../horizontal-bar-chart-multi-series";
+import { ChartSeriesConfigItem } from "src/components";
+import { shortValueFormatter } from "src/components/charts/utils";
+import { LaChartData } from "src/components/charts/table-chart";
+
+export function BenchmarkChartSection251<
+  TData extends LocalAuthoritySection251,
+>({ chartTitle, data, valueField }: BenchmarkChartSection251Props<TData>) {
+  const mergedData = useMemo(() => {
+    const dataPoints: LaChartData[] = [];
+
+    data?.forEach((s) => {
+      const outturnValue = s.outturn && (s.outturn[valueField] as number);
+      const budgetValue = s.budget && (s.budget[valueField] as number);
+
+      dataPoints.push({
+        laCode: s.code,
+        laName: s.name,
+        outturn:
+          outturnValue === undefined ||
+          outturnValue === null ||
+          isNaN(outturnValue)
+            ? undefined
+            : outturnValue,
+        budget:
+          budgetValue === undefined ||
+          budgetValue === null ||
+          isNaN(budgetValue)
+            ? undefined
+            : budgetValue,
+      });
+    });
+
+    return {
+      tableHeadings: ["Local authority", "Actual", "Planned"],
+      dataPoints,
+    };
+  }, [data, valueField]);
+
+  const seriesConfig: { [key: string]: ChartSeriesConfigItem } = {
+    outturn: {
+      visible: true,
+      valueFormatter: (v) =>
+        shortValueFormatter(v, {
+          valueUnit: "currency",
+        }),
+    },
+    budget: {
+      visible: true,
+      valueFormatter: (v) =>
+        shortValueFormatter(v, {
+          valueUnit: "currency",
+        }),
+    },
+  };
+
+  return (
+    <HorizontalBarChartMultiSeries
+      chartTitle={chartTitle}
+      data={mergedData}
+      keyField="laCode"
+      seriesConfig={seriesConfig}
+      seriesLabelField="laName"
+      showCopyImageButton
+      valueUnit="currency"
+    >
+      <h3 className="govuk-heading-m">{chartTitle}</h3>
+    </HorizontalBarChartMultiSeries>
+  );
+}

--- a/front-end-components/src/composed/benchmark-chart-section-251/index.tsx
+++ b/front-end-components/src/composed/benchmark-chart-section-251/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/composed/benchmark-chart-section-251/types";
+export * from "src/composed/benchmark-chart-section-251/component";

--- a/front-end-components/src/composed/benchmark-chart-section-251/types.tsx
+++ b/front-end-components/src/composed/benchmark-chart-section-251/types.tsx
@@ -1,0 +1,13 @@
+import { ResolvedStatProps } from "src/components/charts/resolved-stat";
+import {
+  LocalAuthoritySection251,
+  LocalAuthoritySection251Benchmark,
+} from "src/services";
+
+export interface BenchmarkChartSection251Props<
+  TData extends LocalAuthoritySection251,
+> {
+  chartTitle: string;
+  data: LocalAuthoritySection251Benchmark<TData>[] | undefined;
+  valueField: ResolvedStatProps<TData>["valueField"];
+}

--- a/front-end-components/src/composed/benchmark-chart-send-2/component.tsx
+++ b/front-end-components/src/composed/benchmark-chart-send-2/component.tsx
@@ -1,0 +1,43 @@
+import { useMemo } from "react";
+import { BenchmarkChartSend2Props } from "src/composed/benchmark-chart-send-2";
+import { LocalAuthoritySend2Benchmark } from "src/services";
+import { LaChartData } from "src/components/charts/table-chart";
+import { HorizontalBarChartWrapper } from "../horizontal-bar-chart-wrapper";
+
+export function BenchmarkChartSend2<
+  TData extends LocalAuthoritySend2Benchmark,
+>({ chartTitle, data, valueField }: BenchmarkChartSend2Props<TData>) {
+  const mergedData = useMemo(() => {
+    const dataPoints: LaChartData[] = [];
+
+    data?.forEach((s) => {
+      const value = s && (s[valueField] as number);
+
+      dataPoints.push({
+        laCode: s.code,
+        laName: s.name,
+        value:
+          value === undefined || value === null || isNaN(value)
+            ? undefined
+            : value,
+      });
+    });
+
+    return {
+      tableHeadings: ["Local authority", "Amount"],
+      dataPoints,
+    };
+  }, [data, valueField]);
+
+  return (
+    <HorizontalBarChartWrapper
+      chartTitle={chartTitle}
+      data={mergedData}
+      localAuthority
+      showCopyImageButton
+      valueUnit="currency"
+    >
+      <h3 className="govuk-heading-m">{chartTitle}</h3>
+    </HorizontalBarChartWrapper>
+  );
+}

--- a/front-end-components/src/composed/benchmark-chart-send-2/index.tsx
+++ b/front-end-components/src/composed/benchmark-chart-send-2/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/composed/benchmark-chart-send-2/types";
+export * from "src/composed/benchmark-chart-send-2/component";

--- a/front-end-components/src/composed/benchmark-chart-send-2/types.tsx
+++ b/front-end-components/src/composed/benchmark-chart-send-2/types.tsx
@@ -1,0 +1,17 @@
+import { ChartSeriesValue } from "src/components/charts/types";
+import { ResolvedStatProps } from "src/components/charts/resolved-stat";
+import { LocalAuthoritySend2Benchmark } from "src/services";
+import { LaChartData } from "src/components/charts/table-chart";
+
+export interface BenchmarkChartSend2Props<
+  TData extends LocalAuthoritySend2Benchmark,
+> {
+  chartTitle: string;
+  data: TData[] | undefined;
+  valueField: ResolvedStatProps<TData>["valueField"];
+}
+
+export type Send2BenchmarkValue = LaChartData & {
+  outturn?: ChartSeriesValue;
+  budget?: ChartSeriesValue;
+};

--- a/front-end-components/src/composed/horizontal-bar-chart-multi-series/index.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-multi-series/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/composed/horizontal-bar-chart-multi-series/types";
+export * from "src/composed/horizontal-bar-chart-multi-series/composed";

--- a/front-end-components/src/composed/horizontal-bar-chart-multi-series/styles.scss
+++ b/front-end-components/src/composed/horizontal-bar-chart-multi-series/styles.scss
@@ -1,0 +1,40 @@
+$horizontal-bar-chart-multi-series-series-0-colour: #196b24;
+$horizontal-bar-chart-multi-series-series-1-colour: #e97132;
+
+.recharts-wrapper.horizontal-bar-chart-multi-series {
+    &:not(:last-child) {
+        margin-bottom: govuk-spacing(4);
+    }
+
+  .chart-cell.chart-cell-series-0,
+  .chart-cell.chart-cell-series-0.chart-cell-active,
+  .recharts-default-legend .legend-item-0 path {
+    fill: $horizontal-bar-chart-multi-series-series-0-colour;
+    stroke: $horizontal-bar-chart-multi-series-series-0-colour;
+  }
+
+  .chart-cell.chart-cell-series-1,
+  .chart-cell.chart-cell-series-1.chart-cell-active,
+  .recharts-default-legend .legend-item-1 path {
+    fill: $horizontal-bar-chart-multi-series-series-1-colour;
+    stroke: $horizontal-bar-chart-multi-series-series-1-colour;
+  }
+
+  .recharts-default-legend {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+  }
+
+  .recharts-default-legend .recharts-legend-item {
+    white-space: nowrap;
+  }
+
+  .recharts-default-legend .legend-item-0 path {
+    fill: $horizontal-bar-chart-multi-series-series-0-colour;
+  }
+
+  .recharts-default-legend .legend-item-1 path {
+    fill: $horizontal-bar-chart-multi-series-series-1-colour;
+  }
+}

--- a/front-end-components/src/composed/horizontal-bar-chart-multi-series/types.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-multi-series/types.tsx
@@ -1,0 +1,33 @@
+import { ChartProps } from "src/components/charts";
+import { LaChartData } from "src/components/charts/table-chart";
+
+export type HorizontalBarChartMultiSeriesProps<TData extends LaChartData> =
+  Pick<
+    ChartProps<TData>,
+    | "chartTitle"
+    | "keyField"
+    | "seriesConfig"
+    | "seriesLabelField"
+    | "showCopyImageButton"
+    | "valueUnit"
+  > & {
+    children?: React.ReactNode[] | React.ReactNode;
+    data: HorizontalBarChartMultiSeriesPropsData<TData>;
+    xAxisLabel?: string;
+  };
+
+export type HorizontalBarChartMultiSeriesPropsData<TData extends LaChartData> =
+  Omit<HorizontalBarChartMultiSeriesData<TData>, "dataPoints"> & {
+    dataPoints: TData[];
+  };
+
+export type HorizontalBarChartMultiSeriesData<
+  TData extends Omit<LaChartData, "value" | "budget" | "outturn">,
+> = {
+  tableHeadings: string[];
+  dataPoints: (TData & {
+    value: number;
+    budget: number | undefined;
+    outturn: number | undefined;
+  })[];
+};

--- a/front-end-components/src/constants.tsx
+++ b/front-end-components/src/constants.tsx
@@ -23,3 +23,4 @@ export const ShareContentByElementIdDataAttr = "share-content-by-element-id";
 export const LaunchModalDataAttr = "launch-modal";
 export const LaNationalRankViewElementId = "la-national-rank";
 export const HistoricDataHighNeedsElementId = "historic-data-high-needs";
+export const BenchmarkDataHighNeedsElementId = "benchmark-data-high-needs";

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useRef, useState } from "react";
 import ReactDOM from "react-dom/client";
 import { format } from "date-fns";
 import {
+  BenchmarkDataHighNeeds,
   CompareYourCensus,
   CompareYourCosts,
   CompareYourTrust,
@@ -13,28 +14,29 @@ import {
   LaNationalRankView,
 } from "src/views";
 import {
-  CompareCostsElementId,
+  BenchmarkDataHighNeedsElementId,
+  BudgetForecastReturnsElementId,
   CompareCensusElementId,
+  CompareCostsElementId,
+  CompareTrustElementId,
   DeploymentPlanElementId,
   FindOrganisationElementId,
-  HistoricDataElementId,
   HistoricData2ElementId,
+  HistoricDataElementId,
+  HistoricDataHighNeedsElementId,
   HorizontalBarChart1SeriesElementId,
+  HorizontalChartTrustFinancialElementId,
+  LaNationalRankViewElementId,
+  LaSuggesterId,
+  LaunchModalDataAttr,
   LineChart1SeriesElementId,
+  LineChart2SeriesElementId,
+  SchoolSuggesterId,
+  ShareContentByElementIdDataAttr,
   SpendingAndCostsComposedElementId,
+  TrustSuggesterId,
   VerticalBarChart2SeriesElementId,
   VerticalBarChart3SeriesElementId,
-  SchoolSuggesterId,
-  LaSuggesterId,
-  TrustSuggesterId,
-  HorizontalChartTrustFinancialElementId,
-  CompareTrustElementId,
-  LineChart2SeriesElementId,
-  BudgetForecastReturnsElementId,
-  ShareContentByElementIdDataAttr,
-  LaunchModalDataAttr,
-  LaNationalRankViewElementId,
-  HistoricDataHighNeedsElementId,
 } from "src/constants";
 import { HorizontalBarChart } from "./components/charts/horizontal-bar-chart";
 import { VerticalBarChart } from "./components/charts/vertical-bar-chart";
@@ -1019,6 +1021,21 @@ if (historicDataHighNeedsElement) {
           }
           fetchTimeout={30_000}
         />
+      </React.StrictMode>
+    );
+  }
+}
+
+const benchmarkDataHighNeedsElement = document.getElementById(
+  BenchmarkDataHighNeedsElementId
+);
+if (benchmarkDataHighNeedsElement) {
+  const { code } = benchmarkDataHighNeedsElement.dataset;
+  if (code) {
+    const root = ReactDOM.createRoot(benchmarkDataHighNeedsElement);
+    root.render(
+      <React.StrictMode>
+        <BenchmarkDataHighNeeds code={code} fetchTimeout={30_000} />
       </React.StrictMode>
     );
   }

--- a/front-end-components/src/services/education-health-care-plans-api.tsx
+++ b/front-end-components/src/services/education-health-care-plans-api.tsx
@@ -1,7 +1,39 @@
-import { LocalAuthoritySend2History } from "src/services/types";
+import {
+  LocalAuthoritySend2Benchmark,
+  LocalAuthoritySend2History,
+} from "src/services/types";
 import { v4 as uuidv4 } from "uuid";
 
 export class EducationHealthCarePlanApi {
+  static async comparison(
+    code: string,
+    signals?: AbortSignal[]
+  ): Promise<LocalAuthoritySend2Benchmark[]> {
+    const params = new URLSearchParams({
+      code,
+    });
+
+    const response = await fetch(
+      "/api/local-authorities/education-health-care-plans/comparison?" + params,
+      {
+        redirect: "manual",
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Correlation-ID": uuidv4(),
+        },
+        signal: signals?.length ? AbortSignal.any(signals) : undefined,
+      }
+    );
+
+    const json = await response.json();
+    if (json.error) {
+      throw json.error;
+    }
+
+    return json;
+  }
+
   static async history(
     code: string,
     signals?: AbortSignal[]

--- a/front-end-components/src/services/high-needs-api.tsx
+++ b/front-end-components/src/services/high-needs-api.tsx
@@ -1,10 +1,40 @@
 import {
   LocalAuthoritySection251,
+  LocalAuthoritySection251Benchmark,
   LocalAuthoritySection251History,
 } from "src/services/types";
 import { v4 as uuidv4 } from "uuid";
 
 export class HighNeedsApi {
+  static async comparison(
+    code: string,
+    signals?: AbortSignal[]
+  ): Promise<LocalAuthoritySection251Benchmark<LocalAuthoritySection251>[]> {
+    const params = new URLSearchParams({
+      code,
+    });
+
+    const response = await fetch(
+      "/api/local-authorities/high-needs/comparison?" + params,
+      {
+        redirect: "manual",
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Correlation-ID": uuidv4(),
+        },
+        signal: signals?.length ? AbortSignal.any(signals) : undefined,
+      }
+    );
+
+    const json = await response.json();
+    if (json.error) {
+      throw json.error;
+    }
+
+    return json;
+  }
+
   static async history(
     code: string,
     signals?: AbortSignal[]

--- a/front-end-components/src/services/types.tsx
+++ b/front-end-components/src/services/types.tsx
@@ -409,6 +409,18 @@ export type LocalAuthorityRank = {
   rank: number;
 };
 
+export type LocalAuthorityBenchmarkBase = {
+  code: string;
+  name: string;
+};
+
+export type LocalAuthoritySection251Benchmark<
+  T extends LocalAuthoritySection251,
+> = LocalAuthorityBenchmarkBase & {
+  outturn?: T;
+  budget?: T;
+};
+
 export type LocalAuthoritySection251History<
   T extends LocalAuthoritySection251,
 > = HistoryBase & {
@@ -459,4 +471,7 @@ export type LocalAuthorityEducationHealthCarePlan = {
 };
 
 export type LocalAuthoritySend2History = HistoryBase &
+  LocalAuthorityEducationHealthCarePlan;
+
+export type LocalAuthoritySend2Benchmark = LocalAuthorityBenchmarkBase &
   LocalAuthorityEducationHealthCarePlan;

--- a/front-end-components/src/views/benchmark-data-high-needs/index.tsx
+++ b/front-end-components/src/views/benchmark-data-high-needs/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/views/benchmark-data-high-needs/types";
+export * from "src/views/benchmark-data-high-needs/view";

--- a/front-end-components/src/views/benchmark-data-high-needs/partials/benchmark-high-needs-accordion.tsx
+++ b/front-end-components/src/views/benchmark-data-high-needs/partials/benchmark-high-needs-accordion.tsx
@@ -1,0 +1,113 @@
+import {
+  SelectedEstablishmentContext,
+  useChartModeContext,
+} from "src/contexts";
+import { Section251Section, section251Sections } from ".";
+import { BenchmarkDataHighNeedsAccordionProps } from "../types";
+import { Send2Section } from "./send-2-section";
+import { ChartMode } from "src/components";
+import classNames from "classnames";
+import { useCallback, useContext, useEffect, useState } from "react";
+import { DataWarning } from "src/components/charts/data-warning";
+import { Loading } from "src/components/loading";
+import {
+  LocalAuthoritySection251,
+  LocalAuthoritySection251Benchmark,
+  LocalAuthoritySend2Benchmark,
+} from "src/services";
+import { EducationHealthCarePlanApi } from "src/services/education-health-care-plans-api";
+import { HighNeedsApi } from "src/services/high-needs-api";
+
+export const BenchmarkHighNeedsAccordion: React.FC<
+  BenchmarkDataHighNeedsAccordionProps
+> = ({ fetchTimeout }) => {
+  const selectedEstabishment = useContext(SelectedEstablishmentContext);
+  const { chartMode, setChartMode } = useChartModeContext();
+  const [section251LoadError, setSection251LoadError] = useState<string>();
+  const [send2LoadError, setSend2LoadError] = useState<string>();
+  const [send2Data, setSend2Data] = useState<
+    LocalAuthoritySend2Benchmark[] | undefined
+  >();
+  const [section251Data, setSection251Data] = useState<
+    LocalAuthoritySection251Benchmark<LocalAuthoritySection251>[] | undefined
+  >();
+
+  const getSection251Data = useCallback(async () => {
+    setSection251LoadError(undefined);
+    setSection251Data(undefined);
+    return await HighNeedsApi.comparison(
+      selectedEstabishment,
+      fetchTimeout ? [AbortSignal.timeout(fetchTimeout)] : undefined
+    );
+  }, [fetchTimeout, selectedEstabishment]);
+
+  const getSend2Data = useCallback(async () => {
+    setSend2LoadError(undefined);
+    setSend2Data(undefined);
+    return await EducationHealthCarePlanApi.comparison(
+      selectedEstabishment,
+      fetchTimeout ? [AbortSignal.timeout(fetchTimeout)] : undefined
+    );
+  }, [fetchTimeout, selectedEstabishment]);
+
+  useEffect(() => {
+    getSend2Data()
+      .then((result) => {
+        setSend2Data(result);
+      })
+      .catch((e: Error) => {
+        setSend2Data([]);
+
+        if (e.name !== "AbortError") {
+          setSend2LoadError("Unable to load benchmark send 2 data");
+        }
+      });
+  }, [getSend2Data]);
+
+  useEffect(() => {
+    getSection251Data()
+      .then((result) => {
+        setSection251Data(result);
+      })
+      .catch((e: Error) => {
+        setSection251Data([]);
+
+        if (e.name !== "AbortError") {
+          setSection251LoadError("Unable to load benchmark section 251 data");
+        }
+      });
+  }, [getSection251Data]);
+
+  return (
+    <>
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-two-thirds">&nbsp;</div>
+        <div className="govuk-grid-column-one-third">
+          <ChartMode chartMode={chartMode} handleChange={setChartMode} />
+        </div>
+      </div>
+      {section251LoadError || send2LoadError ? (
+        <DataWarning>
+          {section251LoadError}
+          {send2LoadError}
+        </DataWarning>
+      ) : (
+        !send2Data && !section251Data && <Loading />
+      )}
+      <div
+        className={classNames("govuk-accordion", {
+          "govuk-visually-hidden":
+            !section251Data?.length || !send2Data?.length,
+        })}
+        data-module="govuk-accordion"
+        id="accordion-section"
+      >
+        <Section251Section data={section251Data} />
+        <Send2Section
+          data={send2Data}
+          offset={section251Sections?.length ?? 0}
+        />
+      </div>
+    </>
+  );
+};

--- a/front-end-components/src/views/benchmark-data-high-needs/partials/index.tsx
+++ b/front-end-components/src/views/benchmark-data-high-needs/partials/index.tsx
@@ -1,0 +1,192 @@
+import {
+  LocalAuthoritySection251,
+  LocalAuthorityEducationHealthCarePlan,
+} from "src/services";
+import {
+  BenchmarkChartSection251Section,
+  BenchmarkChartSend2Section,
+} from "../types";
+
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/views/benchmark-data-high-needs/partials/section-251-section.tsx";
+export * from "src/views/benchmark-data-high-needs/partials/send-2-section.tsx";
+
+const summary =
+  "Split by phase (for mainstream) and type of institution (specialist provision)";
+
+export const section251Sections: BenchmarkChartSection251Section<LocalAuthoritySection251>[] =
+  [
+    {
+      heading: "High needs amount per head 2-18 population",
+      charts: [
+        {
+          name: "Total place funding for special schools and AP/PRUs",
+          field: "highNeedsAmountTotalPlaceFunding",
+        },
+        {
+          name: "Top up funding (maintained schools, academies, free schools and colleges)",
+          field: "highNeedsAmountTopUpFundingMaintained",
+        },
+        {
+          name: "Top up funding (non-maintained and independent schools and colleges)",
+          field: "highNeedsAmountTopUpFundingNonMaintained",
+        },
+        {
+          name: "SEN support and inclusion services",
+          field: "highNeedsAmountSenServices",
+        },
+        {
+          name: "Alternative provision services",
+          field: "highNeedsAmountAlternativeProvisionServices",
+        },
+        {
+          name: "Hospital education services",
+          field: "highNeedsAmountHospitalServices",
+        },
+        {
+          name: "Therapies and other health related services",
+          field: "highNeedsAmountOtherHealthServices",
+        },
+      ],
+    },
+    {
+      heading: "Place funding",
+      summary,
+      charts: [
+        {
+          name: "Primary place funding per head 2-18 population",
+          field: "placeFundingPrimary",
+        },
+        {
+          name: "Secondary place funding per head 2-18 population",
+          field: "placeFundingSecondary",
+        },
+        {
+          name: "Special place funding per head 2-18 population",
+          field: "placeFundingSpecial",
+        },
+        {
+          name: "Alternative provision place funding per head 2-18 population",
+          field: "placeFundingAlternativeProvision",
+        },
+      ],
+    },
+    {
+      heading:
+        "Top up funding (maintained schools, academies, free schools and colleges)",
+      summary,
+      charts: [
+        {
+          name: "Early years top up funding per head 2-18 population (maintained)",
+          field: "maintainedEarlyYears",
+        },
+        {
+          name: "Primary top up funding per head 2-18 population (maintained)",
+          field: "maintainedPrimary",
+        },
+        {
+          name: "Secondary top up funding per head 2-18 population (maintained)",
+          field: "maintainedSecondary",
+        },
+        {
+          name: "Special top up funding per head 2-18 population (maintained)",
+          field: "maintainedSpecial",
+        },
+        {
+          name: "Alternative provision top up funding per head 2-18 population (maintained)",
+          field: "maintainedAlternativeProvision",
+        },
+        {
+          name: "Post-school top up funding per head 2-18 population (maintained)",
+          field: "maintainedPostSchool",
+        },
+        {
+          name: "Top up funding income per head 2-18 population (maintained)",
+          field: "maintainedIncome",
+        },
+      ],
+    },
+    {
+      heading:
+        "Top up funding (non-maintained schools, and independent schools and colleges)",
+      summary,
+      charts: [
+        {
+          name: "Early years top up funding per head 2-18 population (non-maintained)",
+          field: "nonMaintainedEarlyYears",
+        },
+        {
+          name: "Primary top up funding per head 2-18 population (non-maintained)",
+          field: "nonMaintainedPrimary",
+        },
+        {
+          name: "Secondary top up funding per head 2-18 population (non-maintained)",
+          field: "nonMaintainedSecondary",
+        },
+        {
+          name: "Special top up funding per head 2-18 population (non-maintained)",
+          field: "nonMaintainedSpecial",
+        },
+        {
+          name: "Alternative provision top up funding per head 2-18 population (non-maintained)",
+          field: "nonMaintainedAlternativeProvision",
+        },
+        {
+          name: "Post-school top up funding per head 2-18 population (non-maintained)",
+          field: "nonMaintainedPostSchool",
+        },
+        {
+          name: "Top up funding income per head 2-18 population (non-maintained)",
+          field: "nonMaintainedIncome",
+        },
+      ],
+    },
+  ];
+
+export const send2Sections: BenchmarkChartSend2Section<LocalAuthorityEducationHealthCarePlan>[] =
+  [
+    {
+      heading:
+        "Number aged up to 25 with SEN statement or EHC plan (per 1000 2 to 18 population)",
+      charts: [
+        {
+          name: "Total",
+          field: "total",
+        },
+      ],
+    },
+    {
+      heading:
+        "Placement of pupils aged up to 25 with SEN statement or EHC plan (per 1000 2 to 18 population)",
+      charts: [
+        {
+          name: "Mainstream schools or academies",
+          field: "mainstream",
+        },
+        {
+          name: "Resourced provision or SEN units",
+          field: "resourced",
+        },
+        {
+          name: "Maintained special schools or special academies",
+          field: "special",
+        },
+        {
+          name: "NMSS or independent schools",
+          field: "independent",
+        },
+        {
+          name: "Hospital schools or alternative provisions",
+          field: "hospital",
+        },
+        {
+          name: "Post 16",
+          field: "post16",
+        },
+        {
+          name: "Other",
+          field: "other",
+        },
+      ],
+    },
+  ];

--- a/front-end-components/src/views/benchmark-data-high-needs/partials/section-251-section.tsx
+++ b/front-end-components/src/views/benchmark-data-high-needs/partials/section-251-section.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { section251Sections } from ".";
+import { Section251SectionProps } from "../types";
+import {
+  LocalAuthoritySection251Benchmark,
+  LocalAuthoritySection251,
+} from "src/services";
+import { BenchmarkChartSection251 } from "src/composed/benchmark-chart-section-251/component";
+
+export const Section251Section: React.FC<
+  Section251SectionProps<
+    LocalAuthoritySection251Benchmark<LocalAuthoritySection251>
+  >
+> = ({ data }) => {
+  return (
+    <>
+      {section251Sections.map((section, index) => (
+        <div className="govuk-accordion__section" key={index}>
+          <div className="govuk-accordion__section-header">
+            <h2 className="govuk-accordion__section-heading">
+              <span
+                className="govuk-accordion__section-button"
+                id={`accordion-section-heading-${index + 1}`}
+              >
+                {section.heading}
+              </span>
+            </h2>
+            {section.summary && (
+              <div
+                className="govuk-accordion__section-summary govuk-body"
+                id={`accordion-with-summary-sections-summary-${index + 1}`}
+              >
+                {section.summary}
+              </div>
+            )}
+          </div>
+          <div
+            id={`accordion-section-content-${index + 1}`}
+            className="govuk-accordion__section-content"
+          >
+            {section.charts.map((chart) => (
+              <section key={chart.field}>
+                <BenchmarkChartSection251
+                  chartTitle={chart.name}
+                  data={data}
+                  valueField={chart.field}
+                />
+              </section>
+            ))}
+          </div>
+        </div>
+      ))}
+    </>
+  );
+};

--- a/front-end-components/src/views/benchmark-data-high-needs/partials/send-2-section.tsx
+++ b/front-end-components/src/views/benchmark-data-high-needs/partials/send-2-section.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { send2Sections } from ".";
+import { Send2SectionProps } from "../types";
+import { LocalAuthoritySend2Benchmark } from "src/services";
+import { BenchmarkChartSend2 } from "src/composed/benchmark-chart-send-2";
+
+export const Send2Section: React.FC<
+  Send2SectionProps<LocalAuthoritySend2Benchmark>
+> = ({ data, offset }) => {
+  return (
+    <>
+      {send2Sections.map((section, index) => (
+        <div className="govuk-accordion__section" key={index + offset}>
+          <div className="govuk-accordion__section-header">
+            <h2 className="govuk-accordion__section-heading">
+              <span
+                className="govuk-accordion__section-button"
+                id={`accordion-section-heading-${index + offset + 1}`}
+              >
+                {section.heading}
+              </span>
+            </h2>
+          </div>
+          <div
+            id={`accordion-section-content-${index + offset + 1}`}
+            className="govuk-accordion__section-content"
+          >
+            {section.charts.map((chart) => (
+              <section key={chart.field}>
+                <BenchmarkChartSend2
+                  chartTitle={chart.name}
+                  data={data}
+                  valueField={chart.field}
+                />
+              </section>
+            ))}
+          </div>
+        </div>
+      ))}
+    </>
+  );
+};

--- a/front-end-components/src/views/benchmark-data-high-needs/types.tsx
+++ b/front-end-components/src/views/benchmark-data-high-needs/types.tsx
@@ -1,0 +1,64 @@
+import { ReactNode } from "react";
+import { ResolvedStatProps } from "src/components/charts/resolved-stat";
+import {
+  LocalAuthoritySection251,
+  LocalAuthorityEducationHealthCarePlan,
+} from "src/services";
+
+export type BenchmarkDataHighNeedsProps = {
+  code: string;
+  fetchTimeout?: number;
+};
+
+export type BenchmarkDataHighNeedsViewProps = BenchmarkDataHighNeedsProps & {};
+
+export type BenchmarkDataHighNeedsAccordionProps = Omit<
+  BenchmarkDataHighNeedsProps,
+  "code"
+>;
+
+export type BenchmarkChartSection251Section<
+  TData extends LocalAuthoritySection251,
+> = {
+  heading: string;
+  summary?: string;
+  charts: BenchmarkDataHighNeedsSection251Chart<TData>[];
+};
+
+export type BenchmarkDataHighNeedsSection251Chart<
+  TData extends LocalAuthoritySection251,
+> = {
+  name: string;
+  field: ResolvedStatProps<TData>["valueField"];
+  details?: {
+    label: string;
+    content: ReactNode;
+  };
+};
+
+export type BenchmarkChartSend2Section<
+  TData extends LocalAuthorityEducationHealthCarePlan,
+> = {
+  heading?: string;
+  charts: BenchmarkDataHighNeedsSend2Chart<TData>[];
+};
+
+export type BenchmarkDataHighNeedsSend2Chart<
+  TData extends LocalAuthorityEducationHealthCarePlan,
+> = {
+  name: string;
+  field: ResolvedStatProps<TData>["valueField"];
+  details?: {
+    label: string;
+    content: ReactNode;
+  };
+};
+
+export type Section251SectionProps<TData> = {
+  data?: TData[];
+};
+
+export type Send2SectionProps<TData> = {
+  offset: number;
+  data?: TData[];
+};

--- a/front-end-components/src/views/benchmark-data-high-needs/view.tsx
+++ b/front-end-components/src/views/benchmark-data-high-needs/view.tsx
@@ -1,0 +1,19 @@
+import { BenchmarkDataHighNeedsViewProps } from "src/views/benchmark-data-high-needs/types";
+import { useGovUk } from "src/hooks/useGovUk";
+import { ChartModeChart } from "src/components";
+import { ChartModeProvider, SelectedEstablishmentContext } from "src/contexts";
+import { BenchmarkHighNeedsAccordion } from "./partials/benchmark-high-needs-accordion";
+
+export const BenchmarkDataHighNeeds: React.FC<
+  BenchmarkDataHighNeedsViewProps
+> = ({ code, fetchTimeout }) => {
+  useGovUk();
+
+  return (
+    <SelectedEstablishmentContext.Provider value={code}>
+      <ChartModeProvider initialValue={ChartModeChart}>
+        <BenchmarkHighNeedsAccordion fetchTimeout={fetchTimeout} />
+      </ChartModeProvider>
+    </SelectedEstablishmentContext.Provider>
+  );
+};

--- a/front-end-components/src/views/index.tsx
+++ b/front-end-components/src/views/index.tsx
@@ -7,3 +7,4 @@ export * from "src/views/historic-data-2";
 export * from "src/views/deployment-plan";
 export * from "src/views/find-organisation";
 export * from "src/views/la-national-rank";
+export * from "src/views/benchmark-data-high-needs";

--- a/web/src/Web.App/Controllers/Api/HighNeedsProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/HighNeedsProxyController.cs
@@ -34,7 +34,7 @@ public class HighNeedsProxyController(
                 return NotFound();
             }
 
-            var query = BuildQuery(code);
+            var query = BuildQuery(new[] { code }.Concat(set).ToArray());
             var localAuthorities = await localAuthoritiesApi
                 .GetHighNeeds(query, cancellationToken)
                 .GetResultOrThrow<LocalAuthority<HighNeeds>[]>();


### PR DESCRIPTION
### Context
[AB#252630](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/252630) [AB#249557](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249557)

### Change proposed in this pull request
- New view that calls proxy endpoints to display S251 and SEND2 data for the LAs in the comparator set
- Layout, colours, etc. likely to need tweaking based on feedback/design crit (especially for multi-series outturn vs budget charts)

### Guidance to review 
Run the local Vite dev server to preview the new components after having first created a comparator set during the current Web session.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] You have reviewed with UX/Design

