### PR TITLE
Remaining E2E test coverage over High needs benchmarking pages

### DIFF
--- a/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsBenchmarking.feature
+++ b/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsBenchmarking.feature
@@ -1,0 +1,42 @@
+﻿Feature: Local Authority high needs benchmarking
+
+    Background:
+        Given I am on local authority high needs start benchmarking for local authority with code '201'
+        And I have no comparators selected
+        And I add the comparator matching the value 'hack'
+        And I click the Save and continue button
+
+    @HighNeedsFlagEnabled
+    Scenario: Can view local authority benchmarking charts
+        Given I am on local authority high needs benchmarking for local authority with code '201'
+        When I click on show all sections
+        Then all sections on the page are expanded
+        And chart view is visible, showing '33' charts
+
+    @HighNeedsFlagEnabled
+    Scenario: Can view local authority benchmarking tables
+        Given I am on local authority high needs benchmarking for local authority with code '201'
+        When I click on show all sections
+        And I click on view as table
+        Then all sections on the page are expanded
+        And table view is visible, showing '33' tables
+
+    @HighNeedsFlagEnabled
+    Scenario: Can view local authority benchmarking table data for S251
+        Given I am on local authority high needs benchmarking for local authority with code '201'
+        When I click on show all sections
+        And I click on view as table
+        Then the table at index '0' contains the following S251 values:
+          | Name                | Actual     | Planned    |
+          | Local authority 201 | £1,002,226 | £1,102,226 |
+          | Local authority 204 | £1,002,229 | £1,102,229 |
+
+    @HighNeedsFlagEnabled
+    Scenario: Can view local authority benchmarking table data for SEND2
+        Given I am on local authority high needs benchmarking for local authority with code '201'
+        When I click on show all sections
+        And I click on view as table
+        Then the table at index '32' contains the following SEND2 values:
+          | Name                | Amount |
+          | Local authority 201 | £1.00  |
+          | Local authority 204 | £5.00  |

--- a/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsDashboard.feature
+++ b/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsDashboard.feature
@@ -2,18 +2,18 @@
 
     @HighNeedsFlagEnabled
     Scenario: Go to start benchmarking page
-        Given I am on local authority high needs benchmarking for local authority with code '204'
+        Given I am on local authority high needs dashboard for local authority with code '204'
         When I click on start benchmarking
         Then the start benchmarking page is displayed
 
     @HighNeedsFlagEnabled
     Scenario: Go to view national rankings
-        Given I am on local authority high needs benchmarking for local authority with code '204'
+        Given I am on local authority high needs dashboard for local authority with code '204'
         When I click on view national rankings
         Then the national rankings page is displayed
 
     @HighNeedsFlagEnabled
     Scenario: Go to view historic data
-        Given I am on local authority high needs benchmarking for local authority with code '204'
+        Given I am on local authority high needs dashboard for local authority with code '204'
         When I click on view historic data
         Then the historic data page is displayed

--- a/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsStartBenchmarking.feature
+++ b/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsStartBenchmarking.feature
@@ -17,3 +17,21 @@
         And I press the Enter key
         And I press the Enter key again
         Then the comparator 'Hackney' is added to the comparators
+
+    @HighNeedsFlagEnabled
+    Scenario: Can save the comparator set
+        Given I am on local authority high needs start benchmarking for local authority with code '201'
+        And I type 'lee' into the input field
+        And I press the Enter key
+        And I press the Enter key again
+        When I click the Save and continue button
+        Then the local authority high needs benchmarking page is displayed
+
+    @HighNeedsFlagEnabled
+    Scenario: Can cancel the comparator set
+        Given I am on local authority high needs start benchmarking for local authority with code '201'
+        And I type 'south' into the input field
+        And I press the Enter key
+        And I press the Enter key again
+        When I click the cancel button
+        Then the local authority high needs dashboard page is displayed

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsBenchmarkingPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsBenchmarkingPage.cs
@@ -1,78 +1,104 @@
 ﻿using Microsoft.Playwright;
