### PR TITLE
feat: add endpoint to establishment for `/schools/search` for faceted school search

### DIFF
--- a/platform/src/abstractions/Platform.Search/Requests/SearchRequest.cs
+++ b/platform/src/abstractions/Platform.Search/Requests/SearchRequest.cs
@@ -13,10 +13,17 @@ public record SearchRequest
     public int PageSize { get; set; } = 15;
     public int Page { get; set; } = 1;
     public FilterCriteria[]? Filters { get; set; }
+    public OrderByCriteria? OrderBy { get; set; }
 }
 
 [ExcludeFromCodeCoverage]
 public record FilterCriteria
+{
+    public string? Field { get; set; }
+    public string? Value { get; set; }
+}
+
+public record OrderByCriteria
 {
     public string? Field { get; set; }
     public string? Value { get; set; }

--- a/platform/src/abstractions/Platform.Search/SearchService.cs
+++ b/platform/src/abstractions/Platform.Search/SearchService.cs
@@ -33,7 +33,7 @@ public abstract class SearchService<T>(IIndexClient client)
         return response.Value;
     }
 
-    protected async Task<SearchResponse<T>> SearchAsync(SearchRequest request, Func<FilterCriteria[], string?>? filterExpBuilder = null, string[]? facets = null)
+    protected virtual async Task<SearchResponse<T>> SearchAsync(SearchRequest request, Func<FilterCriteria[], string?>? filterExpBuilder = null, string[]? facets = null)
     {
         var options = new SearchOptions
         {
@@ -55,6 +55,12 @@ public abstract class SearchService<T>(IIndexClient client)
             }
         }
 
+        if (request.OrderBy is not null)
+        {
+            var orderByItem = $"{request.OrderBy.Field} {request.OrderBy.Value}";
+            options.OrderBy.Add(orderByItem);
+        }
+
         var searchResponse = await client.SearchAsync<T>(request.SearchText, options);
         var searchResults = searchResponse.Value;
         var outputFacets = searchResults.Facets is { Count: > 0 } ? BuildFacetOutput(searchResults.Facets) : null;
@@ -63,7 +69,7 @@ public abstract class SearchService<T>(IIndexClient client)
         return SearchResponse<T>.Create(results, request.Page, request.PageSize, searchResults.TotalCount, outputFacets);
     }
 
-    protected async Task<SuggestResponse<T>> SuggestAsync(SuggestRequest request, Func<string?>? filterExpBuilder = null, string[]? selectFields = null)
+    protected virtual async Task<SuggestResponse<T>> SuggestAsync(SuggestRequest request, Func<string?>? filterExpBuilder = null, string[]? selectFields = null)
     {
         ArgumentNullException.ThrowIfNull(client);
 

--- a/platform/src/abstractions/Platform.Search/SearchService.cs
+++ b/platform/src/abstractions/Platform.Search/SearchService.cs
@@ -57,7 +57,7 @@ public abstract class SearchService<T>(IIndexClient client)
 
         if (request.OrderBy is not null)
         {
-            var orderByItem = $"{request.OrderBy.Field} {request.OrderBy.Value}";
+            var orderByItem = $"{request.OrderBy.Field} {request.OrderBy.Value?.ToLower()}";
             options.OrderBy.Add(orderByItem);
         }
 

--- a/platform/src/abstractions/Platform.Search/Validators/PostSearchRequestValidator.cs
+++ b/platform/src/abstractions/Platform.Search/Validators/PostSearchRequestValidator.cs
@@ -1,0 +1,19 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using FluentValidation;
+
+namespace Platform.Search;
+
+[ExcludeFromCodeCoverage]
+public class PostSearchRequestValidator : AbstractValidator<SearchRequest>
+{
+    public PostSearchRequestValidator()
+    {
+        RuleFor(p => p.SearchText).NotNull()
+            .MinimumLength(3)
+            .MaximumLength(100);
+
+        RuleFor(x => x.OrderBy)
+            .Must(orderBy => orderBy == null || orderBy.Value == "asc" || orderBy.Value == "desc")
+            .WithMessage("OrderBy Value must be 'asc' or 'desc'");
+    }
+}

--- a/platform/src/abstractions/Platform.Search/Validators/PostSearchRequestValidator.cs
+++ b/platform/src/abstractions/Platform.Search/Validators/PostSearchRequestValidator.cs
@@ -13,7 +13,21 @@ public class PostSearchRequestValidator : AbstractValidator<SearchRequest>
             .MaximumLength(100);
 
         RuleFor(x => x.OrderBy)
-            .Must(orderBy => orderBy == null || orderBy.Value == "asc" || orderBy.Value == "desc")
-            .WithMessage("OrderBy Value must be 'asc' or 'desc'");
+            .Must(orderBy => orderBy == null || Sort.IsValid(orderBy.Value))
+            .WithMessage($"{{PropertyName}} must empty or be one of the supported values: {string.Join(", ", Sort.All)}");
     }
