### PR TITLE
Wire up `EducationHealthCarePlansService.Get()` to underlying database views to replace stubbed version

### DIFF
--- a/platform/src/abstractions/Platform.Sql/QueryBuilders/LocalAuthorityQueries.cs
+++ b/platform/src/abstractions/Platform.Sql/QueryBuilders/LocalAuthorityQueries.cs
@@ -55,3 +55,16 @@ public class LocalAuthorityFinancialDefaultQuery : PlatformQuery
         };
     }
 }
+
+public class LocalAuthorityEducationHealthCarePlansDefaultCurrentQuery(string dimension) : PlatformQuery(GetSql(dimension))
+{
+    private static string GetSql(string dimension)
+    {
+        return dimension switch
+        {
+            Dimensions.EducationHealthCarePlans.Actuals => "SELECT * FROM VW_LocalAuthorityEducationHealthCarePlansDefaultCurrentActual /**where**/",
+            Dimensions.EducationHealthCarePlans.Per1000 => "SELECT * FROM VW_LocalAuthorityEducationHealthCarePlansDefaultCurrentPerPopulation /**where**/",
+            _ => throw new ArgumentOutOfRangeException(nameof(dimension), "Unknown dimension")
+        };
+    }
+}

--- a/platform/src/abstractions/tests/Platform.Sql.Tests/Builders/LocalAuthorityQueryTests.cs
+++ b/platform/src/abstractions/tests/Platform.Sql.Tests/Builders/LocalAuthorityQueryTests.cs
@@ -68,3 +68,28 @@ public class LocalAuthorityFinancialDefaultQueryTests
 
     private static LocalAuthorityFinancialDefaultQuery Create(string dimension, string[] fields) => new(dimension, fields);
 }
+
+public class LocalAuthorityEducationHealthCarePlansDefaultCurrentQueryTests
+{
+    public static TheoryData<string, string> Data => new()
+    {
+        { "Actuals", "SELECT * FROM VW_LocalAuthorityEducationHealthCarePlansDefaultCurrentActual " },
+        { "Per1000", "SELECT * FROM VW_LocalAuthorityEducationHealthCarePlansDefaultCurrentPerPopulation " },
+    };
+
+    [Theory]
+    [MemberData(nameof(Data))]
+    public void ShouldReturnSql(string dimension, string expected)
+    {
+        var builder = Create(dimension);
+        Assert.Equal(expected, builder.QueryTemplate.RawSql);
+    }
+
+    [Fact]
+    public void ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Create("dimension"));
+    }
+
+    private static LocalAuthorityEducationHealthCarePlansDefaultCurrentQuery Create(string dimension) => new(dimension);
+}

