### PR TITLE
Set `Actuals` as default dimension for High needs endpoints and extended stubbed data

### DIFF
--- a/platform/src/abstractions/Platform.Domain/Dimensions.cs
+++ b/platform/src/abstractions/Platform.Domain/Dimensions.cs
@@ -41,10 +41,12 @@ public static class Dimensions
 
     public static class HighNeeds
     {
+        public const string Actuals = nameof(Actuals);
         public const string PerHead = nameof(PerHead);
 
         public static readonly string[] All =
         [
+            Actuals,
             PerHead
         ];
 
@@ -53,11 +55,13 @@ public static class Dimensions
 
     public static class EducationHealthCarePlans
     {
+        public const string Actuals = nameof(Actuals);
         public const string Per1000 = nameof(Per1000);
 
         public static readonly string[] All =
         [
-            Per1000,
+            Actuals,
+            Per1000
         ];
 
         public static bool IsValid(string? dimension) => All.Any(a => a == dimension);

--- a/platform/src/abstractions/tests/Platform.Domain.Tests/WhenDimensionsChecksIsValid.cs
+++ b/platform/src/abstractions/tests/Platform.Domain.Tests/WhenDimensionsChecksIsValid.cs
@@ -29,6 +29,7 @@ public class WhenDimensionsChecksIsValid
     }
 
     [Theory]
+    [InlineData("Actuals", true)]
     [InlineData("PerHead", true)]
     [InlineData("invalid", false)]
     public void ShouldValidateHighNeedsDimensions(string dimension, bool expected)
@@ -38,6 +39,7 @@ public class WhenDimensionsChecksIsValid
     }
 
     [Theory]
+    [InlineData("Actuals", true)]
     [InlineData("Per1000", true)]
     [InlineData("invalid", false)]
     public void ShouldValidateEducationHealthCarePlansDimensions(string dimension, bool expected)

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/Parameters/HighNeedsDimensionedParameters.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/Parameters/HighNeedsDimensionedParameters.cs
@@ -1,13 +1,12 @@
 ﻿using System.Collections.Specialized;
 using Platform.Domain;
-using Platform.Functions;
 using Platform.Functions.Extensions;
 
 namespace Platform.Api.LocalAuthorityFinances.Features.HighNeeds.Parameters;
 
 public record HighNeedsDimensionedParameters : HighNeedsParameters
 {
-    public string Dimension { get; private set; } = Dimensions.HighNeeds.PerHead;
+    public string Dimension { get; private set; } = Dimensions.HighNeeds.Actuals;
 
     public override void SetValues(NameValueCollection query)
     {

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/Services/HighNeedsStubService.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/Services/HighNeedsStubService.cs
@@ -100,12 +100,13 @@ public class HighNeedsStubService : IHighNeedsService
             baseValue = code.Length;
         }
 
+        var baseMultiplier = dimension == "Actuals" ? 1_000 : 1;
         return new LocalAuthority<Models.HighNeeds>
         {
             Code = code,
             Name = $"Local authority {code}",
-            Budget = GetStubbedRow(code, 2024, 1_100_000 + baseValue, 1_110_000 + baseValue % 2),
-            Outturn = GetStubbedRow(code, 2024, 1_000_000 + baseValue, 1_010_000 + baseValue % 2)
+            Budget = GetStubbedRow(code, 2024, 1_100 * baseMultiplier + baseValue, 1_110 * baseMultiplier + baseValue % 2),
+            Outturn = GetStubbedRow(code, 2024, 1_000 * baseMultiplier + baseValue, 1_010 * baseMultiplier + baseValue % 2)
         };
     }
 }

