### PR TITLE
chore: bumped `front-end` to `1.1.81`

### DIFF
--- a/web/src/Web.App/package-lock.json
+++ b/web/src/Web.App/package-lock.json
@@ -1441,9 +1441,9 @@
       }
     },
     "node_modules/front-end": {
-      "version": "1.1.80",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-1.1.80.tgz",
-      "integrity": "sha1-5+UAYEPR1mOhbcmhEBLvHEc1E60=",
+      "version": "1.1.81",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-1.1.81.tgz",
+      "integrity": "sha1-7Ka2Mkmg8yJ8zlb/ukQwQZEYjkE=",
       "dependencies": {
         "accessible-autocomplete": "^3.0.0",
         "classnames": "^2.5.1",


### PR DESCRIPTION
### Context
#2229 

### Change proposed in this pull request
bump to `front-end` following updates to `front-end-components` on #2229

### Guidance to review 
n/a

### Checklist (add/remove as appropriate)
- [ ] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally

