### PR TITLE
Added and categorised Find Organisation E2E tests with/out feature flag

### DIFF
--- a/pipelines/web/steps/run-e2e-tests.yaml
+++ b/pipelines/web/steps/run-e2e-tests.yaml
@@ -31,6 +31,7 @@ steps:
     inputs:
       command: test
       projects: '${{ parameters.workspaceDir }}/e2e-tests-files/Web.E2ETests/Web.E2ETests.dll'
+      arguments: --filter Category!=FacetedSearchEnabled
 
   - publish: ${{ parameters.workspaceDir }}/e2e-tests-files/Web.E2ETests/screenshots
     artifact: e2e-test-outputs-$(System.JobAttempt)

--- a/web/tests/Web.E2ETests/Features/FindOrganisation.feature
+++ b/web/tests/Web.E2ETests/Features/FindOrganisation.feature
@@ -1,5 +1,6 @@
 ﻿Feature: Find organisation
 
+    @FindOrganisationEnabled
     Scenario: Goto school homepage
         Given I am on find organisation page
         And 'school' organisation type is selected
@@ -7,6 +8,7 @@
         When I click Continue
         Then the school homepage is displayed
 
+    @FindOrganisationEnabled
     Scenario: Displaying relevant search suggestions when entering a keyword
         Given I am on find organisation page
         And 'school' organisation type is selected
@@ -23,4 +25,10 @@
       | London             |
       | Greater Manchester |
       | ABC                |
-      
+
+    @FacetedSearchEnabled
+    Scenario: Go to school search page
+        Given I am on find organisation page
+        And 'school' organisation type is selected
+        When I click Continue to school search
+        Then the school search page is displayed

--- a/web/tests/Web.E2ETests/Pages/FindOrganisationPage.cs
+++ b/web/tests/Web.E2ETests/Pages/FindOrganisationPage.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Playwright;
+using Web.E2ETests.Pages.School;
+
 namespace Web.E2ETests.Pages;
 
 public enum OrganisationTypes
@@ -41,11 +43,18 @@ public class FindOrganisationPage(IPage page)
         await page.Keyboard.PressAsync(Keyboard.EnterKey);
     }
 
-    public async Task<School.HomePage> ClickContinue()
+    public async Task<School.HomePage> ClickContinueToSchool()
     {
         await ContinueButton.ClickAsync();
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
         return new School.HomePage(page);
+    }
+
+    public async Task<SearchPage> ClickContinueToSchoolSearch()
+    {
+        await ContinueButton.ClickAsync();
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        return new SearchPage(page);
     }
 
     public async Task SelectOrganisationType(OrganisationTypes type)

--- a/web/tests/Web.E2ETests/Pages/School/SearchPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/SearchPage.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Playwright;
+
+namespace Web.E2ETests.Pages.School;
+
+public class SearchPage(IPage page)
+{
+    private ILocator PageH1Heading => page.Locator($"main {Selectors.H1}");
+
+    public async Task IsDisplayed()
+    {
+        await PageH1Heading.ShouldBeVisible();
+    }
+}

--- a/web/tests/Web.E2ETests/Steps/FindOrganisationSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/FindOrganisationSteps.cs
@@ -1,6 +1,6 @@
-﻿using Reqnroll;
-using Web.E2ETests.Drivers;
+﻿using Web.E2ETests.Drivers;
 using Web.E2ETests.Pages;
+using Web.E2ETests.Pages.School;
 using Xunit;
 using HomePage = Web.E2ETests.Pages.School.HomePage;
 
@@ -12,6 +12,7 @@ public class FindOrganisationSteps(PageDriver driver)
 {
     private FindOrganisationPage? _findOrganisationPage;
     private HomePage? _schoolHomePage;
+    private SearchPage? _schoolSearchPage;
 
     [Given(@"I am on find organisation page")]
     public async Task GivenIAmOnFindOrganisationPage()
@@ -39,12 +40,11 @@ public class FindOrganisationSteps(PageDriver driver)
         await _findOrganisationPage.TypeIntoSchoolSearchBox(keyword);
     }
 
-
     [When("I click Continue")]
     public async Task WhenIClickContinue()
     {
         Assert.NotNull(_findOrganisationPage);
-        _schoolHomePage = await _findOrganisationPage.ClickContinue();
+        _schoolHomePage = await _findOrganisationPage.ClickContinueToSchool();
     }
 
     [Then("the school homepage is displayed")]
@@ -69,5 +69,22 @@ public class FindOrganisationSteps(PageDriver driver)
         await _findOrganisationPage.AssertSearchResults(keyword);
     }
 
-    private static string FindOrganisationUrl() => $"{TestConfiguration.ServiceUrl}/find-organisation";
+    [When("I click Continue to school search")]
+    public async Task WhenIClickContinueToSchoolSearch()
+    {
+        Assert.NotNull(_findOrganisationPage);
+        _schoolSearchPage = await _findOrganisationPage.ClickContinueToSchoolSearch();
+    }
+
+    [Then("the school search page is displayed")]
+    public async Task ThenTheSchoolSearchPageIsDisplayed()
+    {
+        Assert.NotNull(_schoolSearchPage);
+        await _schoolSearchPage.IsDisplayed();
+    }
+
+    private static string FindOrganisationUrl()
+    {
+        return $"{TestConfiguration.ServiceUrl}/find-organisation";
+    }
 }


### PR DESCRIPTION
### Context
[AB#255274](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/255274) [AB#250281](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/250281)

### Change proposed in this pull request
E2E for organisation faceted search, toggle-able via category

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

