### PR TITLE
Modified `<Stat>` and `<LabelList>` value formatting on High needs charts

### DIFF
--- a/front-end-components/src/components/charts/utils.test.ts
+++ b/front-end-components/src/components/charts/utils.test.ts
@@ -198,6 +198,32 @@ describe("Chart utils", () => {
       );
     });
 
+    describe("with compact currency option", () => {
+      const theories: { input: ValueFormatterValue; expected: string }[] = [
+        { input: -987.65, expected: "-£987.65" },
+        { input: 0, expected: "£0.00" },
+        { input: 1, expected: "£1.00" },
+        { input: 2.3456789, expected: "£2.35" },
+        { input: 12345.67, expected: "£12k" },
+        { input: 890123456, expected: "£890m" },
+        { input: "not-a-number", expected: "not-a-number" },
+      ];
+
+      const options: Partial<ValueFormatterOptions> = {
+        compact: true,
+        valueUnit: "currency",
+      };
+
+      theoretically(
+        "the value {input} is formatted using compact notation as {expected}",
+        theories,
+        ({ input, expected }) => {
+          const result = statValueFormatter(input, options);
+          expect(result).toBe(expected);
+        }
+      );
+    });
+
     describe("with currency option", () => {
       const theories: { input: ValueFormatterValue; expected: string }[] = [
         { input: -987.65, expected: "-£988" },

--- a/front-end-components/src/components/charts/utils.ts
+++ b/front-end-components/src/components/charts/utils.ts
@@ -47,6 +47,10 @@ export function shortValueFormatter(
         : options?.valueUnit === "%"
           ? 1
           : 2,
+    minimumFractionDigits:
+      options?.valueUnit === "currency" && value % 1 && Math.abs(value) < 1000
+        ? 2
+        : undefined,
   })
     .format(options?.valueUnit === "%" ? value / 100 : value)
     .toLowerCase();
@@ -72,7 +76,19 @@ export function statValueFormatter(
     currency: options?.valueUnit === "currency" ? "GBP" : undefined,
     currencyDisplay: options?.currencyAsName ? "name" : "symbol",
     maximumFractionDigits:
-      options?.valueUnit === "%" ? 1 : options?.compact ? undefined : 0,
+      options?.valueUnit === "%"
+        ? 1
+        : options?.compact
+          ? options?.valueUnit === "currency" && Math.abs(value) < 1000
+            ? 2
+            : undefined
+          : 0,
+    minimumFractionDigits:
+      options?.compact &&
+      options?.valueUnit === "currency" &&
+      Math.abs(value) < 1000
+        ? 2
+        : undefined,
   })
     .format(options?.valueUnit === "%" ? value / 100 : value)
     .toLowerCase();

--- a/front-end-components/src/composed/historic-chart-section-251-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-section-251-composed/component.tsx
@@ -100,7 +100,11 @@ export function HistoricChartSection251<
     seriesFormatter: () => label,
     seriesLabelField: "term",
     small: true,
-    valueFormatter: statValueFormatter,
+    valueFormatter: (value) =>
+      statValueFormatter(value, {
+        compact: true,
+        valueUnit: valueUnit ?? "currency",
+      }),
     valueUnit: valueUnit ?? "currency",
   });
 


### PR DESCRIPTION
### Context
[AB#254085](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/254085) [AB#253802](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/253802)

### Change proposed in this pull request
- Number formatting fix for <kbd>Stat</kbd>s in High needs history.
- Number formatting fix for <kbd>LabelList</kbd> currency values

### Guidance to review 
`front-end` will need to be bumped in `Web` after the build pipeline publishes the new artefact.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