--- a/platform/src/apis/Platform.Api.NonFinancial/Features/EducationHealthCarePlans/EducationHealthCarePlansFeature.cs
+++ b/platform/src/apis/Platform.Api.NonFinancial/Features/EducationHealthCarePlans/EducationHealthCarePlansFeature.cs
@@ -13,7 +13,7 @@ public static class EducationHealthCarePlansFeature
     public static IServiceCollection AddEducationHealthCarePlansFeature(this IServiceCollection serviceCollection)
     {
         serviceCollection
-            .AddSingleton<IEducationHealthCarePlansService, EducationHealthCarePlansStubService>();
+            .AddSingleton<IEducationHealthCarePlansService, EducationHealthCarePlansService>();
 
         serviceCollection
             .AddTransient<IValidator<EducationHealthCarePlansParameters>, EducationHealthCarePlansParametersValidator>()

--- a/platform/src/apis/Platform.Api.NonFinancial/Features/EducationHealthCarePlans/Models/LocalAuthorityNumberOfPlans.cs
+++ b/platform/src/apis/Platform.Api.NonFinancial/Features/EducationHealthCarePlans/Models/LocalAuthorityNumberOfPlans.cs
@@ -1,10 +1,13 @@
 // ReSharper disable PropertyCanBeMadeInitOnly.Global
 // ReSharper disable UnusedAutoPropertyAccessor.Global
+using System.Text.Json.Serialization;
+
 namespace Platform.Api.NonFinancial.Features.EducationHealthCarePlans.Models;
 
 public record LocalAuthorityNumberOfPlans
 {
-    public string? Code { get; set; }
+    [JsonPropertyName("code")]
+    public string? LaCode { get; set; }
     public string? Name { get; set; }
     public decimal? Total { get; set; }
     public decimal? Mainstream { get; set; }

--- a/platform/src/apis/Platform.Api.NonFinancial/Features/EducationHealthCarePlans/Services/EducationHealthCarePlansService.cs
+++ b/platform/src/apis/Platform.Api.NonFinancial/Features/EducationHealthCarePlans/Services/EducationHealthCarePlansService.cs
@@ -1,6 +1,9 @@
-﻿using System.Threading;
+﻿using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Platform.Api.NonFinancial.Features.EducationHealthCarePlans.Models;
+using Platform.Sql;
+using Platform.Sql.QueryBuilders;
 
 namespace Platform.Api.NonFinancial.Features.EducationHealthCarePlans.Services;
 
@@ -8,4 +11,17 @@ public interface IEducationHealthCarePlansService
 {
     Task<LocalAuthorityNumberOfPlans[]> Get(string[] codes, string dimension, CancellationToken cancellationToken = default);
     Task<History<LocalAuthorityNumberOfPlansYear>> GetHistory(string[] codes, CancellationToken cancellationToken = default);
+}
+
+public class EducationHealthCarePlansService(IDatabaseFactory dbFactory) : EducationHealthCarePlansStubService
+{
+    public override async Task<LocalAuthorityNumberOfPlans[]> Get(string[] codes, string dimension, CancellationToken cancellationToken = default)
+    {
+        using var conn = await dbFactory.GetConnection();
+        var builder = new LocalAuthorityEducationHealthCarePlansDefaultCurrentQuery(dimension)
+            .WhereLaCodesIn(codes);
+
+        var results = await conn.QueryAsync<LocalAuthorityNumberOfPlans>(builder, cancellationToken);
+        return results.ToArray();
+    }
 }

--- a/platform/src/apis/Platform.Api.NonFinancial/Features/EducationHealthCarePlans/Services/EducationHealthCarePlansStubService.cs
+++ b/platform/src/apis/Platform.Api.NonFinancial/Features/EducationHealthCarePlans/Services/EducationHealthCarePlansStubService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Platform.Api.NonFinancial.Features.EducationHealthCarePlans.Models;
@@ -7,26 +8,10 @@ namespace Platform.Api.NonFinancial.Features.EducationHealthCarePlans.Services;
 
 public class EducationHealthCarePlansStubService : IEducationHealthCarePlansService
 {
+    public virtual Task<LocalAuthorityNumberOfPlans[]> Get(string[] codes, string dimension, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
     // TODO: remove and replace once db / data ingestion changes are in place to provide actual data
     // this generates stubbed data for usage in development prior to db updates
-    public Task<LocalAuthorityNumberOfPlans[]> Get(string[] codes, string dimension, CancellationToken cancellationToken = default)
-    {
-        const int year = 2024;
-        List<LocalAuthorityNumberOfPlans> plans = [];
-
-        for (var i = 0; i < codes.Length; i++)
-        {
-            var code = codes[i];
-
-            var parsedCode = int.TryParse(code, out var parsedValue) ? parsedValue : 200;
-            var baseNumber = parsedCode + i + year;
-            var yearData = GetStubbedYear(year, code, baseNumber, dimension);
-            plans.Add(yearData);
-        }
-
-        return Task.FromResult(plans.ToArray());
-    }
-
     public Task<History<LocalAuthorityNumberOfPlansYear>> GetHistory(string[] codes, CancellationToken cancellationToken = default)
     {
         const int startYear = 2020;
@@ -71,7 +56,7 @@ public class EducationHealthCarePlansStubService : IEducationHealthCarePlansServ
         return new LocalAuthorityNumberOfPlansYear
         {
             Year = year,
-            Code = code,
+            LaCode = code,
             Name = $"Local authority {code}",
             Mainstream = mainstream,
             Resourced = resourced,

--- a/platform/tests/Platform.NonFinancial.Tests/EducationHealthCarePlans/Services/WhenEducationHealthCarePlansServiceQueriesAsync.cs
+++ b/platform/tests/Platform.NonFinancial.Tests/EducationHealthCarePlans/Services/WhenEducationHealthCarePlansServiceQueriesAsync.cs
@@ -1,0 +1,52 @@
+﻿using AutoFixture;
+using Moq;
+using Platform.Api.NonFinancial.Features.EducationHealthCarePlans.Models;
+using Platform.Api.NonFinancial.Features.EducationHealthCarePlans.Services;
+using Platform.Domain;
+using Platform.Sql;
+using Platform.Sql.QueryBuilders;
+using Xunit;
+
+namespace Platform.NonFinancial.Tests.EducationHealthCarePlans.Services;
+
+public class WhenEducationHealthCarePlansServiceQueriesAsync
+{
+    private readonly Mock<IDatabaseConnection> _connection;
+    private readonly Fixture _fixture = new();
+    private readonly EducationHealthCarePlansService _service;
+
+    public WhenEducationHealthCarePlansServiceQueriesAsync()
+    {
+        _connection = new Mock<IDatabaseConnection>();
+
+        var dbFactory = new Mock<IDatabaseFactory>();
+        dbFactory.Setup(d => d.GetConnection()).ReturnsAsync(_connection.Object);
+
+        _service = new EducationHealthCarePlansService(dbFactory.Object);
+    }
+
+    [Fact]
+    public async Task ShouldQueryAsyncWhenGetAll()
+    {
+        // arrange
+        const string dimension = Dimensions.EducationHealthCarePlans.Per1000;
+        string[] codes = ["code1", "code2", "code3"];
+        var results = _fixture.Build<LocalAuthorityNumberOfPlans>().CreateMany().ToArray();
+        string? actualSql = null;
+
+        _connection
+            .Setup(c => c.QueryAsync<LocalAuthorityNumberOfPlans>(It.IsAny<PlatformQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<PlatformQuery, CancellationToken>((query, _) =>
+            {
+                actualSql = query.QueryTemplate.RawSql.Trim();
+            })
+            .ReturnsAsync(results);
+
+        // act
+        var actual = await _service.Get(codes, dimension, CancellationToken.None);
+
+        // assert
+        Assert.Equal(results, actual);
+        Assert.Equal("SELECT * FROM VW_LocalAuthorityEducationHealthCarePlansDefaultCurrentPerPopulation WHERE LaCode IN @LaCodes", actualSql);
+    }
+}


### PR DESCRIPTION
### Context
[AB#253442](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/253442) [AB#253282](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/253282)

### Change proposed in this pull request
- Replaced stubbed version of the above service method
- Used correct database view dependent on dimension using new `PlatformQuery`, with test coverage

### Guidance to review 
- Remaining stubbed service implementations with dependency on LA non-financials to be resolve as part of other work items.
- E2E and API tests will be in a failing state until seed data added as part of other work items. These are currently excluded from pipeline runs anyway, so this change should not block upstream deployments.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~



