### PR TITLE
Display warning banner instead of historical High needs when historical data missing

### DIFF
--- a/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsHistoricDataViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsHistoricDataViewModel.cs
@@ -1,0 +1,11 @@
+﻿using Web.App.Domain;
+using Web.App.Domain.LocalAuthorities;
+
+namespace Web.App.ViewModels;
+
+public class LocalAuthorityHighNeedsHistoricDataViewModel(LocalAuthority localAuthority, LocalAuthority<HighNeeds>[]? highNeeds)
+{
+    public bool HasHighNeeds = highNeeds?.Select(h => h.Outturn?.HighNeedsAmount).FirstOrDefault() != null;
+    public string? Code => localAuthority.Code;
+    public string? Name => localAuthority.Name;
+}

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsHistoricData/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsHistoricData/Index.cshtml
@@ -1,4 +1,4 @@
-@model Web.App.ViewModels.LocalAuthorityViewModel
+@model Web.App.ViewModels.LocalAuthorityHighNeedsHistoricDataViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.LocalAuthorityHighNeedsHistoricData;
 }
@@ -11,4 +11,17 @@
     kind = OrganisationTypes.LocalAuthority
 })
 
-<div id="historic-data-high-needs" data-code="@Model.Code"></div>
+@if (Model.HasHighNeeds)
+{
+    <div id="historic-data-high-needs" data-code="@Model.Code"></div>
+}
+else
+{
+    <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+            <span class="govuk-visually-hidden">Warning</span>
+            There isn't enough information available to view High needs historic data for this local authority.
+        </strong>
+    </div>
+}

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsHistoricData.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsHistoricData.cs
@@ -1,0 +1,86 @@
+﻿using System.Net;
+using AngleSharp.Html.Dom;
+using AutoFixture;
+using Web.App.Domain;
+using Web.App.Domain.LocalAuthorities;
+using Xunit;
+
+namespace Web.Integration.Tests.Pages.LocalAuthorities;
+
+public class WhenViewingHighNeedsHistoricData(SchoolBenchmarkingWebAppClient client) : PageBase<SchoolBenchmarkingWebAppClient>(client)
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanDisplay(bool hasHighNeeds)
+    {
+        var (page, authority, highNeeds) = await SetupNavigateInitPage(hasHighNeeds);
+
+        AssertPageLayout(page, authority, highNeeds);
+    }
+
+    [Fact]
+    public async Task CanDisplayProblemWithService()
+    {
+        const string code = "123";
+        var page = await Client.SetupEstablishmentWithException()
+            .Navigate(Paths.LocalAuthorityHighNeedsHistoricData(code));
+
+        PageAssert.IsProblemPage(page);
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeedsHistoricData(code).ToAbsolute(), HttpStatusCode.InternalServerError);
+    }
+
+    [Fact]
+    public async Task CanDisplayNotFound()
+    {
+        const string code = "123";
+        var page = await Client.SetupEstablishmentWithNotFound()
+            .Navigate(Paths.LocalAuthorityHighNeedsHistoricData(code));
+
+        PageAssert.IsNotFoundPage(page);
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeedsHistoricData(code).ToAbsolute(), HttpStatusCode.NotFound);
+    }
+
+    private async Task<(
+        IHtmlDocument page,
+        LocalAuthority authority,
+        LocalAuthority<HighNeeds>[]? highNeeds)> SetupNavigateInitPage(bool hasHighNeeds = true)
+    {
+        var authority = Fixture.Build<LocalAuthority>()
+            .Create();
+
+        var highNeeds = hasHighNeeds ? Fixture.Build<LocalAuthority<HighNeeds>>().CreateMany().ToArray() : [];
+
+        var page = await Client.SetupEstablishment(authority)
+            .SetupHighNeeds(highNeeds, null)
+            .SetupInsights()
+            .Navigate(Paths.LocalAuthorityHighNeedsHistoricData(authority.Code));
+
+        return (page, authority, highNeeds);
+    }
+
+    private static void AssertPageLayout(
+        IHtmlDocument page,
+        LocalAuthority authority,
+        LocalAuthority<HighNeeds>[]? highNeeds)
+    {
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeedsHistoricData(authority.Code).ToAbsolute());
+
+        var expectedBreadcrumbs = new[] { ("Home", Paths.ServiceHome.ToAbsolute()) };
+        DocumentAssert.Breadcrumbs(page, expectedBreadcrumbs);
+
+        Assert.NotNull(authority.Name);
+        DocumentAssert.TitleAndH1(page, "High needs historic data - Financial Benchmarking and Insights Tool - GOV.UK", "High needs historic data");
+
+        var warning = page.QuerySelector(".govuk-warning-text");
+        if (highNeeds != null && highNeeds.Length != 0)
+        {
+            Assert.Null(warning);
+        }
+        else
+        {
+            Assert.NotNull(warning);
+            DocumentAssert.AssertNodeText(warning, "!  Warning\n            There isn't enough information available to view High needs historic data for this local authority.");
+        }
+    }
+}