+using Web.E2ETests.Assist;
+using Xunit;
 
 namespace Web.E2ETests.Pages.LocalAuthority;
 
 public class HighNeedsBenchmarkingPage(IPage page)
 {
     private ILocator PageH1Heading => page.Locator($"main {Selectors.H1}");
-    private ILocator StartBenchmarkingButton => page.Locator(Selectors.CtaButton, new PageLocatorOptions
-    {
-        HasText = "Start benchmarking"
-    });
-    private ILocator ViewNationalRankingsButton => page.Locator(Selectors.CtaButton, new PageLocatorOptions
-    {
-        HasText = "View full national rankings"
-    });
-    private ILocator ViewHistoricDataButton => page.Locator(Selectors.CtaButton, new PageLocatorOptions
-    {
-        HasText = "View full historic data"
-    });
-    private ILocator BenchmarkHighNeedsCard => page.Locator(Selectors.GovSummaryCard, new PageLocatorOptions
-    {
-        Has = page.Locator(Selectors.GovSummaryCardTitle, new PageLocatorOptions
-        {
-            HasText = "Benchmark high needs data"
-        })
-    });
-    private ILocator HeadlineFiguresCard => page.Locator(Selectors.GovSummaryCard, new PageLocatorOptions
-    {
-        Has = page.Locator(Selectors.GovSummaryCardTitle, new PageLocatorOptions
-        {
-            HasText = "Total number of EHC plans and cost"
-        })
-    });
-    private ILocator NationalRankingsCard => page.Locator(Selectors.GovSummaryCard, new PageLocatorOptions
-    {
-        Has = page.Locator(Selectors.GovSummaryCardTitle, new PageLocatorOptions
-        {
-            HasText = "National Ranking"
-        })
-    });
-    private ILocator HistoricDataCard => page.Locator(Selectors.GovSummaryCard, new PageLocatorOptions
-    {
-        Has = page.Locator(Selectors.GovSummaryCardTitle, new PageLocatorOptions
-        {
-            HasText = "Historical spending"
-        })
-    });
+    private ILocator ViewAsTableRadio => page.Locator(Selectors.ModeTable);
+    private ILocator ViewAsChartRadio => page.Locator(Selectors.ModeChart);
+    private ILocator ShowHideAllSectionsLink => page.Locator(Selectors.GovShowAllLinkText);
+    private ILocator Sections => page.Locator(Selectors.GovAccordionSection);
+    private ILocator Charts => page.Locator(Selectors.Charts);
+    private ILocator Tables => page.Locator(Selectors.SectionTable);
 
     public async Task IsDisplayed()
     {
         await PageH1Heading.ShouldBeVisible();
-        await BenchmarkHighNeedsCard.ShouldBeVisible();
-        await HeadlineFiguresCard.ShouldBeVisible();
-        await NationalRankingsCard.ShouldBeVisible();
-        await HistoricDataCard.ShouldBeVisible();
-        await StartBenchmarkingButton.ShouldBeVisible();
-        await ViewHistoricDataButton.ShouldBeVisible();
-        await ViewNationalRankingsButton.ShouldBeVisible();
     }
 
-    public async Task<HighNeedsStartBenchmarkingPage> ClickStartBenchmarking()
+    public async Task ClickShowAllSections()
     {
-        await StartBenchmarkingButton.Click();
-        return new HighNeedsStartBenchmarkingPage(page);
+        var text = await ShowHideAllSectionsLink.TextContentAsync();
+        if (text == "Show all sections")
+        {
+            await ShowHideAllSectionsLink.Click();
+        }
     }
 
-    public async Task<HighNeedsNationalRankingsPage> ClickViewNationalRankings()
+    public async Task AreSectionsExpanded()
     {
-        await ViewNationalRankingsButton.Click();
-        return new HighNeedsNationalRankingsPage(page);
+        var sections = await Sections.AllAsync();
+        foreach (var section in sections)
+        {
+            await section.AssertLocatorClass("govuk-accordion__section govuk-accordion__section--expanded");
+        }
     }
 
-    public async Task<HighNeedsHistoricDataPage> ClickViewHistoricData()
+    public async Task ClickViewAsChart()
     {
-        await ViewHistoricDataButton.Click();
-        return new HighNeedsHistoricDataPage(page);
+        await ViewAsChartRadio.Click();
+    }
+
+    public async Task AreChartsDisplayed(int count)
+    {
+        var charts = await Charts.AllAsync();
+        Assert.Equal(count, charts.Count);
+        await charts.ShouldBeVisible();
+    }
+
+    public async Task ClickViewAsTable()
+    {
+        await ViewAsTableRadio.Click();
+    }
+
+    public async Task AreTablesDisplayed(int count)
+    {
+        var tables = await Tables.AllAsync();
+        Assert.Equal(count, tables.Count);
+        await tables.ShouldBeVisible();
+    }
+
+    public async Task TableContainsSection251(int index, DataTable expected)
+    {
+        var table = Tables.Nth(index);
+        await table.ShouldBeVisible();
+        var rows = await table.Locator("tbody > tr").AllAsync();
+
+        var set = new List<dynamic>();
+        foreach (var row in rows)
+        {
+            var cells = await row.Locator("td").AllAsync();
+            set.Add(new
+            {
+                Name = await cells.ElementAt(0).InnerTextAsync(),
+                Actual = await cells.ElementAt(1).InnerTextAsync(),
+                Planned = await cells.ElementAt(2).InnerTextAsync()
+            });
+        }
+
+        expected.CompareToDynamicSet(set);
+    }
+
+    public async Task TableContainsSend2(int index, DataTable expected)
+    {
+        var table = Tables.Nth(index);
+        await table.ShouldBeVisible();
+        var rows = await table.Locator("tbody > tr").AllAsync();
+
+        var set = new List<dynamic>();
+        foreach (var row in rows)
+        {
+            var cells = await row.Locator("td").AllAsync();
+            set.Add(new
+            {
+                Name = await cells.ElementAt(0).InnerTextAsync(),
+                Amount = await cells.ElementAt(1).InnerTextAsync()
+            });
+        }
+
+        expected.CompareToDynamicSet(set);
     }
 }

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsDashboardPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsDashboardPage.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.Playwright;
+
+namespace Web.E2ETests.Pages.LocalAuthority;
+
+public class HighNeedsDashboardPage(IPage page)
+{
+    private ILocator PageH1Heading => page.Locator($"main {Selectors.H1}");
+    private ILocator StartBenchmarkingButton => page.Locator(Selectors.CtaButton, new PageLocatorOptions
+    {
+        HasText = "Start benchmarking"
+    });
+    private ILocator ViewNationalRankingsButton => page.Locator(Selectors.CtaButton, new PageLocatorOptions
+    {
+        HasText = "View full national rankings"
+    });
+    private ILocator ViewHistoricDataButton => page.Locator(Selectors.CtaButton, new PageLocatorOptions
+    {
+        HasText = "View full historic data"
+    });
+    private ILocator BenchmarkHighNeedsCard => page.Locator(Selectors.GovSummaryCard, new PageLocatorOptions
+    {
+        Has = page.Locator(Selectors.GovSummaryCardTitle, new PageLocatorOptions
+        {
+            HasText = "Benchmark high needs data"
+        })
+    });
+    private ILocator HeadlineFiguresCard => page.Locator(Selectors.GovSummaryCard, new PageLocatorOptions
+    {
+        Has = page.Locator(Selectors.GovSummaryCardTitle, new PageLocatorOptions
+        {
+            HasText = "Total number of EHC plans and cost"
+        })
+    });
+    private ILocator NationalRankingsCard => page.Locator(Selectors.GovSummaryCard, new PageLocatorOptions
+    {
+        Has = page.Locator(Selectors.GovSummaryCardTitle, new PageLocatorOptions
+        {
+            HasText = "National Ranking"
+        })
+    });
+    private ILocator HistoricDataCard => page.Locator(Selectors.GovSummaryCard, new PageLocatorOptions
+    {
+        Has = page.Locator(Selectors.GovSummaryCardTitle, new PageLocatorOptions
+        {
+            HasText = "Historical spending"
+        })
+    });
+
+    public async Task IsDisplayed()
+    {
+        await PageH1Heading.ShouldBeVisible();
+        await BenchmarkHighNeedsCard.ShouldBeVisible();
+        await HeadlineFiguresCard.ShouldBeVisible();
+        await NationalRankingsCard.ShouldBeVisible();
+        await HistoricDataCard.ShouldBeVisible();
+        await StartBenchmarkingButton.ShouldBeVisible();
+        await ViewHistoricDataButton.ShouldBeVisible();
+        await ViewNationalRankingsButton.ShouldBeVisible();
+    }
+
+    public async Task<HighNeedsStartBenchmarkingPage> ClickStartBenchmarking()
+    {
+        await StartBenchmarkingButton.Click();
+        return new HighNeedsStartBenchmarkingPage(page);
+    }
+
+    public async Task<HighNeedsNationalRankingsPage> ClickViewNationalRankings()
+    {
+        await ViewNationalRankingsButton.Click();
+        return new HighNeedsNationalRankingsPage(page);
+    }
+
+    public async Task<HighNeedsHistoricDataPage> ClickViewHistoricData()
+    {
+        await ViewHistoricDataButton.Click();
+        return new HighNeedsHistoricDataPage(page);
+    }
+}

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsStartBenchmarkingPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsStartBenchmarkingPage.cs
@@ -9,6 +9,18 @@ public class HighNeedsStartBenchmarkingPage(IPage page)
     private ILocator LaInputField => page.Locator("#LaInput");
     private ILocator LaDropdown => page.Locator("#LaInput__listbox");
     private ILocator ComparatorsTable => page.Locator("#current-comparators-la");
