### PR TITLE
fix: lower-case "1 day" Academies check

### DIFF
--- a/data-pipeline/src/pipeline/pre_processing/academies/academies.py
+++ b/data-pipeline/src/pipeline/pre_processing/academies/academies.py
@@ -52,7 +52,7 @@ def prepare_aar_data(aar_path, year: int):
     ).items():
         aar[column] = aar.eval(eval_)
 
-    aar = aar[~(aar["ACADEMYTRUSTSTATUS"] == "1 day")]
+    aar = aar[~(aar["ACADEMYTRUSTSTATUS"].str.lower() == "1 day")]
 
     aar["Income_Direct revenue finance"] = aar[
         "BNCH21707 (Direct revenue financing (Revenue contributions to capital))"


### PR DESCRIPTION
### Context

the casing for an `ACADEMYTRUSTSTATUS` of `1 day` has changed in the most recent AAR data.

### Change proposed in this pull request

the casing for an `ACADEMYTRUSTSTATUS` of `1 day` has changed in the most recent AAR data: lower-case the value to avoid any mis-matches.

### Guidance to review 
Include any useful information needed to review this change. Include any dependencies that are required for this change. 

### Checklist (add/remove as appropriate)

- [ ] ~Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)~
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~You have reviewed with UX/Design~