+}
+
+public static class Sort
+{
+    public const string Asc = nameof(Asc);
+    public const string Desc = nameof(Desc);
+
+    public static readonly string[] All =
+    [
+        Asc.ToLower(),
+        Desc.ToLower()
+    ];
+
+    public static bool IsValid(string? order) => All.Any(a => a.Equals(order, StringComparison.OrdinalIgnoreCase));
 }

--- a/platform/src/abstractions/tests/Platform.Search.Tests/SearchSearchTests.cs
+++ b/platform/src/abstractions/tests/Platform.Search.Tests/SearchSearchTests.cs
@@ -89,6 +89,98 @@ public class SearchSearchTests
     }
 
     [Fact]
+    public async Task SearchShouldCorrectlyPassOrderByWithOrderBy()
+    {
+        SearchOptions? capturedOptions = null;
+
+        var orderBy = new OrderByCriteria
+        {
+            Field = nameof(OrderByCriteria.Field),
+            Value = nameof(OrderByCriteria.Value)
+        };
+
+        string[] expectedOrderBy = [$"{orderBy.Field} {orderBy.Value}"];
+
+        var request = new SearchRequest
+        {
+            OrderBy = orderBy,
+            PageSize = Size,
+            Page = Page,
+            SearchText = Search
+        };
+
+        var result = new TestType();
+        var searchResults = SearchModelFactory.SearchResults(
+            [SearchModelFactory.SearchResult(result, ResultScore, new Dictionary<string, IList<string>>())],
+            TotalCount,
+            null,
+            null,
+            Mock.Of<Response>());
+
+        _client
+            .Setup(c => c.SearchAsync<TestType>(
+                Search,
+                It.Is<SearchOptions>(o =>
+                    o.Size == Size
+                    && o.Skip == 0
+                    && o.IncludeTotalCount == true
+                    && o.Filter == null
+                    && o.QueryType == SearchQueryType.Simple)))
+            .Callback((string _, SearchOptions options) =>
+            {
+                capturedOptions = options;
+            })
+            .ReturnsAsync(Response.FromValue(searchResults, Mock.Of<Response>()));
+
+        await _service.CallSearchAsync(request);
+
+        Assert.NotNull(capturedOptions);
+        Assert.NotEmpty(capturedOptions.OrderBy);
+        Assert.Equal(expectedOrderBy, capturedOptions.OrderBy);
+    }
+
+    [Fact]
+    public async Task SearchShouldCorrectlyNotPassOrderByWithoutOrderBy()
+    {
+        SearchOptions? capturedOptions = null;
+
+        var request = new SearchRequest
+        {
+            PageSize = Size,
+            Page = Page,
+            SearchText = Search
+        };
+
+        var result = new TestType();
+        var searchResults = SearchModelFactory.SearchResults(
+            [SearchModelFactory.SearchResult(result, ResultScore, new Dictionary<string, IList<string>>())],
+            TotalCount,
+            null,
+            null,
+            Mock.Of<Response>());
+
+        _client
+            .Setup(c => c.SearchAsync<TestType>(
+                Search,
+                It.Is<SearchOptions>(o =>
+                    o.Size == Size
+                    && o.Skip == 0
+                    && o.IncludeTotalCount == true
+                    && o.Filter == null
+                    && o.QueryType == SearchQueryType.Simple)))
+            .Callback((string _, SearchOptions options) =>
+            {
+                capturedOptions = options;
+            })
+            .ReturnsAsync(Response.FromValue(searchResults, Mock.Of<Response>()));
+
+        await _service.CallSearchAsync(request);
+
+        Assert.NotNull(capturedOptions);
+        Assert.Empty(capturedOptions.OrderBy);
+    }
+
+    [Fact]
     public async Task SearchShouldReturnExpectedResultsWithFacets()
     {
         FilterCriteria[] filters =

--- a/platform/src/abstractions/tests/Platform.Search.Tests/SearchSearchTests.cs
+++ b/platform/src/abstractions/tests/Platform.Search.Tests/SearchSearchTests.cs
@@ -99,7 +99,7 @@ public class SearchSearchTests
             Value = nameof(OrderByCriteria.Value)
         };
 