+    private ILocator SaveAndContinueButton => page.Locator(Selectors.Button, new PageLocatorOptions
+    {
+        HasText = "Save and continue"
+    });
+    private ILocator CancelButton => page.Locator(".govuk-button--secondary", new PageLocatorOptions
+    {
+        HasText = "Cancel"
+    });
+    private ILocator RemoveButtons => page.Locator(Selectors.WarningButton, new PageLocatorOptions
+    {
+        HasText = "Remove"
+    });
 
     public async Task IsDisplayed()
     {
@@ -50,5 +62,28 @@ public class HighNeedsStartBenchmarkingPage(IPage page)
 
         var cells = await ComparatorsTable.Locator("tbody > tr > td:first-child").AllInnerTextsAsync();
         Assert.Contains(name, cells);
+    }
+
+    public async Task<HighNeedsBenchmarkingPage> ClickSaveAndContinueButton()
+    {
+        await SaveAndContinueButton.ClickAsync();
+        return new HighNeedsBenchmarkingPage(page);
+    }
+
+    public async Task<HighNeedsDashboardPage> ClickCancelButton()
+    {
+        await CancelButton.ClickAsync();
+        return new HighNeedsDashboardPage(page);
+    }
+
+    public async Task<bool> HasComparators()
+    {
+        return await RemoveButtons.CountAsync() > 0;
+    }
+
+    public async Task<HighNeedsDashboardPage> ClickRemoveButton()
+    {
+        await RemoveButtons.First.ClickAsync();
+        return new HighNeedsDashboardPage(page);
     }
 }

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/HomePage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/HomePage.cs
@@ -42,9 +42,9 @@ public class HomePage(IPage page)
         return new BenchmarkCensusPage(page);
     }
 
