### PR TITLE
feat: process LA Statistical Neighbours Excel file

### DIFF
--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -588,11 +588,11 @@ def pre_process_local_authorities(
     )
 
     logger.info(
-        f"Reading LA statistical neighbours: default/{year}/SNsWithNewDorsetBCP.csv"
+        f"Reading LA statistical neighbours: default/{year}/High-needs-local-authority-benchmarking-tool.xlsm"
     )
     la_statistical_neighbours_data = get_blob(
         raw_container,
-        f"default/{year}/SNsWithNewDorsetBCP.csv",
+        f"default/{year}/High-needs-local-authority-benchmarking-tool.xlsm",
     )
 
     logger.info(

--- a/data-pipeline/src/pipeline/pre_processing/local_authority.py
+++ b/data-pipeline/src/pipeline/pre_processing/local_authority.py
@@ -276,8 +276,10 @@ def _prepare_la_statistical_neighbours(
     :return: Local Authority statistical neighbours data
     """
     logger.info("Processing Local Authority statistical neighbours data.")
-    df = pd.read_csv(
+    df = pd.read_excel(
         filepath_or_buffer,
+        engine="calamine",
+        sheet_name="SNsWithNewDorsetBCP",
         index_col=input_schemas.la_statistical_neighbours_index_col,
         dtype=input_schemas.la_statistical_neighbours.get(
             year, input_schemas.la_statistical_neighbours["default"]

--- a/data-pipeline/tests/unit/pre_processing/local_authorities/conftest.py
+++ b/data-pipeline/tests/unit/pre_processing/local_authorities/conftest.py
@@ -234,7 +234,11 @@ def la_statistical_neighbours() -> io.StringIO:
 
     test_data_df = pd.DataFrame(data, columns=columns)
 
-    return io.StringIO(test_data_df.to_csv())
+    buffer = io.BytesIO()
+    test_data_df.to_excel(buffer, sheet_name="SNsWithNewDorsetBCP")
+    buffer.seek(0)
+
+    return buffer
 
 
 @pytest.fixture


### PR DESCRIPTION
### Context

Previously we were manually exporting the worksheet of interest as a CSV, rather than processing the "raw" file.

[AB#250505](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/250505)

### Change proposed in this pull request

process the single worksheet in the Statistical Neighbours Excel file, rather than exporting as a CSV.

### Guidance to review 

Re. the tests, Pandas' [`to_excel`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_excel.html) is slightly less elegant than it's `to_csv` counterpart, insofar as you have to pass it a writer/sink.

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~You have reviewed with UX/Design~