--- a/platform/src/apis/Platform.Api.NonFinancial/Features/EducationHealthCarePlans/Parameters/EducationHealthCarePlansDimensionedParameters.cs
+++ b/platform/src/apis/Platform.Api.NonFinancial/Features/EducationHealthCarePlans/Parameters/EducationHealthCarePlansDimensionedParameters.cs
@@ -6,7 +6,7 @@ namespace Platform.Api.NonFinancial.Features.EducationHealthCarePlans.Parameters
 
 public record EducationHealthCarePlansDimensionedParameters : EducationHealthCarePlansParameters
 {
-    public string Dimension { get; private set; } = Dimensions.EducationHealthCarePlans.Per1000;
+    public string Dimension { get; private set; } = Dimensions.EducationHealthCarePlans.Actuals;
 
     public override void SetValues(NameValueCollection query)
     {

--- a/platform/src/apis/Platform.Api.NonFinancial/Features/EducationHealthCarePlans/Services/EducationHealthCarePlansStubService.cs
+++ b/platform/src/apis/Platform.Api.NonFinancial/Features/EducationHealthCarePlans/Services/EducationHealthCarePlansStubService.cs
@@ -20,7 +20,7 @@ public class EducationHealthCarePlansStubService : IEducationHealthCarePlansServ
 
             var parsedCode = int.TryParse(code, out var parsedValue) ? parsedValue : 200;
             var baseNumber = parsedCode + i + year;
-            var yearData = GetStubbedYear(year, code, baseNumber);
+            var yearData = GetStubbedYear(year, code, baseNumber, dimension);
             plans.Add(yearData);
         }
 
@@ -55,16 +55,17 @@ public class EducationHealthCarePlansStubService : IEducationHealthCarePlansServ
         return Task.FromResult(result);
     }
 
