### PR TITLE
Set correct `valueUnit` for SEND2 benchmarking charts

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -101,7 +101,7 @@
     ></div>-->
     <!--<div id="compare-your-costs" data-type="school" data-id="150203" data-suppress-negative-or-zero="true"></div>-->
     <!--<div id="historic-data" data-type="school" data-id="990095"></div>-->
-    <div id="historic-data-2" data-type="school" data-id="123456" data-phase="Primary" data-finance-type="Maintained"></div>
+    <!--<div id="historic-data-2" data-type="school" data-id="123456" data-phase="Primary" data-finance-type="Maintained"></div>-->
     <!--<div
       id="compare-your-costs"
       data-type="local-authority"
@@ -150,7 +150,7 @@
     </svg> -->
     <!--<div id="la-national-rank" data-code="201"></div>-->
     <!--<div id="historic-data-high-needs" data-code="201"></div>-->
-    <!--<div id="benchmark-data-high-needs" data-code="201"></div>-->
+    <div id="benchmark-data-high-needs" data-code="201"></div>
     <!-- <div id="historic-data" data-type="school" data-id="114504"></div> -->
     <script type="module" src="/src/main.tsx"></script>
     <script

--- a/front-end-components/package-lock.json
+++ b/front-end-components/package-lock.json
@@ -1802,9 +1802,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
-      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },

--- a/front-end-components/src/composed/benchmark-chart-send-2/component.tsx
+++ b/front-end-components/src/composed/benchmark-chart-send-2/component.tsx
@@ -44,7 +44,7 @@ export function BenchmarkChartSend2<
       localAuthority
       missingDataKeys={missingDataKeys}
       showCopyImageButton
-      valueUnit="currency"
+      valueUnit="amount"
     >
       <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{chartTitle}</h3>
       {missingDataKeys.length > 0 && (

--- a/web/src/Web.App/package-lock.json
+++ b/web/src/Web.App/package-lock.json
@@ -21,9 +21,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.9",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/runtime/-/runtime-7.26.9.tgz",
-      "integrity": "sha1-qkxvrMZbnLP4fXUSX/1HeBtHVDM=",
+      "version": "7.26.10",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha1-oHtNj6J68TGmM9ezUk24A+tHZMI=",
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"

--- a/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsBenchmarking.feature
+++ b/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsBenchmarking.feature
@@ -32,5 +32,5 @@
         When I click on view as table
         Then the table at index '32' contains the following SEND2 values:
           | Name           | Amount |
-          | City of London | £7.04  |
+          | City of London | 7.04   |
           | Hackney        |        |

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsBenchmarkingPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsBenchmarkingPage.cs
@@ -79,6 +79,6 @@ public class HighNeedsBenchmarkingPage(IPage page)
             });
         }
 
-        expected.CompareToDynamicSet(set);
+        expected.CompareToDynamicSet(set, false);
     }
 }


### PR DESCRIPTION
### Context
[AB#254031](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/254031) [AB#249557](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249557)

### Change proposed in this pull request
- Updated units
- Updated E2E tests
- Bumped `@babel/runtime`

### Guidance to review 
`front-end` will need to be bumped in `Web` once its pipeline has completed

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

