### PR TITLE
Treat `Nursery` overall phase type the same as `Primary` in CFP journey

### DIFF
--- a/web/src/Web.App/Controllers/SchoolPlanningCreatePlanController.cs
+++ b/web/src/Web.App/Controllers/SchoolPlanningCreatePlanController.cs
@@ -251,7 +251,7 @@ public class SchoolPlanningCreateController(
                         urn,
                         year
                     })
-                    : school.IsPrimary
+                    : school.IsPrimaryOrNursery
                         ? RedirectToAction("PrimaryHasMixedAgeClasses", new
                         {
                             urn,
@@ -468,7 +468,7 @@ public class SchoolPlanningCreateController(
                         urn,
                         year
                     })
-                    : school.IsPrimary
+                    : school.IsPrimaryOrNursery
                         ? RedirectToAction("TotalEducationSupport", new
                         {
                             urn,
@@ -578,7 +578,7 @@ public class SchoolPlanningCreateController(
         async Task<IActionResult> Action()
         {
             var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
-            var backAction = school.IsPrimary
+            var backAction = school.IsPrimaryOrNursery
                 ? TotalEducationSupportBackLink(urn, year)
                 : TotalTeacherCostsBackLink(urn, year);
 
@@ -623,7 +623,7 @@ public class SchoolPlanningCreateController(
             }
 
             var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
-            var backAction = school.IsPrimary
+            var backAction = school.IsPrimaryOrNursery
                 ? TotalEducationSupportBackLink(urn, year)
                 : TotalTeacherCostsBackLink(urn, year);
 
@@ -905,7 +905,7 @@ public class SchoolPlanningCreateController(
         async Task<IActionResult> Action()
         {
             var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
-            var backAction = school.IsPrimary
+            var backAction = school.IsPrimaryOrNursery
                 ? PrimaryPupilFiguresBackLink(urn, year)
                 : PupilFiguresBackLink(urn, year);
 
@@ -935,7 +935,7 @@ public class SchoolPlanningCreateController(
             if (results.IsValid)
             {
                 await financialPlanService.Update(urn, year, User.UserId(), stage);
-                return school.IsPrimary
+                return school.IsPrimaryOrNursery
                     ? RedirectToAction("TeachingAssistantFigures", new
                     {
                         urn,
@@ -948,7 +948,7 @@ public class SchoolPlanningCreateController(
                     });
             }
 
-            var backAction = school.IsPrimary
+            var backAction = school.IsPrimaryOrNursery
                 ? PrimaryPupilFiguresBackLink(urn, year)
                 : PupilFiguresBackLink(urn, year);
 
@@ -1037,7 +1037,7 @@ public class SchoolPlanningCreateController(
         async Task<IActionResult> Action()
         {
             var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
-            var backAction = school.IsPrimary
+            var backAction = school.IsPrimaryOrNursery
                 ? TeachingAssistantFiguresBackLink(urn, year)
                 : TeacherPeriodAllocationBackLink(urn, year);
 
@@ -1096,7 +1096,7 @@ public class SchoolPlanningCreateController(
             }
 
             var school = await establishmentApi.GetSchool(urn).GetResultOrThrow<School>();
-            var backAction = school.IsPrimary
+            var backAction = school.IsPrimaryOrNursery
                 ? TeachingAssistantFiguresBackLink(urn, year)
                 : TeacherPeriodAllocationBackLink(urn, year);
 

--- a/web/src/Web.App/Domain/Establishment/School.cs
+++ b/web/src/Web.App/Domain/Establishment/School.cs
@@ -34,7 +34,7 @@ public record School
     public string? AddressCounty { get; set; }
     public string? AddressPostcode { get; set; }
     public string? Address { get; set; }
-    public bool IsPrimary => OverallPhase == OverallPhaseTypes.Primary;
+    public bool IsPrimaryOrNursery => OverallPhase is OverallPhaseTypes.Primary or OverallPhaseTypes.Nursery;
     public bool IsPartOfTrust => !string.IsNullOrEmpty(TrustCompanyNumber);
     public FederationSchool[] FederationSchools { get; set; } = [];
 }

--- a/web/src/Web.App/ViewModels/SchoolDeploymentPlanViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolDeploymentPlanViewModel.cs
@@ -7,7 +7,7 @@ namespace Web.App.ViewModels;
 public class SchoolDeploymentPlanViewModel(School school, DeploymentPlan plan)
 {
     public string? Name => school.SchoolName;
-    public bool IsPrimary => school.IsPrimary;
+    public bool IsPrimaryOrNursery => school.IsPrimaryOrNursery;
     public int Year => plan.Year;
     public string? Urn => plan.URN;
     public int TotalIncome => plan.TotalIncome;
@@ -35,7 +35,7 @@ public class SchoolDeploymentPlanViewModel(School school, DeploymentPlan plan)
     public decimal TotalPupils => plan.TotalPupils;
     public decimal TotalTeachingAssistants => plan.TotalTeachingAssistants;
     public decimal TotalTeachingPeriods => plan.TotalTeachingPeriods;
-    public string ChartData => IsPrimary
+    public string ChartData => IsPrimaryOrNursery
         ? PrimaryStaffDeployment.Select((x, i) => new
         {
             group = x.Description,

--- a/web/src/Web.App/Views/SchoolPlanning/View.cshtml
+++ b/web/src/Web.App/Views/SchoolPlanning/View.cshtml
@@ -36,7 +36,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <h2 class="govuk-heading-m">Staff deployment</h2>
-        @if (Model.IsPrimary)
+        @if (Model.IsPrimaryOrNursery)
         {
             @await Html.PartialAsync("_StaffDeploymentPrimary", Model)
         }

--- a/web/src/Web.App/Views/SchoolPlanning/_CalculateFinancialMetrics.cshtml
+++ b/web/src/Web.App/Views/SchoolPlanning/_CalculateFinancialMetrics.cshtml
@@ -49,7 +49,7 @@
             @Model.AverageTeacherCost.ToCurrency()
         </td>
     </tr>
-    @if (Model.IsPrimary)
+    @if (Model.IsPrimaryOrNursery)
     {
         <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header">Average teaching assistant cost</th>

--- a/web/src/Web.App/Views/SchoolPlanning/_InputMetrics.cshtml
+++ b/web/src/Web.App/Views/SchoolPlanning/_InputMetrics.cshtml
@@ -37,7 +37,7 @@
             </a>
         </td>
     </tr>
-    @if (Model.IsPrimary)
+    @if (Model.IsPrimaryOrNursery)
     {
         <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header">Total education support staff costs</th>

--- a/web/src/Web.App/Views/SchoolPlanningCreate/ManagementRoles.cshtml
+++ b/web/src/Web.App/Views/SchoolPlanningCreate/ManagementRoles.cshtml
@@ -35,7 +35,7 @@
                             <span class="govuk-visually-hidden">Error:</span> @ViewData.ModelState["ManagementRoles"]?.Errors.First().ErrorMessage
                         </p>
                     }
-                    @if (Model.School.IsPrimary)
+                    @if (Model.School.IsPrimaryOrNursery)
                     {
                         @await Html.PartialAsync("_ManagementRolesPrimary", Model)
                     }

--- a/web/src/Web.App/Views/SchoolPlanningCreate/PrePopulateData.cshtml
+++ b/web/src/Web.App/Views/SchoolPlanningCreate/PrePopulateData.cshtml
@@ -45,7 +45,7 @@
                     @Model.Expenditure?.TeachingStaffCosts.ToCurrency(0)
                 </dd>
             </div>
-            @if (Model.School.IsPrimary)
+            @if (Model.School.IsPrimaryOrNursery)
             {
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__key">

--- a/web/src/Web.App/Views/SchoolPlanningCreate/TeacherPeriodAllocation.cshtml
+++ b/web/src/Web.App/Views/SchoolPlanningCreate/TeacherPeriodAllocation.cshtml
@@ -34,7 +34,7 @@
                         </p>
                     </div>
 
-                    @if (Model.School.IsPrimary)
+                    @if (Model.School.IsPrimaryOrNursery)
                     {
                         @await Html.PartialAsync("_TeacherPeriodAllocationPrimary", Model)
                     }

--- a/web/tests/Web.Integration.Tests/Pages/Schools/FinancialPlanning/WhenViewingPlanningPrimaryPupilFigures.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/FinancialPlanning/WhenViewingPlanningPrimaryPupilFigures.cs
@@ -14,13 +14,17 @@ public class WhenViewingPlanningPrimaryPupilFigures(SchoolBenchmarkingWebAppClie
         DateTime.UtcNow.Month < 9 ? DateTime.UtcNow.Year - 1 : DateTime.UtcNow.Year;
 
     [Theory]
-    [InlineData(EstablishmentTypes.Academies, true)]
-    [InlineData(EstablishmentTypes.Academies, false)]
-    [InlineData(EstablishmentTypes.Maintained, true)]
-    [InlineData(EstablishmentTypes.Maintained, false)]
-    public async Task CanDisplay(string financeType, bool hasMixedAge)
+    [InlineData(EstablishmentTypes.Academies, true, OverallPhaseTypes.Primary)]
+    [InlineData(EstablishmentTypes.Academies, true, OverallPhaseTypes.Nursery)]
+    [InlineData(EstablishmentTypes.Academies, false, OverallPhaseTypes.Primary)]
+    [InlineData(EstablishmentTypes.Academies, false, OverallPhaseTypes.Nursery)]
+    [InlineData(EstablishmentTypes.Maintained, true, OverallPhaseTypes.Primary)]
+    [InlineData(EstablishmentTypes.Maintained, true, OverallPhaseTypes.Nursery)]
+    [InlineData(EstablishmentTypes.Maintained, false, OverallPhaseTypes.Primary)]
+    [InlineData(EstablishmentTypes.Maintained, false, OverallPhaseTypes.Nursery)]
+    public async Task CanDisplay(string financeType, bool hasMixedAge, string overallPhase)
     {
-        var (page, school, plan) = await SetupNavigateInitPage(financeType, hasMixedAge);
+        var (page, school, plan) = await SetupNavigateInitPage(financeType, hasMixedAge, overallPhase);
 
         AssertPageLayout(page, school, plan);
     }
@@ -65,7 +69,7 @@ public class WhenViewingPlanningPrimaryPupilFigures(SchoolBenchmarkingWebAppClie
     [InlineData(false)]
     public async Task CanDisplayNotFoundOnSubmit(bool hasMixed)
     {
-        var (page, school, _) = await SetupNavigateInitPage(EstablishmentTypes.Academies, hasMixed);
+        var (page, school, _) = await SetupNavigateInitPage(EstablishmentTypes.Academies, hasMixed, OverallPhaseTypes.Primary);
         var action = page.QuerySelector("main .govuk-button");
 
         Assert.NotNull(action);
@@ -129,7 +133,7 @@ public class WhenViewingPlanningPrimaryPupilFigures(SchoolBenchmarkingWebAppClie
             .Without(x => x.PupilsYear5)
             .Without(x => x.PupilsYear6);
 
-        var (page, school, plan) = await SetupNavigateInitPage(EstablishmentTypes.Academies, false, composer);
+        var (page, school, plan) = await SetupNavigateInitPage(EstablishmentTypes.Academies, false, OverallPhaseTypes.Primary, composer);
         AssertPageLayout(page, school, plan);
         var action = page.QuerySelector("main .govuk-button");
         Assert.NotNull(action);
@@ -182,7 +186,7 @@ public class WhenViewingPlanningPrimaryPupilFigures(SchoolBenchmarkingWebAppClie
             .Without(x => x.PupilsMixedYear4Year5)
             .Without(x => x.PupilsMixedYear5Year6);
 
-        var (page, school, plan) = await SetupNavigateInitPage(EstablishmentTypes.Academies, true, composer);
+        var (page, school, plan) = await SetupNavigateInitPage(EstablishmentTypes.Academies, true, OverallPhaseTypes.Primary, composer);
         AssertPageLayout(page, school, plan);
         var action = page.QuerySelector("main .govuk-button");
         Assert.NotNull(action);
@@ -205,12 +209,12 @@ public class WhenViewingPlanningPrimaryPupilFigures(SchoolBenchmarkingWebAppClie
     }
 
     private async Task<(IHtmlDocument page, School school, FinancialPlanInput plan)> SetupNavigateInitPage(
-        string financeType, bool hasMixedClasses, IPostprocessComposer<FinancialPlanInput>? planComposer = null)
+        string financeType, bool hasMixedClasses, string overallPhase, IPostprocessComposer<FinancialPlanInput>? planComposer = null)
     {
         var school = Fixture.Build<School>()
             .With(x => x.URN, "12345")
             .With(x => x.FinanceType, financeType)
-            .With(x => x.OverallPhase, OverallPhaseTypes.Primary)
+            .With(x => x.OverallPhase, overallPhase)
             .Create();
 
         planComposer ??= Fixture.Build<FinancialPlanInput>();

--- a/web/tests/Web.Integration.Tests/Pages/Schools/FinancialPlanning/WhenViewingPlanningTeacherPeriodAllocation.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/FinancialPlanning/WhenViewingPlanningTeacherPeriodAllocation.cs
@@ -20,11 +20,11 @@ public class WhenViewingPlanningTeacherPeriodAllocation(SchoolBenchmarkingWebApp
     [InlineData(EstablishmentTypes.Academies, OverallPhaseTypes.Primary)]
     [InlineData(EstablishmentTypes.Maintained, OverallPhaseTypes.Secondary)]
     [InlineData(EstablishmentTypes.Maintained, OverallPhaseTypes.Primary)]
-    public async Task CanDisplay(string financeType, string phase)
+    public async Task CanDisplay(string financeType, string overallPhase)
     {
-        var (page, school) = await SetupNavigateInitPage(financeType, phase);
+        var (page, school) = await SetupNavigateInitPage(financeType, overallPhase);
 
-        AssertPageLayout(page, school);
+        AssertPageLayout(page, school, overallPhase);
     }
 
     /*[Fact]
@@ -120,13 +120,13 @@ public class WhenViewingPlanningTeacherPeriodAllocation(SchoolBenchmarkingWebApp
         return (page, school);
     }
 
-    private static void AssertPageLayout(IHtmlDocument page, School school)
+    private static void AssertPageLayout(IHtmlDocument page, School school, string overallPhase)
     {
-        var expectBack = school.IsPrimary
+        var expectedBackLink = overallPhase is OverallPhaseTypes.Primary or OverallPhaseTypes.Nursery
             ? Paths.SchoolFinancialPlanningPrimaryPupilFigures(school.URN, CurrentYear).ToAbsolute()
             : Paths.SchoolFinancialPlanningPupilFigures(school.URN, CurrentYear).ToAbsolute();
 
-        DocumentAssert.BackLink(page, "Back", expectBack);
+        DocumentAssert.BackLink(page, "Back", expectedBackLink);
         DocumentAssert.TitleAndH1(page,
             "What are your teacher period allocation figures? - Financial Benchmarking and Insights Tool - GOV.UK",
             "What are your teacher period allocation figures?");

--- a/web/tests/Web.Integration.Tests/Pages/Schools/FinancialPlanning/WhenViewingPlanningTotalNumberTeachers.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/FinancialPlanning/WhenViewingPlanningTotalNumberTeachers.cs
@@ -12,15 +12,17 @@ public class WhenViewingPlanningTotalNumberTeachers(SchoolBenchmarkingWebAppClie
     private static readonly int CurrentYear = DateTime.UtcNow.Month < 9 ? DateTime.UtcNow.Year - 1 : DateTime.UtcNow.Year;
 
     [Theory]
-    [InlineData(EstablishmentTypes.Academies, true)]
-    [InlineData(EstablishmentTypes.Academies, false)]
-    [InlineData(EstablishmentTypes.Maintained, true)]
-    [InlineData(EstablishmentTypes.Maintained, false)]
-    public async Task CanDisplay(string financeType, bool isPrimary)
+    [InlineData(EstablishmentTypes.Academies, OverallPhaseTypes.Primary)]
+    [InlineData(EstablishmentTypes.Academies, OverallPhaseTypes.Nursery)]
+    [InlineData(EstablishmentTypes.Academies, OverallPhaseTypes.Secondary)]
+    [InlineData(EstablishmentTypes.Maintained, OverallPhaseTypes.Primary)]
+    [InlineData(EstablishmentTypes.Maintained, OverallPhaseTypes.Nursery)]
+    [InlineData(EstablishmentTypes.Maintained, OverallPhaseTypes.Secondary)]
+    public async Task CanDisplay(string financeType, string overallPhase)
     {
-        var (page, school) = await SetupNavigateInitPage(financeType, isPrimary);
+        var (page, school) = await SetupNavigateInitPage(financeType, overallPhase);
 
-        AssertPageLayout(page, school);
+        AssertPageLayout(page, school, overallPhase);
     }
 
     /*
@@ -48,8 +50,9 @@ public class WhenViewingPlanningTotalNumberTeachers(SchoolBenchmarkingWebAppClie
     [InlineData(EstablishmentTypes.Maintained)]
     public async Task CanSubmit(string financeType)
     {
-        var (page, school) = await SetupNavigateInitPage(financeType, false);
-        AssertPageLayout(page, school);
+        const string overallPhase = OverallPhaseTypes.Secondary;
+        var (page, school) = await SetupNavigateInitPage(financeType, overallPhase);
+        AssertPageLayout(page, school, overallPhase);
         var action = page.QuerySelector("main .govuk-button");
         Assert.NotNull(action);
 
@@ -86,7 +89,7 @@ public class WhenViewingPlanningTotalNumberTeachers(SchoolBenchmarkingWebAppClie
     [Fact]
     public async Task CanDisplayNotFoundOnSubmit()
     {
-        var (page, school) = await SetupNavigateInitPage(EstablishmentTypes.Academies, false);
+        var (page, school) = await SetupNavigateInitPage(EstablishmentTypes.Academies, OverallPhaseTypes.Secondary);
         var action = page.QuerySelector("main .govuk-button");
 
         Assert.NotNull(action);
@@ -118,7 +121,7 @@ public class WhenViewingPlanningTotalNumberTeachers(SchoolBenchmarkingWebAppClie
     [Fact]
     public async Task CanDisplayProblemWithServiceOnSubmit()
     {
-        var (page, school) = await SetupNavigateInitPage(EstablishmentTypes.Academies, false);
+        var (page, school) = await SetupNavigateInitPage(EstablishmentTypes.Academies, OverallPhaseTypes.Secondary);
         var action = page.QuerySelector("main .govuk-button");
 
         Assert.NotNull(action);
@@ -142,9 +145,9 @@ public class WhenViewingPlanningTotalNumberTeachers(SchoolBenchmarkingWebAppClie
     [InlineData(0.9)]
     public async Task ShowsErrorOnInValidSubmit(double? value)
     {
-
-        var (page, school) = await SetupNavigateInitPage(EstablishmentTypes.Academies, false);
-        AssertPageLayout(page, school);
+        const string overallPhase = OverallPhaseTypes.Secondary;
+        var (page, school) = await SetupNavigateInitPage(EstablishmentTypes.Academies, overallPhase);
+        AssertPageLayout(page, school, overallPhase);
         var action = page.QuerySelector("main .govuk-button");
         Assert.NotNull(action);
 
@@ -169,12 +172,12 @@ public class WhenViewingPlanningTotalNumberTeachers(SchoolBenchmarkingWebAppClie
         DocumentAssert.FormErrors(page, ("TotalNumberOfTeachersFte", expectedMsg));
     }
 
-    private async Task<(IHtmlDocument page, School school)> SetupNavigateInitPage(string financeType, bool isPrimary)
+    private async Task<(IHtmlDocument page, School school)> SetupNavigateInitPage(string financeType, string overallPhase)
     {
         var school = Fixture.Build<School>()
             .With(x => x.URN, "12345")
             .With(x => x.FinanceType, financeType)
-            .With(x => x.OverallPhase, isPrimary ? OverallPhaseTypes.Primary : OverallPhaseTypes.Secondary)
+            .With(x => x.OverallPhase, overallPhase)
             .Create();
 
         var plan = Fixture.Build<FinancialPlanInput>()
@@ -191,9 +194,9 @@ public class WhenViewingPlanningTotalNumberTeachers(SchoolBenchmarkingWebAppClie
         return (page, school);
     }
 
-    private static void AssertPageLayout(IHtmlDocument page, School school)
+    private static void AssertPageLayout(IHtmlDocument page, School school, string overallPhase)
     {
-        var expectedBackLink = school.IsPrimary
+        var expectedBackLink = overallPhase is OverallPhaseTypes.Primary or OverallPhaseTypes.Nursery
             ? Paths.SchoolFinancialPlanningTotalEducationSupport(school.URN, CurrentYear).ToAbsolute()
             : Paths.SchoolFinancialPlanningTotalTeacherCost(school.URN, CurrentYear).ToAbsolute();
 


### PR DESCRIPTION
### Context
AB#254433 AB#256043

### Change proposed in this pull request
- Ensured `Nursery` journey through CFP is the same as `Primary` overall phase type
- Integration test updates

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

