### PR TITLE
Display missing data warning on LA benchmarking

### DIFF
--- a/front-end-components/src/components/charts/data-warning/component.tsx
+++ b/front-end-components/src/components/charts/data-warning/component.tsx
@@ -1,8 +1,11 @@
+import classNames from "classnames";
 import { DataWarningProps } from "./types";
 
-export function DataWarning({ children }: DataWarningProps) {
+export function DataWarning({ children, className }: DataWarningProps) {
   return (
-    <div className="govuk-warning-text govuk-!-margin-0">
+    <div
+      className={classNames("govuk-warning-text govuk-!-margin-0", className)}
+    >
       <span className="govuk-warning-text__icon" aria-hidden="true">
         !
       </span>

--- a/front-end-components/src/components/charts/data-warning/types.tsx
+++ b/front-end-components/src/components/charts/data-warning/types.tsx
@@ -1,3 +1,5 @@
 import { PropsWithChildren } from "react";
 
-export interface DataWarningProps extends PropsWithChildren {}
+export interface DataWarningProps extends PropsWithChildren {
+  className?: string;
+}

--- a/front-end-components/src/components/charts/establishment-tick/component.tsx
+++ b/front-end-components/src/components/charts/establishment-tick/component.tsx
@@ -39,6 +39,12 @@ export function EstablishmentTick(props: EstablishmentTickProps) {
     );
   }, [key, specialItemFlags]);
 
+  const missingData = useMemo(() => {
+    return (
+      key && specialItemFlags && specialItemFlags(key).includes("missingData")
+    );
+  }, [key, specialItemFlags]);
+
   const [textBoundingBox, setTextBoundingBox] = useState<{
     x?: number;
     y?: number;
@@ -60,9 +66,14 @@ export function EstablishmentTick(props: EstablishmentTickProps) {
   };
   if (!key || !linkToEstablishment) {
     return (
-      <text {...textProps} {...rest}>
-        {value}
-      </text>
+      <>
+        {(partYear || missingData) && (
+          <Exclamation x={textBoundingBox?.x} y={textBoundingBox?.y} />
+        )}
+        <text {...textProps} ref={textRef} {...rest}>
+          {value}
+        </text>
+      </>
     );
   }
 
@@ -80,7 +91,7 @@ export function EstablishmentTick(props: EstablishmentTickProps) {
         height={rest.height}
         className="establishment-tick-focus"
       ></line>
-      {partYear && (
+      {(partYear || missingData) && (
         <Exclamation x={textBoundingBox?.x} y={textBoundingBox?.y} />
       )}
       <text {...textProps} ref={textRef} {...rest}>

--- a/front-end-components/src/components/charts/types.tsx
+++ b/front-end-components/src/components/charts/types.tsx
@@ -26,7 +26,7 @@ export interface ChartProps<TData extends ChartDataSeries>
   hideYAxis?: boolean;
   highlightActive?: boolean;
   highlightedItemKeys?: ChartSeriesValue[];
-  specialItemKeys?: Record<SpecialItemFlag, ChartSeriesValue[]>;
+  specialItemKeys?: Partial<Record<SpecialItemFlag, ChartSeriesValue[]>>;
   keyField: keyof TData;
   labels?: boolean;
   legend?: boolean;
@@ -37,6 +37,7 @@ export interface ChartProps<TData extends ChartDataSeries>
   legendWrapperStyle?: CSSProperties;
   linkToEstablishment?: boolean;
   margin?: number;
+  missingDataKeys?: string[];
   multiLineAxisLabel?: boolean;
   onImageCopied?: (fileName: string) => void;
   onImageLoading?: (loading: boolean) => void;
@@ -105,7 +106,7 @@ export type ValueFormatterType = (
   options?: Partial<ValueFormatterOptions>
 ) => string;
 
-export type SpecialItemFlag = "partYear";
+export type SpecialItemFlag = "partYear" | "missingData";
 
 export type CategoricalChartWrapper = PureComponent<
   unknown,

--- a/front-end-components/src/composed/benchmark-chart-section-251/component.tsx
+++ b/front-end-components/src/composed/benchmark-chart-section-251/component.tsx
@@ -5,6 +5,7 @@ import { HorizontalBarChartMultiSeries } from "../horizontal-bar-chart-multi-ser
 import { ChartSeriesConfigItem } from "src/components";
 import { shortValueFormatter } from "src/components/charts/utils";
 import { LaChartData } from "src/components/charts/table-chart";
+import { DataWarning } from "src/components/charts/data-warning";
 
 export function BenchmarkChartSection251<
   TData extends LocalAuthoritySection251,
@@ -61,17 +62,29 @@ export function BenchmarkChartSection251<
     },
   };
 
+  const missingDataKeys = mergedData.dataPoints
+    .filter((d) => !d.actual && !d.planned)
+    .map((d) => d.laCode);
+
   return (
     <HorizontalBarChartMultiSeries
       chartTitle={chartTitle}
       data={mergedData}
       keyField="laCode"
+      missingDataKeys={missingDataKeys}
       seriesConfig={seriesConfig}
       seriesLabelField="laName"
       showCopyImageButton
       valueUnit="currency"
     >
       <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{chartTitle}</h3>
+      {missingDataKeys.length > 0 && (
+        <DataWarning className="govuk-!-margin-top-3">
+          {missingDataKeys.length > 1
+            ? "Comparator local authorities have missing data"
+            : "Comparator local authority has missing data"}
+        </DataWarning>
+      )}
     </HorizontalBarChartMultiSeries>
   );
 }

--- a/front-end-components/src/composed/benchmark-chart-send-2/component.tsx
+++ b/front-end-components/src/composed/benchmark-chart-send-2/component.tsx
@@ -3,6 +3,7 @@ import { BenchmarkChartSend2Props } from "src/composed/benchmark-chart-send-2";
 import { LocalAuthoritySend2Benchmark } from "src/services";
 import { LaChartData } from "src/components/charts/table-chart";
 import { HorizontalBarChartWrapper } from "../horizontal-bar-chart-wrapper";
+import { DataWarning } from "src/components/charts/data-warning";
 
 export function BenchmarkChartSend2<
   TData extends LocalAuthoritySend2Benchmark,
@@ -31,16 +32,28 @@ export function BenchmarkChartSend2<
     };
   }, [data, valueField]);
 