-        string[] expectedOrderBy = [$"{orderBy.Field} {orderBy.Value}"];
+        string[] expectedOrderBy = [$"{orderBy.Field} {orderBy.Value.ToLower()}"];
 
         var request = new SearchRequest
         {

--- a/platform/src/abstractions/tests/Platform.Search.Tests/WhenPostSearchRequestValidatorValidates.cs
+++ b/platform/src/abstractions/tests/Platform.Search.Tests/WhenPostSearchRequestValidatorValidates.cs
@@ -1,0 +1,87 @@
+using Xunit;
+using System.Collections;
+
+namespace Platform.Search.Tests;
+
+public class WhenPostSearchRequestValidatorValidates
+{
+    private readonly PostSearchRequestValidator _validator = new();
+
+    [Theory]
+    [ClassData(typeof(ValidSearchRequestData))]
+    public async Task ShouldBeValidWithGoodRequest(SearchRequest request)
+    {
+        var actual = await _validator.ValidateAsync(request);
+        Assert.True(actual.IsValid);
+        Assert.Empty(actual.Errors);
+    }
+
+    [Theory]
+    [ClassData(typeof(InvalidSearchRequestData))]
+    public async Task ShouldBeInvalidWithBadRequest(SearchRequest request, string expectedErrorMessage)
+    {
+        var actual = await _validator.ValidateAsync(request);
+        Assert.False(actual.IsValid);
+        Assert.NotEmpty(actual.Errors);
+        Assert.Equal(expectedErrorMessage, actual.Errors[0].ErrorMessage);
+    }
+}
+
+public class ValidSearchRequestData : IEnumerable<object[]>
+{
+    public IEnumerator<object[]> GetEnumerator()
+    {
+        yield return [new SearchRequest { SearchText = "tes" }];
+        yield return
+            [
+                new SearchRequest
+                {
+                    SearchText = new string('a', 100)
+                }
+            ];
+        yield return
+            [
+                new SearchRequest
+                { SearchText = "test", OrderBy = new OrderByCriteria { Field = "SchoolName", Value = "asc" } }
+            ];
+
+        yield return
+            [
+                new SearchRequest
+                { SearchText = "test", OrderBy = new OrderByCriteria { Field = "SchoolName", Value = "desc" } }
+            ];
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+public class InvalidSearchRequestData : IEnumerable<object[]>
+{
+    public IEnumerator<object[]> GetEnumerator()
+    {
+        yield return [new SearchRequest { SearchText = null }, "'Search Text' must not be empty."];
+        yield return
+            [
+                new SearchRequest { SearchText = "te" },
+                "The length of 'Search Text' must be at least 3 characters. You entered 2 characters."
+            ];
+        yield return
+            [
+                new SearchRequest
+                {
+                    SearchText = new string('a', 101)
+                },
+                "The length of 'Search Text' must be 100 characters or fewer. You entered 101 characters."
+            ];
+        yield return
+            [
+                new SearchRequest
+                {
+                    SearchText = "test",
+                    OrderBy = new OrderByCriteria { Field = "SchoolName", Value = "test" }
+                },
+                "OrderBy Value must be 'asc' or 'desc'"
+            ];
+    }
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/platform/src/abstractions/tests/Platform.Search.Tests/WhenPostSearchRequestValidatorValidates.cs
+++ b/platform/src/abstractions/tests/Platform.Search.Tests/WhenPostSearchRequestValidatorValidates.cs
@@ -80,7 +80,7 @@ public class InvalidSearchRequestData : IEnumerable<object[]>
                     SearchText = "test",
                     OrderBy = new OrderByCriteria { Field = "SchoolName", Value = "test" }
                 },
-                "OrderBy Value must be 'asc' or 'desc'"
+                $"Order By must empty or be one of the supported values: {string.Join(", ", Sort.All)}"
             ];
     }
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/platform/src/apis/Platform.Api.Establishment/Features/Schools/PostSchoolsSearchFunction.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Schools/PostSchoolsSearchFunction.cs
@@ -1,11 +1,10 @@
-using System.Net;
+﻿using System.Net;
 using System.Threading.Tasks;
 using FluentValidation;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Platform.Api.Establishment.Features.Schools.Models;
-using Platform.Api.Establishment.Features.Schools.Requests;
 using Platform.Api.Establishment.Features.Schools.Services;
 using Platform.Functions;
 using Platform.Functions.Extensions;
@@ -14,19 +13,19 @@ using Platform.Search;
 
 namespace Platform.Api.Establishment.Features.Schools;
 
-public class PostSchoolsSuggestFunction(ISchoolsService service, IValidator<SuggestRequest> validator)
+public class PostSchoolsSearchFunction(ISchoolsService service, IValidator<SearchRequest> validator)
 {
-    [Function(nameof(PostSchoolsSuggestFunction))]
+    [Function(nameof(PostSchoolsSearchFunction))]
     [OpenApiSecurityHeader]
-    [OpenApiOperation(nameof(PostSchoolsSuggestFunction), "Schools")]
-    [OpenApiRequestBody(ContentType.ApplicationJson, typeof(SchoolSuggestRequest), Description = "The suggest object")]
-    [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(SuggestResponse<School>))]
+    [OpenApiOperation(nameof(PostSchoolsSearchFunction), "Schools")]
+    [OpenApiRequestBody(ContentType.ApplicationJson, typeof(SearchRequest), Description = "The search request")]
+    [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(SearchResponse<School>))]
     [OpenApiResponseWithBody(HttpStatusCode.BadRequest, ContentType.ApplicationJson, typeof(ValidationError[]))]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Post, Route = Routes.SchoolsSuggest)]
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Post, Route = Routes.SchoolsSearch)]
         HttpRequestData req)
     {
-        var body = await req.ReadAsJsonAsync<SchoolSuggestRequest>();
+        var body = await req.ReadAsJsonAsync<SearchRequest>();
 
         var validationResult = await validator.ValidateAsync(body);
         if (!validationResult.IsValid)
@@ -34,7 +33,7 @@ public class PostSchoolsSuggestFunction(ISchoolsService service, IValidator<Sugg
             return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
         }
 
-        var schools = await service.SchoolsSuggestAsync(body);
+        var schools = await service.SchoolsSearchAsync(body);
         return await req.CreateJsonResponseAsync(schools);
     }
 }