-    public async Task<HighNeedsBenchmarkingPage> ClickHighNeedsBenchmarking()
+    public async Task<HighNeedsDashboardPage> ClickHighNeedsBenchmarking()
     {
         await HighNeedsBenchmarkingLink.Click();
-        return new HighNeedsBenchmarkingPage(page);
+        return new HighNeedsDashboardPage(page);
     }
 }

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -66,6 +66,7 @@ public static class Selectors
     public const string Modal = "div.modal";
     public const string ModalButton = $"{Modal} {Button}";
     public const string CtaButton = "[role='button'][class*='govuk-button']";
+    public const string WarningButton = "button.govuk-button--warning";
 
     public const string ComparisonChartsAndTables = "#compare-your-costs";
     public const string ComparisonTables = "#compare-your-costs table.govuk-table";

--- a/web/tests/Web.E2ETests/Steps/LocalAuthority/HighNeedsBenchmarkingSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/LocalAuthority/HighNeedsBenchmarkingSteps.cs
@@ -5,18 +5,27 @@ using Xunit;
 namespace Web.E2ETests.Steps.LocalAuthority;
 
 [Binding]
-[Scope(Feature = "Local Authority high needs dashboard")]
+[Scope(Feature = "Local Authority high needs benchmarking")]
 public class HighNeedsBenchmarkingSteps(PageDriver driver)
 {
     private HighNeedsBenchmarkingPage? _highNeedsBenchmarkingPage;
-    private HighNeedsHistoricDataPage? _highNeedsHistoricDataPage;
-    private HighNeedsNationalRankingsPage? _highNeedsNationalRankingsPage;
     private HighNeedsStartBenchmarkingPage? _highNeedsStartBenchmarkingPage;
 
-    [Given("I am on local authority high needs dashboard for local authority with code '(.*)'")]
-    public async Task GivenIAmOnLocalAuthorityHighNeedsDashboardForLocalAuthorityWithCode(string laCode)
+    [Given("I am on local authority high needs start benchmarking for local authority with code '(.*)'")]
+    public async Task GivenIAmOnLocalAuthorityHighNeedsStartBenchmarkingForLocalAuthorityWithCode(string laCode)
     {
-        var url = LocalAuthorityHighNeedsDashboardUrl(laCode);
+        var url = LocalAuthorityHighNeedsStartBenchmarkingUrl(laCode);
+        var page = await driver.Current;
+        await page.GotoAndWaitForLoadAsync(url);
+
+        _highNeedsStartBenchmarkingPage = new HighNeedsStartBenchmarkingPage(page);
+        await _highNeedsStartBenchmarkingPage.IsDisplayed();
+    }
+
+    [Given("I am on local authority high needs benchmarking for local authority with code '(.*)'")]
+    public async Task GivenIAmOnLocalAuthorityHighNeedsBenchmarkingForLocalAuthorityWithCode(string laCode)
+    {
+        var url = LocalAuthorityHighNeedsBenchmarkingUrl(laCode);
         var page = await driver.Current;
         await page.GotoAndWaitForLoadAsync(url);
 
@@ -24,50 +33,88 @@ public class HighNeedsBenchmarkingSteps(PageDriver driver)
         await _highNeedsBenchmarkingPage.IsDisplayed();
     }
 
-    [When("I click on start benchmarking")]
-    public async Task WhenIClickOnStartBenchmarking()
-    {
-        Assert.NotNull(_highNeedsBenchmarkingPage);
-        _highNeedsStartBenchmarkingPage = await _highNeedsBenchmarkingPage.ClickStartBenchmarking();
-    }
-
-    [When("I click on view national rankings")]
-    public async Task WhenIClickOnViewNationalRankings()
-    {
-        Assert.NotNull(_highNeedsBenchmarkingPage);
-        _highNeedsNationalRankingsPage = await _highNeedsBenchmarkingPage.ClickViewNationalRankings();
-    }
-
-    [When("I click on view historic data")]
-    public async Task WhenIClickOnViewHistoricData()
-    {
-        Assert.NotNull(_highNeedsBenchmarkingPage);
-        _highNeedsHistoricDataPage = await _highNeedsBenchmarkingPage.ClickViewHistoricData();
-    }
-
-    [Then("the start benchmarking page is displayed")]
-    public async Task ThenTheStartBenchmarkingPageIsDisplayed()
+    [Given("I have no comparators selected")]
+    public async Task GivenIHaveNoComparatorsSelected()
     {
         Assert.NotNull(_highNeedsStartBenchmarkingPage);
-        await _highNeedsStartBenchmarkingPage.IsDisplayed();
+        while (await _highNeedsStartBenchmarkingPage.HasComparators())
+        {
+            await _highNeedsStartBenchmarkingPage.ClickRemoveButton();
+        }
     }
 
-    [Then("the national rankings page is displayed")]
-    public async Task ThenTheNationalRankingsPageIsDisplayed()
+    [Given("I add the comparator matching the value '(.*)'")]
+    public async Task GivenIAddTheComparatorMatchingTheValue(string name)
     {
-        Assert.NotNull(_highNeedsNationalRankingsPage);
-        await _highNeedsNationalRankingsPage.IsDisplayed();
+        Assert.NotNull(_highNeedsStartBenchmarkingPage);
+        await _highNeedsStartBenchmarkingPage.TypeIntoInputField(name);
+        await _highNeedsStartBenchmarkingPage.PressEnterKey();
+        await _highNeedsStartBenchmarkingPage.PressEnterKey();
     }
 
-    [Then("the historic data page is displayed")]
-    public async Task ThenTheHistoricDataPageIsDisplayed()
+    [Given("I click the Save and continue button")]
+    public async Task GivenIClickTheSaveAndContinueButton()
     {
-        Assert.NotNull(_highNeedsHistoricDataPage);
-        await _highNeedsHistoricDataPage.IsDisplayed();
+        Assert.NotNull(_highNeedsStartBenchmarkingPage);
+        _highNeedsBenchmarkingPage = await _highNeedsStartBenchmarkingPage.ClickSaveAndContinueButton();
     }
 
-    private static string LocalAuthorityHighNeedsDashboardUrl(string laCode)
+    [When("I click on show all sections")]
+    public async Task WhenIClickOnShowAllSections()
     {
-        return $"{TestConfiguration.ServiceUrl}/local-authority/{laCode}/high-needs";
+        Assert.NotNull(_highNeedsBenchmarkingPage);
+        await _highNeedsBenchmarkingPage.ClickShowAllSections();
+    }
+
+    [When("I click on view as table")]
+    public async Task WhenIClickOnViewAsTable()
+    {
+        Assert.NotNull(_highNeedsBenchmarkingPage);
+        await _highNeedsBenchmarkingPage.ClickViewAsTable();
+    }
+
+    [Then("all sections on the page are expanded")]
+    public async Task ThenAllSectionsOnThePageAreExpanded()
+    {
+        Assert.NotNull(_highNeedsBenchmarkingPage);
+        await _highNeedsBenchmarkingPage.AreSectionsExpanded();
+    }
+
+    [Then("chart view is visible, showing '(\\d+)' charts")]
+    public async Task ThenChartViewIsVisibleShowingCharts(string charts)
+    {
+        Assert.NotNull(_highNeedsBenchmarkingPage);
+        await _highNeedsBenchmarkingPage.AreChartsDisplayed(int.Parse(charts));
+    }
+
+    [Then("table view is visible, showing '(\\d+)' tables")]
+    public async Task ThenTableViewIsVisibleShowingTables(string tables)
+    {
+        Assert.NotNull(_highNeedsBenchmarkingPage);
+        await _highNeedsBenchmarkingPage.AreTablesDisplayed(int.Parse(tables));
+    }
+
+    [Then("the table at index '(\\d+)' contains the following S251 values:")]
+    public async Task ThenTheTableAtIndexContainsTheFollowingSValues(string index, DataTable table)
+    {
+        Assert.NotNull(_highNeedsBenchmarkingPage);
+        await _highNeedsBenchmarkingPage.TableContainsSection251(int.Parse(index), table);
+    }
+
+    [Then("the table at index '(\\d+)' contains the following SEND2 values:")]
+    public async Task ThenTheTableAtIndexContainsTheFollowingSendValues(string index, DataTable table)
+    {
+        Assert.NotNull(_highNeedsBenchmarkingPage);
+        await _highNeedsBenchmarkingPage.TableContainsSend2(int.Parse(index), table);
+    }
+
+    private static string LocalAuthorityHighNeedsBenchmarkingUrl(string laCode)
+    {
+        return $"{TestConfiguration.ServiceUrl}/local-authority/{laCode}/high-needs/benchmarking";
+    }
+
+    private static string LocalAuthorityHighNeedsStartBenchmarkingUrl(string laCode)
+    {
+        return $"{TestConfiguration.ServiceUrl}/local-authority/{laCode}/high-needs/benchmarking/comparators";
     }
 }