+  const missingDataKeys = mergedData.dataPoints
+    .filter((d) => !d.value)
+    .map((d) => d.laCode);
+
   return (
     <HorizontalBarChartWrapper
       chartTitle={chartTitle}
       data={mergedData}
       xAxisLabel="Amount"
       localAuthority
+      missingDataKeys={missingDataKeys}
       showCopyImageButton
       valueUnit="currency"
     >
       <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{chartTitle}</h3>
+      {missingDataKeys.length > 0 && (
+        <DataWarning className="govuk-!-margin-top-3">
+          {missingDataKeys.length > 1
+            ? "Comparator local authorities have missing data"
+            : "Comparator local authority has missing data"}
+        </DataWarning>
+      )}
     </HorizontalBarChartWrapper>
   );
 }

--- a/front-end-components/src/composed/horizontal-bar-chart-multi-series/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-multi-series/composed.tsx
@@ -7,12 +7,15 @@ import {
 } from "src/contexts";
 import { Loading } from "src/components/loading";
 import { HorizontalBarChartMultiSeriesProps } from "src/composed/horizontal-bar-chart-multi-series";
-import { ChartModeChart, ChartModeTable } from "src/components";
+import {
+  ChartModeChart,
+  ChartModeTable,
+  SpecialItemFlag,
+} from "src/components";
 import { shortValueFormatter } from "src/components/charts/utils";
 import { EstablishmentTick } from "src/components/charts/establishment-tick";
 import { ShareContentByElement } from "src/components/share-content-by-element";
 import { v4 as uuidv4 } from "uuid";
