### PR TITLE
Commentary and CTA on High needs benchmarking page

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -149,8 +149,8 @@
       <circle r="45" cx="50" cy="50" fill="purple" />
     </svg> -->
     <!-- <div id="la-national-rank" data-code="942"></div> -->
-    <div id="historic-data-high-needs" data-code="201"></div>
-    <!--<div id="benchmark-data-high-needs" data-code="201"></div>-->
+    <!--<div id="historic-data-high-needs" data-code="201"></div>-->
+    <div id="benchmark-data-high-needs" data-code="201"></div>
     <!-- <div id="historic-data" data-type="school" data-id="114504"></div> -->
     <script type="module" src="/src/main.tsx"></script>
     <script

--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -150,7 +150,7 @@
     </svg> -->
     <!-- <div id="la-national-rank" data-code="942"></div> -->
     <!--<div id="historic-data-high-needs" data-code="201"></div>-->
-    <div id="benchmark-data-high-needs" data-code="201"></div>
+    <div id="benchmark-data-high-needs" data-code="201" data-set='["202", "203", "204"]' data-edit-link="/edit-link"></div>
     <!-- <div id="historic-data" data-type="school" data-id="114504"></div> -->
     <script type="module" src="/src/main.tsx"></script>
     <script

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -1034,12 +1034,17 @@ const benchmarkDataHighNeedsElement = document.getElementById(
   BenchmarkDataHighNeedsElementId
 );
 if (benchmarkDataHighNeedsElement) {
-  const { code } = benchmarkDataHighNeedsElement.dataset;
+  const { code, count, editLink } = benchmarkDataHighNeedsElement.dataset;
   if (code) {
     const root = ReactDOM.createRoot(benchmarkDataHighNeedsElement);
     root.render(
       <React.StrictMode>
-        <BenchmarkDataHighNeeds code={code} fetchTimeout={30_000} />
+        <BenchmarkDataHighNeeds
+          code={code}
+          count={count ? parseInt(count) : undefined}
+          editLink={editLink}
+          fetchTimeout={30_000}
+        />
       </React.StrictMode>
     );
   }

--- a/front-end-components/src/main.tsx
+++ b/front-end-components/src/main.tsx
@@ -1034,14 +1034,14 @@ const benchmarkDataHighNeedsElement = document.getElementById(
   BenchmarkDataHighNeedsElementId
 );
 if (benchmarkDataHighNeedsElement) {
-  const { code, count, editLink } = benchmarkDataHighNeedsElement.dataset;
+  const { code, editLink, set } = benchmarkDataHighNeedsElement.dataset;
   if (code) {
     const root = ReactDOM.createRoot(benchmarkDataHighNeedsElement);
     root.render(
       <React.StrictMode>
         <BenchmarkDataHighNeeds
           code={code}
-          count={count ? parseInt(count) : undefined}
+          set={set ? (JSON.parse(set) as string[]) : []}
           editLink={editLink}
           fetchTimeout={30_000}
         />

--- a/front-end-components/src/services/education-health-care-plans-api.tsx
+++ b/front-end-components/src/services/education-health-care-plans-api.tsx
@@ -7,10 +7,15 @@ import { v4 as uuidv4 } from "uuid";
 export class EducationHealthCarePlanApi {
   static async comparison(
     code: string,
+    set?: string[],
     signals?: AbortSignal[]
   ): Promise<LocalAuthoritySend2Benchmark[]> {
     const params = new URLSearchParams({
       code,
+    });
+
+    (set || []).forEach((s) => {
+      params.append("set", s);
     });
 
     const response = await fetch(

--- a/front-end-components/src/services/high-needs-api.tsx
+++ b/front-end-components/src/services/high-needs-api.tsx
@@ -8,10 +8,15 @@ import { v4 as uuidv4 } from "uuid";
 export class HighNeedsApi {
   static async comparison(
     code: string,
+    set?: string[],
     signals?: AbortSignal[]
   ): Promise<LocalAuthoritySection251Benchmark<LocalAuthoritySection251>[]> {
     const params = new URLSearchParams({
       code,
+    });
+
+    (set || []).forEach((s) => {
+      params.append("set", s);
     });
 
     const response = await fetch(

--- a/front-end-components/src/views/benchmark-data-high-needs/partials/benchmark-high-needs.tsx
+++ b/front-end-components/src/views/benchmark-data-high-needs/partials/benchmark-high-needs.tsx
@@ -20,7 +20,7 @@ import { HighNeedsApi } from "src/services/high-needs-api";
 
 export const BenchmarkHighNeeds: React.FC<
   BenchmarkDataHighNeedsAccordionProps
-> = ({ count, editLink, fetchTimeout }) => {
+> = ({ set, editLink, fetchTimeout }) => {
   const selectedEstabishment = useContext(SelectedEstablishmentContext);
   const { chartMode, setChartMode } = useChartModeContext();
   const [section251LoadError, setSection251LoadError] = useState<string>();
@@ -37,18 +37,20 @@ export const BenchmarkHighNeeds: React.FC<
     setSection251Data(undefined);
     return await HighNeedsApi.comparison(
       selectedEstabishment,
+      set,
       fetchTimeout ? [AbortSignal.timeout(fetchTimeout)] : undefined
     );
-  }, [fetchTimeout, selectedEstabishment]);
+  }, [fetchTimeout, selectedEstabishment, set]);
 
   const getSend2Data = useCallback(async () => {
     setSend2LoadError(undefined);
     setSend2Data(undefined);
     return await EducationHealthCarePlanApi.comparison(
       selectedEstabishment,
+      set,
       fetchTimeout ? [AbortSignal.timeout(fetchTimeout)] : undefined
     );
-  }, [fetchTimeout, selectedEstabishment]);
+  }, [fetchTimeout, selectedEstabishment, set]);
 
   useEffect(() => {
     getSend2Data()
@@ -82,10 +84,10 @@ export const BenchmarkHighNeeds: React.FC<
     <>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
-          {count && (
+          {set.length && (
             <p className="govuk-body govuk-!-font-weight-bold">
-              Currently comparing against {count} local
-              {count === 1 ? " authority" : " authorities"}
+              Currently comparing against {set.length} local
+              {set.length === 1 ? " authority" : " authorities"}
             </p>
           )}
           {editLink && (

--- a/front-end-components/src/views/benchmark-data-high-needs/partials/benchmark-high-needs.tsx
+++ b/front-end-components/src/views/benchmark-data-high-needs/partials/benchmark-high-needs.tsx
@@ -20,7 +20,7 @@ import { HighNeedsApi } from "src/services/high-needs-api";
 
 export const BenchmarkHighNeeds: React.FC<
   BenchmarkDataHighNeedsAccordionProps
-> = ({ fetchTimeout }) => {
+> = ({ count, editLink, fetchTimeout }) => {
   const selectedEstabishment = useContext(SelectedEstablishmentContext);
   const { chartMode, setChartMode } = useChartModeContext();
   const [section251LoadError, setSection251LoadError] = useState<string>();
@@ -81,7 +81,23 @@ export const BenchmarkHighNeeds: React.FC<
   return (
     <>
       <div className="govuk-grid-row">
-        <div className="govuk-grid-column-two-thirds">&nbsp;</div>
+        <div className="govuk-grid-column-two-thirds">
+          {count && (
+            <p className="govuk-body govuk-!-font-weight-bold">
+              Currently comparing against {count} local
+              {count === 1 ? " authority" : " authorities"}
+            </p>
+          )}
+          {editLink && (
+            <a
+              href={editLink}
+              role="button"
+              className="govuk-button govuk-button--secondary govuk-!-margin-bottom-9"
+            >
+              Change comparators
+            </a>
+          )}
+        </div>
         <div className="govuk-grid-column-one-third">
           <ChartMode chartMode={chartMode} handleChange={setChartMode} />
         </div>

--- a/front-end-components/src/views/benchmark-data-high-needs/types.tsx
+++ b/front-end-components/src/views/benchmark-data-high-needs/types.tsx
@@ -7,6 +7,8 @@ import {
 
 export type BenchmarkDataHighNeedsProps = {
   code: string;
+  count?: number;
+  editLink?: string;
   fetchTimeout?: number;
 };
 

--- a/front-end-components/src/views/benchmark-data-high-needs/types.tsx
+++ b/front-end-components/src/views/benchmark-data-high-needs/types.tsx
@@ -7,9 +7,9 @@ import {
 
 export type BenchmarkDataHighNeedsProps = {
   code: string;
-  count?: number;
   editLink?: string;
   fetchTimeout?: number;
+  set: string[];
 };
 
 export type BenchmarkDataHighNeedsViewProps = BenchmarkDataHighNeedsProps & {};

--- a/front-end-components/src/views/benchmark-data-high-needs/view.tsx
+++ b/front-end-components/src/views/benchmark-data-high-needs/view.tsx
@@ -6,13 +6,13 @@ import { BenchmarkHighNeeds } from "./partials/benchmark-high-needs";
 
 export const BenchmarkDataHighNeeds: React.FC<
   BenchmarkDataHighNeedsViewProps
-> = ({ code, fetchTimeout }) => {
+> = ({ code, ...props }) => {
   useGovUk();
 
   return (
     <SelectedEstablishmentContext.Provider value={code}>
       <ChartModeProvider initialValue={ChartModeChart}>
-        <BenchmarkHighNeeds fetchTimeout={fetchTimeout} />
+        <BenchmarkHighNeeds {...props} />
       </ChartModeProvider>
     </SelectedEstablishmentContext.Provider>
   );

--- a/web/src/Web.App/Controllers/Api/EducationHealthCarePlansProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/EducationHealthCarePlansProxyController.cs
@@ -14,22 +14,21 @@ namespace Web.App.Controllers.Api;
 [Route("api/local-authorities/education-health-care-plans")]
 public class EducationHealthCarePlansProxyController(
     ILogger<EducationHealthCarePlansProxyController> logger,
-    IEducationHealthCarePlansApi educationHealthCarePlansApi,
-    ILocalAuthorityComparatorSetService comparatorSetService) : Controller
+    IEducationHealthCarePlansApi educationHealthCarePlansApi) : Controller
 {
     /// <param name="code" example="201"></param>
+    /// <param name="set" example="202,203,204"></param>
     /// <param name="cancellationToken"></param>
     [HttpGet]
     [Produces("application/json")]
     [ProducesResponseType<EducationHealthCarePlansComparisonResponse[]>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Route("comparison")]
-    public async Task<IActionResult> Comparison([FromQuery] string code, CancellationToken cancellationToken)
+    public async Task<IActionResult> Comparison([FromQuery] string code, [FromQuery] string[]? set = null, CancellationToken cancellationToken = default)
     {
         try
         {
-            var set = comparatorSetService.ReadUserDefinedComparatorSetFromSession(code).Set;
-            if (set.Length == 0)
+            if (set == null || set.All(string.IsNullOrWhiteSpace))
             {
                 return NotFound();
             }

--- a/web/src/Web.App/Controllers/Api/HighNeedsProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/HighNeedsProxyController.cs
@@ -6,7 +6,6 @@ using Web.App.Domain.LocalAuthorities;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.LocalAuthorities;
 using Web.App.Infrastructure.Extensions;
-using Web.App.Services;
 
 namespace Web.App.Controllers.Api;
 
@@ -14,22 +13,21 @@ namespace Web.App.Controllers.Api;
 [Route("api/local-authorities/high-needs")]
 public class HighNeedsProxyController(
     ILogger<HighNeedsProxyController> logger,
-    ILocalAuthoritiesApi localAuthoritiesApi,
-    ILocalAuthorityComparatorSetService comparatorSetService) : Controller
+    ILocalAuthoritiesApi localAuthoritiesApi) : Controller
 {
     /// <param name="code" example="201"></param>
+    /// <param name="set" example="202,203,204"></param>
     /// <param name="cancellationToken"></param>
     [HttpGet]
     [Produces("application/json")]
     [ProducesResponseType<LocalAuthorityHighNeedsComparisonResponse[]>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Route("comparison")]
-    public async Task<IActionResult> Comparison([FromQuery] string code, CancellationToken cancellationToken)
+    public async Task<IActionResult> Comparison([FromQuery] string code, [FromQuery] string[]? set = null, CancellationToken cancellationToken = default)
     {
         try
         {
-            var set = comparatorSetService.ReadUserDefinedComparatorSetFromSession(code).Set;
-            if (set.Length == 0)
+            if (set == null || set.All(string.IsNullOrWhiteSpace))
             {
                 return NotFound();
             }

--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsBenchmarkingController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsBenchmarkingController.cs
@@ -48,7 +48,7 @@ public class LocalAuthorityHighNeedsBenchmarkingController(
                     return NotFound();
                 }
 
-                return View(new LocalAuthorityViewModel(localAuthority));
+                return View(new LocalAuthorityHighNeedsBenchmarkingViewModel(localAuthority, set));
             }
             catch (Exception e)
             {
@@ -74,7 +74,7 @@ public class LocalAuthorityHighNeedsBenchmarkingController(
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.LocalAuthorityHome(code);
 
                 var localAuthority = await LocalAuthorityStatisticalNeighbours(code);
-                var viewModel = new LocalAuthorityHighNeedsBenchmarkingViewModel(
+                var viewModel = new LocalAuthorityHighNeedsStartBenchmarkingViewModel(
                     localAuthority,
                     localAuthorityComparatorSetService.ReadUserDefinedComparatorSetFromSession(code).Set,
                     referrer);
@@ -134,7 +134,7 @@ public class LocalAuthorityHighNeedsBenchmarkingController(
                 }
 
                 var localAuthority = await LocalAuthorityStatisticalNeighbours(code);
-                return View(nameof(Comparators), new LocalAuthorityHighNeedsBenchmarkingViewModel(localAuthority, comparators.ToArray(), viewModel.Referrer));
+                return View(nameof(Comparators), new LocalAuthorityHighNeedsStartBenchmarkingViewModel(localAuthority, comparators.ToArray(), viewModel.Referrer));
             }
             catch (Exception e)
             {

--- a/web/src/Web.App/ViewModels/LocalAuthorityComparatorSetViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityComparatorSetViewModel.cs
@@ -1,9 +1,0 @@
-﻿using Web.App.Domain;
-namespace Web.App.ViewModels;
-
-public class LocalAuthorityComparatorSetViewModel(LocalAuthority localAuthority, string[] strings)
-{
-    public string? Code => localAuthority.Code;
-    public string? Name => localAuthority.Name;
-
-}

--- a/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsBenchmarkingViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsBenchmarkingViewModel.cs
@@ -2,11 +2,10 @@ using Web.App.Domain;
 
 namespace Web.App.ViewModels;
 
-public class LocalAuthorityHighNeedsBenchmarkingViewModel(LocalAuthority localAuthority, string[] comparators, string? referrer)
+public class LocalAuthorityHighNeedsBenchmarkingViewModel(LocalAuthority localAuthority, string[] comparators)
 {
     public string? Code => localAuthority.Code;
     public string? Name => localAuthority.Name;
-    public string? Referrer => referrer;
 
     public string[] Comparators => comparators
         .Where(c => c != Code)

--- a/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsBenchmarkingViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsBenchmarkingViewModel.cs
@@ -2,19 +2,11 @@ using Web.App.Domain;
 
 namespace Web.App.ViewModels;
 
-public class LocalAuthorityHighNeedsBenchmarkingViewModel(LocalAuthorityStatisticalNeighbours localAuthority, string[] comparators, string? referrer)
+public class LocalAuthorityHighNeedsBenchmarkingViewModel(LocalAuthority localAuthority, string[] comparators, string? referrer)
 {
     public string? Code => localAuthority.Code;
     public string? Name => localAuthority.Name;
     public string? Referrer => referrer;
-
-    public string[] StatisticalNeighbours => localAuthority.StatisticalNeighbours?
-        .OrderBy(n => n.Position)
-        .ThenBy(n => n.Name)
-        .Where(n => !string.IsNullOrWhiteSpace(n.Name))
-        .Select(n => n.Name)
-        .Cast<string>()
-        .ToArray() ?? [];
 
     public string[] Comparators => comparators
         .Where(c => c != Code)

--- a/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsStartBenchmarkingViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsStartBenchmarkingViewModel.cs
@@ -2,10 +2,11 @@ using Web.App.Domain;
 
 namespace Web.App.ViewModels;
 
-public class LocalAuthorityHighNeedsStartBenchmarkingViewModel(LocalAuthorityStatisticalNeighbours localAuthority, string[] comparators)
+public class LocalAuthorityHighNeedsStartBenchmarkingViewModel(LocalAuthorityStatisticalNeighbours localAuthority, string[] comparators, string? referrer)
 {
     public string? Code => localAuthority.Code;
     public string? Name => localAuthority.Name;
+    public string? Referrer => referrer;
 
     public string[] StatisticalNeighbours => localAuthority.StatisticalNeighbours?
         .OrderBy(n => n.Position)

--- a/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsStartBenchmarkingViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsStartBenchmarkingViewModel.cs
@@ -1,0 +1,22 @@
+using Web.App.Domain;
+
+namespace Web.App.ViewModels;
+
+public class LocalAuthorityHighNeedsStartBenchmarkingViewModel(LocalAuthorityStatisticalNeighbours localAuthority, string[] comparators)
+{
+    public string? Code => localAuthority.Code;
+    public string? Name => localAuthority.Name;
+
+    public string[] StatisticalNeighbours => localAuthority.StatisticalNeighbours?
+        .OrderBy(n => n.Position)
+        .ThenBy(n => n.Name)
+        .Where(n => !string.IsNullOrWhiteSpace(n.Name))
+        .Select(n => n.Name)
+        .Cast<string>()
+        .ToArray() ?? [];
+
+    public string[] Comparators => comparators
+        .Where(c => c != Code)
+        .Distinct()
+        .ToArray();
+}

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsBenchmarking/Comparators.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsBenchmarking/Comparators.cshtml
@@ -1,7 +1,7 @@
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @using Web.App.Domain
 @using Web.App.ViewModels
-@model Web.App.ViewModels.LocalAuthorityHighNeedsBenchmarkingViewModel
+@model Web.App.ViewModels.LocalAuthorityHighNeedsStartBenchmarkingViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.LocalAuthorityHighNeedsStartBenchmarking;
     var referrer = Url.Action(

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsBenchmarking/Comparators.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsBenchmarking/Comparators.cshtml
@@ -66,7 +66,7 @@
 <form action="@Url.Action("Comparators", "LocalAuthorityHighNeedsBenchmarking", new { Model.Code })" method="post">
     @if (!string.IsNullOrWhiteSpace(Model.Referrer))
     {
-        <input name="@nameof(LocalAuthorityHighNeedsBenchmarkingViewModel.Referrer)" value="@Model.Referrer"
+        <input name="@nameof(LocalAuthorityHighNeedsStartBenchmarkingViewModel.Referrer)" value="@Model.Referrer"
                type="hidden"/>
     }
     

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsBenchmarking/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsBenchmarking/Index.cshtml
@@ -1,3 +1,5 @@
+@using Newtonsoft.Json
+@using Web.App.Extensions
 @model Web.App.ViewModels.LocalAuthorityHighNeedsBenchmarkingViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.LocalAuthorityHighNeedsBenchmarking;
@@ -20,5 +22,5 @@
     flagAggregatedHighNeeds = true
 })
 
-<div id="benchmark-data-high-needs" data-code="@Model.Code" data-count="@Model.Comparators.Length"
+<div id="benchmark-data-high-needs" data-code="@Model.Code" data-set="@Model.Comparators.ToJson(Formatting.None)"
      data-edit-link="@Url.Action("Comparators", "LocalAuthorityHighNeedsBenchmarking", new { code = Model.Code, referrer = "benchmarking" })"></div>

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsBenchmarking/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsBenchmarking/Index.cshtml
@@ -3,6 +3,8 @@
     ViewData[ViewDataKeys.Title] = PageTitles.LocalAuthorityHighNeedsBenchmarking;
 }
 
+@Html.ActionLink("High needs homepage", "Index", "LocalAuthorityHighNeeds", new { code = Model.Code }, new { @class = "govuk-back-link govuk-!-margin-top-0" })
+
 @await Component.InvokeAsync("EstablishmentHeading", new
 {
     title = ViewData[ViewDataKeys.Title],

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsBenchmarking/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsBenchmarking/Index.cshtml
@@ -1,4 +1,4 @@
-@model Web.App.ViewModels.LocalAuthorityViewModel
+@model Web.App.ViewModels.LocalAuthorityHighNeedsBenchmarkingViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.LocalAuthorityHighNeedsBenchmarking;
 }
@@ -13,9 +13,10 @@
 
 @await Component.InvokeAsync("DataSource", new
 {
-organisationType = OrganisationTypes.LocalAuthority,
-sourceType = DataSourceTypes.HighNeeds,
-flagAggregatedHighNeeds = true
+    organisationType = OrganisationTypes.LocalAuthority,
+    sourceType = DataSourceTypes.HighNeeds,
+    flagAggregatedHighNeeds = true
 })
 
-<div id="benchmark-data-high-needs" data-code="@Model.Code"></div>
+<div id="benchmark-data-high-needs" data-code="@Model.Code" data-count="@Model.Comparators.Length"
+     data-edit-link="@Url.Action("Comparators", "LocalAuthorityHighNeedsBenchmarking", new { code = Model.Code, referrer = "benchmarking" })"></div>

--- a/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsBenchmarking.feature
+++ b/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsBenchmarking.feature
@@ -7,6 +7,17 @@
         And I click the Save and continue button
 
     @HighNeedsFlagEnabled
+    Scenario: Can view local authority benchmarking commentary
+        Given I am on local authority high needs benchmarking for local authority with code '201'
+        Then comparator commentary label is visible, showing local authority count of '1'
+
+    @HighNeedsFlagEnabled
+    Scenario: Can click local authority benchmarking CTA
+        Given I am on local authority high needs benchmarking for local authority with code '201'
+        When I click the Change comparators button
+        Then the local authority high needs start benchmarking page is displayed
+
+    @HighNeedsFlagEnabled
     Scenario: Can view local authority benchmarking charts
         Given I am on local authority high needs benchmarking for local authority with code '201'
         Then chart view is visible, showing '33' charts

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsBenchmarkingPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsBenchmarkingPage.cs
@@ -11,6 +11,11 @@ public class HighNeedsBenchmarkingPage(IPage page)
     private ILocator ViewAsChartRadio => page.Locator(Selectors.ModeChart);
     private ILocator Charts => page.Locator(Selectors.Charts);
     private ILocator Tables => page.Locator(Selectors.GovTable);
+    private ILocator Commentary => page.Locator("#benchmark-data-high-needs > .govuk-grid-row > .govuk-grid-column-two-thirds > p");
+    private ILocator ChangeComparatorsButton => page.Locator(Selectors.CtaButton, new PageLocatorOptions
+    {
+        HasText = "Change comparators"
+    });
 
     public async Task IsDisplayed()
     {
@@ -20,6 +25,18 @@ public class HighNeedsBenchmarkingPage(IPage page)
     public async Task ClickViewAsChart()
     {
         await ViewAsChartRadio.Click();
+    }
+
+    public async Task IsComparatorCommentaryDisplayed(int comparators)
+    {
+        await Commentary.ShouldBeVisible();
+        await Commentary.ShouldContainText($"Currently comparing against {comparators} local authorit");
+    }
+
+    public async Task<HighNeedsStartBenchmarkingPage> ClickChangeComparatorsButton()
+    {
+        await ChangeComparatorsButton.ClickAsync();
+        return new HighNeedsStartBenchmarkingPage(page);
     }
 
     public async Task AreChartsDisplayed(int count)

--- a/web/tests/Web.E2ETests/Steps/LocalAuthority/HighNeedsBenchmarkingSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/LocalAuthority/HighNeedsBenchmarkingSteps.cs
@@ -66,6 +66,13 @@ public class HighNeedsBenchmarkingSteps(PageDriver driver)
         await _highNeedsBenchmarkingPage.ClickViewAsTable();
     }
 
+    [Then("comparator commentary label is visible, showing local authority count of '(\\d+)'")]
+    public async Task ThenComparatorCommentaryLabelIsVisibleShowingLocalAuthorityCountOf(string comparators)
+    {
+        Assert.NotNull(_highNeedsBenchmarkingPage);
+        await _highNeedsBenchmarkingPage.IsComparatorCommentaryDisplayed(int.Parse(comparators));
+    }
+
     [Then("chart view is visible, showing '(\\d+)' charts")]
     public async Task ThenChartViewIsVisibleShowingCharts(string charts)
     {
@@ -92,6 +99,20 @@ public class HighNeedsBenchmarkingSteps(PageDriver driver)
     {
         Assert.NotNull(_highNeedsBenchmarkingPage);
         await _highNeedsBenchmarkingPage.TableContainsSend2(25, table);
+    }
+
+    [When("I click the Change comparators button")]
+    public async Task WhenIClickTheChangeComparatorsButton()
+    {
+        Assert.NotNull(_highNeedsBenchmarkingPage);
+        _highNeedsStartBenchmarkingPage = await _highNeedsBenchmarkingPage.ClickChangeComparatorsButton();
+    }
+
+    [Then("the local authority high needs start benchmarking page is displayed")]
+    public async Task ThenTheLocalAuthorityHighNeedsStartBenchmarkingPageIsDisplayed()
+    {
+        Assert.NotNull(_highNeedsStartBenchmarkingPage);
+        await _highNeedsStartBenchmarkingPage.IsDisplayed();
     }
 
     private static string LocalAuthorityHighNeedsBenchmarkingUrl(string laCode)

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsBenchmarking.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsBenchmarking.cs
@@ -69,5 +69,9 @@ public class WhenViewingHighNeedsBenchmarking(SchoolBenchmarkingWebAppClient cli
 
         Assert.NotNull(authority.Name);
         DocumentAssert.TitleAndH1(page, "Benchmark High needs - Financial Benchmarking and Insights Tool - GOV.UK", "Benchmark High needs");
+
+        var backLink = page.QuerySelector("a.govuk-back-link") as IHtmlAnchorElement;
+        Assert.NotNull(backLink);
+        Assert.Equal(Paths.LocalAuthorityHighNeedsDashboard(authority.Code).ToAbsolute(), backLink.Href);
     }
 }

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -357,17 +357,17 @@ public static class Paths
     {
         return $"api/local-authorities/national-rank?ranking={ranking}&sort={sort}";
     }
-    public static string ApiHighNeedsComparison(string code)
+    public static string ApiHighNeedsComparison(string code, string[] set)
     {
-        return $"api/local-authorities/high-needs/comparison?code={code}";
+        return $"api/local-authorities/high-needs/comparison?code={code}&set={string.Join("&set=", set)}";
     }
     public static string ApiHighNeedsHistory(string code)
     {
         return $"api/local-authorities/high-needs/history?code={code}";
     }
-    public static string ApiEducationHealthCarePlansComparison(string code)
+    public static string ApiEducationHealthCarePlansComparison(string code, string[] set)
     {
-        return $"api/local-authorities/education-health-care-plans/comparison?code={code}";
+        return $"api/local-authorities/education-health-care-plans/comparison?code={code}&set={string.Join("&set=", set)}";
     }
     public static string ApiEducationHealthCarePlansHistory(string code)
     {

--- a/web/tests/Web.Integration.Tests/Proxy/WhenRequestingEducationHealthCarePlansComparison.cs
+++ b/web/tests/Web.Integration.Tests/Proxy/WhenRequestingEducationHealthCarePlansComparison.cs
@@ -25,9 +25,8 @@ public class WhenEducationHealthCarePlansComparison(SchoolBenchmarkingWebAppClie
             .ToArray();
 
         var response = await client
-            .SetupLocalAuthoritiesComparators(code, set)
             .SetupEducationHealthCarePlans(plans, null)
-            .Get(Paths.ApiEducationHealthCarePlansComparison(code));
+            .Get(Paths.ApiEducationHealthCarePlansComparison(code, set));
 
         Assert.IsType<HttpResponseMessage>(response);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -62,8 +61,7 @@ public class WhenEducationHealthCarePlansComparison(SchoolBenchmarkingWebAppClie
         string[] set = [];
 
         var response = await client
-            .SetupLocalAuthoritiesComparators(code, set)
-            .Get(Paths.ApiEducationHealthCarePlansComparison(code));
+            .Get(Paths.ApiEducationHealthCarePlansComparison(code, set));
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
@@ -75,9 +73,8 @@ public class WhenEducationHealthCarePlansComparison(SchoolBenchmarkingWebAppClie
         var set = new[] { "code2", "code3" };
 
         var response = await client
-            .SetupLocalAuthoritiesComparators(code, set)
             .SetupEducationHealthCarePlansWithException()
-            .Get(Paths.ApiEducationHealthCarePlansComparison(code));
+            .Get(Paths.ApiEducationHealthCarePlansComparison(code, set));
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
     }

--- a/web/tests/Web.Integration.Tests/Proxy/WhenRequestingHighNeedsComparison.cs
+++ b/web/tests/Web.Integration.Tests/Proxy/WhenRequestingHighNeedsComparison.cs
@@ -26,9 +26,8 @@ public class WhenRequestingHighNeedsComparison(SchoolBenchmarkingWebAppClient cl
             .ToArray();
 
         var response = await client
-            .SetupLocalAuthoritiesComparators(code, set)
             .SetupHighNeeds(localAuthorities, null)
-            .Get(Paths.ApiHighNeedsComparison(code));
+            .Get(Paths.ApiHighNeedsComparison(code, set));
 
         Assert.IsType<HttpResponseMessage>(response);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -55,8 +54,7 @@ public class WhenRequestingHighNeedsComparison(SchoolBenchmarkingWebAppClient cl
         string[] set = [];
 
         var response = await client
-            .SetupLocalAuthoritiesComparators(code, set)
-            .Get(Paths.ApiHighNeedsComparison(code));
+            .Get(Paths.ApiHighNeedsComparison(code, set));
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
@@ -68,9 +66,8 @@ public class WhenRequestingHighNeedsComparison(SchoolBenchmarkingWebAppClient cl
         var set = new[] { "code2", "code3" };
 
         var response = await client
-            .SetupLocalAuthoritiesComparators(code, set)
             .SetupLocalAuthoritiesWithException()
-            .Get(Paths.ApiHighNeedsComparison(code));
+            .Get(Paths.ApiHighNeedsComparison(code, set));
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
     }


### PR DESCRIPTION
### Context
[AB#256807](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/256807) [AB#255674](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/255674)

### Change proposed in this pull request
- Comparator count and CTA added to benchmarking page, along with 'Back' link
- Passed comparator set to `<BenchmarkDataHighNeeds>` component to prevent requesting again from session via proxy
- E2E and integration test updates

### Guidance to review 
`referrer` query string implementation added in #2236, but there should not be any conflicts with this PR. This will require a `front-end` bump.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