--- a/web/tests/Web.E2ETests/Steps/LocalAuthority/HighNeedsDashboardSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/LocalAuthority/HighNeedsDashboardSteps.cs
@@ -1,0 +1,73 @@
+using Web.E2ETests.Drivers;
+using Web.E2ETests.Pages.LocalAuthority;
+using Xunit;
+
+namespace Web.E2ETests.Steps.LocalAuthority;
+
+[Binding]
+[Scope(Feature = "Local Authority high needs dashboard")]
+public class HighNeedsBenchmarkingDashboardSteps(PageDriver driver)
+{
+    private HighNeedsDashboardPage? _highNeedsBenchmarkingPage;
+    private HighNeedsHistoricDataPage? _highNeedsHistoricDataPage;
+    private HighNeedsNationalRankingsPage? _highNeedsNationalRankingsPage;
+    private HighNeedsStartBenchmarkingPage? _highNeedsStartBenchmarkingPage;
+
+    [Given("I am on local authority high needs dashboard for local authority with code '(.*)'")]
+    public async Task GivenIAmOnLocalAuthorityHighNeedsDashboardForLocalAuthorityWithCode(string laCode)
+    {
+        var url = LocalAuthorityHighNeedsDashboardUrl(laCode);
+        var page = await driver.Current;
+        await page.GotoAndWaitForLoadAsync(url);
+
+        _highNeedsBenchmarkingPage = new HighNeedsDashboardPage(page);
+        await _highNeedsBenchmarkingPage.IsDisplayed();
+    }
+
+    [When("I click on start benchmarking")]
+    public async Task WhenIClickOnStartBenchmarking()
+    {
+        Assert.NotNull(_highNeedsBenchmarkingPage);
+        _highNeedsStartBenchmarkingPage = await _highNeedsBenchmarkingPage.ClickStartBenchmarking();
+    }
+
+    [When("I click on view national rankings")]
+    public async Task WhenIClickOnViewNationalRankings()
+    {
+        Assert.NotNull(_highNeedsBenchmarkingPage);
+        _highNeedsNationalRankingsPage = await _highNeedsBenchmarkingPage.ClickViewNationalRankings();
+    }
+
+    [When("I click on view historic data")]
+    public async Task WhenIClickOnViewHistoricData()
+    {
+        Assert.NotNull(_highNeedsBenchmarkingPage);
+        _highNeedsHistoricDataPage = await _highNeedsBenchmarkingPage.ClickViewHistoricData();
+    }
+
+    [Then("the start benchmarking page is displayed")]
+    public async Task ThenTheStartBenchmarkingPageIsDisplayed()
+    {
+        Assert.NotNull(_highNeedsStartBenchmarkingPage);
+        await _highNeedsStartBenchmarkingPage.IsDisplayed();
+    }
+
+    [Then("the national rankings page is displayed")]
+    public async Task ThenTheNationalRankingsPageIsDisplayed()
+    {
+        Assert.NotNull(_highNeedsNationalRankingsPage);
+        await _highNeedsNationalRankingsPage.IsDisplayed();
+    }
+
+    [Then("the historic data page is displayed")]
+    public async Task ThenTheHistoricDataPageIsDisplayed()
+    {
+        Assert.NotNull(_highNeedsHistoricDataPage);
+        await _highNeedsHistoricDataPage.IsDisplayed();
+    }
+
+    private static string LocalAuthorityHighNeedsDashboardUrl(string laCode)
+    {
+        return $"{TestConfiguration.ServiceUrl}/local-authority/{laCode}/high-needs";
+    }
+}