-import { CostCodesList } from "src/components/cost-codes-list";
 import "./styles.scss";
 
 export function HorizontalBarChartMultiSeries<TData extends LaChartData>({
@@ -20,6 +23,7 @@ export function HorizontalBarChartMultiSeries<TData extends LaChartData>({
   children,
   data,
   keyField,
+  missingDataKeys,
   seriesConfig,
   seriesLabelField,
   showCopyImageButton,
@@ -35,6 +39,15 @@ export function HorizontalBarChartMultiSeries<TData extends LaChartData>({
     if (index != undefined && index < data.dataPoints.length) {
       return data.dataPoints[index]?.laCode;
     }
+  };
+
+  const getSpecialItemFlags = (key: string) => {
+    const flags: SpecialItemFlag[] = [];
+    if (missingDataKeys && missingDataKeys.indexOf(key) > -1) {
+      flags.push("missingData");
+    }
+
+    return flags;
   };
 
   const handleImageCopied = () => {
@@ -79,7 +92,6 @@ export function HorizontalBarChartMultiSeries<TData extends LaChartData>({
         >
           {hasData ? (
             <>
-              <CostCodesList category={chartTitle} />
               {chartMode == ChartModeChart && (
                 <HorizontalBarChart
                   barCategoryGap={5}
@@ -102,6 +114,7 @@ export function HorizontalBarChartMultiSeries<TData extends LaChartData>({
                   margin={20}
                   seriesConfig={seriesConfig as object}
                   seriesLabelField={seriesLabelField}
+                  specialItemKeys={{ missingData: missingDataKeys }}
                   tickWidth={200}
                   tick={(t) => {
                     return (
@@ -111,6 +124,7 @@ export function HorizontalBarChartMultiSeries<TData extends LaChartData>({
                         establishmentKeyResolver={(_: string, index) =>
                           getEstablishmentKey(index)
                         }
+                        specialItemFlags={getSpecialItemFlags}
                       />
                     );
                   }}

--- a/front-end-components/src/composed/horizontal-bar-chart-multi-series/types.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-multi-series/types.tsx
@@ -6,6 +6,7 @@ export type HorizontalBarChartMultiSeriesProps<TData extends LaChartData> =
     ChartProps<TData>,
     | "chartTitle"
     | "keyField"
+    | "missingDataKeys"
     | "seriesConfig"
     | "seriesLabelField"
     | "showCopyImageButton"

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -43,6 +43,7 @@ export function HorizontalBarChartWrapper<
   data,
   linkToEstablishment,
   localAuthority,
+  missingDataKeys,
   showCopyImageButton,
   sort,
   tooltip,
@@ -188,6 +189,10 @@ export function HorizontalBarChartWrapper<
       flags.push("partYear");
     }
 
+    if (missingDataKeys && missingDataKeys.indexOf(key) > -1) {
+      flags.push("missingData");
+    }
+
     return flags;
   };
 
@@ -247,7 +252,6 @@ export function HorizontalBarChartWrapper<
                   highlightedItemKeys={
                     selectedEstabishment ? [selectedEstabishment] : undefined
                   }
-                  specialItemKeys={{ partYear: partYearKeys }}
                   keyField={keyField}
                   onImageCopied={handleImageCopied}
                   onImageLoading={setImageLoading}
@@ -255,6 +259,10 @@ export function HorizontalBarChartWrapper<
                   margin={20}
                   seriesConfig={seriesConfig as object}
                   seriesLabelField={seriesLabelField}
+                  specialItemKeys={{
+                    partYear: partYearKeys,
+                    missingData: missingDataKeys,
+                  }}
                   tickWidth={localAuthority ? 200 : 400}
                   tick={(t) => {
                     return (

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/types.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/types.tsx
@@ -9,7 +9,11 @@ export type HorizontalBarChartWrapperProps<
   TData extends SchoolChartData | TrustChartData | LaChartData,
 > = Pick<
   ChartProps<TData>,
-  "chartTitle" | "showCopyImageButton" | "valueUnit" | "linkToEstablishment"
+  | "chartTitle"
+  | "linkToEstablishment"
+  | "missingDataKeys"
+  | "showCopyImageButton"
+  | "valueUnit"
 > & {
   children?: React.ReactNode[] | React.ReactNode;
   data: HorizontalBarChartWrapperPropsData<TData>;


### PR DESCRIPTION
### Context
[AB#253550](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/253550) [AB#249557](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249557)

### Change proposed in this pull request
Updated front-end components to render warning on horizontal bar charts when expected data is missing. e.g.:

![image](https://github.com/user-attachments/assets/54122862-def1-4e42-b312-2c0f6611d72b)

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

