### PR TITLE
feat: add dict variant for multiple-keys

### DIFF
--- a/data-pipeline/src/pipeline/utils/input.py
+++ b/data-pipeline/src/pipeline/utils/input.py
@@ -1,0 +1,48 @@
+from collections import abc
+
+
+class MultiKeyDefaultDict(abc.Mapping):
+    """
+    Variant of `dict` which should:
+
+    - allow multiple keys to mapped to the same value
+    - always return a (mandatory) default if a key is missing
+
+    Intended to reduce multiple declarations which occur in a lot of
+    input-file schemas.
+    """
+
+    def __init__(self, _dict: dict[tuple[int], dict], *, default: dict):
+        self._dict = {}
+        for key, value in _dict.items():
+            for k in key:
+                self._dict[k] = value
+        self.default = default
+
+    def __getitem__(self, key):
+        return self._dict.get(key, self.default)
+
+    def __iter__(self):
+        return iter(self._dict)
+
+    def __len__(self):
+        return len(self._dict)
+
+    def get(self, key, default=None):
+        """
+        Prevent any default value being used, save the one passed on
+        initialisation.
+
+        Retrieving values via `[key]` should _never_ fail to return a
+        value (as it returns either the value corresponding to the key
+        or the default passed on initialisation) but this should avoid
+        any confusion.
+
+        :param key: to be retrieved
+        :param default: prohibited
+        :return: value corresponding to key
+        """
+        if default is not None:
+            raise ValueError("Cannot pass default argument.")
+
+        return super().get(key)

--- a/data-pipeline/tests/unit/test_utils.py
+++ b/data-pipeline/tests/unit/test_utils.py
@@ -1,0 +1,74 @@
+import pytest
+
+from pipeline.utils import input
+
+
+@pytest.mark.parametrize(
+    "dict_,expected",
+    [
+        ({}, 0),
+        ({("a",): {}}, 1),
+        (
+            {
+                (
+                    "a",
+                    "b",
+                ): {}
+            },
+            2,
+        ),
+    ],
+)
+def test_multikeydict_len(dict_: dict, expected: int):
+    result = input.MultiKeyDefaultDict(dict_, default={})
+
+    assert len(result) == expected
+
+
+@pytest.mark.parametrize(
+    "default",
+    [
+        ({},),
+        ({("a",): []},),
+    ],
+)
+def test_multikeydict_initialised_default(default: dict):
+    result = input.MultiKeyDefaultDict({}, default=default)
+
+    assert result[1] == default
+    assert result.get(1) == default
+
+
+@pytest.mark.parametrize(
+    "default",
+    [
+        ({},),
+        ({("a",): []},),
+    ],
+)
+def test_multikeydict_default(default: dict):
+    result = input.MultiKeyDefaultDict({}, default=default)
+
+    with pytest.raises(ValueError):
+        result.get(1, {"n": "n"})
+
+
+def test_multikeydict_multi():
+    value = {"c": "c"}
+    result = input.MultiKeyDefaultDict(
+        {
+            (
+                1,
+                2,
+                3,
+            ): value,
+        },
+        default={},
+    )
+
+    assert result[1] == value
+    assert result[2] == value
+    assert result[3] == value
+    assert result.get(1) == value
+    assert result.get(2) == value
+    assert result.get(3) == value


### PR DESCRIPTION
### Context

Now that we define variable input-schemas for each year, for a given data source, there are numerous occurrences where the same year will have the same config. (but not in the current/majority so cannot be considered a "default" value).

Python doesn't have a data structure to accommodate this, hence this addition.

### Change proposed in this pull request

add a `dict` variant to accommodate multiple keys addressing the same value: this should a fair amount of repetition in some of the `input_schemas` definitions.

### Guidance to review 

WIP for discussion.

### Checklist (add/remove as appropriate)

- [ ] ~Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)~
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~You have reviewed with UX/Design~

