### PR TITLE
Baseline load tests against `d13` feature environment

### DIFF
--- a/documentation/quality-assurance/performance-test-plans/0007_Web-ssr-charts-load-test-plan.md
+++ b/documentation/quality-assurance/performance-test-plans/0007_Web-ssr-charts-load-test-plan.md
@@ -17,6 +17,7 @@ This includes both URL tests and Web tests in order to include coverage over dow
   - typical load conditions using a Web based test
   - peak conditions using a Web based test
 - Compare all of the above once [SSR chart spike](https://dfe-ssp.visualstudio.com/s198-DfE-Benchmarking-service/_workitems/edit/248027) is complete
+- Compare Web based tests during development of the above in a feature environment (`d13`)
 
 ## Procedure
 
@@ -56,7 +57,7 @@ Manually scale core database to S2 tier to replicate production infrastucture fo
 **Pages Under Test:**
 
 | Page                                      | Test Type | Load Type | DB DTUs |
-|-------------------------------------------|-----------|-----------| ------- |
+|-------------------------------------------|-----------|-----------|---------|
 | `/school/{identifier}/spending-and-costs` | URL       | Average   | S1      |
 | `/school/{identifier}/spending-and-costs` | URL       | Peak      | S2      |
 | `/school/{identifier}/spending-and-costs` | Web       | Average   | S1      |
@@ -71,12 +72,14 @@ Manually scale core database to S2 tier to replicate production infrastucture fo
 ## Test Output
 
 <!-- take care with final separator line in piped table, as pandoc uses this for relative column widths -->
-| Load Test Name                                                        | Initiated on         | Max VUs | Duration | Response time | Errors   | Throughput | Result |
-|-----------------------------------------------------------------------|----------------------|---------|----------|---------------|----------|------------|--------|
-| Average URL                                                           | 20/03/2025, 07:06:46 | 15      | 6m       | 320 ms        | 0.01 %   | 49.99 /s   | [✅ Passed](https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport/resourceId/%2Fsubscriptions%2Fa5c0a8d7-a54d-4a6d-ab79-4ca64a3b750f%2Fresourcegroups%2Fs198t01-ebis-perf-tests%2Fproviders%2Fmicrosoft.loadtestservice%2Floadtests%2Fs198t01-load-tests/testId/64328db8-47e9-4214-9182-b5b7505ff027/testRunId/ffdcb805-e405-4f6b-a735-cbcb90ad7027) |
-| Peak URL                                                              | 20/03/2025, 10:46:26 | 30      | 6m  5s   | 694 ms        | 0.00 %   | 67.49 /s   | [✅ Passed](https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport/resourceId/%2Fsubscriptions%2Fa5c0a8d7-a54d-4a6d-ab79-4ca64a3b750f%2Fresourcegroups%2Fs198t01-ebis-perf-tests%2Fproviders%2Fmicrosoft.loadtestservice%2Floadtests%2Fs198t01-load-tests/testId/c661f194-eb06-4513-82fc-a3234deca4ae/testRunId/6a131fd9-7a2e-4b7e-8140-9a9ed9dd96d1) |
-| Average Web                                                           | 20/03/2025, 11:10:07 | 15      | 5m 7s    | 350 ms        | 0.00 %   | 113.76 /s  | [✅ Passed](https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport/resourceId/%2Fsubscriptions%2Fa5c0a8d7-a54d-4a6d-ab79-4ca64a3b750f%2Fresourcegroups%2Fs198t01-ebis-perf-tests%2Fproviders%2Fmicrosoft.loadtestservice%2Floadtests%2Fs198t01-load-tests/testId/6a131fd9-7a2e-4b7e-8140-9a9ed9dd9b0b/testRunId/6a131fd9-7a2e-4b7e-8140-9a9ed9dd9b3f) |
-| Peak Web                                                              | 20/03/2025, 10:46:26 | 30      | 5m  4s   | 420 ms        | 0.00 %   | 68.72 /s   | [✅ Passed](https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport/resourceId/%2Fsubscriptions%2Fa5c0a8d7-a54d-4a6d-ab79-4ca64a3b750f%2Fresourcegroups%2Fs198t01-ebis-perf-tests%2Fproviders%2Fmicrosoft.loadtestservice%2Floadtests%2Fs198t01-load-tests/testId/1f5453f4-9d9c-4cab-8911-b676df16842a/testRunId/6a131fd9-7a2e-4b7e-8140-9a9ed9dd98aa) |
+| Load Test Name           | Environment | Initiated on         | Max VUs | Duration | Response time | Errors | Throughput | Result          |
+|--------------------------|-------------|----------------------|---------|----------|---------------|--------|------------|-----------------|
+| Average URL (baseline)   | `t01`       | 20/03/2025, 07:06:46 | 15      | 6m       | 320 ms        | 0.01 % | 49.99 /s   | [✅ Passed](https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport/resourceId/%2Fsubscriptions%2Fa5c0a8d7-a54d-4a6d-ab79-4ca64a3b750f%2Fresourcegroups%2Fs198t01-ebis-perf-tests%2Fproviders%2Fmicrosoft.loadtestservice%2Floadtests%2Fs198t01-load-tests/testId/64328db8-47e9-4214-9182-b5b7505ff027/testRunId/ffdcb805-e405-4f6b-a735-cbcb90ad7027) |
+| Peak URL (baseline)      | `t01`       | 20/03/2025, 10:46:26 | 30      | 6m  5s   | 694 ms        | 0.00 % | 67.49 /s   | [✅ Passed](https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport/resourceId/%2Fsubscriptions%2Fa5c0a8d7-a54d-4a6d-ab79-4ca64a3b750f%2Fresourcegroups%2Fs198t01-ebis-perf-tests%2Fproviders%2Fmicrosoft.loadtestservice%2Floadtests%2Fs198t01-load-tests/testId/c661f194-eb06-4513-82fc-a3234deca4ae/testRunId/6a131fd9-7a2e-4b7e-8140-9a9ed9dd96d1) |
+| Average Web (baseline)   | `t01`       | 20/03/2025, 11:10:07 | 15      | 5m 7s    | 350 ms        | 0.00 % | 113.76 /s  | [✅ Passed](https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport/resourceId/%2Fsubscriptions%2Fa5c0a8d7-a54d-4a6d-ab79-4ca64a3b750f%2Fresourcegroups%2Fs198t01-ebis-perf-tests%2Fproviders%2Fmicrosoft.loadtestservice%2Floadtests%2Fs198t01-load-tests/testId/6a131fd9-7a2e-4b7e-8140-9a9ed9dd9b0b/testRunId/6a131fd9-7a2e-4b7e-8140-9a9ed9dd9b3f) |
+| Peak Web (baseline)      | `t01`       | 20/03/2025, 10:46:26 | 30      | 5m  4s   | 420 ms        | 0.00 % | 68.72 /s   | [✅ Passed](https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport/resourceId/%2Fsubscriptions%2Fa5c0a8d7-a54d-4a6d-ab79-4ca64a3b750f%2Fresourcegroups%2Fs198t01-ebis-perf-tests%2Fproviders%2Fmicrosoft.loadtestservice%2Floadtests%2Fs198t01-load-tests/testId/1f5453f4-9d9c-4cab-8911-b676df16842a/testRunId/6a131fd9-7a2e-4b7e-8140-9a9ed9dd98aa) |
+| Average Web (baseline)   | `d13`       | 26/03/2025, 10:10:28 | 15      | 5m 1s    | 1.23 s        | 0.00 % | 34.28 /s   | [✅ Passed](https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport/resourceId/%2Fsubscriptions%2Fa5c0a8d7-a54d-4a6d-ab79-4ca64a3b750f%2Fresourcegroups%2Fs198t01-ebis-perf-tests%2Fproviders%2Fmicrosoft.loadtestservice%2Floadtests%2Fs198t01-load-tests/testId/6a131fd9-7a2e-4b7e-8140-9a9ed9dd9b0b/testRunId/466a5fff-5bcf-4705-8f2a-003ae8055257) |
+| Peak Web (baseline)      | `d13`       | 26/03/2025, 10:22:23 | 30      | 5m 6s    | 2.3 s         | 0.00 % | 35.05 /s   | [✅ Passed](https://portal.azure.com/#blade/Microsoft_Azure_CloudNativeTesting/NewReport/resourceId/%2Fsubscriptions%2Fa5c0a8d7-a54d-4a6d-ab79-4ca64a3b750f%2Fresourcegroups%2Fs198t01-ebis-perf-tests%2Fproviders%2Fmicrosoft.loadtestservice%2Floadtests%2Fs198t01-load-tests/testId/1f5453f4-9d9c-4cab-8911-b676df16842a/testRunId/466a5fff-5bcf-4705-8f2a-003ae805559b) |
 
 **Findings and Recommendations:**
 

--- a/performance-tests/src/web/jmeter/average/school/spending-and-costs/config.yaml
+++ b/performance-tests/src/web/jmeter/average/school/spending-and-costs/config.yaml
@@ -7,8 +7,80 @@ testType: JMX
 splitAllCSVs: False
 configurationFiles:
 - schools.csv
-failureCriteria: 
+failureCriteria:
 - percentage(error) > 0.1
+referenceIdentities:
+- kind: Metrics
+  type: SystemAssigned
+env:
+- name: hostname
+  value: s198t01-education-benchmarking-dmazdedtfhaqezd7.a01.azurefd.net
 autoStop:
   errorPercentage: 90
   timeWindow: 60
+appComponents:
+- resourceId: /subscriptions/a5c0a8d7-a54d-4a6d-ab79-4ca64a3b750f/resourceGroups/s198t01-ebis-core/providers/Microsoft.Sql/servers/s198t01-sql/databases/data
+  resourceName: data
+  kind: v12.0,user
+  metrics:
+  - name: cpu_percent
+    aggregation: Total
+    namespace: microsoft.sql/servers/databases
+  - name: connection_failed
+    aggregation: Maximum
+    namespace: microsoft.sql/servers/databases
+  - name: deadlock
+    aggregation: Total
+    namespace: microsoft.sql/servers/databases
+- resourceId: /subscriptions/a5c0a8d7-a54d-4a6d-ab79-4ca64a3b750f/resourceGroups/s198t01-ebis-platform/providers/Microsoft.Web/sites/s198t01-ebis-benchmark-fa
+  resourceName: s198t01-ebis-benchmark-fa
+  kind: functionapp
+  metrics:
+  - name: Http5xx
+    aggregation: Total
+    namespace: microsoft.web/sites
+  - name: Requests
+    aggregation: Total
+    namespace: microsoft.web/sites
+  - name: HttpResponseTime
+    aggregation: Average
+    namespace: microsoft.web/sites
+- resourceId: /subscriptions/a5c0a8d7-a54d-4a6d-ab79-4ca64a3b750f/resourceGroups/s198t01-ebis-platform/providers/Microsoft.Web/sites/s198t01-ebis-establishment-fa
+  resourceName: s198t01-ebis-establishment-fa
+  kind: functionapp
+  metrics:
+  - name: Http5xx
+    aggregation: Total
+    namespace: microsoft.web/sites
+  - name: Requests
+    aggregation: Total
+    namespace: microsoft.web/sites
+  - name: HttpResponseTime
+    aggregation: Average
+    namespace: microsoft.web/sites
+- resourceId: /subscriptions/a5c0a8d7-a54d-4a6d-ab79-4ca64a3b750f/resourceGroups/s198t01-ebis-platform/providers/Microsoft.Web/sites/s198t01-ebis-insight-fa
+  resourceName: s198t01-ebis-insight-fa
+  kind: functionapp
+  metrics:
+  - name: Http5xx
+    aggregation: Total
+    namespace: microsoft.web/sites
+  - name: Requests
+    aggregation: Total
+    namespace: microsoft.web/sites
+  - name: HttpResponseTime
+    aggregation: Average
+    namespace: microsoft.web/sites
+- resourceId: /subscriptions/a5c0a8d7-a54d-4a6d-ab79-4ca64a3b750f/resourceGroups/s198t01-ebis-web/providers/Microsoft.Web/sites/s198t01-education-benchmarking
+  resourceName: s198t01-education-benchmarking
+  kind: app
+  metrics:
+  - name: Http5xx
+    aggregation: Total
+    namespace: microsoft.web/sites
+  - name: Requests
+    aggregation: Total
+    namespace: microsoft.web/sites
+  - name: HttpResponseTime
+    aggregation: Average
+    namespace: microsoft.web/sites

--- a/performance-tests/src/web/jmeter/average/school/spending-and-costs/jmeter-test.jmx
+++ b/performance-tests/src/web/jmeter/average/school/spending-and-costs/jmeter-test.jmx
@@ -6,8 +6,21 @@
       <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
         <collectionProp name="Arguments.arguments"/>
       </elementProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
     </TestPlan>
     <hashTree>
+      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="domain" elementType="Argument">
+            <stringProp name="Argument.name">domain</stringProp>
+            <stringProp name="Argument.value">${__BeanShell( System.getenv("hostname") )}</stringProp>
+            <stringProp name="Argument.desc">Web app host name</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Web endpoint test">
         <intProp name="ThreadGroup.num_threads">15</intProp>
         <intProp name="ThreadGroup.ramp_time">10</intProp>
@@ -26,8 +39,8 @@
           <boolProp name="HTTPSampler.image_parser">true</boolProp>
           <boolProp name="HTTPSampler.concurrentDwn">true</boolProp>
           <intProp name="HTTPSampler.concurrentPool">6</intProp>
-          <stringProp name="HTTPSampler.embedded_url_re">(?i).*s198t01-education-benchmarking.*</stringProp>
-          <stringProp name="HTTPSampler.domain">s198t01-education-benchmarking-dmazdedtfhaqezd7.a01.azurefd.net</stringProp>
+          <stringProp name="HTTPSampler.embedded_url_re">(?i).*-education-benchmarking.*</stringProp>
+          <stringProp name="HTTPSampler.domain">${domain}</stringProp>
           <stringProp name="HTTPSampler.protocol">https</stringProp>
           <stringProp name="HTTPSampler.path">/school/${identifier}/spending-and-costs</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
@@ -56,7 +69,7 @@
           </CacheManager>
           <hashTree/>
         </hashTree>
-        <CSVDataSet guiclass="TestBeanGUI" testclass="CSVDataSet" testname="CSV Data Set Config">
+        <CSVDataSet guiclass="TestBeanGUI" testclass="CSVDataSet" testname="CSV Data Set Config" enabled="true">
           <stringProp name="filename">schools.csv</stringProp>
           <stringProp name="variableNames">identifier,name</stringProp>
           <boolProp name="ignoreFirstLine">false</boolProp>

--- a/performance-tests/src/web/jmeter/peak/school/spending-and-costs/config.yaml
+++ b/performance-tests/src/web/jmeter/peak/school/spending-and-costs/config.yaml
@@ -9,6 +9,78 @@ configurationFiles:
 - schools.csv
 failureCriteria: 
 - percentage(error) > 0.1
+referenceIdentities:
+- kind: Metrics
+  type: SystemAssigned
+env:
+- name: hostname
+  value: s198t01-education-benchmarking-dmazdedtfhaqezd7.a01.azurefd.net
 autoStop:
   errorPercentage: 90
   timeWindow: 60
+appComponents:
+- resourceId: /subscriptions/a5c0a8d7-a54d-4a6d-ab79-4ca64a3b750f/resourceGroups/s198t01-ebis-core/providers/Microsoft.Sql/servers/s198t01-sql/databases/data
+  resourceName: data
+  kind: v12.0,user
+  metrics:
+  - name: cpu_percent
+    aggregation: Total
+    namespace: microsoft.sql/servers/databases
+  - name: connection_failed
+    aggregation: Maximum
+    namespace: microsoft.sql/servers/databases
+  - name: deadlock
+    aggregation: Total
+    namespace: microsoft.sql/servers/databases
+- resourceId: /subscriptions/a5c0a8d7-a54d-4a6d-ab79-4ca64a3b750f/resourceGroups/s198t01-ebis-platform/providers/Microsoft.Web/sites/s198t01-ebis-benchmark-fa
+  resourceName: s198t01-ebis-benchmark-fa
+  kind: functionapp
+  metrics:
+  - name: Http5xx
+    aggregation: Total
+    namespace: microsoft.web/sites
+  - name: Requests
+    aggregation: Total
+    namespace: microsoft.web/sites
+  - name: HttpResponseTime
+    aggregation: Average
+    namespace: microsoft.web/sites
+- resourceId: /subscriptions/a5c0a8d7-a54d-4a6d-ab79-4ca64a3b750f/resourceGroups/s198t01-ebis-platform/providers/Microsoft.Web/sites/s198t01-ebis-establishment-fa
+  resourceName: s198t01-ebis-establishment-fa
+  kind: functionapp
+  metrics:
+  - name: Http5xx
+    aggregation: Total
+    namespace: microsoft.web/sites
+  - name: Requests
+    aggregation: Total
+    namespace: microsoft.web/sites
+  - name: HttpResponseTime
+    aggregation: Average
+    namespace: microsoft.web/sites
+- resourceId: /subscriptions/a5c0a8d7-a54d-4a6d-ab79-4ca64a3b750f/resourceGroups/s198t01-ebis-platform/providers/Microsoft.Web/sites/s198t01-ebis-insight-fa
+  resourceName: s198t01-ebis-insight-fa
+  kind: functionapp
+  metrics:
+  - name: Http5xx
+    aggregation: Total
+    namespace: microsoft.web/sites
+  - name: Requests
+    aggregation: Total
+    namespace: microsoft.web/sites
+  - name: HttpResponseTime
+    aggregation: Average
+    namespace: microsoft.web/sites
+- resourceId: /subscriptions/a5c0a8d7-a54d-4a6d-ab79-4ca64a3b750f/resourceGroups/s198t01-ebis-web/providers/Microsoft.Web/sites/s198t01-education-benchmarking
+  resourceName: s198t01-education-benchmarking
+  kind: app
+  metrics:
+  - name: Http5xx
+    aggregation: Total
+    namespace: microsoft.web/sites
+  - name: Requests
+    aggregation: Total
+    namespace: microsoft.web/sites
+  - name: HttpResponseTime
+    aggregation: Average
+    namespace: microsoft.web/sites

--- a/performance-tests/src/web/jmeter/peak/school/spending-and-costs/jmeter-test.jmx
+++ b/performance-tests/src/web/jmeter/peak/school/spending-and-costs/jmeter-test.jmx
@@ -6,8 +6,21 @@
       <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
         <collectionProp name="Arguments.arguments"/>
       </elementProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
     </TestPlan>
     <hashTree>
+      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="domain" elementType="Argument">
+            <stringProp name="Argument.name">domain</stringProp>
+            <stringProp name="Argument.value">${__BeanShell( System.getenv("hostname") )}</stringProp>
+            <stringProp name="Argument.desc">Web app host name</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Web endpoint test">
         <intProp name="ThreadGroup.num_threads">30</intProp>
         <intProp name="ThreadGroup.ramp_time">10</intProp>
@@ -26,8 +39,8 @@
           <boolProp name="HTTPSampler.image_parser">true</boolProp>
           <boolProp name="HTTPSampler.concurrentDwn">true</boolProp>
           <intProp name="HTTPSampler.concurrentPool">6</intProp>
-          <stringProp name="HTTPSampler.embedded_url_re">(?i).*s198t01-education-benchmarking.*</stringProp>
-          <stringProp name="HTTPSampler.domain">s198t01-education-benchmarking-dmazdedtfhaqezd7.a01.azurefd.net</stringProp>
+          <stringProp name="HTTPSampler.embedded_url_re">(?i).*-education-benchmarking.*</stringProp>
+          <stringProp name="HTTPSampler.domain">${domain}</stringProp>
           <stringProp name="HTTPSampler.protocol">https</stringProp>
           <stringProp name="HTTPSampler.path">/school/${identifier}/spending-and-costs</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
@@ -56,7 +69,7 @@
           </CacheManager>
           <hashTree/>
         </hashTree>
-        <CSVDataSet guiclass="TestBeanGUI" testclass="CSVDataSet" testname="CSV Data Set Config">
+        <CSVDataSet guiclass="TestBeanGUI" testclass="CSVDataSet" testname="CSV Data Set Config" enabled="true">
           <stringProp name="filename">schools.csv</stringProp>
           <stringProp name="variableNames">identifier,name</stringProp>
           <boolProp name="ignoreFirstLine">false</boolProp>


### PR DESCRIPTION
### Context
AB#254333 AB#248027 #2140

### Change proposed in this pull request
Modified `.jmx` load tests to parameterise host name (as per [docs](https://learn.microsoft.com/en-gb/azure/load-testing/how-to-parameterize-load-tests?wt.mc_id=azureportal_loadtesting_inproduct_params&tabs=jmeter#envvars)). 
Ran and documented baseline results against `d13` feature environment.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)

