### PR TITLE
Update content on High needs 'start benchmarking' page

### DIFF
--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -559,14 +559,6 @@ hr.govuk-section-break--print {
   }
 }
 
-.govuk-inset-text {
-  > .govuk-list {
-    &.govuk-list--number {
-      padding-left: govuk-spacing(6);
-    }
-  }
-}
-
 table#current-comparators-la {
   > tbody > tr > td.govuk-table__cell {
     vertical-align: middle;

--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsBenchmarkingController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsBenchmarkingController.cs
@@ -61,11 +61,12 @@ public class LocalAuthorityHighNeedsBenchmarkingController(
     [HttpGet]
     [LocalAuthorityRequestTelemetry(TrackedRequestFeature.HighNeeds)]
     [Route("comparators")]
-    public async Task<IActionResult> Comparators(string code)
+    public async Task<IActionResult> Comparators(string code, [FromQuery] string? referrer = null)
     {
         using (logger.BeginScope(new
         {
-            code
+            code,
+            referrer
         }))
         {
             try
@@ -75,7 +76,8 @@ public class LocalAuthorityHighNeedsBenchmarkingController(
                 var localAuthority = await LocalAuthorityStatisticalNeighbours(code);
                 var viewModel = new LocalAuthorityHighNeedsBenchmarkingViewModel(
                     localAuthority,
-                    localAuthorityComparatorSetService.ReadUserDefinedComparatorSetFromSession(code).Set);
+                    localAuthorityComparatorSetService.ReadUserDefinedComparatorSetFromSession(code).Set,
+                    referrer);
                 return View(viewModel);
             }
             catch (Exception e)
@@ -132,7 +134,7 @@ public class LocalAuthorityHighNeedsBenchmarkingController(
                 }
 
                 var localAuthority = await LocalAuthorityStatisticalNeighbours(code);
-                return View(nameof(Comparators), new LocalAuthorityHighNeedsBenchmarkingViewModel(localAuthority, comparators.ToArray()));
+                return View(nameof(Comparators), new LocalAuthorityHighNeedsBenchmarkingViewModel(localAuthority, comparators.ToArray(), viewModel.Referrer));
             }
             catch (Exception e)
             {

--- a/web/src/Web.App/ViewModels/LocalAuthorityComparatorSetViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityComparatorSetViewModel.cs
@@ -1,0 +1,9 @@
+﻿using Web.App.Domain;
+namespace Web.App.ViewModels;
+
+public class LocalAuthorityComparatorSetViewModel(LocalAuthority localAuthority, string[] strings)
+{
+    public string? Code => localAuthority.Code;
+    public string? Name => localAuthority.Name;
+
+}

--- a/web/src/Web.App/ViewModels/LocalAuthorityComparatorViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityComparatorViewModel.cs
@@ -9,8 +9,7 @@ public class LocalAuthorityComparatorViewModel
 {
     [Required]
     public string? Action { get; set; }
-
     public string? LaInput { get; set; }
-
     public string[] Selected { get; set; } = [];
+    public string? Referrer { get; set; }
 }

--- a/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsBenchmarkingViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsBenchmarkingViewModel.cs
@@ -2,10 +2,11 @@ using Web.App.Domain;
 
 namespace Web.App.ViewModels;
 
-public class LocalAuthorityHighNeedsBenchmarkingViewModel(LocalAuthorityStatisticalNeighbours localAuthority, string[] comparators)
+public class LocalAuthorityHighNeedsBenchmarkingViewModel(LocalAuthorityStatisticalNeighbours localAuthority, string[] comparators, string? referrer)
 {
     public string? Code => localAuthority.Code;
     public string? Name => localAuthority.Name;
+    public string? Referrer => referrer;
 
     public string[] StatisticalNeighbours => localAuthority.StatisticalNeighbours?
         .OrderBy(n => n.Position)

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsBenchmarking/Comparators.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsBenchmarking/Comparators.cshtml
@@ -4,6 +4,10 @@
 @model Web.App.ViewModels.LocalAuthorityHighNeedsBenchmarkingViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.LocalAuthorityHighNeedsStartBenchmarking;
+    var referrer = Url.Action(
+        "Index",
+        Model.Referrer == "benchmarking" ? "LocalAuthorityHighNeedsBenchmarking" : "LocalAuthorityHighNeeds",
+        new { Model.Code });
 }
 
 @await Component.InvokeAsync("EstablishmentHeading", new
@@ -18,36 +22,35 @@
 
 @if (Model.StatisticalNeighbours.Any())
 {
-    <div class="govuk-inset-text">
-        <p class="govuk-body">
-            These local authorities are your ten closest statistical neighbours which are deemed to have similar
-            characteristics:
-        </p>
-        <ol class="govuk-list govuk-list--number">
-            @foreach (var neighbour in Model.StatisticalNeighbours)
-            {
-                <li>@neighbour</li>
-            }
-        </ol>
-    </div>
+    <p class="govuk-body">
+        Add your statistical neighbours or any other local authority below.
+    </p>
 
     <details class="govuk-details">
         <summary class="govuk-details__summary">
             <span class="govuk-details__summary-text">
-                More about statistical neighbours
+                Find out your 10 closest statistical neighbours
             </span>
         </summary>
         <div class="govuk-details__text">
-            <p class="govuk-body-s">
-                Statistical neighbours provide suggestions for local authorities to compare against.
+            <p class="govuk-body govuk-!-font-weight-bold">
+                These local authorities are your ten closest statistical neighbours which are deemed to have similar
+                characteristics:
             </p>
-            <p class="govuk-body-s">
+            <ol class="govuk-list govuk-list--number govuk-!-padding-left-6">
+                @foreach (var neighbour in Model.StatisticalNeighbours)
+                {
+                    <li>@neighbour</li>
+                }
+            </ol>
+            <p class="govuk-body">
+                Statistical neighbours provide suggestions for local authorities to compare against.
                 For each local authority, 10 local authorities are listed which are deemed to have
                 similar characteristics. These designated local authorities are known as statistical
                 neighbours and are listed in order from the statistically closest (top) to least close
                 (bottom).
             </p>
-            <p class="govuk-body-s">
+            <p class="govuk-body">
                 The National Foundation for Educational Research (NFER) was commissioned in
                 2007 by the Department for Education (DfE) to identify and group similar local
                 authorities in terms of the socio-economic characteristic.
@@ -61,6 +64,12 @@
 </h2>
 
 <form action="@Url.Action("Comparators", "LocalAuthorityHighNeedsBenchmarking", new { Model.Code })" method="post">
+    @if (!string.IsNullOrWhiteSpace(Model.Referrer))
+    {
+        <input name="@nameof(LocalAuthorityHighNeedsBenchmarkingViewModel.Referrer)" value="@Model.Referrer"
+               type="hidden"/>
+    }
+    
     @await Component.InvokeAsync("LocalAuthorityComparators", new
     {
         Model.Code,
@@ -72,8 +81,7 @@
                 value="@FormAction.Continue">
             Save and continue
         </button>
-        <a class="govuk-button govuk-button--secondary" data-module="govuk-button"
-           href="@Url.Action("Index", "LocalAuthorityHighNeeds", new { Model.Code })">
+        <a class="govuk-link govuk-link--no-visited-state" href="@referrer">
             Cancel
         </a>
     </div>

--- a/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsStartBenchmarking.feature
+++ b/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsStartBenchmarking.feature
@@ -35,3 +35,12 @@
         And I press the Enter key again
         When I click the cancel button
         Then the local authority high needs dashboard page is displayed
+
+    @HighNeedsFlagEnabled
+    Scenario: Can cancel the comparator set when referred from benchmarking page
+        Given I am on local authority high needs start benchmarking from referrer 'benchmarking' for local authority with code '201'
+        And I type 'south' into the input field
+        And I press the Enter key
+        And I press the Enter key again
+        When I click the cancel button
+        Then the local authority high needs benchmarking page is displayed

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsStartBenchmarkingPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsStartBenchmarkingPage.cs
@@ -13,7 +13,7 @@ public class HighNeedsStartBenchmarkingPage(IPage page)
     {
         HasText = "Save and continue"
     });
-    private ILocator CancelButton => page.Locator(".govuk-button--secondary", new PageLocatorOptions
+    private ILocator CancelButton => page.Locator(".govuk-link", new PageLocatorOptions
     {
         HasText = "Cancel"
     });
@@ -70,10 +70,10 @@ public class HighNeedsStartBenchmarkingPage(IPage page)
         return new HighNeedsBenchmarkingPage(page);
     }
 
-    public async Task<HighNeedsDashboardPage> ClickCancelButton()
+    public async Task<T> ClickCancelButton<T>(Func<IPage, T> next)
     {
         await CancelButton.ClickAsync();
-        return new HighNeedsDashboardPage(page);
+        return next(page);
     }
 
     public async Task<bool> HasComparators()

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -389,9 +389,15 @@ public static class Paths
     {
         return $"/local-authority/{code}/high-needs/benchmarking";
     }
-    public static string LocalAuthorityHighNeedsStartBenchmarking(string? code)
+    public static string LocalAuthorityHighNeedsStartBenchmarking(string? code, string? referrer = null)
     {
-        return $"/local-authority/{code}/high-needs/benchmarking/comparators";
+        var suffix = string.Empty;
+        if (!string.IsNullOrWhiteSpace(referrer))
+        {
+            suffix = $"?referrer={referrer}";
+        }
+
+        return $"/local-authority/{code}/high-needs/benchmarking/comparators{suffix}";
     }
     public static string LocalAuthorityHighNeedsNationalRankings(string? code)
     {


### PR DESCRIPTION
### Context
[AB#256803](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/256803) [AB#255674](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/255674)

### Change proposed in this pull request
- Move content to within details component
- Conditional 'cancel' button logic based on referrer query string
- E2E and integration test updates

### Guidance to review 
Follow-up work to wire up the `referrer` query string from the benchmarking page in #2237.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

