### PR TITLE
fix: population data ingestion for the year previous to the `run_id`

### DIFF
--- a/data-pipeline/src/pipeline/pre_processing/local_authority.py
+++ b/data-pipeline/src/pipeline/pre_processing/local_authority.py
@@ -310,13 +310,13 @@ def _prepare_ons_la_population_data(
     `AREA_CODE`) will be summed to provide a single figure, to be
     rounded to a whole integer.
 
-    Population data is published July of the given year.
+    Population data is published for July of each calendar year.
     The data we ingest for the given year needs to fall within
     April to March financial year, here we ingest the data for
-    the year prior to the passed year (run_id).
+    the year prior to the input year.
 
-    ie: 2024 year will be for period 2023/2024 and therefore 2023 data
-    is required.
+    For example, if the year is 2024, the relevant data is for the 2023/2024 financial year,
+    and thus data from 2023 should be ingested.
 
     :param ons_filepath_or_buffer: source for ONS LA population data
     :param year: financial year in question


### PR DESCRIPTION
### Context
[AB#258233](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/258233) [AB#258238](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/258238)

Population data is published July. The data we ingest for a given year needs to fall within April to March financial year.
For a `run_id` of 2024 population data for July 2023 should be used.

### Change proposed in this pull request
Updates `_prepare_ons_la_population_data` so that the ONS population data for the correct year is used.

### Guidance to review 
Runs locally and population figures for `LocalAuthorityNonFinancial` are as expected

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

