### PR TITLE
Exclude schools with missing financial data from user defined comparator set creation

### DIFF
--- a/core-infrastructure/src/db/Core.Database/Views/020-SchoolSummary.sql
+++ b/core-infrastructure/src/db/Core.Database/Views/020-SchoolSummary.sql
@@ -1,0 +1,15 @@
+CREATE VIEW VW_SchoolSummary
+AS
+    SELECT s.URN,
+           s.SchoolName,
+           s.AddressStreet,
+           s.AddressLocality,
+           s.AddressLine3,
+           s.AddressTown,
+           s.AddressCounty,
+           s.AddressPostcode,
+           s.OverallPhase,
+           f.PeriodCoveredByReturn
+    FROM School s
+             LEFT JOIN CurrentDefaultFinancial f on f.URN = s.URN
+GO

--- a/core-infrastructure/src/db/Core.Database/Views/021-SchoolSummary.sql
+++ b/core-infrastructure/src/db/Core.Database/Views/021-SchoolSummary.sql
@@ -1,3 +1,6 @@
+DROP VIEW IF EXISTS VW_SchoolSummary
+GO
+
 CREATE VIEW VW_SchoolSummary
 AS
     SELECT s.URN,

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -829,7 +829,8 @@ if (spendingAndCostsComposedElements) {
 
 const schoolSuggesterElement = document.getElementById(SchoolSuggesterId);
 if (schoolSuggesterElement) {
-  const { input, urn, exclude } = schoolSuggesterElement.dataset;
+  const { input, urn, exclude, excludeMissingFinancialData } =
+    schoolSuggesterElement.dataset;
   const root = ReactDOM.createRoot(schoolSuggesterElement);
   root.render(
     <React.StrictMode>
@@ -837,6 +838,9 @@ if (schoolSuggesterElement) {
         input={input || ""}
         urn={urn || ""}
         exclude={exclude ? exclude.split(",") : undefined}
+        excludeMissingFinancialData={
+          excludeMissingFinancialData === "true" ? true : undefined
+        }
       />
     </React.StrictMode>
   );

--- a/front-end-components/src/views/find-organisation/partials/school-input.tsx
+++ b/front-end-components/src/views/find-organisation/partials/school-input.tsx
@@ -9,7 +9,7 @@ import { v4 as uuidv4 } from "uuid";
 import { suggestionFormatter } from "../utils";
 
 const SchoolInput: React.FunctionComponent<SchoolInputProps> = (props) => {
-  const { input, urn, exclude } = props;
+  const { input, urn, exclude, excludeMissingFinancialData } = props;
   const [inputValue, setInputValue] = useState<string>(input);
   const [selectedUrn, setSelectedUrn] = useState<string>(urn);
 
@@ -18,10 +18,18 @@ const SchoolInput: React.FunctionComponent<SchoolInputProps> = (props) => {
       type: "school",
       search: query,
     });
+
     if (exclude) {
       exclude.forEach((e) => {
         params.append("exclude", e);
       });
+    }
+
+    if (excludeMissingFinancialData) {
+      params.append(
+        "excludeMissingFinancialData",
+        excludeMissingFinancialData.toString().toLowerCase()
+      );
     }
 
     try {

--- a/front-end-components/src/views/find-organisation/types.tsx
+++ b/front-end-components/src/views/find-organisation/types.tsx
@@ -21,6 +21,7 @@ export type SchoolInputProps = {
   input: string;
   urn: string;
   exclude?: string[];
+  excludeMissingFinancialData?: boolean;
 };
 
 export type SuggestResult<T> = {

--- a/platform/Platform.sln.DotSettings
+++ b/platform/Platform.sln.DotSettings
@@ -3,6 +3,8 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_INITIALIZER_ON_SINGLE_LINE/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARRAY_INITIALIZER_STYLE/@EntryValue">WRAP_IF_LONG</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=FTE/@EntryIndexedValue">FTE</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LA/@EntryIndexedValue">LA</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=URN/@EntryIndexedValue">URN</s:String>
 	<s:Boolean x:Key="/Default/Environment/Filtering/FileMasksToExclude/=_002A_002Eg_002Ecs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>

--- a/platform/src/abstractions/Platform.Domain/Characteristics.cs
+++ b/platform/src/abstractions/Platform.Domain/Characteristics.cs
@@ -80,6 +80,58 @@ public static class ExpressionBuilder
         return list;
     }
 
+    public static List<string> NotValuesFilter(this List<string> list, string fieldName, CharacteristicList? characteristic)
+    {
+        if (characteristic is not null)
+        {
+            list.Add($"({string.Join(") and (", characteristic.Values.Select(a => $"{fieldName} ne '{a}'"))})");
+        }
+
+        return list;
+    }
+
+    public static List<string> NullValueFilter(this List<string> list, string fieldName)
+    {
+        list.Add($"({fieldName} eq null)");
+        return list;
+    }
+
+    public static List<string> NotNullValueFilter(this List<string> list, string fieldName)
+    {
+        list.Add($"({fieldName} ne null)");
+        return list;
+    }
+
+    public static List<string> ConditionalValueFilter(this List<string> list, string fieldName, bool? condition, string expressionIfTrue, string? expressionIfFalse = null)
+    {
+        switch (condition)
+        {
+            case true when !string.IsNullOrEmpty(expressionIfTrue):
+                list.Add($"({fieldName} {expressionIfTrue})");
+                break;
+            case false when !string.IsNullOrEmpty(expressionIfFalse):
+                list.Add($"({fieldName} {expressionIfFalse})");
+                break;
+        }
+
+        return list;
+    }
+
+    public static List<string> ConditionalExpressionFilter(this List<string> list, bool? condition, Func<List<string>, List<string>>? expressionIfTrue, Func<List<string>, List<string>>? expressionIfFalse = null)
+    {
+        switch (condition)
+        {
+            case true:
+                expressionIfTrue?.Invoke(list);
+                break;
+            case false:
+                expressionIfFalse?.Invoke(list);
+                break;
+        }
+
+        return list;
+    }
+
     public static string BuildFilter(this List<string> list) => string.Join(" and ", list);
 
     public static List<string> ListSearch(this List<string> list, string fieldName, CharacteristicList? characteristic)

--- a/platform/src/apis/Platform.Api.Establishment/Features/Schools/Requests/SchoolComparatorsRequest.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Schools/Requests/SchoolComparatorsRequest.cs
@@ -41,6 +41,7 @@ public record SchoolComparatorsRequest
 
     public string FilterExpression(string urn) => new List<string>()
         .NotValueFilter("URN", urn)
+        .NotNullValueFilter("PeriodCoveredByReturn")
         .RangeFilter(nameof(TotalPupils), TotalPupils)
         .RangeFilter(nameof(BuildingAverageAge), BuildingAverageAge)
         .RangeFilter(nameof(TotalInternalFloorArea), TotalInternalFloorArea)

--- a/platform/src/apis/Platform.Api.Establishment/Features/Schools/Requests/SchoolSuggestRequest.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Schools/Requests/SchoolSuggestRequest.cs
@@ -1,6 +1,11 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Platform.Domain;
 using Platform.Infrastructure;
 using Platform.Search;
+
+// ReSharper disable AutoPropertyCanBeMadeGetOnly.Global
+// ReSharper disable MemberCanBePrivate.Global
 
 namespace Platform.Api.Establishment.Features.Schools.Requests;
 
@@ -8,6 +13,16 @@ namespace Platform.Api.Establishment.Features.Schools.Requests;
 public record SchoolSuggestRequest : SuggestRequest
 {
     public override string SuggesterName => ResourceNames.Search.Suggesters.School;
-
     public string[] Exclude { get; set; } = [];
+    public bool ExcludeMissingFinancialData { get; set; } = false;
+
+    public string FilterExpression() => new List<string>()
+        .NotValuesFilter("URN", Exclude.Length > 0
+            ? new CharacteristicList
+            {
+                Values = Exclude
+            }
+            : null)
+        .ConditionalExpressionFilter(ExcludeMissingFinancialData, x => x.NotNullValueFilter("PeriodCoveredByReturn"))
+        .BuildFilter();
 }

--- a/platform/src/apis/Platform.Api.Establishment/Features/Schools/Services/SchoolsService.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Schools/Services/SchoolsService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Platform.Api.Establishment.Features.Schools.Models;

--- a/platform/src/apis/Platform.Api.Establishment/Features/Schools/Services/SchoolsService.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Schools/Services/SchoolsService.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Platform.Api.Establishment.Features.Schools.Models;
@@ -59,14 +58,7 @@ public class SchoolsService(
             nameof(School.AddressPostcode)
         };
 
-        return SuggestAsync(request, CreateFilterExpression, fields);
-
-        string? CreateFilterExpression()
-        {
-            return request.Exclude is not { Length: > 0 }
-                ? null
-                : $"({string.Join(") and ( ", request.Exclude.Select(a => $"URN ne '{a}'"))})";
-        }
+        return SuggestAsync(request, request.FilterExpression, fields);
     }
 
     public Task<SearchResponse<School>> SchoolsSearchAsync(SearchRequest request)

--- a/platform/src/search/Platform.Search.Resources/School/SchoolDataSourceConnectionBuilder.cs
+++ b/platform/src/search/Platform.Search.Resources/School/SchoolDataSourceConnectionBuilder.cs
@@ -7,16 +7,16 @@ namespace Platform.Search.Resources.School;
 
 public class SchoolDataSourceConnectionBuilder(string? connectionString) : DataSourceConnectionBuilder
 {
-    public override string Name => ResourceNames.Search.DataSources.School;
     private readonly string _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
+    public override string Name => ResourceNames.Search.DataSources.School;
 
     public override async Task Build(SearchIndexerClient client)
     {
         var dataSource = new SearchIndexerDataSourceConnection(
-            name: Name,
-            type: SearchIndexerDataSourceType.AzureSql,
-            connectionString: _connectionString,
-            container: new SearchIndexerDataContainer("School"));
+            Name,
+            SearchIndexerDataSourceType.AzureSql,
+            _connectionString,
+            new SearchIndexerDataContainer("VW_SchoolSummary"));
 
         await client.CreateOrUpdateDataSourceConnectionAsync(dataSource);
     }

--- a/platform/src/search/Platform.Search.Resources/School/SchoolIndex.cs
+++ b/platform/src/search/Platform.Search.Resources/School/SchoolIndex.cs
@@ -1,4 +1,5 @@
 using Azure.Search.Documents.Indexes;
+// ReSharper disable UnusedMember.Global
 
 namespace Platform.Search.Resources.School;
 
@@ -30,4 +31,7 @@ public class SchoolIndex
 
     [SimpleField(IsFilterable = true, IsSortable = false, IsFacetable = true)]
     public string? OverallPhase { get; set; }
+
+    [SimpleField(IsFilterable = true, IsFacetable = false, IsSortable = false)]
+    public int? PeriodCoveredByReturn { get; set; }
 }

--- a/platform/src/search/Platform.Search.Resources/SchoolComparators/SchoolComparatorsIndex.cs
+++ b/platform/src/search/Platform.Search.Resources/SchoolComparators/SchoolComparatorsIndex.cs
@@ -1,5 +1,6 @@
 using Azure.Search.Documents.Indexes;
 using Azure.Search.Documents.Indexes.Models;
+// ReSharper disable UnusedMember.Global
 
 namespace Platform.Search.Resources.SchoolComparators;
 
@@ -91,4 +92,7 @@ public class SchoolComparatorsIndex
 
     [SimpleField(IsFilterable = true, IsFacetable = false, IsSortable = false)]
     public double? PercentWithASD { get; set; }
+
+    [SimpleField(IsFilterable = true, IsFacetable = false, IsSortable = false)]
+    public int? PeriodCoveredByReturn { get; set; }
 }

--- a/web/src/Web.App/Controllers/Api/SuggestProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/SuggestProxyController.cs
@@ -17,7 +17,11 @@ public class SuggestProxyController(
     [ProducesResponseType<IEnumerable<SuggestValue<Trust>>>(StatusCodes.Status200OK)]
     [ProducesResponseType<IEnumerable<SuggestValue<School>>>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> Suggest([FromQuery] string search, [FromQuery] string type, [FromQuery] string[]? exclude = null)
+    public async Task<IActionResult> Suggest(
+        [FromQuery] string search,
+        [FromQuery] string type,
+        [FromQuery] string[]? exclude = null,
+        [FromQuery] bool? excludeMissingFinancialData = null)
     {
         using (logger.BeginScope(new
         {
@@ -29,7 +33,7 @@ public class SuggestProxyController(
                 switch (type.ToLower())
                 {
                     case OrganisationTypes.School:
-                        var schools = await suggestService.SchoolSuggestions(search, exclude);
+                        var schools = await suggestService.SchoolSuggestions(search, exclude, excludeMissingFinancialData == true);
                         return new JsonResult(schools);
                     case OrganisationTypes.Trust:
                         var trusts = await suggestService.TrustSuggestions(search, exclude);

--- a/web/src/Web.App/Infrastructure/Apis/ApiRequests/SchoolSuggestRequest.cs
+++ b/web/src/Web.App/Infrastructure/Apis/ApiRequests/SchoolSuggestRequest.cs
@@ -1,0 +1,10 @@
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+namespace Web.App.Infrastructure.Apis;
+
+public record SchoolSuggestRequest
+{
+    public string? SearchText { get; set; }
+    public int? Size { get; set; }
+    public string[]? Exclude { get; set; }
+    public bool? ExcludeMissingFinancialData { get; set; }
+}

--- a/web/src/Web.App/Infrastructure/Apis/Establishment/EstablishmentApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Establishment/EstablishmentApi.cs
@@ -32,13 +32,19 @@ public class EstablishmentApi(HttpClient httpClient, string? key = default) : Ap
         return GetAsync(Api.Establishment.LocalAuthorities);
     }
 
-    public Task<ApiResult> SuggestSchools(string search, string[]? exclude = null)
+    public Task<ApiResult> SuggestSchools(string search, string[]? exclude = null, bool? excludeMissingFinancialData = null)
     {
         return SendAsync(new HttpRequestMessage
         {
             Method = HttpMethod.Post,
             RequestUri = new Uri($"{Api.Establishment.SchoolSuggest}", UriKind.Relative),
-            Content = new JsonContent(new { SearchText = search, Size = 10, Exclude = exclude })
+            Content = new JsonContent(new SchoolSuggestRequest
+            {
+                SearchText = search,
+                Size = 10,
+                Exclude = exclude,
+                ExcludeMissingFinancialData = excludeMissingFinancialData
+            })
         });
     }
 
@@ -71,7 +77,7 @@ public interface IEstablishmentApi
     Task<ApiResult> GetLocalAuthorityStatisticalNeighbours(string? identifier);
     Task<ApiResult> GetLocalAuthoritiesNationalRank(ApiQuery? query = null, CancellationToken cancellationToken = default);
     Task<ApiResult> GetLocalAuthorities();
-    Task<ApiResult> SuggestSchools(string search, string[]? exclude = null);
+    Task<ApiResult> SuggestSchools(string search, string[]? exclude = null, bool? excludeMissingFinancialData = null);
     Task<ApiResult> SuggestTrusts(string search, string[]? exclude = null);
     Task<ApiResult> SuggestLocalAuthorities(string search, string[]? exclude = null);
 }

--- a/web/src/Web.App/Services/SuggestService.cs
+++ b/web/src/Web.App/Services/SuggestService.cs
@@ -7,16 +7,16 @@ namespace Web.App.Services;
 
 public interface ISuggestService
 {
-    Task<IEnumerable<SuggestValue<School>>> SchoolSuggestions(string search, string[]? excludeSchools = null);
+    Task<IEnumerable<SuggestValue<School>>> SchoolSuggestions(string search, string[]? excludeSchools = null, bool? excludeMissingFinancialData = null);
     Task<IEnumerable<SuggestValue<Trust>>> TrustSuggestions(string search, string[]? excludeTrusts = null);
     Task<IEnumerable<SuggestValue<LocalAuthority>>> LocalAuthoritySuggestions(string search, string[]? excludeLas = null);
 }
 
 public class SuggestService(IEstablishmentApi establishmentApi) : ISuggestService
 {
-    public async Task<IEnumerable<SuggestValue<School>>> SchoolSuggestions(string search, string[]? excludeSchools = null)
+    public async Task<IEnumerable<SuggestValue<School>>> SchoolSuggestions(string search, string[]? excludeSchools = null, bool? excludeMissingFinancialData = null)
     {
-        var suggestions = await establishmentApi.SuggestSchools(search, excludeSchools).GetResultOrThrow<SuggestOutput<School>>();
+        var suggestions = await establishmentApi.SuggestSchools(search, excludeSchools, excludeMissingFinancialData).GetResultOrThrow<SuggestOutput<School>>();
         return suggestions.Results.Select(SchoolSuggestValue);
     }
 

--- a/web/src/Web.App/Views/SchoolComparatorsCreateBy/Name.cshtml
+++ b/web/src/Web.App/Views/SchoolComparatorsCreateBy/Name.cshtml
@@ -32,7 +32,7 @@
             <p class="govuk-body govuk-hint">Search by name, address, postcode or unique reference number (URN)</p>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-three-quarters">
-                    <div id="school-suggester" data-exclude="@(string.Join(",", Model.ExcludeUrns))"></div>
+                    <div id="school-suggester" data-exclude="@(string.Join(",", Model.ExcludeUrns))" data-exclude-missing-financial-data="true"></div>
                 </div>
                 <div class="govuk-grid-column-one-quarter">
                     <button

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -229,7 +229,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         EstablishmentApi.Setup(api => api.GetLocalAuthority(It.IsAny<string>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.GetLocalAuthorityStatisticalNeighbours(It.IsAny<string>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.GetLocalAuthorities()).Throws(new Exception());
-        EstablishmentApi.Setup(api => api.SuggestSchools(It.IsAny<string>(), It.IsAny<string[]?>())).Throws(new Exception());
+        EstablishmentApi.Setup(api => api.SuggestSchools(It.IsAny<string>(), It.IsAny<string[]?>(), It.IsAny<bool?>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.SuggestTrusts(It.IsAny<string>(), It.IsAny<string[]?>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.SuggestLocalAuthorities(It.IsAny<string>(), It.IsAny<string[]?>())).Throws(new Exception());
         return this;

--- a/web/tests/Web.Tests/Infrastructure/GivenAnEstablishmentApi.cs
+++ b/web/tests/Web.Tests/Infrastructure/GivenAnEstablishmentApi.cs
@@ -72,6 +72,19 @@ public class GivenAnEstablishmentApi(ITestOutputHelper testOutputHelper) : ApiCl
     }
 
     [Fact]
+    public async Task SuggestSchoolsWithFinancialExclusionShouldCallCorrectUrl()
+    {
+        var api = new EstablishmentApi(HttpClient);
+
+        await api.SuggestSchools("term", null, true);
+
+        VerifyCall(
+            HttpMethod.Post,
+            "api/schools/suggest",
+            "{\"searchText\":\"term\",\"size\":10,\"excludeMissingFinancialData\":true}");
+    }
+
+    [Fact]
     public async Task SuggestTrustsShouldCallCorrectUrl()
     {
         var api = new EstablishmentApi(HttpClient);

--- a/web/tests/Web.Tests/Services/WhenSchoolSuggestionsIsCalled.cs
+++ b/web/tests/Web.Tests/Services/WhenSchoolSuggestionsIsCalled.cs
@@ -28,7 +28,7 @@ public class WhenSchoolSuggestionsIsCalled
             Results = [value]
         };
 
-        _api.Setup(x => x.SuggestSchools(It.IsAny<string>(), It.IsAny<string[]?>())).ReturnsAsync(ApiResult.Ok(response));
+        _api.Setup(x => x.SuggestSchools(It.IsAny<string>(), It.IsAny<string[]?>(), It.IsAny<bool?>())).ReturnsAsync(ApiResult.Ok(response));
 
         var service = new SuggestService(_api.Object);
         var actual = await service.SchoolSuggestions("school");
@@ -53,7 +53,7 @@ public class WhenSchoolSuggestionsIsCalled
             Results = [value]
         };
 
-        _api.Setup(x => x.SuggestSchools(It.IsAny<string>(), It.IsAny<string[]?>())).ReturnsAsync(ApiResult.Ok(response));
+        _api.Setup(x => x.SuggestSchools(It.IsAny<string>(), It.IsAny<string[]?>(), It.IsAny<bool?>())).ReturnsAsync(ApiResult.Ok(response));
 
         var service = new SuggestService(_api.Object);
         var actual = await service.SchoolSuggestions("school");
@@ -78,7 +78,7 @@ public class WhenSchoolSuggestionsIsCalled
             Results = [value]
         };
 
-        _api.Setup(x => x.SuggestSchools(It.IsAny<string>(), It.IsAny<string[]?>())).ReturnsAsync(ApiResult.Ok(response));
+        _api.Setup(x => x.SuggestSchools(It.IsAny<string>(), It.IsAny<string[]?>(), It.IsAny<bool?>())).ReturnsAsync(ApiResult.Ok(response));
 
         var service = new SuggestService(_api.Object);
         var actual = await service.SchoolSuggestions("school");
@@ -103,7 +103,7 @@ public class WhenSchoolSuggestionsIsCalled
             Results = [value]
         };
 
-        _api.Setup(x => x.SuggestSchools(It.IsAny<string>(), It.IsAny<string[]?>())).ReturnsAsync(ApiResult.Ok(response));
+        _api.Setup(x => x.SuggestSchools(It.IsAny<string>(), It.IsAny<string[]?>(), It.IsAny<bool?>())).ReturnsAsync(ApiResult.Ok(response));
 
         var service = new SuggestService(_api.Object);
         var actual = await service.SchoolSuggestions("school");
@@ -128,7 +128,7 @@ public class WhenSchoolSuggestionsIsCalled
             Results = [value]
         };
 
-        _api.Setup(x => x.SuggestSchools(It.IsAny<string>(), It.IsAny<string[]?>())).ReturnsAsync(ApiResult.Ok(response));
+        _api.Setup(x => x.SuggestSchools(It.IsAny<string>(), It.IsAny<string[]?>(), It.IsAny<bool?>())).ReturnsAsync(ApiResult.Ok(response));
 
         var service = new SuggestService(_api.Object);
         var actual = await service.SchoolSuggestions("school");
@@ -153,7 +153,7 @@ public class WhenSchoolSuggestionsIsCalled
             Results = [value]
         };
 
-        _api.Setup(x => x.SuggestSchools(It.IsAny<string>(), It.IsAny<string[]?>())).ReturnsAsync(ApiResult.Ok(response));
+        _api.Setup(x => x.SuggestSchools(It.IsAny<string>(), It.IsAny<string[]?>(), It.IsAny<bool?>())).ReturnsAsync(ApiResult.Ok(response));
 
         var service = new SuggestService(_api.Object);
         var actual = await service.SchoolSuggestions("school");
@@ -178,7 +178,7 @@ public class WhenSchoolSuggestionsIsCalled
             Results = [value]
         };
 
-        _api.Setup(x => x.SuggestSchools(It.IsAny<string>(), It.IsAny<string[]?>())).ReturnsAsync(ApiResult.Ok(response));
+        _api.Setup(x => x.SuggestSchools(It.IsAny<string>(), It.IsAny<string[]?>(), It.IsAny<bool?>())).ReturnsAsync(ApiResult.Ok(response));
 
         var service = new SuggestService(_api.Object);
         var actual = await service.SchoolSuggestions("school");
@@ -203,7 +203,7 @@ public class WhenSchoolSuggestionsIsCalled
             Results = [value]
         };
 
-        _api.Setup(x => x.SuggestSchools(It.IsAny<string>(), It.IsAny<string[]?>())).ReturnsAsync(ApiResult.Ok(response));
+        _api.Setup(x => x.SuggestSchools(It.IsAny<string>(), It.IsAny<string[]?>(), It.IsAny<bool?>())).ReturnsAsync(ApiResult.Ok(response));
 
         var service = new SuggestService(_api.Object);
         var actual = await service.SchoolSuggestions("school");


### PR DESCRIPTION
### Context
[AB#256180](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/256180) [AB#256183](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/256183) [AB#254434](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/254434)

### Change proposed in this pull request
- New `VW_SchoolSummary` view that includes `PeriodCoveredByReturn`
- Included `PeriodCoveredByReturn` in `SchoolIndex` and `SchoolComparatorsIndex`
- Ensured `PeriodCoveredByReturn ne null` for specific `SchoolIndex` suggest requests
- Ensured `PeriodCoveredByReturn ne null` for all `SchoolComparatorsIndex` search requests
- Wired up Web/proxy/component to ensure financial exclusions only set on Suggest requests from 'add comparator by name' page

### Guidance to review 
`front-end` will need to be built and copied to `Web` to validate locally. The changes to the indexes and data source (including new view) will also need to have been deployed to Azure search and a re-index completed. This has been done in the `d12` environment.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

