### PR TITLE
chore: bump `front-end` to `1.1.83`

### DIFF
--- a/web/src/Web.App/package-lock.json
+++ b/web/src/Web.App/package-lock.json
@@ -1441,9 +1441,9 @@
       }
     },
     "node_modules/front-end": {
-      "version": "1.1.82",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-1.1.82.tgz",
-      "integrity": "sha1-CdiEnoTrM/jH9vrP19AgtTCoXVY=",
+      "version": "1.1.83",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-1.1.83.tgz",
+      "integrity": "sha1-vN9OpsKmXJ3LyVMI6nvZt2TqrfI=",
       "dependencies": {
         "accessible-autocomplete": "^3.0.0",
         "classnames": "^2.5.1",


### PR DESCRIPTION
### Context
[AB#255674](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/255674) - #2237 

### Change proposed in this pull request
bump `front-end` following changes on #2237 

### Guidance to review 
n/a

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