--- a/web/tests/Web.E2ETests/Steps/LocalAuthority/HighNeedsStartBenchmarkingSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/LocalAuthority/HighNeedsStartBenchmarkingSteps.cs
@@ -9,6 +9,8 @@ namespace Web.E2ETests.Steps.LocalAuthority;
 public class HighNeedsStartBenchmarkingSteps(PageDriver driver, PageDriverWithJavaScriptDisabled driverNoJs)
 {
     private HighNeedsStartBenchmarkingPage? _highNeedsStartBenchmarkingPage;
+    private HighNeedsBenchmarkingPage? _highNeedsBenchmarkingPage;
+    private HighNeedsDashboardPage? _highNeedsDashboardPage;
     private bool _javascriptDisabled;
 
     [Given("JavaScript is '(.*)'")]
@@ -36,6 +38,7 @@ public class HighNeedsStartBenchmarkingSteps(PageDriver driver, PageDriverWithJa
     }
 
     [When("I type '(.*)' into the input field")]
+    [Given("I type '(.*)' into the input field")]
     public async Task WhenITypeIntoTheInputField(string name)
     {
         Assert.NotNull(_highNeedsStartBenchmarkingPage);
@@ -51,6 +54,8 @@ public class HighNeedsStartBenchmarkingSteps(PageDriver driver, PageDriverWithJa
 
     [When("I press the Enter key")]
     [When("I press the Enter key again")]
+    [Given("I press the Enter key")]
+    [Given("I press the Enter key again")]
     public async Task WhenIPressTheEnterKey()
     {
         Assert.NotNull(_highNeedsStartBenchmarkingPage);
@@ -62,6 +67,34 @@ public class HighNeedsStartBenchmarkingSteps(PageDriver driver, PageDriverWithJa
     {
         Assert.NotNull(_highNeedsStartBenchmarkingPage);
         await _highNeedsStartBenchmarkingPage.ComparatorsContains(name);
+    }
+
+    [When("I click the Save and continue button")]
+    public async Task WhenIClickTheSaveAndContinueButton()
+    {
+        Assert.NotNull(_highNeedsStartBenchmarkingPage);
+        _highNeedsBenchmarkingPage = await _highNeedsStartBenchmarkingPage.ClickSaveAndContinueButton();
+    }
+
+    [Then("the local authority high needs benchmarking page is displayed")]
+    public async Task ThenTheLocalAuthorityHighNeedsBenchmarkingPageIsDisplayed()
+    {
+        Assert.NotNull(_highNeedsBenchmarkingPage);
+        await _highNeedsBenchmarkingPage.IsDisplayed();
+    }
+
+    [When("I click the cancel button")]
+    public async Task WhenIClickTheCancelButton()
+    {
+        Assert.NotNull(_highNeedsStartBenchmarkingPage);
+        _highNeedsDashboardPage = await _highNeedsStartBenchmarkingPage.ClickCancelButton();
+    }
+
+    [Then("the local authority high needs dashboard page is displayed")]
+    public async Task ThenTheLocalAuthorityHighNeedsDashboardPageIsDisplayed()
+    {
+        Assert.NotNull(_highNeedsDashboardPage);
+        await _highNeedsDashboardPage.IsDisplayed();
     }
 
     private static string LocalAuthorityHighNeedsStartBenchmarkingUrl(string laCode)

--- a/web/tests/Web.E2ETests/Steps/LocalAuthority/HomeSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/LocalAuthority/HomeSteps.cs
@@ -10,7 +10,7 @@ public class HomeSteps(PageDriver driver)
 {
     private BenchmarkCensusPage? _benchmarkCensusPage;
     private CompareYourCostsPage? _compareYourCostsPage;
-    private HighNeedsBenchmarkingPage? _highNeedsBenchmarkingPage;
+    private HighNeedsDashboardPage? _highNeedsBenchmarkingPage;
     private HomePage? _localAuthorityHomePage;
 
     [Given("I am on local authority homepage for local authority with code '(.*)'")]
@@ -66,5 +66,8 @@ public class HomeSteps(PageDriver driver)
         await _highNeedsBenchmarkingPage.IsDisplayed();
     }
 
-    private static string LocalAuthorityHomeUrl(string laCode) => $"{TestConfiguration.ServiceUrl}/local-authority/{laCode}";
+    private static string LocalAuthorityHomeUrl(string laCode)
+    {
+        return $"{TestConfiguration.ServiceUrl}/local-authority/{laCode}";
+    }
 }


### PR DESCRIPTION
### Context
[AB#252632](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/252632) [AB#249557](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249557) [AB#251848](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/251848) [AB#249552](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249552)

### Change proposed in this pull request
E2E test coverage

### Guidance to review 
It is known that another pass will be required once the accordions have been removed from the benchmarking page.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] You have reviewed with UX/Design

