### PR TITLE
feat: add file-integrity tables/views

### DIFF
--- a/core-infrastructure/src/db/Core.Database/Scripts/112-CreateTablesFileIntegrity.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/112-CreateTablesFileIntegrity.sql
@@ -1,0 +1,34 @@
+IF NOT EXISTS(SELECT *
+              FROM INFORMATION_SCHEMA.TABLES
+              WHERE table_name = 'DatasetType')
+    BEGIN
+        CREATE TABLE dbo.DatasetType
+        (
+              DatasetName varchar(16)   NOT NULL,
+              Description varchar(255)      NULL
+
+              CONSTRAINT PK_DatasetType PRIMARY KEY (DatasetName)
+        );
+    END
+GO
+
+IF NOT EXISTS(SELECT *
+              FROM INFORMATION_SCHEMA.TABLES
+              WHERE table_name = 'FileIntegrityHistory')
+    BEGIN
+        CREATE TABLE dbo.FileIntegrityHistory
+        (
+                  DatasetName   varchar(16)   NOT NULL,
+                  DatasetYear   smallint      NOT NULL,
+                  FileName      varchar(255)  NOT NULL,
+                  FileSizeBytes int           NOT NULL,
+                  HashValue     varchar(255)  NOT NULL,
+                  HashAlgorithm varchar(16)   NOT NULL,
+                  Description   nvarchar(255)     NULL,
+                  CreatedAt     datetime      NOT NULL
+
+                  CONSTRAINT FK_FileIntegrityHistory_DatasetType FOREIGN KEY (DatasetName) REFERENCES DatasetType(DatasetName),
+                  CONSTRAINT PK_FileIntegrityHistory             PRIMARY KEY (DatasetName, DatasetYear, CreatedAt)
+        );
+    END
+GO

--- a/core-infrastructure/src/db/Core.Database/Views/020-FileIntegrity.sql
+++ b/core-infrastructure/src/db/Core.Database/Views/020-FileIntegrity.sql
@@ -1,0 +1,31 @@
+IF EXISTS(SELECT 1
+          FROM sys.views
+          WHERE name = 'FileIntegrity')
+    BEGIN
+        DROP VIEW FileIntegrity
+    END
+GO
+
+CREATE VIEW FileIntegrity AS
+  SELECT DatasetName,
+         DatasetYear,
+         FileName,
+         FileSizeBytes,
+         HashValue,
+         HashAlgorithm,
+         Description,
+         CreatedAt
+    FROM (
+           SELECT DatasetName,
+                  DatasetYear,
+                  FileName,
+                  FileSizeBytes,
+                  HashValue,
+                  HashAlgorithm,
+                  Description,
+                  CreatedAt,
+                  Row_Number() OVER (PARTITION BY DatasetName ORDER BY DatasetYear DESC) AS rn
+             FROM FileIntegrityHistory
+         ) AS RankedHistory
+     WHERE rn = 1
+GO


### PR DESCRIPTION
### Context

To provide a historical view of all files processed in the service and allow for runtime validation of input data, we will persist details of each file in the database

### Change proposed in this pull request

- add `DatasetType` table for core data types (e.g. AAR, CFR, etc.)
- add `FileIntegrityHistory` table for details of all versions of files (e.g.  AAR for 2023, etc.)
- add `FileIntegrity` view to present the current version of `FileIntegrityHistory`.

### Guidance to review 

`DatasetType` should allow us to add new data types (e.g. the recent LA data) and assure the integrity of the data in `FileIntegrityHistory`.

`FileIntegrityHistory` will allow to track not only the files for each type over the years but each _version_ of those files (e.g. updates/corrections to exports).

Although `FileIntegrityHistory` will contain _all_ data, `FileIntegrity` will present only the current versions, against which runtime validation can take place.

### Checklist (add/remove as appropriate)

- [ ] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally
- [ ] ~You have reviewed with UX/Design~

