### PR TITLE
feat: persist Local Authority SEN2 data

### DIFF
--- a/data-pipeline/src/pipeline/config/__init__.py
+++ b/data-pipeline/src/pipeline/config/__init__.py
@@ -1,4 +1,7 @@
-from .local_authority import la_db_financial_projections
+from .local_authority import (
+    la_db_financial_projections,
+    la_db_non_financial_projections,
+)
 
 income_category_map = {
     "academies": {

--- a/data-pipeline/src/pipeline/config/local_authority.py
+++ b/data-pipeline/src/pipeline/config/local_authority.py
@@ -56,3 +56,18 @@ la_db_financial_projections = {
     "BudgetPlaceFundingSpecial": "BudgetPlaceFundingSpecial",
     "BudgetPlaceFundingAlternativeProvision": "BudgetPlaceFundingAlternativeProvision",
 }
+
+la_db_non_financial_projections = {
+    "RunType": "RunType",
+    "RunId": "RunId",
+    "old_la_code": "LaCode",
+    "Population2To18": "Population2To18",
+    "EHCPTotal": "EHCPTotal",
+    "EHCPMainstream": "EHCPMainstream",
+    "EHCPResourced": "EHCPResourced",
+    "EHCPSpecial": "EHCPSpecial",
+    "EHCPIndependent": "EHCPIndependent",
+    "EHCPHospital": "EHCPHospital",
+    "EHCPPost16": "EHCPPost16",
+    "EHCPOther": "EHCPOther",
+}

--- a/data-pipeline/src/pipeline/database.py
+++ b/data-pipeline/src/pipeline/database.py
@@ -776,3 +776,32 @@ def insert_la_financial(
         run_id=run_id,
         engine=engine,
     )
+
+
+def insert_la_non_financial(
+    run_type: str,
+    run_id: str,
+    df: pd.DataFrame,
+    engine: sqlalchemy.engine.Engine | None = None,
+):
+    """
+    Persist Local Authority SEN2 data to the database.
+
+    :param run_type: "default" or "custom"
+    :param run_id: unique identifier for processing
+    :param df: Local Authority non-financial information
+    :param engine: (optional) SQLAlchemy Engine
+    """
+    write_frame = df.reset_index().rename(
+        columns=config.la_db_non_financial_projections
+    )
+    write_frame["RunType"] = run_type
+    write_frame["RunId"] = run_id
+    write_frame = write_frame[config.la_db_non_financial_projections.values()]
+
+    _write_data(
+        df=write_frame,
+        table="LocalAuthorityNonFinancial",
+        run_id=run_id,
+        engine=engine,
+    )

--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -20,6 +20,7 @@ from pipeline.database import (
     insert_comparator_set,
     insert_financial_data,
     insert_la_financial,
+    insert_la_non_financial,
     insert_metric_rag,
     insert_non_financial_data,
     insert_schools_and_local_authorities,
@@ -629,6 +630,11 @@ def pre_process_local_authorities(
     )
 
     insert_la_financial(
+        run_type="default",
+        run_id=run_id,
+        df=local_authorities,
+    )
+    insert_la_non_financial(
         run_type="default",
         run_id=run_id,
         df=local_authorities,


### PR DESCRIPTION
### Context

The `LocalAuthorityNonFinancial` table needs to be populated with the Local Authority SEN2-derived data.

[AB#253282](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/253282)

### Change proposed in this pull request

store Local Authority SEN2 data in the `LocalAuthorityNonFinancial` table.

### Guidance to review 

Following previous patterns; validated locally.

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~You have reviewed with UX/Design~

