### PR TITLE
feat: persist Local Authority Statistical Neighbour data

### DIFF
--- a/data-pipeline/src/pipeline/config/__init__.py
+++ b/data-pipeline/src/pipeline/config/__init__.py
@@ -1,6 +1,7 @@
 from .local_authority import (
     la_db_financial_projections,
     la_db_non_financial_projections,
+    la_statistical_neighbours_projections,
 )
 
 income_category_map = {

--- a/data-pipeline/src/pipeline/config/local_authority.py
+++ b/data-pipeline/src/pipeline/config/local_authority.py
@@ -71,3 +71,12 @@ la_db_non_financial_projections = {
     "EHCPPost16": "EHCPPost16",
     "EHCPOther": "EHCPOther",
 }
+
+la_statistical_neighbours_projections = {
+    "RunType": "RunType",
+    "RunId": "RunId",
+    "old_la_code": "LaCode",
+    "NeighbourPosition": "NeighbourPosition",
+    "NeighbourLaCode": "NeighbourLaCode",
+    "NeighbourDescription": "NeighbourDescription",
+}

--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -21,6 +21,7 @@ from pipeline.database import (
     insert_financial_data,
     insert_la_financial,
     insert_la_non_financial,
+    insert_la_statistical_neighbours,
     insert_metric_rag,
     insert_non_financial_data,
     insert_schools_and_local_authorities,
@@ -635,6 +636,11 @@ def pre_process_local_authorities(
         df=local_authorities,
     )
     insert_la_non_financial(
+        run_type="default",
+        run_id=run_id,
+        df=local_authorities,
+    )
+    insert_la_statistical_neighbours(
         run_type="default",
         run_id=run_id,
         df=local_authorities,

--- a/data-pipeline/tests/unit/test_database.py
+++ b/data-pipeline/tests/unit/test_database.py
@@ -1,5 +1,7 @@
 import uuid
 
+import pandas as pd
+
 from pipeline import database
 
 
@@ -29,3 +31,26 @@ def test_unique_temp_table_names():
     ]
 
     assert len(temp_tables) == len(set(temp_tables))
+
+
+def test_unpivot_statistical_neighbour_column():
+    df = pd.DataFrame(
+        {
+            "LaCode": ["100", "101", "102"],
+            "1Suffix": ["a", "b", "c"],
+            "2Suffix": ["c", "b", "a"],
+        }
+    )
+
+    result = database._unpivot_statistical_neighbour_column(df, "Suffix", "NewColumn")
+
+    pd.testing.assert_frame_equal(
+        result,
+        pd.DataFrame(
+            {
+                "LaCode": ["100", "101", "102", "100", "101", "102"],
+                "NeighbourPosition": [1, 1, 1, 2, 2, 2],
+                "NewColumn": ["a", "b", "c", "c", "b", "a"],
+            }
+        ),
+    )


### PR DESCRIPTION
### Context

The `LocalAuthorityStatisticalNeighbour` needs to be populated with data derived from the stat. neighbours data.

[AB#253286](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/253286)

### Change proposed in this pull request

un-pivot and store Local Authority Statistical Neighbour data in the `LocalAuthorityStatisticalNeighbour` table.

### Guidance to review 

Un-pivoting the the data from the various `SN`-prefixed columns is more complicated that previous Local Authority data but otherwise, this follows previous patterns.

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~You have reviewed with UX/Design~