-    private static LocalAuthorityNumberOfPlansYear GetStubbedYear(int year, string code, int baseNumber)
+    private static LocalAuthorityNumberOfPlansYear GetStubbedYear(int year, string code, int baseNumber, string? dimension = null)
     {
         // some variation based on input but still repeatable for testing
-        var mainstream = baseNumber % 40;
-        var resourced = baseNumber % 10;
-        var special = baseNumber % 7;
-        var independent = baseNumber % 15;
-        var hospital = baseNumber % 25;
-        var post16 = baseNumber % 30;
-        var other = baseNumber % 8;
+        var multiplier = dimension == "Actuals" ? 1_000 : 1;
+        var mainstream = baseNumber % 40 * multiplier;
+        var resourced = baseNumber % 10 * multiplier;
+        var special = baseNumber % 7 * multiplier;
+        var independent = baseNumber % 15 * multiplier;
+        var hospital = baseNumber % 25 * multiplier;
+        var post16 = baseNumber % 30 * multiplier;
+        var other = baseNumber % 8 * multiplier;
         var total = mainstream + resourced + special + independent + hospital + post16 + other;
 
         return new LocalAuthorityNumberOfPlansYear

--- a/platform/tests/Platform.ApiTests/Features/LocalAuthoritiesHighNeeds.feature
+++ b/platform/tests/Platform.ApiTests/Features/LocalAuthoritiesHighNeeds.feature
@@ -130,8 +130,8 @@ Feature: Local authorities high needs endpoints
         When I submit the high needs request
         Then the high needs history result should be bad request
 
-    Scenario: Sending a valid high needs request with default dimension returns the expected outturn values
-        Given a valid high needs request with dimension '' and LA codes:
+    Scenario: Sending a valid high needs request with Actuals dimension returns the expected outturn values
+        Given a valid high needs request with dimension 'Actuals' and LA codes:
           | Code |
           | 201  |
           | 202  |
@@ -192,8 +192,8 @@ Feature: Local authorities high needs endpoints
           | Special              | 1002249 |
           | AlternativeProvision | 1002250 |
 
-    Scenario: Sending a valid high needs request with default dimension returns the expected budget values
-        Given a valid high needs request with dimension '' and LA codes:
+    Scenario: Sending a valid high needs request with Actuals dimension returns the expected budget values
+        Given a valid high needs request with dimension 'Actuals' and LA codes:
           | Code |
           | 201  |
           | 202  |
@@ -253,6 +253,130 @@ Feature: Local authorities high needs endpoints
           | Secondary            | 1102248 |
           | Special              | 1102249 |
           | AlternativeProvision | 1102250 |
+
+    Scenario: Sending a valid high needs request with PerHead dimension returns the expected outturn values
+        Given a valid high needs request with dimension 'PerHead' and LA codes:
+          | Code |
+          | 201  |
+          | 202  |
+          | 203  |
+        When I submit the high needs request
+        Then the high needs result should be ok and have the following values for '201':
+          | Field | Value               |
+          | Code  | 201                 |
+          | Name  | Local authority 201 |
+        And the high needs result should have the following values for '202':
+          | Field | Value               |
+          | Code  | 202                 |
+          | Name  | Local authority 202 |
+        And the high needs result should have the following values for '203':
+          | Field | Value               |
+          | Code  | 203                 |
+          | Name  | Local authority 203 |
+        And the high needs result should contain the following outturn values for '201':
+          | Field | Value |
+          | Total | 1011  |
+        And the high needs result should contain the following outturn values for '202':
+          | Field | Value |
+          | Total | 1010  |
+        And the high needs result should contain the following outturn values for '203':
+          | Field | Value |
+          | Total | 1011  |
+        And the high needs result should contain the following outturn high needs amount values for '201':
+          | Field                        | Value |
+          | TotalPlaceFunding            | 3226  |
+          | TopUpFundingMaintained       | 3227  |
+          | TopUpFundingNonMaintained    | 3228  |
+          | SenServices                  | 3229  |
+          | AlternativeProvisionServices | 3230  |
+          | HospitalServices             | 3231  |
+          | OtherHealthServices          | 3232  |
+        And the high needs result should contain the following outturn maintained values for '201':
+          | Field                | Value |
+          | EarlyYears           | 3233  |
+          | Primary              | 3234  |
+          | Secondary            | 3235  |
+          | Special              | 3236  |
+          | AlternativeProvision | 3237  |
+          | PostSchool           | 3238  |
+          | Income               | 3239  |
+        And the high needs result should contain the following outturn non maintained values for '201':
+          | Field                | Value |
+          | EarlyYears           | 3240  |
+          | Primary              | 3241  |
+          | Secondary            | 3242  |
+          | Special              | 3243  |
+          | AlternativeProvision | 3244  |
+          | PostSchool           | 3245  |
+          | Income               | 3246  |
+        And the high needs result should contain the following outturn place funding values for '201':
+          | Field                | Value |
+          | Primary              | 3247  |
+          | Secondary            | 3248  |
+          | Special              | 3249  |
+          | AlternativeProvision | 3250  |
+
+    Scenario: Sending a valid high needs request with PerHead dimension returns the expected budget values
+        Given a valid high needs request with dimension 'PerHead' and LA codes:
+          | Code |
+          | 201  |
+          | 202  |
+          | 203  |
+        When I submit the high needs request
+        Then the high needs result should be ok and have the following values for '201':
+          | Field | Value               |
+          | Code  | 201                 |
+          | Name  | Local authority 201 |
+        And the high needs result should have the following values for '202':
+          | Field | Value               |
+          | Code  | 202                 |
+          | Name  | Local authority 202 |
+        And the high needs result should have the following values for '203':
+          | Field | Value               |
+          | Code  | 203                 |
+          | Name  | Local authority 203 |
+        And the high needs result should contain the following budget values for '201':
+          | Field | Value |
+          | Total | 1111  |
+        And the high needs result should contain the following budget values for '202':
+          | Field | Value |
+          | Total | 1110  |
+        And the high needs result should contain the following budget values for '203':
+          | Field | Value |
+          | Total | 1111  |
+        And the high needs result should contain the following budget high needs amount values for '201':
+          | Field                        | Value |
+          | TotalPlaceFunding            | 3326  |
+          | TopUpFundingMaintained       | 3327  |
+          | TopUpFundingNonMaintained    | 3328  |
+          | SenServices                  | 3329  |
+          | AlternativeProvisionServices | 3330  |
+          | HospitalServices             | 3331  |
+          | OtherHealthServices          | 3332  |
+        And the high needs result should contain the following budget maintained values for '201':
+          | Field                | Value |
+          | EarlyYears           | 3333  |
+          | Primary              | 3334  |
+          | Secondary            | 3335  |
+          | Special              | 3336  |
+          | AlternativeProvision | 3337  |
+          | PostSchool           | 3338  |
+          | Income               | 3339  |
+        And the high needs result should contain the following budget non maintained values for '201':
+          | Field                | Value |
+          | EarlyYears           | 3340  |
+          | Primary              | 3341  |
+          | Secondary            | 3342  |
+          | Special              | 3343  |
+          | AlternativeProvision | 3344  |
+          | PostSchool           | 3345  |
+          | Income               | 3346  |
+        And the high needs result should contain the following budget place funding values for '201':
+          | Field                | Value |
+          | Primary              | 3347  |
+          | Secondary            | 3348  |
+          | Special              | 3349  |
+          | AlternativeProvision | 3350  |
 
     Scenario: Sending an invalid high needs request
         Given an invalid high needs request

--- a/platform/tests/Platform.ApiTests/Features/NonFinancialEducationHealthCarePlansLocalAuthorities.feature
+++ b/platform/tests/Platform.ApiTests/Features/NonFinancialEducationHealthCarePlansLocalAuthorities.feature
@@ -54,8 +54,21 @@
         When I submit the education health care plans request
         Then the education health care plans history result should be bad request
 
-    Scenario: Sending a valid education health care plans request with default dimension returns the correct values
-        Given an education health care plans request with dimension '' and LA codes:
+    Scenario: Sending a valid education health care plans request with Actuals dimension returns the correct values
+        Given an education health care plans request with dimension 'Actuals' and LA codes:
+          | Code |
+          | 201  |
+          | 202  |
+          | 203  |
+        When I submit the education health care plans request
+        Then the education health care plans result should be ok and contain the following values:
+          | Code | Name                | Total | Mainstream | Resourced | Special | Independent | Hospital | Post16 | Other |
+          | 201  | Local authority 201 | 47000 | 25000      | 5000      | 6000    | 5000        | 0        | 5000   | 1000  |
+          | 202  | Local authority 202 | 54000 | 27000      | 7000      | 1000    | 7000        | 2000     | 7000   | 3000  |
+          | 203  | Local authority 203 | 68000 | 29000      | 9000      | 3000    | 9000        | 4000     | 9000   | 5000  |
+
+    Scenario: Sending a valid education health care plans request with Per1000 dimension returns the correct values
+        Given an education health care plans request with dimension 'Per1000' and LA codes:
           | Code |
           | 201  |
           | 202  |

--- a/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsBenchmarking.feature
+++ b/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsBenchmarking.feature
@@ -22,9 +22,9 @@
         Given I am on local authority high needs benchmarking for local authority with code '201'
         When I click on view as table
         Then the table at index '0' contains the following S251 values:
-          | Name                | Actual     | Planned    |
-          | Local authority 201 | £1,002,226 | £1,102,226 |
-          | Local authority 204 | £1,002,229 | £1,102,229 |
+          | Name                | Actual | Planned |
+          | Local authority 201 | £3,226 | £3,326  |
+          | Local authority 204 | £3,229 | £3,329  |
 
     @HighNeedsFlagEnabled
     Scenario: Can view local authority benchmarking table data for SEND2


### PR DESCRIPTION
### Context
[AB#253062](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/253062) [AB#249575](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249575) #2101

### Change proposed in this pull request
Also updated affected tests.

### Guidance to review 
Dependency on #2101. There are changes to Benchmarking figures here due to modified stubbed data with the `Actuals` dimensions being made significantly larger than the corresponding `PerXXX` values. E2E coverage has been updated accordingly in anticipation of a future sweep once proper test data is available and stubs dropped.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

