### PR TITLE
fix: correct file-integrity view

### DIFF
--- a/core-infrastructure/src/db/Core.Database/Views/020-FileIntegrity.sql
+++ b/core-infrastructure/src/db/Core.Database/Views/020-FileIntegrity.sql
@@ -24,7 +24,7 @@ CREATE VIEW FileIntegrity AS
                   HashAlgorithm,
                   Description,
                   CreatedAt,
-                  Row_Number() OVER (PARTITION BY DatasetShortCode ORDER BY DatasetYear DESC) AS rn
+                  Row_Number() OVER (PARTITION BY DatasetShortCode, DatasetYear ORDER BY DatasetYear DESC) AS rn
              FROM FileIntegrityHistory
          ) AS RankedHistory
      WHERE rn = 1


### PR DESCRIPTION
### Context

Previous view didn't properly partition the data to include the year.

[AB#249838](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/249838)

### Change proposed in this pull request

Correct data partition to include the year, resulting in the latest per data-type, _per year_.

### Guidance to review 

Validated locally with the data intended to populate these tables in the live service.

### Checklist (add/remove as appropriate)

- [ ] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally
- [ ] You have reviewed with UX/Design