--- a/platform/src/apis/Platform.Api.Establishment/Features/Schools/Routes.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Schools/Routes.cs
@@ -5,4 +5,5 @@ public static class Routes
     public const string SchoolsSuggest = "schools/suggest";
     public const string School = "school/{identifier}";
     public const string SchoolComparators = "school/{identifier}/comparators";
+    public const string SchoolsSearch = "schools/search";
 }

--- a/platform/src/apis/Platform.Api.Establishment/Features/Schools/SchoolsFeature.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Schools/SchoolsFeature.cs
@@ -1,6 +1,9 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
 using Platform.Api.Establishment.Features.Schools.Services;
+using Platform.Api.Establishment.Features.Schools.Validators;
+using Platform.Search;
 
 namespace Platform.Api.Establishment.Features.Schools;
 
@@ -12,6 +15,9 @@ public static class SchoolsFeature
         serviceCollection
             .AddSingleton<ISchoolsService, SchoolsService>()
             .AddSingleton<ISchoolComparatorsService, SchoolComparatorsService>();
+
+        serviceCollection
+            .AddTransient<IValidator<SearchRequest>, SchoolsSearchValidator>();
 
         return serviceCollection;
     }

--- a/platform/src/apis/Platform.Api.Establishment/Features/Schools/Validators/SchoolsSearchValidator.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Schools/Validators/SchoolsSearchValidator.cs
@@ -12,17 +12,17 @@ public class SchoolsSearchValidator : AbstractValidator<SearchRequest>
     {
 
         Include(new PostSearchRequestValidator());
-
+        
         RuleFor(x => x.Filters)
             .Must(filters => filters == null || filters.All(f => f.Field == nameof(School.OverallPhase)))
-            .WithMessage("Each Filter Field must be 'OverallPhase'");
+            .WithMessage($"Each Filter Field must be {nameof(School.OverallPhase)}");
 
         RuleForEach(x => x.Filters)
             .Must(f => f.Value != null && OverallPhase.All.Contains(f.Value))
-            .WithMessage("Each Filter Value must be in OverallPhase.All");
+            .WithMessage($"{{PropertyName}} must be one of the supported values: {string.Join(", ", OverallPhase.All)}");
 
         RuleFor(x => x.OrderBy)
             .Must(orderBy => orderBy == null || orderBy.Field == nameof(School.SchoolName))
-            .WithMessage("OrderBy Field must be 'SchoolName'");
+            .WithMessage($"OrderBy Field must be {nameof(School.SchoolName)}");	
     }
 }

--- a/platform/src/apis/Platform.Api.Establishment/Features/Schools/Validators/SchoolsSearchValidator.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Schools/Validators/SchoolsSearchValidator.cs
@@ -1,0 +1,28 @@
+using System.Linq;
+using FluentValidation;
+using Platform.Api.Establishment.Features.Schools.Models;
+using Platform.Domain;
+using Platform.Search;
+
+namespace Platform.Api.Establishment.Features.Schools.Validators;
+
+public class SchoolsSearchValidator : AbstractValidator<SearchRequest>
+{
+    public SchoolsSearchValidator()
+    {
+
+        Include(new PostSearchRequestValidator());
+
+        RuleFor(x => x.Filters)
+            .Must(filters => filters == null || filters.All(f => f.Field == nameof(School.OverallPhase)))
+            .WithMessage("Each Filter Field must be 'OverallPhase'");
+
+        RuleForEach(x => x.Filters)
+            .Must(f => f.Value != null && OverallPhase.All.Contains(f.Value))
+            .WithMessage("Each Filter Value must be in OverallPhase.All");
+
+        RuleFor(x => x.OrderBy)
+            .Must(orderBy => orderBy == null || orderBy.Field == nameof(School.SchoolName))
+            .WithMessage("OrderBy Field must be 'SchoolName'");
+    }
+}

--- a/platform/src/apis/Platform.Api.Establishment/Features/Schools/Validators/SchoolsSearchValidator.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Schools/Validators/SchoolsSearchValidator.cs
@@ -12,7 +12,7 @@ public class SchoolsSearchValidator : AbstractValidator<SearchRequest>
     {
 
         Include(new PostSearchRequestValidator());
-        
+
         RuleFor(x => x.Filters)
             .Must(filters => filters == null || filters.All(f => f.Field == nameof(School.OverallPhase)))
             .WithMessage($"Each Filter Field must be {nameof(School.OverallPhase)}");
@@ -23,6 +23,6 @@ public class SchoolsSearchValidator : AbstractValidator<SearchRequest>
 
         RuleFor(x => x.OrderBy)
             .Must(orderBy => orderBy == null || orderBy.Field == nameof(School.SchoolName))
-            .WithMessage($"OrderBy Field must be {nameof(School.SchoolName)}");	
+            .WithMessage($"OrderBy Field must be {nameof(School.SchoolName)}");
     }
 }

