### PR TITLE
Always display `OverallPhase` facets relevant to the original search term in search results

### DIFF
--- a/web/src/Web.App/Controllers/SchoolSearchController.cs
+++ b/web/src/Web.App/Controllers/SchoolSearchController.cs
@@ -44,6 +44,7 @@ public class SchoolSearchController(
         [FromQuery] string? term,
         [FromQuery] int? page,
         [FromQuery(Name = "phase")] string[] overallPhase,
+        [FromQuery(Name = "phaseAll")] string[] overallPhaseAll,
         [FromQuery(Name = "sort")] string? orderBy
     )
     {
@@ -52,6 +53,7 @@ public class SchoolSearchController(
             term,
             page,
             overallPhase,
+            allOverallPhase = overallPhaseAll,
             orderBy
         }))
         {
@@ -79,11 +81,21 @@ public class SchoolSearchController(
                 });
             }
 
+            if (overallPhaseAll.Length == 0 && results.Facets != null)
+            {
+                overallPhaseAll = results.Facets
+                    .Where(f => f.Key.Equals("OverallPhase", StringComparison.OrdinalIgnoreCase))
+                    .SelectMany(f => f.Value)
+                    .Select(v => v.Value!)
+                    .ToArray();
+            }
+
             return View(new SchoolSearchResultsViewModel
             {
                 Term = term,
                 OrderBy = orderBy,
                 OverallPhase = overallPhase,
+                OverallPhaseAll = overallPhaseAll,
                 TotalResults = results.TotalResults,
                 PageNumber = results.Page,
                 PageSize = results.PageSize,
@@ -103,7 +115,8 @@ public class SchoolSearchController(
             {
                 Term = viewModel.Term,
                 OrderBy = viewModel.OrderBy,
-                OverallPhase = viewModel.OverallPhase
+                OverallPhase = viewModel.OverallPhase,
+                OverallPhaseAll = viewModel.OverallPhaseAll
             });
         }
 
@@ -120,7 +133,8 @@ public class SchoolSearchController(
         {
             term = viewModel.Term,
             sort = viewModel.OrderBy,
-            phase = viewModel.OverallPhase
+            phase = viewModel.OverallPhase,
+            phaseAll = viewModel.OverallPhaseAll
         });
     }
 }

--- a/web/src/Web.App/ViewModels/Search/SchoolSearchResultsViewModel.cs
+++ b/web/src/Web.App/ViewModels/Search/SchoolSearchResultsViewModel.cs
@@ -1,5 +1,7 @@
 // ReSharper disable PropertyCanBeMadeInitOnly.Global
 
+using Web.App.Domain;
+
 namespace Web.App.ViewModels.Search;
 
 public class SchoolSearchResultsViewModel : SchoolSearchViewModel
@@ -14,5 +16,12 @@ public class SchoolSearchResultsViewModel : SchoolSearchViewModel
     public SearchResultFacetViewModel[] OverallPhaseFacets => Facets
         .Where(f => f.Key == "OverallPhase")
         .SelectMany(f => f.Value)
+        .Union(OverallPhaseAllFacets)
+        .OrderBy(f => f.Value)
+        .ToArray();
+
+    private SearchResultFacetViewModel[] OverallPhaseAllFacets => OverallPhaseAll
+        .Where(f => OverallPhaseTypes.All.Contains(f))
+        .Select(f => new SearchResultFacetViewModel { Value = f, Count = 0 })
         .ToArray();
 }

--- a/web/src/Web.App/ViewModels/Search/SchoolSearchViewModel.cs
+++ b/web/src/Web.App/ViewModels/Search/SchoolSearchViewModel.cs
@@ -7,4 +7,5 @@ public class SchoolSearchViewModel : FindSchoolViewModel
     public string? Action { get; set; }
     public string? OrderBy { get; set; }
     public string[] OverallPhase { get; set; } = [];
+    public string[] OverallPhaseAll { get; set; } = [];
 }

--- a/web/src/Web.App/ViewModels/Search/SearchResultFacetViewModel.cs
+++ b/web/src/Web.App/ViewModels/Search/SearchResultFacetViewModel.cs
@@ -1,12 +1,27 @@
 using Web.App.Infrastructure.Apis;
-// ReSharper disable MemberCanBePrivate.Global
 
+// ReSharper disable MemberCanBePrivate.Global
 namespace Web.App.ViewModels.Search;
 
