### PR TITLE
Added view for Local authority national ranking on spend as percentage of budget

### DIFF
--- a/core-infrastructure/src/db/Core.Database/Views/018-LocalAuthorityFinancial.sql
+++ b/core-infrastructure/src/db/Core.Database/Views/018-LocalAuthorityFinancial.sql
@@ -173,3 +173,19 @@ AS
     FROM Parameters
     WHERE Name = 'CurrentYear')
 GO
+
+DROP VIEW IF EXISTS VW_LocalAuthorityFinancialDefaultCurrentSpendAsPercentageOfBudget 
+GO
+
+CREATE VIEW VW_LocalAuthorityFinancialDefaultCurrentSpendAsPercentageOfBudget
+AS
+    SELECT l.[Code],
+        l.[Name],
+        c.[OutturnTotalHighNeeds] / c.[BudgetTotalHighNeeds] * 100 AS [Value],
+        RANK() OVER (ORDER BY c.[OutturnTotalHighNeeds] / c.[BudgetTotalHighNeeds] DESC) AS [Rank]
+    FROM [LocalAuthority] l
+        LEFT JOIN [VW_LocalAuthorityFinancialDefaultActual] c ON c.[LaCode] = l.[Code]
+    WHERE c.[RunId] = (SELECT [Value]
+    FROM [Parameters]
+    WHERE [Name] = 'CurrentYear')
+GO


### PR DESCRIPTION
### Context
AB#253549 AB#252392

### Change proposed in this pull request
New database view.

### Guidance to review 
To be consumed as part of other work items.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