--- a/web/tests/Web.Tests/ViewModels/GivenALocalAuthorityHighNeedsHistoricDataViewModel.cs
+++ b/web/tests/Web.Tests/ViewModels/GivenALocalAuthorityHighNeedsHistoricDataViewModel.cs
@@ -1,0 +1,54 @@
+using AutoFixture;
+using Web.App.Domain;
+using Web.App.Domain.LocalAuthorities;
+using Web.App.ViewModels;
+using Xunit;
+
+namespace Web.Tests.ViewModels;
+
+public class GivenALocalAuthorityHighNeedsHistoricDataViewModel
+{
+    private readonly Fixture _fixture = new();
+    private readonly LocalAuthority _localAuthority;
+
+    public GivenALocalAuthorityHighNeedsHistoricDataViewModel()
+    {
+        _localAuthority = _fixture
+            .Build<LocalAuthority>()
+            .Create();
+    }
+
+    [Fact]
+    public void ShouldSetHasHighNeedsToTrueWhenContainsHighNeeds()
+    {
+        var highNeeds = _fixture
+            .Build<LocalAuthority<HighNeeds>>()
+            .CreateMany()
+            .ToArray();
+        var model = new LocalAuthorityHighNeedsHistoricDataViewModel(_localAuthority, highNeeds);
+
+        Assert.Equal(_localAuthority.Code, model.Code);
+        Assert.Equal(_localAuthority.Name, model.Name);
+        Assert.True(model.HasHighNeeds);
+    }
+
+    [Fact]
+    public void ShouldSetHasHighNeedsToFalseWhenContainsEmptyHighNeeds()
+    {
+        LocalAuthority<HighNeeds>[] highNeeds = [];
+        var model = new LocalAuthorityHighNeedsHistoricDataViewModel(_localAuthority, highNeeds);
+        Assert.False(model.HasHighNeeds);
+    }
+
+    [Fact]
+    public void ShouldSetHasHighNeedsToFalseWhenContainsMalformedHighNeeds()
+    {
+        var highNeeds = _fixture
+            .Build<LocalAuthority<HighNeeds>>()
+            .With(h => h.Outturn, new HighNeeds())
+            .CreateMany()
+            .ToArray();
+        var model = new LocalAuthorityHighNeedsHistoricDataViewModel(_localAuthority, highNeeds);
+        Assert.False(model.HasHighNeeds);
+    }
+}


### PR DESCRIPTION
### Context
[AB#254461](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/254461) [AB#253802](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/253802)

### Change proposed in this pull request
- Check for valid data when building historical data view model
- If missing display warning banner instead of client-resolved `<div>` for the charts

### Guidance to review 
LAs `825`, `838` and `839` may be used to validate this behaviour.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