-public record SearchResultFacetViewModel
+public class SearchResultFacetViewModel : IEquatable<SearchResultFacetViewModel>
 {
     public string? Value { get; init; }
     public long? Count { get; init; }
+
+    public bool Equals(SearchResultFacetViewModel? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        return Value == other.Value;
+    }
 
     public static Dictionary<string, IEnumerable<SearchResultFacetViewModel>> Create(Dictionary<string, IList<FacetValueResponseModel>>? facets)
     {
@@ -20,5 +35,25 @@ public record SearchResultFacetViewModel
                 key => $"{key[..1].ToUpper()}{key[1..]}",
                 key => facets[key]
                     .Select(x => new SearchResultFacetViewModel { Value = x.Value, Count = x.Count }));
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
+        return obj.GetType() == GetType() && Equals((SearchResultFacetViewModel)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return Value != null ? Value.GetHashCode() : 0;
     }
 }

--- a/web/src/Web.App/Views/SchoolSearch/Search.cshtml
+++ b/web/src/Web.App/Views/SchoolSearch/Search.cshtml
@@ -47,6 +47,11 @@ else
             @using (Html.BeginForm(FormMethod.Post, true, new { novalidate = "novalidate", role = "search" }))
             {
                 <input type="hidden" name="@nameof(FindSchoolViewModel.Term)" value="@Model.Term"/>
+                @foreach (var phase in Model.OverallPhaseAll)
+                {
+                    <input type="hidden" name="@nameof(Model.OverallPhaseAll)" value="@phase"/>
+                }
+                
                 @await Html.PartialAsync("Search/_SchoolSearchResultsOptions", new SchoolSearchResultsOptionsViewModel
                 {
                     OrderBy = Model.OrderBy,
@@ -67,6 +72,7 @@ else
                     term = Model.Term,
                     sort = Model.OrderBy,
                     phase = Model.OverallPhase,
+                    phaseAll = Model.OverallPhaseAll,
                     page
                 })
             })

--- a/web/src/Web.App/Views/Shared/Search/_SchoolSearchResultsOptions.cshtml
+++ b/web/src/Web.App/Views/Shared/Search/_SchoolSearchResultsOptions.cshtml
@@ -63,7 +63,7 @@
                                    @(Model.OverallPhase.Any(o => o == facet.Value) ? "checked" : string.Empty)>
                             <label class="govuk-label govuk-checkboxes__label"
                                    for="@nameof(SchoolSearchResultsOptionsViewModel.OverallPhase)-@facet.Value">
-                                @facet.Value (@facet.Count)
+                                @facet.Value
                             </label>
                         </div>
                     }

--- a/web/tests/Web.Integration.Tests/Pages/Schools/Search/WhenViewingSchoolSearchResults.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/Search/WhenViewingSchoolSearchResults.cs
@@ -102,6 +102,7 @@ public class WhenViewingSchoolSearchResults(SchoolBenchmarkingWebAppClient clien
         const string term = nameof(term);
         const string orderBy = nameof(orderBy);
         const string overallPhase = nameof(overallPhase);
+        const string overallPhaseAll = nameof(overallPhaseAll);
         page = await Client.SubmitForm(page.Forms.Last(), action, f =>
         {
             f.SetFormValues(new Dictionary<string, string>
@@ -114,11 +115,14 @@ public class WhenViewingSchoolSearchResults(SchoolBenchmarkingWebAppClient clien
                 },
                 {
                     "OverallPhase", overallPhase
+                },
+                {
+                    "OverallPhaseAll", overallPhaseAll
                 }
             });
         });
 
-        DocumentAssert.AssertPageUrl(page, Paths.SchoolSearchResults(term, orderBy, [overallPhase]).ToAbsolute());
+        DocumentAssert.AssertPageUrl(page, Paths.SchoolSearchResults(term, orderBy, [overallPhase], [overallPhaseAll, "Secondary"]).ToAbsolute());
     }
 
     [Fact]
@@ -127,18 +131,19 @@ public class WhenViewingSchoolSearchResults(SchoolBenchmarkingWebAppClient clien
         const string term = nameof(term);
         const string orderBy = nameof(orderBy);
         const string overallPhase = nameof(overallPhase);
+        const string overallPhaseAll = nameof(overallPhaseAll);
         var page = await Client
             .SetupEstablishment(SearchResults)
-            .Navigate(Paths.SchoolSearchResults(term, orderBy, [overallPhase]));
+            .Navigate(Paths.SchoolSearchResults(term, orderBy, [overallPhase], [overallPhaseAll]));
 
         var pagination = page.QuerySelectorAll("a.govuk-pagination__link");
         Assert.NotNull(pagination);
 
         page = await Client.Follow(pagination.ElementAt(0));
-        DocumentAssert.AssertPageUrl(page, Paths.SchoolSearchResults(term, orderBy, [overallPhase], 1).ToAbsolute());
+        DocumentAssert.AssertPageUrl(page, Paths.SchoolSearchResults(term, orderBy, [overallPhase], [overallPhaseAll], 1).ToAbsolute());
 
         page = await Client.Follow(pagination.ElementAt(1));
-        DocumentAssert.AssertPageUrl(page, Paths.SchoolSearchResults(term, orderBy, [overallPhase], 2).ToAbsolute());
+        DocumentAssert.AssertPageUrl(page, Paths.SchoolSearchResults(term, orderBy, [overallPhase], [overallPhaseAll], 2).ToAbsolute());
     }
 
     [Fact]

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -266,7 +266,7 @@ public static class Paths
     {
         return $"/school/{urn}/comparators/revert";
     }
