### PR TITLE
A11y coverage over High needs benchmarking page

### DIFF
--- a/web/src/Web.App/package-lock.json
+++ b/web/src/Web.App/package-lock.json
@@ -1441,9 +1441,9 @@
       }
     },
     "node_modules/front-end": {
-      "version": "1.1.68",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-1.1.68.tgz",
-      "integrity": "sha1-yJfOW44ADTzJWrBR1r7NO6eoRN8=",
+      "version": "1.1.69",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-1.1.69.tgz",
+      "integrity": "sha1-ONlUZlvMLESDAZlwDQvynETwvyk=",
       "dependencies": {
         "accessible-autocomplete": "^3.0.0",
         "classnames": "^2.5.1",

--- a/web/tests/Web.A11yTests/Pages/LocalAuthority/WhenViewingHighNeedsBenchmarking.cs
+++ b/web/tests/Web.A11yTests/Pages/LocalAuthority/WhenViewingHighNeedsBenchmarking.cs
@@ -1,0 +1,27 @@
+using Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Web.A11yTests.Pages.LocalAuthority;
+
+[Trait("Category", "HighNeedsFlagEnabled")]
+public class WhenViewingHighNeedsBenchmarking(
+    ITestOutputHelper testOutputHelper,
+    WebDriver webDriver)
+    : PageBase(testOutputHelper, webDriver)
+{
+    protected override string PageUrl => $"/local-authority/{TestConfiguration.LocalAuthority}/high-needs/benchmarking/comparators";
+
+    [Theory]
+    [InlineData("mode-chart")]
+    [InlineData("mode-table")]
+    public async Task ThenThereAreNoAccessibilityIssues(string mode)
+    {
+        await GoToPage();
+        await Page.Locator("#LaInput").FillAsync("Hackney");
+        await Page.Locator("button[type=submit][name=action][value=add]").ClickAsync();
+        await Page.Locator("button[type=submit][name=action][value=continue]").ClickAsync();
+        await Page.Locator($"#{mode}").ClickAsync();
+        await EvaluatePage();
+    }
+}


### PR DESCRIPTION
### Context
[AB#252634](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/252634) [AB#249557](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249557)

### Change proposed in this pull request
- Bumped `front-end` version
- Added Axe coverage

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

