### PR TITLE
Included total pupils and education phase in results listing

### DIFF
--- a/core-infrastructure/src/db/Core.Database/Views/021-SchoolSummary.sql
+++ b/core-infrastructure/src/db/Core.Database/Views/021-SchoolSummary.sql
@@ -12,7 +12,8 @@ AS
            s.AddressCounty,
            s.AddressPostcode,
            s.OverallPhase,
-           f.PeriodCoveredByReturn
+           f.PeriodCoveredByReturn,
+           CONVERT(float, f.TotalPupils) AS TotalPupils
     FROM School s
              LEFT JOIN CurrentDefaultFinancial f on f.URN = s.URN
 GO

--- a/platform/src/apis/Platform.Api.Establishment/Features/Schools/Models/SchoolSummary.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Schools/Models/SchoolSummary.cs
@@ -20,6 +20,4 @@ public record SchoolSummary
     public string? OverallPhase { get; set; }
     public int? PeriodCoveredByReturn { get; set; }
     public double? TotalPupils { get; set; }
-
-    public string Address => string.Join(", ", new List<string?> { AddressStreet, AddressLocality, AddressLine3, AddressTown, AddressCounty, AddressPostcode }.Where(x => !string.IsNullOrEmpty(x)));
 }

--- a/platform/src/apis/Platform.Api.Establishment/Features/Schools/Models/SchoolSummary.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Schools/Models/SchoolSummary.cs
@@ -1,7 +1,12 @@
-﻿// ReSharper disable ClassNeverInstantiated.Global
-// ReSharper disable UnusedAutoPropertyAccessor.Global
-namespace Web.App.Domain;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+// ReSharper disable ClassNeverInstantiated.Global
+// ReSharper disable UnusedMember.Global
 
+namespace Platform.Api.Establishment.Features.Schools.Models;
+
+[ExcludeFromCodeCoverage]
 public record SchoolSummary
 {
     public string? URN { get; set; }
@@ -15,5 +20,6 @@ public record SchoolSummary
     public string? OverallPhase { get; set; }
     public int? PeriodCoveredByReturn { get; set; }
     public double? TotalPupils { get; set; }
-    public string? Address { get; set; }
-};
+
+    public string Address => string.Join(", ", new List<string?> { AddressStreet, AddressLocality, AddressLine3, AddressTown, AddressCounty, AddressPostcode }.Where(x => !string.IsNullOrEmpty(x)));
+}

--- a/platform/src/apis/Platform.Api.Establishment/Features/Schools/Services/SchoolsService.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Schools/Services/SchoolsService.cs
@@ -13,16 +13,16 @@ namespace Platform.Api.Establishment.Features.Schools.Services;
 
 public interface ISchoolsService
 {
-    Task<SuggestResponse<School>> SchoolsSuggestAsync(SchoolSuggestRequest request);
+    Task<SuggestResponse<SchoolSummary>> SchoolsSuggestAsync(SchoolSuggestRequest request);
     Task<School?> GetAsync(string urn);
-    Task<SearchResponse<School>> SchoolsSearchAsync(SearchRequest request);
+    Task<SearchResponse<SchoolSummary>> SchoolsSearchAsync(SearchRequest request);
 }
 
 [ExcludeFromCodeCoverage]
 public class SchoolsService(
     [FromKeyedServices(ResourceNames.Search.Indexes.School)] IIndexClient client,
     IDatabaseFactory dbFactory)