--- a/platform/tests/Platform.Establishment.Tests/Schools/PostSchoolsSearchFunctionTests.cs
+++ b/platform/tests/Platform.Establishment.Tests/Schools/PostSchoolsSearchFunctionTests.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using FluentValidation;
+using FluentValidation.Results;
+using Moq;
+using Platform.Api.Establishment.Features.Schools;
+using Platform.Api.Establishment.Features.Schools.Models;
+using Platform.Api.Establishment.Features.Schools.Services;
+using Platform.Functions;
+using Platform.Search;
+using Platform.Test;
+using Platform.Test.Extensions;
+using Xunit;
+
+namespace Platform.Establishment.Tests.Schools;
+
+public class PostSchoolsSearchFunctionTests : FunctionsTestBase
+{
+    private readonly PostSchoolsSearchFunction _function;
+    private readonly Mock<ISchoolsService> _service;
+    private readonly Mock<IValidator<SearchRequest>> _validator;
+
+    public PostSchoolsSearchFunctionTests()
+    {
+        _service = new Mock<ISchoolsService>();
+        _validator = new Mock<IValidator<SearchRequest>>();
+        _function = new PostSchoolsSearchFunction(_service.Object, _validator.Object);
+    }
+
+    [Fact]
+    public async Task ShouldReturn200OnValidRequest()
+    {
+        _service
+            .Setup(d => d.SchoolsSearchAsync(It.IsAny<SearchRequest>()))
+            .ReturnsAsync(new SearchResponse<School>());
+
+        _validator
+            .Setup(v => v.ValidateAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
+        var result =
+            await _function.RunAsync(CreateHttpRequestDataWithBody(new SearchRequest()));
+
+        Assert.NotNull(result);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal(ContentType.ApplicationJson, result.ContentType());
+
+        var body = await result.ReadAsJsonAsync<SearchResponse<School>>();
+        Assert.NotNull(body);
+    }
+
+    [Fact]
+    public async Task ShouldReturn400OnValidationError()
+    {
+        _validator
+            .Setup(v => v.ValidateAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult([
+                new ValidationFailure(nameof(SearchRequest.SearchText), "error")
+            ]));
+
+        var result = await _function.RunAsync(CreateHttpRequestDataWithBody(new SearchRequest()));
+
+        Assert.NotNull(result);
+        Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
+        Assert.Equal(ContentType.ApplicationJson, result.ContentType());
+
+        var values = await result.ReadAsJsonAsync<IEnumerable<ValidationError>>();
+        Assert.NotNull(values);
+        Assert.Contains(values, p => p.PropertyName == nameof(SearchRequest.SearchText));
+
+        _service
+            .Verify(d => d.SchoolsSearchAsync(It.IsAny<SearchRequest>()), Times.Never);
+    }
+}

--- a/platform/tests/Platform.Establishment.Tests/Schools/PostSchoolsSuggestFunctionTests.cs
+++ b/platform/tests/Platform.Establishment.Tests/Schools/PostSchoolsSuggestFunctionTests.cs
@@ -31,7 +31,7 @@ public class PostSchoolsSuggestFunctionTests : FunctionsTestBase
     public async Task ShouldReturn200OnValidRequest()
     {
         _service
-            .Setup(d => d.SuggestAsync(It.IsAny<SchoolSuggestRequest>()))
+            .Setup(d => d.SchoolsSuggestAsync(It.IsAny<SchoolSuggestRequest>()))
             .ReturnsAsync(new SuggestResponse<School>());
 
         _validator
@@ -67,6 +67,6 @@ public class PostSchoolsSuggestFunctionTests : FunctionsTestBase
         Assert.Contains(values, p => p.PropertyName == nameof(SuggestRequest.SuggesterName));
 
         _service
-            .Verify(d => d.SuggestAsync(It.IsAny<SchoolSuggestRequest>()), Times.Never);
+            .Verify(d => d.SchoolsSuggestAsync(It.IsAny<SchoolSuggestRequest>()), Times.Never);
     }
 }

