### PR TITLE
Show warning message if partial High needs headline figures available

### DIFF
--- a/web/src/Web.App/ViewComponents/LocalAuthorityHighNeedsHeadlinesViewComponent.cs
+++ b/web/src/Web.App/ViewComponents/LocalAuthorityHighNeedsHeadlinesViewComponent.cs
@@ -32,7 +32,7 @@ public class LocalAuthorityHighNeedsHeadlinesViewComponent(
         }
 
         logger.LogWarning("Local authority high needs headlines could not be displayed for {Code}", identifier);
-        return View("MissingData");
+        return View("MissingData", "Headlines");
     }
 
     private static ApiQuery BuildQuery(string code, string dimension)

--- a/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsHeadlines/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsHeadlines/Default.cshtml
@@ -3,29 +3,47 @@
 <table class="govuk-table govuk-!-margin-bottom-1 govuk-table__no-border">
     <caption class="govuk-table__caption govuk-visually-hidden">Headline figures</caption>
     <tbody class="govuk-table__body">
-    <tr class="govuk-table__row">
-        <td class="govuk-table__cell">
-            Total number of EHC plans
-        </td>
-        <td class="govuk-table__cell govuk-table__cell--numeric">
-            @Model.TotalPlans?.ToString("N0")
-        </td>
-    </tr>
-    <tr class="govuk-table__row">
-        <td class="govuk-table__cell">
-            Total spend
-        </td>
-        <td class="govuk-table__cell govuk-table__cell--numeric">
-            @Model.TotalSpend?.ToString("C0")
-        </td>
-    </tr>
-    <tr class="govuk-table__row">
-        <td class="govuk-table__cell">
-            Total spend per EHC plan
-        </td>
-        <td class="govuk-table__cell govuk-table__cell--numeric">
-            @Model.TotalSpendPerPlan?.ToString("C0")
-        </td>
-    </tr>
+    @if (Model.TotalPlans != null)
+    {
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+                Total number of EHC plans
+            </td>
+            <td class="govuk-table__cell govuk-table__cell--numeric">
+                @Model.TotalPlans?.ToString("N0")
+            </td>
+        </tr>
+    }
+    @if (Model.TotalSpend != null)
+    {
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+                Total spend
+            </td>
+            <td class="govuk-table__cell govuk-table__cell--numeric">
+                @Model.TotalSpend?.ToString("C0")
+            </td>
+        </tr>
+    }
+    @if (Model.TotalSpendPerPlan != null)
+    {
+        <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+                Total spend per EHC plan
+            </td>
+            <td class="govuk-table__cell govuk-table__cell--numeric">
+                @Model.TotalSpendPerPlan?.ToString("C0")
+            </td>
+        </tr>
+    }
     </tbody>
 </table>
+
+@if (Model.TotalPlans == null)
+{
+    @await Html.PartialAsync("Components/LocalAuthorityHighNeedsHeadlines/MissingData", "Total number of EHC plans")
+}
+else if (Model.TotalSpend == null)
+{
+    @await Html.PartialAsync("Components/LocalAuthorityHighNeedsHeadlines/MissingData", "Total spend")
+}

--- a/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsHeadlines/MissingData.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsHeadlines/MissingData.cshtml
@@ -1,7 +1,9 @@
+@model string
+
 <div class="govuk-warning-text">
     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
     <strong class="govuk-warning-text__text">
         <span class="govuk-visually-hidden">Warning</span>
-        Headlines could not be displayed.
+        @Model could not be displayed.
     </strong>
 </div>

--- a/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsNationalRankings/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsNationalRankings/Default.cshtml
@@ -27,7 +27,7 @@
                 @(rank.Name)
             </td>
             <td class="govuk-table__cell govuk-table__cell--numeric">
-                @(rank.Value?.ToString("#.#"))%
+                @(rank.Value?.ToString("#.#") ?? "0")%
             </td>
         </tr>
     }


### PR DESCRIPTION
### Context
[AB#254429](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/254429) [AB#249575](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249575)

### Change proposed in this pull request
- Included warning message in the case that some, but not all, headline figures missing
- Set default value for national ranking percentage

![image](https://github.com/user-attachments/assets/a9aeece6-b96b-4d0a-8526-ae1634334f43)

### Guidance to review 
Both of the above issues were observed for new LAs without S251 submissions for the most recent academic year. Follow-up work  may alter the way affected LAs are viewed within the High needs dashboard.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

