### PR TITLE
Added and categorised Find Organisation A11y tests with/out feature flag

### DIFF
--- a/pipelines/web/steps/run-a11y-tests.yaml
+++ b/pipelines/web/steps/run-a11y-tests.yaml
@@ -32,3 +32,4 @@ steps:
     inputs:
       command: test
       projects: '${{ parameters.workspaceDir }}/a11y-tests-files/Web.A11yTests/Web.A11yTests.dll'
+      arguments: --filter Category!=FacetedSearchEnabled

--- a/web/tests/Web.A11yTests/Pages/Schools/WhenViewingSearch.cs
+++ b/web/tests/Web.A11yTests/Pages/Schools/WhenViewingSearch.cs
@@ -1,0 +1,29 @@
+using Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Web.A11yTests.Pages.Schools;
+
+[Trait("Category", "FacetedSearchEnabled")]
+public class WhenViewingSearch(
+    ITestOutputHelper testOutputHelper,
+    WebDriver webDriver)
+    : PageBase(testOutputHelper, webDriver)
+{
+    protected override string PageUrl => "/school";
+
+    [Fact]
+    public async Task ThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await EvaluatePage();
+    }
+
+    [Fact]
+    public async Task ValidationErrorThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await Page.Locator("button[type='submit'][value='reset']").ClickAsync();
+        await EvaluatePage();
+    }
+}

--- a/web/tests/Web.A11yTests/Pages/Schools/WhenViewingSearchResults.cs
+++ b/web/tests/Web.A11yTests/Pages/Schools/WhenViewingSearchResults.cs
@@ -1,0 +1,21 @@
+using Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Web.A11yTests.Pages.Schools;
+
+[Trait("Category", "FacetedSearchEnabled")]
+public class WhenViewingSearchResults(
+    ITestOutputHelper testOutputHelper,
+    WebDriver webDriver)
+    : PageBase(testOutputHelper, webDriver)
+{
+    protected override string PageUrl => "/school/search?term=school";
+
+    [Fact]
+    public async Task ThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await EvaluatePage();
+    }
+}

--- a/web/tests/Web.A11yTests/Pages/WhenViewingFindOrganisation.cs
+++ b/web/tests/Web.A11yTests/Pages/WhenViewingFindOrganisation.cs
@@ -32,6 +32,7 @@ public class WhenViewingFindOrganisation(
     [InlineData("local-authority")]
     [InlineData("school")]
     [InlineData("trust")]
+    [Xunit.TraitAttribute("Category", "FindOrganisationEnabled")]
     public async Task ThenThereAreNoAccessibilityIssues(string organisationType)
     {
         await GoToPage();
@@ -43,11 +44,24 @@ public class WhenViewingFindOrganisation(
     [InlineData("local-authority")]
     [InlineData("school")]
     [InlineData("trust")]
+    [Xunit.TraitAttribute("Category", "FindOrganisationEnabled")]
     public async Task ValidationErrorThenThereAreNoAccessibilityIssues(string organisationType)
     {
         await GoToPage();
         await Page.Locator($"#{organisationType}").ClickAsync();
         await Page.Locator(":text('Continue')").ClickAsync();
         await EvaluatePage(_context);
+    }
+
+    [Theory]
+    [InlineData("local-authority")]
+    [InlineData("school")]
+    [InlineData("trust")]
+    [Xunit.TraitAttribute("Category", "FacetedSearchEnabled")]
+    public async Task ThenThereAreNoAccessibilityIssuesWithFacetedSearch(string organisationType)
+    {
+        await GoToPage();
+        await Page.Locator($"#{organisationType}").ClickAsync();
+        await EvaluatePage();
     }
 }


### PR DESCRIPTION
### Context
[AB#255748](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/255748) [AB#250281](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/250281)

### Change proposed in this pull request
A11y for organisation faceted search, toggle-able via category

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