--- a/platform/tests/Platform.Establishment.Tests/Schools/Services/WhenSchoolsServiceIsCalled.cs
+++ b/platform/tests/Platform.Establishment.Tests/Schools/Services/WhenSchoolsServiceIsCalled.cs
@@ -1,0 +1,191 @@
+using Moq;
+using Moq.Protected;
+using Platform.Api.Establishment.Features.Schools.Models;
+using Platform.Api.Establishment.Features.Schools.Requests;
+using Platform.Api.Establishment.Features.Schools.Services;
+using Platform.Search;
+using Platform.Sql;
+using Xunit;
+
+namespace Platform.Establishment.Tests.Schools.Services;
+
+public class WhenSchoolsServiceIsCalled
+{
+    private readonly Mock<IIndexClient> _client = new();
+    private readonly Mock<IDatabaseFactory> _db = new();
+    private readonly Mock<SchoolsService> _service;
+
+    public WhenSchoolsServiceIsCalled()
+    {
+        _service = new Mock<SchoolsService>(_client.Object, _db.Object) { CallBase = true };
+    }
+
+    [Fact]
+    public async Task SchoolSearchesAsyncShouldCorrectlyPassFacets()
+    {
+        string[]? capturedFacets = null;
+
+        _service.Protected()
+            .Setup<Task<SearchResponse<School>>>(
+                "SearchAsync",
+                ItExpr.IsAny<SearchRequest>(),
+                ItExpr.IsAny<Func<FilterCriteria[], string?>>(),
+                ItExpr.IsAny<string[]?>()
+            )
+            .Callback((SearchRequest _, Func<FilterCriteria[], string?> _, string[] facets) =>
+            {
+                capturedFacets = facets;
+            })
+            .ReturnsAsync(Mock.Of<SearchResponse<School>>());
+
+        var request = new SearchRequest();
+
+        await _service.Object.SchoolsSearchAsync(request);
+
+        Assert.NotNull(capturedFacets);
+        Assert.Contains(nameof(School.OverallPhase), capturedFacets);
+    }
+
+    [Fact]
+    public async Task SchoolSearchesAsyncShouldCorrectlyPassSearchText()
+    {
+        SearchRequest? capturedRequest = null;
+
+        _service.Protected()
+            .Setup<Task<SearchResponse<School>>>(
+                "SearchAsync",
+                ItExpr.IsAny<SearchRequest>(),
+                ItExpr.IsAny<Func<FilterCriteria[], string?>>(),
+                ItExpr.IsAny<string[]?>()
+            )
+            .Callback((SearchRequest request, Func<FilterCriteria[], string?> _, string[] _) =>
+            {
+                capturedRequest = request;
+            })
+            .ReturnsAsync(Mock.Of<SearchResponse<School>>());
+
+        var request = new SearchRequest
+        {
+            SearchText = nameof(SearchRequest.SearchText)
+        };
+
+        await _service.Object.SchoolsSearchAsync(request);
+
+        Assert.NotNull(capturedRequest);
+        Assert.Contains(request.SearchText, capturedRequest.SearchText);
+    }
+
+    [Theory]
+    [InlineData(null, 0)]
+    [InlineData($"({nameof(FilterCriteria.Field)} eq '{nameof(FilterCriteria.Value)}')", 1)]
+    [InlineData($"({nameof(FilterCriteria.Field)} eq '{nameof(FilterCriteria.Value)}' or {nameof(FilterCriteria.Field)} eq '{nameof(FilterCriteria.Value)}')", 2)]
+    public async Task SchoolSearchesAsyncShouldCorrectlyPassFilterExpBuilderThatCreatesCorrectString(string? expected, int filterCount)
+    {
+        Func<FilterCriteria[], string?>? capturedFilterExpBuilder = null;
+
+        _service.Protected()
+            .Setup<Task<SearchResponse<School>>>(
+                "SearchAsync",
+                ItExpr.IsAny<SearchRequest>(),
+                ItExpr.IsAny<Func<FilterCriteria[], string?>>(),
+                ItExpr.IsAny<string[]?>()
+            )
+            .Callback((SearchRequest _, Func<FilterCriteria[], string?> filterExpBuilder, string[] _) =>
+            {
+                capturedFilterExpBuilder = filterExpBuilder;
+            })
+            .ReturnsAsync(Mock.Of<SearchResponse<School>>());
+
+        var request = new SearchRequest
+        {
+            SearchText = nameof(SearchRequest.SearchText)
+        };
+
+        await _service.Object.SchoolsSearchAsync(request);
+
+        Assert.NotNull(capturedFilterExpBuilder);
+        SearchFilterExpBuilderShouldBuildCorrectStringWithFilters(capturedFilterExpBuilder, expected, filterCount);
+    }
+
+    [Fact]
+    public async Task SchoolsSuggestAsyncShouldCorrectlyPassFields()
+    {
+        string[]? capturedFields = null;
+
+        var expected = new[]
+        {
+            nameof(School.SchoolName),
+            nameof(School.URN),
+            nameof(School.AddressStreet),
+            nameof(School.AddressLocality),
+            nameof(School.AddressLine3),
+            nameof(School.AddressTown),
+            nameof(School.AddressCounty),
+            nameof(School.AddressPostcode)
+        };
+
+        _service.Protected()
+            .Setup<Task<SuggestResponse<School>>>(
+                "SuggestAsync",
+                ItExpr.IsAny<SuggestRequest>(),
+                ItExpr.IsAny<Func<string?>?>(),
+                ItExpr.IsAny<string[]?>()
+            )
+            .Callback((SuggestRequest _, Func<string?>? _, string[] fields) =>
+            {
+                capturedFields = fields;
+            })
+            .ReturnsAsync(Mock.Of<SuggestResponse<School>>());
+
+        var request = new SchoolSuggestRequest();
+
+        await _service.Object.SchoolsSuggestAsync(request);
+
+        Assert.NotNull(capturedFields);
+        Assert.Equivalent(expected, capturedFields);
+    }
+
+    [Fact]
+    public async Task SchoolsSuggestAsyncShouldCorrectlyPassSearchText()
+    {
+        SuggestRequest? capturedRequest = null;
+
+        _service.Protected()
+            .Setup<Task<SuggestResponse<School>>>(
+                "SuggestAsync",
+                ItExpr.IsAny<SuggestRequest>(),
+                ItExpr.IsAny<Func<string?>?>(),
+                ItExpr.IsAny<string[]?>()
+            )
+            .Callback((SuggestRequest request, Func<string?>? _, string[] _) =>
+            {
+                capturedRequest = request;
+            })
+            .ReturnsAsync(Mock.Of<SuggestResponse<School>>());
+
+        var request = new SchoolSuggestRequest
+        {
+            SearchText = nameof(SchoolSuggestRequest.SearchText)
+        };
+
+        await _service.Object.SchoolsSuggestAsync(request);
+
+        Assert.NotNull(capturedRequest);
+        Assert.Contains(request.SearchText, capturedRequest.SearchText);
+    }
+
+    private static void SearchFilterExpBuilderShouldBuildCorrectStringWithFilters(Func<FilterCriteria[], string?> filterExpBuilder, string? expected, int filterCount)
+    {
+        var filterCriteria = Enumerable.Range(0, filterCount)
+            .Select(_ => new FilterCriteria
+            {
+                Field = nameof(FilterCriteria.Field),
+                Value = nameof(FilterCriteria.Value)
+            })
+            .ToArray();
+
+        var result = filterExpBuilder.Invoke(filterCriteria);
+
+        Assert.Equal(expected, result);
+    }
+}

