### PR TITLE
Added explicit dimensions to High needs comparator requests

### DIFF
--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/GetHighNeedsFunction.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/GetHighNeedsFunction.cs
@@ -23,7 +23,7 @@ public class GetHighNeedsFunction(IHighNeedsService service, IValidator<HighNeed
     [OpenApiSecurityHeader]
     [OpenApiOperation(nameof(GetHighNeedsFunction), Constants.Features.HighNeeds)]
     [OpenApiParameter("code", In = ParameterLocation.Query, Type = typeof(string[]), Required = true)]
-    [OpenApiParameter("dimension", In = ParameterLocation.Query, Description = "Dimension for resultant values", Type = typeof(string), Required = false, Example = typeof(ExampleHighNeedsDimension))]
+    [OpenApiParameter("dimension", In = ParameterLocation.Query, Description = "Dimension for resultant values", Type = typeof(string), Required = true, Example = typeof(ExampleHighNeedsDimension))]
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(LocalAuthority<HighNeedsYear>[]))]
     [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
     public async Task<HttpResponseData> RunAsync(

--- a/platform/src/apis/Platform.Api.NonFinancial/Features/EducationHealthCarePlans/GetEducationHealthCarePlansLocalAuthoritiesFunction.cs
+++ b/platform/src/apis/Platform.Api.NonFinancial/Features/EducationHealthCarePlans/GetEducationHealthCarePlansLocalAuthoritiesFunction.cs
@@ -25,7 +25,7 @@ public class GetEducationHealthCarePlansLocalAuthoritiesFunction(
     [OpenApiSecurityHeader]
     [OpenApiOperation(nameof(GetEducationHealthCarePlansLocalAuthoritiesFunction), Constants.Features.HighNeeds)]
     [OpenApiParameter("code", In = ParameterLocation.Query, Description = "List of local authority codes", Type = typeof(string[]), Required = true)]
-    [OpenApiParameter("dimension", In = ParameterLocation.Query, Description = "Dimension for resultant values", Type = typeof(string), Required = false, Example = typeof(ExampleEducationHealthCarePlansDimension))]
+    [OpenApiParameter("dimension", In = ParameterLocation.Query, Description = "Dimension for resultant values", Type = typeof(string), Required = true, Example = typeof(ExampleEducationHealthCarePlansDimension))]
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(LocalAuthorityNumberOfPlans[]))]
     [OpenApiResponseWithoutBody(HttpStatusCode.BadRequest)]
     public async Task<HttpResponseData> EducationHealthCarePlans(

--- a/web/src/Web.App/Controllers/Api/EducationHealthCarePlansProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/EducationHealthCarePlansProxyController.cs
@@ -34,7 +34,7 @@ public class EducationHealthCarePlansProxyController(
                 return NotFound();
             }
 
-            var query = BuildQuery(new[] { code }.Concat(set).ToArray());
+            var query = BuildQuery(new[] { code }.Concat(set).ToArray(), "Per1000");
             var plans = await educationHealthCarePlansApi
                 .GetEducationHealthCarePlans(query, cancellationToken)
                 .GetResultOrThrow<LocalAuthorityNumberOfPlans[]>();
@@ -59,7 +59,7 @@ public class EducationHealthCarePlansProxyController(
     {
         try
         {
-            var query = BuildQuery(code);
+            var query = BuildQuery([code]);
             var history = await educationHealthCarePlansApi
                 .GetEducationHealthCarePlansHistory(query, cancellationToken)
                 .GetResultOrThrow<EducationHealthCarePlansHistory<LocalAuthorityNumberOfPlansYear>>();
@@ -73,13 +73,15 @@ public class EducationHealthCarePlansProxyController(
         }
     }
 
-    private static ApiQuery BuildQuery(params string[] code)
+    private static ApiQuery BuildQuery(string[] codes, string? dimension = null)
     {
         var query = new ApiQuery();
-        foreach (var c in code)
+        foreach (var c in codes)
         {
-            query.AddIfNotNull(nameof(code), c);
+            query.AddIfNotNull("code", c);
         }
+
+        query.AddIfNotNull("dimension", dimension);
         return query;
     }
 }

--- a/web/src/Web.App/Controllers/Api/HighNeedsProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/HighNeedsProxyController.cs
@@ -34,7 +34,7 @@ public class HighNeedsProxyController(
                 return NotFound();
             }
 
-            var query = BuildQuery(new[] { code }.Concat(set).ToArray());
+            var query = BuildQuery(new[] { code }.Concat(set).ToArray(), "PerHead");
             var localAuthorities = await localAuthoritiesApi
                 .GetHighNeeds(query, cancellationToken)
                 .GetResultOrThrow<LocalAuthority<HighNeeds>[]>();
@@ -59,7 +59,7 @@ public class HighNeedsProxyController(
     {
         try
         {
-            var query = BuildQuery(code);
+            var query = BuildQuery([code]);
             var history = await localAuthoritiesApi
                 .GetHighNeedsHistory(query, cancellationToken)
                 .GetResultOrThrow<HighNeedsHistory<HighNeedsYear>>();
@@ -73,14 +73,15 @@ public class HighNeedsProxyController(
         }
     }
 
-    private static ApiQuery BuildQuery(params string[] code)
+    private static ApiQuery BuildQuery(string[] codes, string? dimension = null)
     {
         var query = new ApiQuery();
-        foreach (var c in code)
+        foreach (var c in codes)
         {
-            query.AddIfNotNull(nameof(code), c);
+            query.AddIfNotNull("code", c);
         }
 
+        query.AddIfNotNull("dimension", dimension);
         return query;
     }
 }


### PR DESCRIPTION
### Context
[AB#252982](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/252982) [AB#249575](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249575)

### Change proposed in this pull request
Also marked `dimension` as required in OpenAPI spec in dimensioned endpoints.

### Guidance to review 
No functional changes to Benchmarking functionality after this change - even if stubbed data was not in use. Subsequent work items will call High needs endpoints with newly defined dimensions at which point the stubbed data will be modified.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