-    public static string SchoolSearchResults(string? term = null, string? sort = null, string[]? phases = null, int? page = null)
+    public static string SchoolSearchResults(string? term = null, string? sort = null, string[]? phases = null, string[]? allPhases = null, int? page = null)
     {
         var queryString = new QueryString();
         if (!string.IsNullOrWhiteSpace(term))
@@ -282,6 +282,11 @@ public static class Paths
         if (phases != null)
         {
             queryString = phases.Aggregate(queryString, (current, phase) => current.Add(nameof(phase), phase));
+        }
+
+        if (allPhases != null)
+        {
+            queryString = allPhases.Aggregate(queryString, (current, phaseAll) => current.Add(nameof(phaseAll), phaseAll));
         }
 
         if (page.HasValue)

--- a/web/tests/Web.Tests/ViewModels/Search/GivenASchoolSearchResultsViewModel.cs
+++ b/web/tests/Web.Tests/ViewModels/Search/GivenASchoolSearchResultsViewModel.cs
@@ -1,0 +1,87 @@
+using AutoFixture;
+using Web.App.Domain;
+using Web.App.ViewModels.Search;
+using Xunit;
+
+namespace Web.Tests.ViewModels.Search;
+
+public class GivenASchoolSearchResultsViewModel
+{
+    private static readonly Fixture Fixture = new();
+    private static readonly Random Random = new();
+    private static readonly SearchResultFacetViewModel[] OverallPhaseFacets =
+    [
+        new()
+        {
+            Value = OverallPhaseTypes.Secondary,
+            Count = 3
+        },
+        new()
+        {
+            Value = OverallPhaseTypes.Special,
+            Count = 2
+        },
+        new()
+        {
+            Value = OverallPhaseTypes.AllThrough,
+            Count = 1
+        }
+    ];
+
+    public static TheoryData<Dictionary<string, IEnumerable<SearchResultFacetViewModel>>, string[], SearchResultFacetViewModel[]> FilterAndMergeOverallPhaseFacetsData = new()
+    {
+        {
+            new Dictionary<string, IEnumerable<SearchResultFacetViewModel>>
+            {
+                {
+                    "facet", new List<SearchResultFacetViewModel>()
+                }
+            },
+            [],
+            []
+        },
+        {
+            new Dictionary<string, IEnumerable<SearchResultFacetViewModel>>
+            {
+                {
+                    "facet", new List<SearchResultFacetViewModel>()
+                },
+                {
+                    "OverallPhase", OverallPhaseFacets
+                }
+            },
+            [],
+            OverallPhaseFacets
+        },
+        {
+            new Dictionary<string, IEnumerable<SearchResultFacetViewModel>>
+            {
+                {
+                    "facet", new List<SearchResultFacetViewModel>()
+                },
+                {
+                    "OverallPhase", OverallPhaseFacets
+                }
+            },
+            ["Unsupported Phase", OverallPhaseTypes.Primary, OverallPhaseTypes.Nursery, OverallPhaseTypes.Secondary],
+            OverallPhaseFacets.Concat(
+            [
+                new SearchResultFacetViewModel { Value = OverallPhaseTypes.Nursery, Count = 0 },
+                new SearchResultFacetViewModel { Value = OverallPhaseTypes.Primary, Count = 0 }
+            ]).ToArray()
+        }
+    };
+
+    [Theory]
+    [MemberData(nameof(FilterAndMergeOverallPhaseFacetsData))]
+    public void ShouldFilterAndMergeOverallPhaseFacets(Dictionary<string, IEnumerable<SearchResultFacetViewModel>> facets, string[] all, SearchResultFacetViewModel[] expected)
+    {
+        var viewModel = Fixture
+            .Build<SchoolSearchResultsViewModel>()
+            .With(s => s.Facets, facets)
+            .With(s => s.OverallPhaseAll, all)
+            .Create();
+
+        Assert.Equal(expected, viewModel.OverallPhaseFacets);
+    }
+}


### PR DESCRIPTION
### Context
[AB#257253](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/257253) [AB#250281](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/250281)

### Change proposed in this pull request
- `<input type="hidden">` containing originally returned facets when `POST`ing filter(s)
- Merge original facets with current facets in search results view
- Also persist original facets during pagination
- Integration and unit test coverage

### Guidance to review 
This ability to show all facets is an alternative to adding a 'Clear filter' button. User research or an additional design pass may iterate on this once more.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