-    : SearchService<School>(client), ISchoolsService
+    : SearchService<SchoolSummary>(client), ISchoolsService
 {
     public async Task<School?> GetAsync(string urn)
     {
@@ -45,28 +45,28 @@ public class SchoolsService(
         return school;
     }
 
-    public Task<SuggestResponse<School>> SchoolsSuggestAsync(SchoolSuggestRequest request)
+    public Task<SuggestResponse<SchoolSummary>> SchoolsSuggestAsync(SchoolSuggestRequest request)
     {
         var fields = new[]
         {
-            nameof(School.SchoolName),
-            nameof(School.URN),
-            nameof(School.AddressStreet),
-            nameof(School.AddressLocality),
-            nameof(School.AddressLine3),
-            nameof(School.AddressTown),
-            nameof(School.AddressCounty),
-            nameof(School.AddressPostcode)
+            nameof(SchoolSummary.SchoolName),
+            nameof(SchoolSummary.URN),
+            nameof(SchoolSummary.AddressStreet),
+            nameof(SchoolSummary.AddressLocality),
+            nameof(SchoolSummary.AddressLine3),
+            nameof(SchoolSummary.AddressTown),
+            nameof(SchoolSummary.AddressCounty),
+            nameof(SchoolSummary.AddressPostcode)
         };
 
         return SuggestAsync(request, request.FilterExpression, fields);
     }
 
-    public Task<SearchResponse<School>> SchoolsSearchAsync(SearchRequest request)
+    public Task<SearchResponse<SchoolSummary>> SchoolsSearchAsync(SearchRequest request)
     {
         var facets = new[]
         {
-            nameof(School.OverallPhase),
+            nameof(SchoolSummary.OverallPhase),
         };
 
         var response = SearchAsync(request, CreateSearchFilterExpression, facets);

--- a/platform/src/search/Platform.Search.Resources/School/SchoolIndex.cs
+++ b/platform/src/search/Platform.Search.Resources/School/SchoolIndex.cs
@@ -34,4 +34,7 @@ public class SchoolIndex
 
     [SimpleField(IsFilterable = true, IsFacetable = false, IsSortable = false)]
     public int? PeriodCoveredByReturn { get; set; }
+
+    [SimpleField(IsFilterable = true, IsFacetable = false, IsSortable = false)]
+    public double? TotalPupils { get; set; }
 }

--- a/platform/tests/Platform.Establishment.Tests/Schools/PostSchoolsSearchFunctionTests.cs
+++ b/platform/tests/Platform.Establishment.Tests/Schools/PostSchoolsSearchFunctionTests.cs
@@ -31,7 +31,7 @@ public class PostSchoolsSearchFunctionTests : FunctionsTestBase
     {
         _service
             .Setup(d => d.SchoolsSearchAsync(It.IsAny<SearchRequest>()))
-            .ReturnsAsync(new SearchResponse<School>());
+            .ReturnsAsync(new SearchResponse<SchoolSummary>());
 
         _validator
             .Setup(v => v.ValidateAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
@@ -44,7 +44,7 @@ public class PostSchoolsSearchFunctionTests : FunctionsTestBase
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         Assert.Equal(ContentType.ApplicationJson, result.ContentType());
 
-        var body = await result.ReadAsJsonAsync<SearchResponse<School>>();
+        var body = await result.ReadAsJsonAsync<SearchResponse<SchoolSummary>>();
         Assert.NotNull(body);
     }
 

--- a/platform/tests/Platform.Establishment.Tests/Schools/PostSchoolsSuggestFunctionTests.cs
+++ b/platform/tests/Platform.Establishment.Tests/Schools/PostSchoolsSuggestFunctionTests.cs
@@ -32,7 +32,7 @@ public class PostSchoolsSuggestFunctionTests : FunctionsTestBase
     {
         _service
             .Setup(d => d.SchoolsSuggestAsync(It.IsAny<SchoolSuggestRequest>()))
-            .ReturnsAsync(new SuggestResponse<School>());
+            .ReturnsAsync(new SuggestResponse<SchoolSummary>());
 
         _validator
             .Setup(v => v.ValidateAsync(It.IsAny<SuggestRequest>(), It.IsAny<CancellationToken>()))
@@ -45,7 +45,7 @@ public class PostSchoolsSuggestFunctionTests : FunctionsTestBase
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         Assert.Equal(ContentType.ApplicationJson, result.ContentType());
 
-        var body = await result.ReadAsJsonAsync<SuggestResponse<School>>();
+        var body = await result.ReadAsJsonAsync<SuggestResponse<SchoolSummary>>();
         Assert.NotNull(body);
     }
 

--- a/platform/tests/Platform.Establishment.Tests/Schools/Services/WhenSchoolsServiceIsCalled.cs
+++ b/platform/tests/Platform.Establishment.Tests/Schools/Services/WhenSchoolsServiceIsCalled.cs
@@ -26,7 +26,7 @@ public class WhenSchoolsServiceIsCalled
         string[]? capturedFacets = null;
 
         _service.Protected()
-            .Setup<Task<SearchResponse<School>>>(
+            .Setup<Task<SearchResponse<SchoolSummary>>>(
                 "SearchAsync",
                 ItExpr.IsAny<SearchRequest>(),
                 ItExpr.IsAny<Func<FilterCriteria[], string?>>(),
@@ -36,7 +36,7 @@ public class WhenSchoolsServiceIsCalled
             {
                 capturedFacets = facets;
             })
-            .ReturnsAsync(Mock.Of<SearchResponse<School>>());
+            .ReturnsAsync(Mock.Of<SearchResponse<SchoolSummary>>());
 
         var request = new SearchRequest();
 
@@ -52,7 +52,7 @@ public class WhenSchoolsServiceIsCalled
         SearchRequest? capturedRequest = null;
 
         _service.Protected()
-            .Setup<Task<SearchResponse<School>>>(
+            .Setup<Task<SearchResponse<SchoolSummary>>>(
                 "SearchAsync",
                 ItExpr.IsAny<SearchRequest>(),
                 ItExpr.IsAny<Func<FilterCriteria[], string?>>(),
@@ -62,7 +62,7 @@ public class WhenSchoolsServiceIsCalled
             {
                 capturedRequest = request;
             })
-            .ReturnsAsync(Mock.Of<SearchResponse<School>>());
+            .ReturnsAsync(Mock.Of<SearchResponse<SchoolSummary>>());
 
         var request = new SearchRequest
         {
@@ -84,7 +84,7 @@ public class WhenSchoolsServiceIsCalled
         Func<FilterCriteria[], string?>? capturedFilterExpBuilder = null;
 
         _service.Protected()
-            .Setup<Task<SearchResponse<School>>>(
+            .Setup<Task<SearchResponse<SchoolSummary>>>(
                 "SearchAsync",
                 ItExpr.IsAny<SearchRequest>(),
                 ItExpr.IsAny<Func<FilterCriteria[], string?>>(),
@@ -94,7 +94,7 @@ public class WhenSchoolsServiceIsCalled
             {
                 capturedFilterExpBuilder = filterExpBuilder;
             })
-            .ReturnsAsync(Mock.Of<SearchResponse<School>>());
+            .ReturnsAsync(Mock.Of<SearchResponse<SchoolSummary>>());
 
         var request = new SearchRequest
         {
@@ -125,7 +125,7 @@ public class WhenSchoolsServiceIsCalled
         };
 
         _service.Protected()
-            .Setup<Task<SuggestResponse<School>>>(
+            .Setup<Task<SuggestResponse<SchoolSummary>>>(
                 "SuggestAsync",
                 ItExpr.IsAny<SuggestRequest>(),
                 ItExpr.IsAny<Func<string?>?>(),
@@ -135,7 +135,7 @@ public class WhenSchoolsServiceIsCalled
             {
                 capturedFields = fields;
             })
-            .ReturnsAsync(Mock.Of<SuggestResponse<School>>());
+            .ReturnsAsync(Mock.Of<SuggestResponse<SchoolSummary>>());
 
         var request = new SchoolSuggestRequest();
 
@@ -151,7 +151,7 @@ public class WhenSchoolsServiceIsCalled
         SuggestRequest? capturedRequest = null;
 
         _service.Protected()
-            .Setup<Task<SuggestResponse<School>>>(
+            .Setup<Task<SuggestResponse<SchoolSummary>>>(
                 "SuggestAsync",
                 ItExpr.IsAny<SuggestRequest>(),
                 ItExpr.IsAny<Func<string?>?>(),
@@ -161,7 +161,7 @@ public class WhenSchoolsServiceIsCalled
             {
                 capturedRequest = request;
             })
-            .ReturnsAsync(Mock.Of<SuggestResponse<School>>());
+            .ReturnsAsync(Mock.Of<SuggestResponse<SchoolSummary>>());
 
         var request = new SchoolSuggestRequest
         {

--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -702,7 +702,7 @@ table#current-comparators-la {
 
 .govuk-list {
   &.govuk-list--result {
-    li {
+    > li {
       padding-top: govuk-spacing(5);
       padding-bottom: govuk-spacing(1);
       border-top: 1px solid $govuk-border-colour;

--- a/web/src/Web.App/Controllers/SchoolSearchController.cs
+++ b/web/src/Web.App/Controllers/SchoolSearchController.cs
@@ -55,7 +55,7 @@ public class SchoolSearchController(
             orderBy
         }))
         {
-            SearchResponse<School> results;
+            SearchResponse<SchoolSummary> results;
             try
             {
                 results = await searchService.SchoolSearch(term, 50, page, overallPhase.Length == 0

--- a/web/src/Web.App/Domain/Insight/SchoolSummary.cs
+++ b/web/src/Web.App/Domain/Insight/SchoolSummary.cs
@@ -15,5 +15,4 @@ public record SchoolSummary
     public string? OverallPhase { get; set; }
     public int? PeriodCoveredByReturn { get; set; }
     public double? TotalPupils { get; set; }
-    public string? Address { get; set; }
-};
+}

--- a/web/src/Web.App/Services/SearchService.cs
+++ b/web/src/Web.App/Services/SearchService.cs
@@ -7,12 +7,12 @@ namespace Web.App.Services;
 
 public interface ISearchService
 {
-    Task<SearchResponse<School>> SchoolSearch(string? term, int? pageSize = null, int? page = null, Dictionary<string, IEnumerable<string>>? filters = null, (string Field, string Order)? orderBy = null);
+    Task<SearchResponse<SchoolSummary>> SchoolSearch(string? term, int? pageSize = null, int? page = null, Dictionary<string, IEnumerable<string>>? filters = null, (string Field, string Order)? orderBy = null);
 }
 
 public class SearchService(IEstablishmentApi establishmentApi) : ISearchService
 {
-    public async Task<SearchResponse<School>> SchoolSearch(string? term, int? pageSize = null, int? page = null, Dictionary<string, IEnumerable<string>>? filters = null, (string Field, string Order)? orderBy = null)
+    public async Task<SearchResponse<SchoolSummary>> SchoolSearch(string? term, int? pageSize = null, int? page = null, Dictionary<string, IEnumerable<string>>? filters = null, (string Field, string Order)? orderBy = null)
     {
         List<(string Field, string Filter)>? flattenedFilters = null;
         if (filters is { Keys.Count: > 0, Values.Count: > 0 })
@@ -22,6 +22,6 @@ public class SearchService(IEstablishmentApi establishmentApi) : ISearchService
         }
 
         return await establishmentApi.SearchSchools(SearchRequest.Create(term, pageSize, page, flattenedFilters, orderBy))
-            .GetResultOrThrow<SearchResponse<School>>();
+            .GetResultOrThrow<SearchResponse<SchoolSummary>>();
     }
 }

--- a/web/src/Web.App/Services/SuggestService.cs
+++ b/web/src/Web.App/Services/SuggestService.cs
@@ -7,16 +7,16 @@ namespace Web.App.Services;
 
 public interface ISuggestService
 {
-    Task<IEnumerable<SuggestValue<School>>> SchoolSuggestions(string search, string[]? excludeSchools = null, bool? excludeMissingFinancialData = null);
+    Task<IEnumerable<SuggestValue<SchoolSummary>>> SchoolSuggestions(string search, string[]? excludeSchools = null, bool? excludeMissingFinancialData = null);
     Task<IEnumerable<SuggestValue<Trust>>> TrustSuggestions(string search, string[]? excludeTrusts = null);
     Task<IEnumerable<SuggestValue<LocalAuthority>>> LocalAuthoritySuggestions(string search, string[]? excludeLas = null);
 }
 
 public class SuggestService(IEstablishmentApi establishmentApi) : ISuggestService
 {
-    public async Task<IEnumerable<SuggestValue<School>>> SchoolSuggestions(string search, string[]? excludeSchools = null, bool? excludeMissingFinancialData = null)
+    public async Task<IEnumerable<SuggestValue<SchoolSummary>>> SchoolSuggestions(string search, string[]? excludeSchools = null, bool? excludeMissingFinancialData = null)
     {
-        var suggestions = await establishmentApi.SuggestSchools(search, excludeSchools, excludeMissingFinancialData).GetResultOrThrow<SuggestOutput<School>>();
+        var suggestions = await establishmentApi.SuggestSchools(search, excludeSchools, excludeMissingFinancialData).GetResultOrThrow<SuggestOutput<SchoolSummary>>();
         return suggestions.Results.Select(SchoolSuggestValue);
     }
 
@@ -75,7 +75,7 @@ public class SuggestService(IEstablishmentApi establishmentApi) : ISuggestServic
     }
 
 
-    private static SuggestValue<School> SchoolSuggestValue(SuggestValue<School> value)
+    private static SuggestValue<SchoolSummary> SchoolSuggestValue(SuggestValue<SchoolSummary> value)
     {
         var text = value.Text?.Replace("*", "");
 
@@ -95,7 +95,7 @@ public class SuggestService(IEstablishmentApi establishmentApi) : ISuggestServic
         return value;
     }
 
-    private static List<string?> SchoolAdditionalDetails(SuggestValue<School> value, string? text)
+    private static List<string?> SchoolAdditionalDetails(SuggestValue<SchoolSummary> value, string? text)
     {
 
         return text == value.Document?.URN
@@ -103,7 +103,7 @@ public class SuggestService(IEstablishmentApi establishmentApi) : ISuggestServic
             : SchoolAddressAdditionalDetails(value, text);
     }
 
-    private static List<string?> SchoolAddressAdditionalDetails(SuggestValue<School> value, string? text)
+    private static List<string?> SchoolAddressAdditionalDetails(SuggestValue<SchoolSummary> value, string? text)
     {
         var additionalDetails = new List<string?>();
 

--- a/web/src/Web.App/ViewModels/Search/SchoolSearchResultViewModel.cs
+++ b/web/src/Web.App/ViewModels/Search/SchoolSearchResultViewModel.cs
@@ -13,8 +13,10 @@ public record SchoolSearchResultViewModel
     public string? AddressTown { get; init; }
     public string? AddressCounty { get; init; }
     public string? AddressPostcode { get; init; }
+    public int? PeriodCoveredByReturn { get; init; }
+    public double? TotalPupils { get; init; }
 
-    public static SchoolSearchResultViewModel Create(School school)
+    public static SchoolSearchResultViewModel Create(SchoolSummary school)
     {
         return new SchoolSearchResultViewModel
         {
@@ -25,7 +27,9 @@ public record SchoolSearchResultViewModel
             AddressLine3 = school.AddressLine3,
             AddressTown = school.AddressTown,
             AddressCounty = school.AddressCounty,
-            AddressPostcode = school.AddressPostcode
+            AddressPostcode = school.AddressPostcode,
+            PeriodCoveredByReturn = school.PeriodCoveredByReturn,
+            TotalPupils = school.TotalPupils
         };
     }
 }

--- a/web/src/Web.App/ViewModels/Search/SchoolSearchResultViewModel.cs
+++ b/web/src/Web.App/ViewModels/Search/SchoolSearchResultViewModel.cs
@@ -1,4 +1,6 @@
+using System.Text;
 using Web.App.Domain;
+
 // ReSharper disable MemberCanBePrivate.Global
 
 namespace Web.App.ViewModels.Search;
@@ -13,11 +15,35 @@ public record SchoolSearchResultViewModel
     public string? AddressTown { get; init; }
     public string? AddressCounty { get; init; }
     public string? AddressPostcode { get; init; }
+    public string? Address { get; init; }
+    public string? OverallPhase { get; init; }
     public int? PeriodCoveredByReturn { get; init; }
     public double? TotalPupils { get; init; }
 
     public static SchoolSearchResultViewModel Create(SchoolSummary school)
     {
+        var components = new[]
+        {
+            school.AddressStreet?.Replace(school.SchoolName!, string.Empty).TrimStart(',').Trim(),
+            school.AddressLocality?.Replace(school.SchoolName!, string.Empty).TrimStart(',').Trim(),
+            school.AddressLine3?.Replace(school.SchoolName!, string.Empty).TrimStart(',').Trim(),
+            school.AddressTown,
+            school.AddressCounty,
+            school.AddressPostcode
+        }.Where(x => !string.IsNullOrEmpty(x)).ToArray();
+        var address = new StringBuilder(components.First());
+        for (var i = 1; i < components.Length; i++)
+        {
+            var component = components.ElementAt(i);
+            if (component == components.ElementAt(i - 1))
+            {
+                continue;
+            }
+
+            address.Append(", ");
+            address.Append(component);
+        }
+
         return new SchoolSearchResultViewModel
         {
             URN = school.URN,
@@ -28,6 +54,8 @@ public record SchoolSearchResultViewModel
             AddressTown = school.AddressTown,
             AddressCounty = school.AddressCounty,
             AddressPostcode = school.AddressPostcode,
+            Address = address.ToString(),
+            OverallPhase = school.OverallPhase,
             PeriodCoveredByReturn = school.PeriodCoveredByReturn,
             TotalPupils = school.TotalPupils
         };

--- a/web/src/Web.App/Views/Shared/Search/_SchoolSearchResults.cshtml
+++ b/web/src/Web.App/Views/Shared/Search/_SchoolSearchResults.cshtml
@@ -6,37 +6,28 @@
         <li id="search-result-@result.URN">
             <a href="@Url.Action("Index", "School", new { urn = result.URN })"
                class="govuk-link govuk-link--no-visited-state govuk-heading-s govuk-!-margin-bottom-2">@result.SchoolName</a>
-            <p class="govuk-body-s">
-                @if (!string.IsNullOrWhiteSpace(result.AddressStreet))
+            <ul class="govuk-list">
+                @if (!string.IsNullOrWhiteSpace(result.Address))
                 {
-                    @result.AddressStreet
-                    <br/>
+                    <li class="govuk-!-padding-bottom-1">
+                        <span>@result.Address</span>
+                    </li>
                 }
-                @if (!string.IsNullOrWhiteSpace(result.AddressLocality))
+                @if (!string.IsNullOrWhiteSpace(result.OverallPhase))
                 {
-                    @result.AddressLocality
-                    <br/>
+                    <li>
+                        <span class="govuk-!-font-weight-bold">Education phase:</span>
+                        <span>@(result.OverallPhase)</span>
+                    </li>
                 }
-                @if (!string.IsNullOrWhiteSpace(result.AddressLine3))
+                @if (result.TotalPupils.GetValueOrDefault() > 0)
                 {
-                    @result.AddressLine3
-                    <br/>
+                    <li>
+                        <span class="govuk-!-font-weight-bold">Number of pupils:</span>
+                        <span class="govuk-!-font-tabular-numbers">@(result.TotalPupils)</span>
+                    </li>
                 }
-                @if (!string.IsNullOrWhiteSpace(result.AddressTown))
-                {
-                    @result.AddressTown
-                    <br/>
-                }
-                @if (!string.IsNullOrWhiteSpace(result.AddressCounty))
-                {
-                    @result.AddressCounty
-                    <br/>
-                }
-                @if (!string.IsNullOrWhiteSpace(result.AddressPostcode))
-                {
-                    @result.AddressPostcode
-                }
-            </p>
+            </ul>
         </li>
     }
 </ul>

--- a/web/src/Web.App/Views/Shared/Search/_SchoolSearchResultsOptions.cshtml
+++ b/web/src/Web.App/Views/Shared/Search/_SchoolSearchResultsOptions.cshtml
@@ -49,7 +49,7 @@
             <fieldset class="govuk-fieldset">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
                     <h2 class="govuk-fieldset__heading">
-                        Education Phase
+                        Education phase
                     </h2>
                 </legend>
                 <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">

--- a/web/tests/Web.Tests/Services/WhenSchoolSearchServiceIsCalled.cs
+++ b/web/tests/Web.Tests/Services/WhenSchoolSearchServiceIsCalled.cs
@@ -1,5 +1,4 @@
-﻿using AutoFixture;
-using Moq;
+﻿using Moq;
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.Establishment;
@@ -11,7 +10,6 @@ namespace Web.Tests.Services;
 public class WhenSchoolSearchServiceIsCalled
 {
     private readonly Mock<IEstablishmentApi> _api = new();
-    private readonly Fixture _fixture = new();
 
     public static TheoryData<string?, int?, int?, Dictionary<string, IEnumerable<string>>?, (string Field, string Order)?, SearchRequest?> WhenSendRequestData = new()
     {
@@ -58,7 +56,7 @@ public class WhenSchoolSearchServiceIsCalled
     [MemberData(nameof(WhenSendRequestData))]
     public async Task ShouldSendRequest(string? term, int? pageSize = null, int? page = null, Dictionary<string, IEnumerable<string>>? filters = null, (string Field, string Order)? orderBy = null, SearchRequest? expected = null)
     {
-        var response = new SearchResponse<School>();
+        var response = new SearchResponse<SchoolSummary>();
 
         SearchRequest? actualRequest = null;
         _api.Setup(x => x.SearchSchools(It.IsAny<SearchRequest>()))

--- a/web/tests/Web.Tests/Services/WhenSchoolSuggestionsIsCalled.cs
+++ b/web/tests/Web.Tests/Services/WhenSchoolSuggestionsIsCalled.cs
@@ -16,14 +16,14 @@ public class WhenSchoolSuggestionsIsCalled
     [Fact]
     public async Task ShouldDisplayUrnOnMatch()
     {
-        var school = _fixture.Create<School>();
-        var value = new SuggestValue<School>
+        var school = _fixture.Create<SchoolSummary>();
+        var value = new SuggestValue<SchoolSummary>
         {
             Text = school.URN,
             Document = school
         };
 
-        var response = new SuggestOutput<School>
+        var response = new SuggestOutput<SchoolSummary>
         {
             Results = [value]
         };
@@ -32,7 +32,7 @@ public class WhenSchoolSuggestionsIsCalled
 
         var service = new SuggestService(_api.Object);
         var actual = await service.SchoolSuggestions("school");
-        var array = actual as SuggestValue<School>[] ?? actual.ToArray();
+        var array = actual as SuggestValue<SchoolSummary>[] ?? actual.ToArray();
 
         Assert.Single(array);
         Assert.Equal($"{school.SchoolName} ({school.URN})", array.First().Text);
@@ -41,14 +41,14 @@ public class WhenSchoolSuggestionsIsCalled
     [Fact]
     public async Task ShouldDisplaySchoolNameOnMatch()
     {
-        var school = _fixture.Create<School>();
-        var value = new SuggestValue<School>
+        var school = _fixture.Create<SchoolSummary>();
+        var value = new SuggestValue<SchoolSummary>
         {
             Text = school.SchoolName,
             Document = school
         };
 
-        var response = new SuggestOutput<School>
+        var response = new SuggestOutput<SchoolSummary>
         {
             Results = [value]
         };
@@ -57,7 +57,7 @@ public class WhenSchoolSuggestionsIsCalled
 
         var service = new SuggestService(_api.Object);
         var actual = await service.SchoolSuggestions("school");
-        var array = actual as SuggestValue<School>[] ?? actual.ToArray();
+        var array = actual as SuggestValue<SchoolSummary>[] ?? actual.ToArray();
 
         Assert.Single(array);
         Assert.Equal($"{school.SchoolName} ({school.AddressTown}, {school.AddressPostcode})", array.First().Text);
@@ -66,14 +66,14 @@ public class WhenSchoolSuggestionsIsCalled
     [Fact]
     public async Task ShouldDisplayAddressStreetOnMatch()
     {
-        var school = _fixture.Create<School>();
-        var value = new SuggestValue<School>
+        var school = _fixture.Create<SchoolSummary>();
+        var value = new SuggestValue<SchoolSummary>
         {
             Text = school.AddressStreet,
             Document = school
         };
 
-        var response = new SuggestOutput<School>
+        var response = new SuggestOutput<SchoolSummary>
         {
             Results = [value]
         };
@@ -82,7 +82,7 @@ public class WhenSchoolSuggestionsIsCalled
 
         var service = new SuggestService(_api.Object);
         var actual = await service.SchoolSuggestions("school");
-        var array = actual as SuggestValue<School>[] ?? actual.ToArray();
+        var array = actual as SuggestValue<SchoolSummary>[] ?? actual.ToArray();
 
         Assert.Single(array);
         Assert.Equal($"{school.SchoolName} ({school.AddressStreet}, {school.AddressTown}, {school.AddressPostcode})", array.First().Text);
@@ -91,14 +91,14 @@ public class WhenSchoolSuggestionsIsCalled
     [Fact]
     public async Task ShouldDisplayAddressLocalityOnMatch()
     {
-        var school = _fixture.Create<School>();
-        var value = new SuggestValue<School>
+        var school = _fixture.Create<SchoolSummary>();
+        var value = new SuggestValue<SchoolSummary>
         {
             Text = school.AddressLocality,
             Document = school
         };
 
-        var response = new SuggestOutput<School>
+        var response = new SuggestOutput<SchoolSummary>
         {
             Results = [value]
         };
@@ -107,7 +107,7 @@ public class WhenSchoolSuggestionsIsCalled
 
         var service = new SuggestService(_api.Object);
         var actual = await service.SchoolSuggestions("school");
-        var array = actual as SuggestValue<School>[] ?? actual.ToArray();
+        var array = actual as SuggestValue<SchoolSummary>[] ?? actual.ToArray();
 
         Assert.Single(array);
         Assert.Equal($"{school.SchoolName} ({school.AddressLocality}, {school.AddressTown}, {school.AddressPostcode})", array.First().Text);
@@ -116,14 +116,14 @@ public class WhenSchoolSuggestionsIsCalled
     [Fact]
     public async Task ShouldDisplayAddressLine3OnMatch()
     {
-        var school = _fixture.Create<School>();
-        var value = new SuggestValue<School>
+        var school = _fixture.Create<SchoolSummary>();
+        var value = new SuggestValue<SchoolSummary>
         {
             Text = school.AddressLine3,
             Document = school
         };
 
-        var response = new SuggestOutput<School>
+        var response = new SuggestOutput<SchoolSummary>
         {
             Results = [value]
         };
@@ -132,7 +132,7 @@ public class WhenSchoolSuggestionsIsCalled
 
         var service = new SuggestService(_api.Object);
         var actual = await service.SchoolSuggestions("school");
-        var array = actual as SuggestValue<School>[] ?? actual.ToArray();
+        var array = actual as SuggestValue<SchoolSummary>[] ?? actual.ToArray();
 
         Assert.Single(array);
         Assert.Equal($"{school.SchoolName} ({school.AddressLine3}, {school.AddressTown}, {school.AddressPostcode})", array.First().Text);
@@ -141,14 +141,14 @@ public class WhenSchoolSuggestionsIsCalled
     [Fact]
     public async Task ShouldDisplayAddressTownOnMatch()
     {
-        var school = _fixture.Create<School>();
-        var value = new SuggestValue<School>
+        var school = _fixture.Create<SchoolSummary>();
+        var value = new SuggestValue<SchoolSummary>
         {
             Text = school.AddressTown,
             Document = school
         };
 
-        var response = new SuggestOutput<School>
+        var response = new SuggestOutput<SchoolSummary>
         {
             Results = [value]
         };
@@ -157,7 +157,7 @@ public class WhenSchoolSuggestionsIsCalled
 
         var service = new SuggestService(_api.Object);
         var actual = await service.SchoolSuggestions("school");
-        var array = actual as SuggestValue<School>[] ?? actual.ToArray();
+        var array = actual as SuggestValue<SchoolSummary>[] ?? actual.ToArray();
 
         Assert.Single(array);
         Assert.Equal($"{school.SchoolName} ({school.AddressTown}, {school.AddressPostcode})", array.First().Text);
@@ -166,14 +166,14 @@ public class WhenSchoolSuggestionsIsCalled
     [Fact]
     public async Task ShouldDisplayAddressCountyOnMatch()
     {
-        var school = _fixture.Create<School>();
-        var value = new SuggestValue<School>
+        var school = _fixture.Create<SchoolSummary>();
+        var value = new SuggestValue<SchoolSummary>
         {
             Text = school.AddressCounty,
             Document = school
         };
 
-        var response = new SuggestOutput<School>
+        var response = new SuggestOutput<SchoolSummary>
         {
             Results = [value]
         };
@@ -182,7 +182,7 @@ public class WhenSchoolSuggestionsIsCalled
 
         var service = new SuggestService(_api.Object);
         var actual = await service.SchoolSuggestions("school");
-        var array = actual as SuggestValue<School>[] ?? actual.ToArray();
+        var array = actual as SuggestValue<SchoolSummary>[] ?? actual.ToArray();
 
         Assert.Single(array);
         Assert.Equal($"{school.SchoolName} ({school.AddressTown}, {school.AddressCounty}, {school.AddressPostcode})", array.First().Text);
@@ -191,14 +191,14 @@ public class WhenSchoolSuggestionsIsCalled
     [Fact]
     public async Task ShouldDisplayAddressPostcodeOnMatch()
     {
-        var school = _fixture.Create<School>();
-        var value = new SuggestValue<School>
+        var school = _fixture.Create<SchoolSummary>();
+        var value = new SuggestValue<SchoolSummary>
         {
             Text = school.AddressPostcode,
             Document = school
         };
 
-        var response = new SuggestOutput<School>
+        var response = new SuggestOutput<SchoolSummary>
         {
             Results = [value]
         };
@@ -207,7 +207,7 @@ public class WhenSchoolSuggestionsIsCalled
 
         var service = new SuggestService(_api.Object);
         var actual = await service.SchoolSuggestions("school");
-        var array = actual as SuggestValue<School>[] ?? actual.ToArray();
+        var array = actual as SuggestValue<SchoolSummary>[] ?? actual.ToArray();
 
         Assert.Single(array);
         Assert.Equal($"{school.SchoolName} ({school.AddressTown}, {school.AddressPostcode})", array.First().Text);

--- a/web/tests/Web.Tests/ViewModels/Search/GivenASchoolSearchResultViewModel.cs
+++ b/web/tests/Web.Tests/ViewModels/Search/GivenASchoolSearchResultViewModel.cs
@@ -12,7 +12,14 @@ public class GivenASchoolSearchResultViewModel
     [Fact]
     public void WhenCreateShouldMapFacetsIfSupplied()
     {
-        var school = _fixture.Create<SchoolSummary>();
+        var addressStreet = _fixture.Create<string>();
+        var school = _fixture
+            .Build<SchoolSummary>()
+            .With(s => s.SchoolName, "SchoolName")
+            .With(s => s.AddressStreet, $"SchoolName, {addressStreet}")
+            .With(s => s.AddressLocality, "AddressLocality")
+            .With(s => s.AddressLine3, "AddressLocality")
+            .Create();
 
         var actual = SchoolSearchResultViewModel.Create(school);
 
@@ -24,6 +31,8 @@ public class GivenASchoolSearchResultViewModel
         Assert.Equal(school.AddressTown, actual.AddressTown);
         Assert.Equal(school.AddressCounty, actual.AddressCounty);
         Assert.Equal(school.AddressPostcode, actual.AddressPostcode);
+        Assert.Equal($"{addressStreet}, {school.AddressLocality}, {school.AddressTown}, {school.AddressCounty}, {school.AddressPostcode}", actual.Address);
+        Assert.Equal(school.OverallPhase, actual.OverallPhase);
         Assert.Equal(school.PeriodCoveredByReturn, actual.PeriodCoveredByReturn);
         Assert.Equal(school.TotalPupils, actual.TotalPupils);
     }

--- a/web/tests/Web.Tests/ViewModels/Search/GivenASchoolSearchResultViewModel.cs
+++ b/web/tests/Web.Tests/ViewModels/Search/GivenASchoolSearchResultViewModel.cs
@@ -12,7 +12,7 @@ public class GivenASchoolSearchResultViewModel
     [Fact]
     public void WhenCreateShouldMapFacetsIfSupplied()
     {
-        var school = _fixture.Create<School>();
+        var school = _fixture.Create<SchoolSummary>();
 
         var actual = SchoolSearchResultViewModel.Create(school);
 
@@ -24,5 +24,7 @@ public class GivenASchoolSearchResultViewModel
         Assert.Equal(school.AddressTown, actual.AddressTown);
         Assert.Equal(school.AddressCounty, actual.AddressCounty);
         Assert.Equal(school.AddressPostcode, actual.AddressPostcode);
+        Assert.Equal(school.PeriodCoveredByReturn, actual.PeriodCoveredByReturn);
+        Assert.Equal(school.TotalPupils, actual.TotalPupils);
     }
 }


### PR DESCRIPTION
### Context
[AB#256517](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/256517) [AB#250281](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/250281) #2227 

### Change proposed in this pull request
- Included `TotalPupils` in `SearchIndex` and related results
- Included total pupils and education phase in results listing

### Guidance to review 
Dependent on #2227.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

