### PR TITLE
Added `s251` to default pipeline message years schema in Orchestrator

### DIFF
--- a/data-pipeline/README.md
+++ b/data-pipeline/README.md
@@ -195,7 +195,8 @@ To run the pipeline locally, follow these steps:
         "year": {
             "aar": <year>,
             "cfr": <year>,
-            "bfr": <year>
+            "bfr": <year>,
+            "s251": <year>
         }
     }
     ```

--- a/documentation/data/4_Releases.md
+++ b/documentation/data/4_Releases.md
@@ -60,7 +60,8 @@ Once the respective data has been loaded to the Azure Storage Container, the pip
     "year": {
         "aar": <YYYY>,
         "cfr": <YYYY>,
-        "bfr": <YYYY>
+        "bfr": <YYYY>,
+        "s251": <YYYY>
     }
 }
  ```

--- a/platform/src/abstractions/Platform.Domain/Messages/PipelineStartDefault.cs
+++ b/platform/src/abstractions/Platform.Domain/Messages/PipelineStartDefault.cs
@@ -56,4 +56,5 @@ public record PipelineMessageYears
     public int? Aar { get; set; }
     public int? Cfr { get; set; }
     public int? Bfr { get; set; }
+    public int? S251 { get; set; }
 }

--- a/platform/src/abstractions/tests/Platform.Domain.Tests/Messages/WhenPipelineStartDefaultCreatesFromPending.cs
+++ b/platform/src/abstractions/tests/Platform.Domain.Tests/Messages/WhenPipelineStartDefaultCreatesFromPending.cs
@@ -19,7 +19,8 @@ public class WhenPipelineStartDefaultCreatesFromPending
             {
                 Aar = 2021,
                 Bfr = 2022,
-                Cfr = 2023
+                Cfr = 2023,
+                S251 = 2024
             })
         };
 
@@ -35,7 +36,8 @@ public class WhenPipelineStartDefaultCreatesFromPending
             {
                 Aar = 2021,
                 Bfr = 2022,
-                Cfr = 2023
+                Cfr = 2023,
+                S251 = 2024
             }
         };
         Assert.Equivalent(expected, result);

--- a/platform/tests/Platform.Orchestrator.Tests/Functions/ActivityTrigger/WhenPipelineStartDefaultJobTriggered.cs
+++ b/platform/tests/Platform.Orchestrator.Tests/Functions/ActivityTrigger/WhenPipelineStartDefaultJobTriggered.cs
@@ -21,13 +21,14 @@ public class WhenPipelineStartDefaultJobTriggered(ITestOutputHelper testOutputHe
             {
                 Aar = 2021,
                 Bfr = 2022,
-                Cfr = 2023
+                Cfr = 2023,
+                S251 = 2024
             }
         };
 
         var result = Functions.OnStartDefaultJobTrigger(message);
 
-        const string expected = """{"runId":2020,"year":{"aar":2021,"cfr":2023,"bfr":2022},"jobId":"jobId","type":"type","runType":"runType"}""";
+        const string expected = """{"runId":2020,"year":{"aar":2021,"cfr":2023,"bfr":2022,"s251":2024},"jobId":"jobId","type":"type","runType":"runType"}""";
         Assert.Single(result);
         Assert.Equal(expected, result.Single());
     }


### PR DESCRIPTION
### Context
[AB#253140](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/253140) [AB#250667](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/250667)

### Change proposed in this pull request
Updated `default` message format processed and forwarded by Orchestrator

### Guidance to review 
May be validated by running Orchestrator and placing message of the new format onto the attached `pending` queue. Once moved to the `start-default` queue the new field should still be present.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