--- a/platform/tests/Platform.Establishment.Tests/Schools/Validators/WhenSchoolsSearchValidatorValidates.cs
+++ b/platform/tests/Platform.Establishment.Tests/Schools/Validators/WhenSchoolsSearchValidatorValidates.cs
@@ -144,7 +144,7 @@ public class InvalidSearchRequestData : IEnumerable<object[]>
                 Filters = [new FilterCriteria { Field = "OverallPhase", Value = "test" }]
             },
             $"Filters must be one of the supported values: {string.Join(", ", OverallPhase.All)}"
-        ];	
+        ];
     }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/platform/tests/Platform.Establishment.Tests/Schools/Validators/WhenSchoolsSearchValidatorValidates.cs
+++ b/platform/tests/Platform.Establishment.Tests/Schools/Validators/WhenSchoolsSearchValidatorValidates.cs
@@ -1,0 +1,149 @@
+﻿using Xunit;
+using Platform.Api.Establishment.Features.Schools.Validators;
+using Platform.Search;
+using System.Collections;
+
+namespace Platform.Establishment.Tests.Schools.Validators;
+
+public class WhenSchoolsSearchValidatorValidates
+{
+    private readonly SchoolsSearchValidator _validator = new();
+
+    [Theory]
+    [ClassData(typeof(ValidSearchRequestData))]
+    public async Task ShouldBeValidWithGoodRequest(SearchRequest request)
+    {
+        var actual = await _validator.ValidateAsync(request);
+        Assert.True(actual.IsValid);
+        Assert.Empty(actual.Errors);
+    }
+
+    [Theory]
+    [ClassData(typeof(InvalidSearchRequestData))]
+    public async Task ShouldBeInvalidWithBadRequest(SearchRequest request, string expectedErrorMessage)
+    {
+        var actual = await _validator.ValidateAsync(request);
+        Assert.False(actual.IsValid);
+        Assert.NotEmpty(actual.Errors);
+        Assert.Equal(expectedErrorMessage, actual.Errors[0].ErrorMessage);
+    }
+}
+
+public class ValidSearchRequestData : IEnumerable<object[]>
+{
+    public IEnumerator<object[]> GetEnumerator()
+    {
+        yield return [new SearchRequest { SearchText = "tes" }];
+        yield return
+            [
+                new SearchRequest
+                {
+                    SearchText = new string('a', 100)
+                }
+            ];
+        yield return
+            [
+                new SearchRequest
+                {
+                    SearchText = "test",
+                    Filters =
+                    [
+                        new FilterCriteria { Field = "OverallPhase", Value = "Primary" }
+                    ]
+                }
+            ];
+        yield return
+            [
+                new SearchRequest
+                {
+                    SearchText = "test",
+                    Filters =
+                    [
+                        new FilterCriteria { Field = "OverallPhase", Value = "Primary" },
+                        new FilterCriteria { Field = "OverallPhase", Value = "Secondary" },
+                        new FilterCriteria { Field = "OverallPhase", Value = "All-through" }
+                    ]
+                }
+            ];
+        yield return
+            [
+                new SearchRequest
+                { SearchText = "test", OrderBy = new OrderByCriteria { Field = "SchoolName", Value = "asc" } }
+            ];
+        yield return
+            [
+                new SearchRequest
+                { SearchText = "test", OrderBy = new OrderByCriteria { Field = "SchoolName", Value = "desc" } }
+            ];
+        yield return
+            [
+                new SearchRequest
+                {
+                    SearchText = "test",
+                    Filters = [new FilterCriteria { Field = "OverallPhase", Value = "Primary" }],
+                    OrderBy = new OrderByCriteria { Field = "SchoolName", Value = "asc" }
+                }
+            ];
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+public class InvalidSearchRequestData : IEnumerable<object[]>
+{
+    public IEnumerator<object[]> GetEnumerator()
+    {
+        yield return [new SearchRequest { SearchText = null }, "'Search Text' must not be empty."];
+        yield return
+            [
+                new SearchRequest { SearchText = "te" },
+                "The length of 'Search Text' must be at least 3 characters. You entered 2 characters."
+            ];
+        yield return
+            [
+                new SearchRequest
+                {
+                    SearchText = new string('a', 101)
+                },
+                "The length of 'Search Text' must be 100 characters or fewer. You entered 101 characters."
+            ];
+        yield return
+            [
+                new SearchRequest
+                {
+                    SearchText = "test",
+                    OrderBy = new OrderByCriteria { Field = "test", Value = "asc" }
+                },
+                "OrderBy Field must be 'SchoolName'"
+            ];
+        yield return
+            [
+                new SearchRequest
+                {
+                    SearchText = "test",
+                    OrderBy = new OrderByCriteria { Field = "SchoolName", Value = "test" }
+                },
+                "OrderBy Value must be 'asc' or 'desc'"
+            ];
+        yield return
+            [
+                new SearchRequest
+                {
+                    SearchText = "test",
+                    Filters = [new FilterCriteria { Field = "test", Value = "Primary" }]
+                },
+                "Each Filter Field must be 'OverallPhase'"
+            ];
+        yield return
+            [
+                new SearchRequest
+                {
+                    SearchText = "test",
+                    Filters = [new FilterCriteria { Field = "OverallPhase", Value = "test" }]
+                },
+                "Each Filter Value must be in OverallPhase.All"
+            ];
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/platform/tests/Platform.Establishment.Tests/Schools/Validators/WhenSchoolsSearchValidatorValidates.cs
+++ b/platform/tests/Platform.Establishment.Tests/Schools/Validators/WhenSchoolsSearchValidatorValidates.cs
@@ -2,6 +2,8 @@
 using Platform.Api.Establishment.Features.Schools.Validators;
 using Platform.Search;
 using System.Collections;
+using Platform.Api.Establishment.Features.Schools.Models;
+using Platform.Domain;
 
 namespace Platform.Establishment.Tests.Schools.Validators;
 
@@ -108,41 +110,41 @@ public class InvalidSearchRequestData : IEnumerable<object[]>
                 "The length of 'Search Text' must be 100 characters or fewer. You entered 101 characters."
             ];
         yield return
-            [
-                new SearchRequest
-                {
-                    SearchText = "test",
-                    OrderBy = new OrderByCriteria { Field = "test", Value = "asc" }
-                },
-                "OrderBy Field must be 'SchoolName'"
-            ];
+        [
+            new SearchRequest
+            {
+                SearchText = "test",
+                OrderBy = new OrderByCriteria { Field = "test", Value = "asc" }
+            },
+            $"OrderBy Field must be {nameof(School.SchoolName)}"
+        ];
         yield return
-            [
-                new SearchRequest
-                {
-                    SearchText = "test",
-                    OrderBy = new OrderByCriteria { Field = "SchoolName", Value = "test" }
-                },
-                "OrderBy Value must be 'asc' or 'desc'"
-            ];
+        [
+            new SearchRequest
+            {
+                SearchText = "test",
+                OrderBy = new OrderByCriteria { Field = "SchoolName", Value = "test" }
+            },
+            $"Order By must empty or be one of the supported values: {string.Join(", ", Sort.All)}"
+        ];
         yield return
-            [
-                new SearchRequest
-                {
-                    SearchText = "test",
-                    Filters = [new FilterCriteria { Field = "test", Value = "Primary" }]
-                },
-                "Each Filter Field must be 'OverallPhase'"
-            ];
+        [
+            new SearchRequest
+            {
+                SearchText = "test",
+                Filters = [new FilterCriteria { Field = "test", Value = "Primary" }]
+            },
+            $"Each Filter Field must be {nameof(School.OverallPhase)}"
+        ];
         yield return
-            [
-                new SearchRequest
-                {
-                    SearchText = "test",
-                    Filters = [new FilterCriteria { Field = "OverallPhase", Value = "test" }]
-                },
-                "Each Filter Value must be in OverallPhase.All"
-            ];
+        [
+            new SearchRequest
+            {
+                SearchText = "test",
+                Filters = [new FilterCriteria { Field = "OverallPhase", Value = "test" }]
+            },
+            $"Filters must be one of the supported values: {string.Join(", ", OverallPhase.All)}"
+        ];	
     }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();


### PR DESCRIPTION
### Context
[AB#250281](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/250281) - [AB#255009](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/255009)

### Change proposed in this pull request
Adds new endpoint to establishment `/schools/search`
- facet as `OverallPhase`
- sort ascending or descending on `SchoolName`
- Updates to `abstractions/Platform.Search`
  - `SearchService` to use `OrderBy` for sorting
- test coverage for the above
- renames `SchoolsService` method `SuggestAsync` to `SchoolSuggestAsync` and adds some unit tests

### Guidance to review 
Platform API tests to follow on a future PR

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

