### PR TITLE
Readme for test projects

### DIFF
--- a/web/tests/Web.A11yTests/README.md
+++ b/web/tests/Web.A11yTests/README.md
@@ -11,8 +11,9 @@ To run the tests locally and ensure they match pipeline behavior, follow these s
 
 Follow the configuration structure outlined in [`web/README.md`](../../README.md#accessibility-tests) and create or update your `appsettings.local.json` file in the `Web.A11yTests` project directory.
 
-- Set the correct `"ServiceUrl"` for the [automated test environment](https://s198d02-education-benchmarking-fqhxhwdsdyh3cded.a02.azurefd.net)
+Ensure you:
 
+- Set the correct `"ServiceUrl"` for the [automated test environment](https://s198d02-education-benchmarking-fqhxhwdsdyh3cded.a02.azurefd.net)
 
 ### 2. Manage Secrets Securely
 

--- a/web/tests/Web.A11yTests/README.md
+++ b/web/tests/Web.A11yTests/README.md
@@ -1,0 +1,26 @@
+﻿# Running Accessibility (A11y) Automated Tests locally
+
+This guide outlines how to configure and run the automated accessibility (A11y) tests for the project. These tests are designed to run against the same environment used by the CI/CD pipeline to ensure accessibility compliance and coverage.
+
+## 🚀 Getting Started
+
+Follow these steps to set up and execute A11y tests locally:
+
+### 1. Update Your `appsettings.local.json`
+
+Create or update the `appsettings.local.json` file in the test project directory to point to the correct  [automated test environment](https://s198d02-education-benchmarking-fqhxhwdsdyh3cded.a02.azurefd.net)
+
+### 2. Populate Required Variables
+
+Refer to the `appsettings.json` file for all required configuration keys. You must replicate these keys in `appsettings.local.json` with appropriate values.
+
+### 3. Authentication
+
+The A11y tests use the following test account:
+
+- **Username:** `dsi.ebfi.a11yacc1@outlook.com`
+- **Password:** _Obtain this from a member of the Tech Team._
+
+> ⚠️ **Important:** Do not commit credentials to version control. Treat this account as sensitive and follow your team's security practices.
+### Running the tests
+Once you've configured appsettings.local.json, you need to build the project and then can run as per your preferred command line tool. 

--- a/web/tests/Web.A11yTests/README.md
+++ b/web/tests/Web.A11yTests/README.md
@@ -1,6 +1,7 @@
 ﻿# Running Accessibility (A11y) Tests Locally
 
-This guide provides an overview for setting up and running accessibility (A11y) tests for the project, consistent with the CI/CD pipeline configuration.  
+This guide provides an overview for setting up and running accessibility (A11y) tests for the project,
+consistent with the CI/CD pipeline configuration.  
 It complements the detailed setup instructions already available in [`web/README.md`](../../README.md#accessibility-tests).
 
 ## 🚀 Getting Started
@@ -9,7 +10,8 @@ To run the tests locally and ensure they match pipeline behavior, follow these s
 
 ### 1. Configure `appsettings.local.json`
 
-Follow the configuration structure outlined in [`web/README.md`](../../README.md#accessibility-tests) and create or update your `appsettings.local.json` file in the `Web.A11yTests` project directory.
+Follow the configuration structure outlined in [`web/README.md`](../../README.md#accessibility-tests).
+Create or update your `appsettings.local.json` file in the `Web.A11yTests` project directory.
 
 Ensure you:
 

--- a/web/tests/Web.A11yTests/README.md
+++ b/web/tests/Web.A11yTests/README.md
@@ -1,26 +1,32 @@
-﻿# Running Accessibility (A11y) Automated Tests locally
+﻿# Running Accessibility (A11y) Tests Locally
 
-This guide outlines how to configure and run the automated accessibility (A11y) tests for the project. These tests are designed to run against the same environment used by the CI/CD pipeline to ensure accessibility compliance and coverage.
+This guide provides an overview for setting up and running accessibility (A11y) tests for the project, consistent with the CI/CD pipeline configuration.  
+It complements the detailed setup instructions already available in [`web/README.md`](../../README.md#accessibility-tests).
 
 ## 🚀 Getting Started
 
-Follow these steps to set up and execute A11y tests locally:
+To run the tests locally and ensure they match pipeline behavior, follow these steps:
 
-### 1. Update Your `appsettings.local.json`
+### 1. Configure `appsettings.local.json`
 
-Create or update the `appsettings.local.json` file in the test project directory to point to the correct  [automated test environment](https://s198d02-education-benchmarking-fqhxhwdsdyh3cded.a02.azurefd.net)
+Follow the configuration structure outlined in [`web/README.md`](../../README.md#accessibility-tests) and create or update your `appsettings.local.json` file in the `Web.A11yTests` project directory.
 
-### 2. Populate Required Variables
+- Set the correct `"ServiceUrl"` for the [automated test environment](https://s198d02-education-benchmarking-fqhxhwdsdyh3cded.a02.azurefd.net)
 
-Refer to the `appsettings.json` file for all required configuration keys. You must replicate these keys in `appsettings.local.json` with appropriate values.
 
-### 3. Authentication
+### 2. Manage Secrets Securely
 
-The A11y tests use the following test account:
+- **Credentials** (`dfe-signin-testa11y-username` and `dfe-signin-testa11y-password`) are stored securely in Azure DevOps:
 
-- **Username:** `dsi.ebfi.a11yacc1@outlook.com`
-- **Password:** _Obtain this from a member of the Tech Team._
+  > `Library` → `Automated Tests App Settings`
 
-> ⚠️ **Important:** Do not commit credentials to version control. Treat this account as sensitive and follow your team's security practices.
-### Running the tests
-Once you've configured appsettings.local.json, you need to build the project and then can run as per your preferred command line tool. 
+Fetch any other required variable values from the same library.
+
+- **Benchmark Host and Key** must be retrieved from **Azure Key Vault**.  
+
+### 3. Running the Tests
+
+Once your local settings are configured, run the tests from the `web` directory root with:
+
+```bash
+dotnet test tests/Web.A11yTests

--- a/web/tests/Web.E2ETests/README.md
+++ b/web/tests/Web.E2ETests/README.md
@@ -10,6 +10,7 @@ To run the tests locally and ensure they mirror the CI/CD pipeline environment, 
 ### 1. Configure `appsettings.local.json`
 
 Follow the detailed instructions in [`web/README.md`](../../README.md#end-to-end-tests) to create or update your `appsettings.local.json` file in the `Web.E2ETests` project.  
+
 Ensure you:
 
 - Set the correct `"ServiceUrl"` for the [automated test environment](https://s198d02-education-benchmarking-fqhxhwdsdyh3cded.a02.azurefd.net)

--- a/web/tests/Web.E2ETests/README.md
+++ b/web/tests/Web.E2ETests/README.md
@@ -1,0 +1,35 @@
+﻿# Running Automated End-to-End (E2E) Tests locally
+
+This guide provides instructions on how to run the automated E2E tests for the project, specifically targeting the same environment used by the CI/CD pipeline.
+
+## 🚀 Getting Started
+
+To run the tests locally and ensure they mimic the behavior and environment of the pipeline, follow these steps:
+
+### 1. Update Your `appsettings.local.json`
+
+Create or update the `appsettings.local.json` file in the test project directory to point to the correct  [automated test environment](https://s198d02-education-benchmarking-fqhxhwdsdyh3cded.a02.azurefd.net)
+
+### 2. Populate Required Variables
+
+Refer to the `appsettings.json` file for all required configuration keys. You must replicate these keys in `appsettings.local.json` with appropriate values.
+
+### 3. Authentication
+
+The E2E tests use the following test account:
+
+- **Username:** `dsi.ebfi.acc1@outlook.com`
+- **Password:** _Obtain this from a member of the Tech Team._
+
+> ⚠️ **Important:** Do not commit credentials to version control. Treat this account as sensitive and follow your team's security practices.
+
+### 4. Headless Mode (Optional)
+
+To run tests in headless mode (without opening a browser window), you can add the following variable in `appsettings.local.json`:
+
+```json
+"Headless": true 
+```
+
+### Running the tests
+Once you've configured appsettings.local.json, you need to build the project and then can run as per your preferred command line tool. 

--- a/web/tests/Web.E2ETests/README.md
+++ b/web/tests/Web.E2ETests/README.md
@@ -9,7 +9,8 @@ To run the tests locally and ensure they mirror the CI/CD pipeline environment, 
 
 ### 1. Configure `appsettings.local.json`
 
-Follow the detailed instructions in [`web/README.md`](../../README.md#end-to-end-tests) to create or update your `appsettings.local.json` file in the `Web.E2ETests` project.  
+Follow the detailed instructions in [`web/README.md`](../../README.md#end-to-end-tests).
+Create or update your `appsettings.local.json` file in the `Web.E2ETests` project.
 
 Ensure you:
 

--- a/web/tests/Web.E2ETests/README.md
+++ b/web/tests/Web.E2ETests/README.md
@@ -1,35 +1,30 @@
-﻿# Running Automated End-to-End (E2E) Tests locally
+﻿# Running Automated End-to-End (E2E) Tests Locally
 
-This guide provides instructions on how to run the automated E2E tests for the project, specifically targeting the same environment used by the CI/CD pipeline.
+This guide provides an overview for setting up and running automated E2E tests for the project, aligned with the CI/CD pipeline setup.  
+It complements the more detailed instructions already available in [`web/README.md`](../../README.md#end-to-end-tests).
 
 ## 🚀 Getting Started
 
-To run the tests locally and ensure they mimic the behavior and environment of the pipeline, follow these steps:
+To run the tests locally and ensure they mirror the CI/CD pipeline environment, follow these high-level steps:
 
-### 1. Update Your `appsettings.local.json`
+### 1. Configure `appsettings.local.json`
 
-Create or update the `appsettings.local.json` file in the test project directory to point to the correct  [automated test environment](https://s198d02-education-benchmarking-fqhxhwdsdyh3cded.a02.azurefd.net)
+Follow the detailed instructions in [`web/README.md`](../../README.md#end-to-end-tests) to create or update your `appsettings.local.json` file in the `Web.E2ETests` project.  
+Ensure you:
 
-### 2. Populate Required Variables
+- Set the correct `"ServiceUrl"` for the [automated test environment](https://s198d02-education-benchmarking-fqhxhwdsdyh3cded.a02.azurefd.net)
 
-Refer to the `appsettings.json` file for all required configuration keys. You must replicate these keys in `appsettings.local.json` with appropriate values.
+### 2. Manage Credentials Securely
 
-### 3. Authentication
+- **Credentials** (`dfe-signin-test-username` and `dfe-signin-test-password`) are stored securely in Azure DevOps:
 
-The E2E tests use the following test account:
+  > `Library` → `Automated Tests App Settings`
+  
+Fetch any other required variable values from the same library.  
 
-- **Username:** `dsi.ebfi.acc1@outlook.com`
-- **Password:** _Obtain this from a member of the Tech Team._
+### 3. Running the Tests
 
-> ⚠️ **Important:** Do not commit credentials to version control. Treat this account as sensitive and follow your team's security practices.
+Once your `appsettings.local.json` is configured, build and run the E2E test project using the following command from the `web` directory root:
 
-### 4. Headless Mode (Optional)
-
-To run tests in headless mode (without opening a browser window), you can add the following variable in `appsettings.local.json`:
-
-```json
-"Headless": true 
-```
-
-### Running the tests
-Once you've configured appsettings.local.json, you need to build the project and then can run as per your preferred command line tool. 
+```bash
+dotnet test tests/Web.E2ETests


### PR DESCRIPTION
added readme to e2e and a11y tests projects to make test documentation more structured and manageable. 