### PR TITLE
Wired up Trust Filtered Search to API

### DIFF
--- a/web/Directory.Packages.props
+++ b/web/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.4" />
     <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.3.2" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="8.1.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2">
@@ -28,7 +28,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
-    <PackageVersion Include="AngleSharp" Version="1.2.0" />
+    <PackageVersion Include="AngleSharp" Version="1.3.0" />
     <PackageVersion Include="AngleSharp.Css" Version="1.0.0-beta.151" />
     <PackageVersion Include="AngleSharp.XPath" Version="2.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.15" />

--- a/web/src/Web.App/Controllers/SchoolSearchController.cs
+++ b/web/src/Web.App/Controllers/SchoolSearchController.cs
@@ -4,7 +4,6 @@ using Web.App.Attributes.RequestTelemetry;
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
 using Web.App.Services;
-using Web.App.ViewModels;
 using Web.App.ViewModels.Search;
 
 namespace Web.App.Controllers;
@@ -60,13 +59,8 @@ public class SchoolSearchController(
             {
                 results = await searchService.SchoolSearch(term, 50, page, overallPhase.Length == 0
                         ? null
-                        : new Dictionary<string, IEnumerable<string>>
-                        {
-                            {
-                                "OverallPhase", overallPhase
-                            }
-                        },
-                    string.IsNullOrWhiteSpace(orderBy) ? null : ("SchoolNameSortable", orderBy)
+                        : new SearchFilters("OverallPhase", overallPhase),
+                    string.IsNullOrWhiteSpace(orderBy) ? null : new SearchOrderBy("SchoolNameSortable", orderBy)
                 );
             }
             catch (Exception e)

--- a/web/src/Web.App/Controllers/TrustSearchController.cs
+++ b/web/src/Web.App/Controllers/TrustSearchController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.FeatureManagement.Mvc;
 using Web.App.Attributes.RequestTelemetry;
+using Web.App.Services;
 using Web.App.ViewModels.Search;
 
 namespace Web.App.Controllers;
@@ -9,7 +10,9 @@ namespace Web.App.Controllers;
 [Route("trust")]
 [TrustRequestTelemetry(TrackedRequestFeature.Search)]
 [FeatureGate(FeatureFlags.FilteredSearch)]
-public class TrustSearchController(ILogger<TrustSearchController> logger)
+public class TrustSearchController(
+    ILogger<TrustSearchController> logger,
+    ISearchService searchService)
     : Controller
 {
     [HttpGet]
@@ -34,7 +37,7 @@ public class TrustSearchController(ILogger<TrustSearchController> logger)
 
     [HttpGet]
     [Route("search")]
-    public IActionResult Search(
+    public async Task<IActionResult> Search(
         [FromQuery] string? term,
         [FromQuery] int? page,
         [FromQuery(Name = "sort")] string? orderBy
@@ -47,6 +50,9 @@ public class TrustSearchController(ILogger<TrustSearchController> logger)
             orderBy
         }))
         {
+            var results = await searchService.TrustSearch(term, 50, page, string.IsNullOrWhiteSpace(orderBy) ? null : ("TrustNameSortable", orderBy));
+
+            // todo: display results 
             return NotFound();
         }
     }

--- a/web/src/Web.App/Controllers/TrustSearchController.cs
+++ b/web/src/Web.App/Controllers/TrustSearchController.cs
@@ -50,7 +50,7 @@ public class TrustSearchController(
             orderBy
         }))
         {
-            var results = await searchService.TrustSearch(term, 50, page, string.IsNullOrWhiteSpace(orderBy) ? null : ("TrustNameSortable", orderBy));
+            var results = await searchService.TrustSearch(term, 50, page, string.IsNullOrWhiteSpace(orderBy) ? null : new SearchOrderBy("TrustNameSortable", orderBy));
 
             // todo: display results 
             return NotFound();

--- a/web/src/Web.App/Infrastructure/Apis/Establishment/Api.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Establishment/Api.cs
@@ -8,6 +8,7 @@ public static class Api
         public static string SchoolSuggest => "api/schools/suggest";
         public static string SchoolSearch => "api/schools/search";
         public static string TrustSuggest => "api/trusts/suggest";
+        public static string TrustSearch => "api/trusts/search";
         public static string LocalAuthorities => "api/local-authorities";
         public static string LocalAuthoritySuggest => "api/local-authorities/suggest";
         public static string LocalAuthorityNationalRank => "api/local-authorities/national-rank";

--- a/web/src/Web.App/Infrastructure/Apis/Establishment/EstablishmentApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Establishment/EstablishmentApi.cs
@@ -77,6 +77,16 @@ public class EstablishmentApi(HttpClient httpClient, string? key = default) : Ap
             Content = new JsonContent(request)
         });
     }
+
+    public Task<ApiResult> SearchTrusts(SearchRequest request)
+    {
+        return SendAsync(new HttpRequestMessage
+        {
+            Method = HttpMethod.Post,
+            RequestUri = new Uri(Api.Establishment.TrustSearch, UriKind.Relative),
+            Content = new JsonContent(request)
+        });
+    }
 }
 
 public interface IEstablishmentApi
@@ -91,4 +101,5 @@ public interface IEstablishmentApi
     Task<ApiResult> SuggestTrusts(string search, string[]? exclude = null);
     Task<ApiResult> SuggestLocalAuthorities(string search, string[]? exclude = null);
     Task<ApiResult> SearchSchools(SearchRequest request);
+    Task<ApiResult> SearchTrusts(SearchRequest request);
 }

--- a/web/src/Web.App/Services/SearchService.cs
+++ b/web/src/Web.App/Services/SearchService.cs
@@ -8,6 +8,7 @@ namespace Web.App.Services;
 public interface ISearchService
 {
     Task<SearchResponse<SchoolSummary>> SchoolSearch(string? term, int? pageSize = null, int? page = null, Dictionary<string, IEnumerable<string>>? filters = null, (string Field, string Order)? orderBy = null);
+    Task<SearchResponse<TrustSummary>> TrustSearch(string? term, int? pageSize = null, int? page = null, (string Field, string Order)? orderBy = null);
 }
 
 public class SearchService(IEstablishmentApi establishmentApi) : ISearchService
@@ -23,5 +24,11 @@ public class SearchService(IEstablishmentApi establishmentApi) : ISearchService
 
         return await establishmentApi.SearchSchools(SearchRequest.Create(term, pageSize, page, flattenedFilters, orderBy))
             .GetResultOrThrow<SearchResponse<SchoolSummary>>();
+    }
+
+    public async Task<SearchResponse<TrustSummary>> TrustSearch(string? term, int? pageSize = null, int? page = null, (string Field, string Order)? orderBy = null)
+    {
+        return await establishmentApi.SearchTrusts(SearchRequest.Create(term, pageSize, page, null, orderBy))
+            .GetResultOrThrow<SearchResponse<TrustSummary>>();
     }
 }

--- a/web/src/Web.App/Services/SearchService.cs
+++ b/web/src/Web.App/Services/SearchService.cs
@@ -7,13 +7,25 @@ namespace Web.App.Services;
 
 public interface ISearchService
 {
-    Task<SearchResponse<SchoolSummary>> SchoolSearch(string? term, int? pageSize = null, int? page = null, Dictionary<string, IEnumerable<string>>? filters = null, (string Field, string Order)? orderBy = null);
-    Task<SearchResponse<TrustSummary>> TrustSearch(string? term, int? pageSize = null, int? page = null, (string Field, string Order)? orderBy = null);
+    Task<SearchResponse<SchoolSummary>> SchoolSearch(string? term, int? pageSize = null, int? page = null, SearchFilters? filters = null, SearchOrderBy? orderBy = null);
+    Task<SearchResponse<TrustSummary>> TrustSearch(string? term, int? pageSize = null, int? page = null, SearchOrderBy? orderBy = null);
 }
+
+public class SearchFilters : Dictionary<string, IEnumerable<string>>
+{
+    public SearchFilters() { }
+
+    public SearchFilters(string field, string[] values)
+    {
+        this[field] = values;
+    }
+}
+
+public record SearchOrderBy(string Field, string Order);
 
 public class SearchService(IEstablishmentApi establishmentApi) : ISearchService
 {
-    public async Task<SearchResponse<SchoolSummary>> SchoolSearch(string? term, int? pageSize = null, int? page = null, Dictionary<string, IEnumerable<string>>? filters = null, (string Field, string Order)? orderBy = null)
+    public async Task<SearchResponse<SchoolSummary>> SchoolSearch(string? term, int? pageSize = null, int? page = null, SearchFilters? filters = null, SearchOrderBy? orderBy = null)
     {
         List<(string Field, string Filter)>? flattenedFilters = null;
         if (filters is { Keys.Count: > 0, Values.Count: > 0 })
@@ -22,13 +34,15 @@ public class SearchService(IEstablishmentApi establishmentApi) : ISearchService
             flattenedFilters.AddRange(filters.Keys.SelectMany(key => filters[key], (key, value) => (key, value)));
         }
 
-        return await establishmentApi.SearchSchools(SearchRequest.Create(term, pageSize, page, flattenedFilters, orderBy))
+        var request = SearchRequest.Create(term, pageSize, page, flattenedFilters, orderBy == null ? null : (orderBy.Field, orderBy.Order));
+        return await establishmentApi.SearchSchools(request)
             .GetResultOrThrow<SearchResponse<SchoolSummary>>();
     }
 
-    public async Task<SearchResponse<TrustSummary>> TrustSearch(string? term, int? pageSize = null, int? page = null, (string Field, string Order)? orderBy = null)
+    public async Task<SearchResponse<TrustSummary>> TrustSearch(string? term, int? pageSize = null, int? page = null, SearchOrderBy? orderBy = null)
     {
-        return await establishmentApi.SearchTrusts(SearchRequest.Create(term, pageSize, page, null, orderBy))
+        var request = SearchRequest.Create(term, pageSize, page, null, orderBy == null ? null : (orderBy.Field, orderBy.Order));
+        return await establishmentApi.SearchTrusts(request)
             .GetResultOrThrow<SearchResponse<TrustSummary>>();
     }
 }

--- a/web/src/Web.App/packages.lock.json
+++ b/web/src/Web.App/packages.lock.json
@@ -230,14 +230,14 @@
       },
       "Swashbuckle.AspNetCore": {
         "type": "Direct",
-        "requested": "[7.3.2, )",
-        "resolved": "7.3.2",
-        "contentHash": "WEkW7Cl8bexT75eURuqrqM/TQx+ftWKOWlCHzmw3Fl3oAmxiBO/lDVOuuqZsaBCHQIBcZxA6BbyiG5dv2mD2tw==",
+        "requested": "[8.1.1, )",
+        "resolved": "8.1.1",
+        "contentHash": "HJHexmU0PiYevgTLvKjYkxEtclF2w4O7iTd3Ef3p6KeT0kcYLpkFVgCw6glpGS57h8769anv8G+NFi9Kge+/yw==",
         "dependencies": {
           "Microsoft.Extensions.ApiDescription.Server": "6.0.5",
-          "Swashbuckle.AspNetCore.Swagger": "7.3.2",
-          "Swashbuckle.AspNetCore.SwaggerGen": "7.3.2",
-          "Swashbuckle.AspNetCore.SwaggerUI": "7.3.2"
+          "Swashbuckle.AspNetCore.Swagger": "8.1.1",
+          "Swashbuckle.AspNetCore.SwaggerGen": "8.1.1",
+          "Swashbuckle.AspNetCore.SwaggerUI": "8.1.1"
         }
       },
       "Azure.Core": {
@@ -754,8 +754,8 @@
       },
       "Microsoft.OpenApi": {
         "type": "Transitive",
-        "resolved": "1.6.22",
-        "contentHash": "aBvunmrdu/x+4CaA/UP1Jx4xWGwk4kymhoIRnn2Vp+zi5/KOPQJ9EkSXHRUr01WcGKtYl3Au7XfkPJbU1G2sjQ=="
+        "resolved": "1.6.23",
+        "contentHash": "tZ1I0KXnn98CWuV8cpI247A17jaY+ILS9vvF7yhI0uPPEqF4P1d7BWL5Uwtel10w9NucllHB3nTkfYTAcHAh8g=="
       },
       "Microsoft.Win32.SystemEvents": {
         "type": "Transitive",
@@ -870,24 +870,24 @@
       },
       "Swashbuckle.AspNetCore.Swagger": {
         "type": "Transitive",
-        "resolved": "7.3.2",
-        "contentHash": "39Z2N3cLHDcDinu2IW5IaQO9wGPKTbc+vKbjIT/6gN3jFYypWY5U3O8i7Y9rmYDgxkm6niICnkcFZ3hEvikIHA==",
+        "resolved": "8.1.1",
+        "contentHash": "h+8D5jQtnl6X4f2hJQwf0Khj0SnCQANzirCELjXJ6quJ4C1aNNCvJrAsQ+4fOKAMqJkvW48cKj79ftG+YoGcRg==",
         "dependencies": {
-          "Microsoft.OpenApi": "1.6.22"
+          "Microsoft.OpenApi": "1.6.23"
         }
       },
       "Swashbuckle.AspNetCore.SwaggerGen": {
         "type": "Transitive",
-        "resolved": "7.3.2",
-        "contentHash": "x5famjpcgazpT/8eEIlpSYSTZDq6ojMARhuJgj6O67Uk+Yb1DdDM5yikdL7GK1pMk5rYBETUCRWYP6rp+vHnlA==",
+        "resolved": "8.1.1",
+        "contentHash": "2EuPzXSNleOOzYvziERWRLnk1Oz9i0Z1PimaUFy1SasBqeV/rG+eMfwFAMtTaf4W6gvVOzRcUCNRHvpBIIzr+A==",
         "dependencies": {
-          "Swashbuckle.AspNetCore.Swagger": "7.3.2"
+          "Swashbuckle.AspNetCore.Swagger": "8.1.1"
         }
       },
       "Swashbuckle.AspNetCore.SwaggerUI": {
         "type": "Transitive",
-        "resolved": "7.3.2",
-        "contentHash": "SNQuFjYin9KhkoCSVOD5/Y4VEyAjKBDeZkIqqY6x+oI21HMKzzVkeJA9V7tWFXf5df4m/+pTIlbKO7g5W9UroQ=="
+        "resolved": "8.1.1",
+        "contentHash": "GDLX/MpK4oa2nYC1N/zN2UidQTtVKLPF6gkdEmGb0RITEwpJG9Gu8olKqPYnKqVeFn44JZoCS0M2LGRKXP8B/A=="
       },
       "System.Buffers": {
         "type": "Transitive",

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -244,10 +244,10 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         return this;
     }
 
-    public BenchmarkingWebAppClient SetupEstablishment(SearchResponse<TrustSummary> schools)
+    public BenchmarkingWebAppClient SetupEstablishment(SearchResponse<TrustSummary> trusts)
     {
         EstablishmentApi.Reset();
-        EstablishmentApi.Setup(api => api.SearchTrusts(It.IsAny<SearchRequest>())).ReturnsAsync(ApiResult.Ok(schools));
+        EstablishmentApi.Setup(api => api.SearchTrusts(It.IsAny<SearchRequest>())).ReturnsAsync(ApiResult.Ok(trusts));
         return this;
     }
 

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -233,6 +233,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         EstablishmentApi.Setup(api => api.SuggestTrusts(It.IsAny<string>(), It.IsAny<string[]?>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.SuggestLocalAuthorities(It.IsAny<string>(), It.IsAny<string[]?>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.SearchSchools(It.IsAny<SearchRequest>())).Throws(new Exception());
+        EstablishmentApi.Setup(api => api.SearchTrusts(It.IsAny<SearchRequest>())).Throws(new Exception());
         return this;
     }
 
@@ -240,6 +241,13 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     {
         EstablishmentApi.Reset();
         EstablishmentApi.Setup(api => api.SearchSchools(It.IsAny<SearchRequest>())).ReturnsAsync(ApiResult.Ok(schools));
+        return this;
+    }
+
+    public BenchmarkingWebAppClient SetupEstablishment(SearchResponse<TrustSummary> schools)
+    {
+        EstablishmentApi.Reset();
+        EstablishmentApi.Setup(api => api.SearchTrusts(It.IsAny<SearchRequest>())).ReturnsAsync(ApiResult.Ok(schools));
         return this;
     }
 

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/Search/WhenViewingTrustSearch.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/Search/WhenViewingTrustSearch.cs
@@ -1,11 +1,34 @@
 using System.Net;
 using AngleSharp.Dom;
+using Web.App.Domain;
+using Web.App.Infrastructure.Apis;
 using Xunit;
 
 namespace Web.Integration.Tests.Pages.Trusts.Search;
 
 public class WhenViewingTrustSearch(SchoolBenchmarkingWebAppClient client) : PageBase<SchoolBenchmarkingWebAppClient>(client)
 {
+    private static SearchResponse<TrustSummary> SearchResults => new()
+    {
+        TotalResults = 54,
+        Page = 1,
+        PageSize = 10,
+        PageCount = 2,
+        Results =
+        [
+            new TrustSummary
+            {
+                CompanyNumber = "123456",
+                TrustName = "Trust Name 1"
+            },
+            new TrustSummary
+            {
+                CompanyNumber = "654321",
+                TrustName = "Trust Name 2"
+            }
+        ]
+    };
+
     [Fact]
     public async Task CanDisplay()
     {
@@ -19,6 +42,7 @@ public class WhenViewingTrustSearch(SchoolBenchmarkingWebAppClient client) : Pag
     public async Task CanSubmitSearch()
     {
         var page = await Client
+            .SetupEstablishment(SearchResults)
             .Navigate(Paths.TrustSearch);
         var action = page.QuerySelectorAll("button[type='submit']").First();
         Assert.NotNull(action);

--- a/web/tests/Web.Integration.Tests/packages.lock.json
+++ b/web/tests/Web.Integration.Tests/packages.lock.json
@@ -4,9 +4,9 @@
     "net8.0": {
       "AngleSharp": {
         "type": "Direct",
-        "requested": "[1.2.0, )",
-        "resolved": "1.2.0",
-        "contentHash": "uF/PzSCVcb+b2nqVvHZbOqexoJ9R6QLjonugPf0PQl+0h7YKaFZeXyspctbHe5HGlx7/Iuk5BErtk+t63ac/ZA=="
+        "requested": "[1.3.0, )",
+        "resolved": "1.3.0",
+        "contentHash": "iHzfn4cK6CmhuURNdEpmSQCq5/HZFldEpkbnmqT9My8+6l2Sz3F+NxoqRA8z/jTkWB+SAu5boRdp4v/WtyjuIQ=="
       },
       "AngleSharp.Css": {
         "type": "Direct",
@@ -818,8 +818,8 @@
       },
       "Microsoft.OpenApi": {
         "type": "Transitive",
-        "resolved": "1.6.22",
-        "contentHash": "aBvunmrdu/x+4CaA/UP1Jx4xWGwk4kymhoIRnn2Vp+zi5/KOPQJ9EkSXHRUr01WcGKtYl3Au7XfkPJbU1G2sjQ=="
+        "resolved": "1.6.23",
+        "contentHash": "tZ1I0KXnn98CWuV8cpI247A17jaY+ILS9vvF7yhI0uPPEqF4P1d7BWL5Uwtel10w9NucllHB3nTkfYTAcHAh8g=="
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
@@ -1119,24 +1119,24 @@
       },
       "Swashbuckle.AspNetCore.Swagger": {
         "type": "Transitive",
-        "resolved": "7.3.2",
-        "contentHash": "39Z2N3cLHDcDinu2IW5IaQO9wGPKTbc+vKbjIT/6gN3jFYypWY5U3O8i7Y9rmYDgxkm6niICnkcFZ3hEvikIHA==",
+        "resolved": "8.1.1",
+        "contentHash": "h+8D5jQtnl6X4f2hJQwf0Khj0SnCQANzirCELjXJ6quJ4C1aNNCvJrAsQ+4fOKAMqJkvW48cKj79ftG+YoGcRg==",
         "dependencies": {
-          "Microsoft.OpenApi": "1.6.22"
+          "Microsoft.OpenApi": "1.6.23"
         }
       },
       "Swashbuckle.AspNetCore.SwaggerGen": {
         "type": "Transitive",
-        "resolved": "7.3.2",
-        "contentHash": "x5famjpcgazpT/8eEIlpSYSTZDq6ojMARhuJgj6O67Uk+Yb1DdDM5yikdL7GK1pMk5rYBETUCRWYP6rp+vHnlA==",
+        "resolved": "8.1.1",
+        "contentHash": "2EuPzXSNleOOzYvziERWRLnk1Oz9i0Z1PimaUFy1SasBqeV/rG+eMfwFAMtTaf4W6gvVOzRcUCNRHvpBIIzr+A==",
         "dependencies": {
-          "Swashbuckle.AspNetCore.Swagger": "7.3.2"
+          "Swashbuckle.AspNetCore.Swagger": "8.1.1"
         }
       },
       "Swashbuckle.AspNetCore.SwaggerUI": {
         "type": "Transitive",
-        "resolved": "7.3.2",
-        "contentHash": "SNQuFjYin9KhkoCSVOD5/Y4VEyAjKBDeZkIqqY6x+oI21HMKzzVkeJA9V7tWFXf5df4m/+pTIlbKO7g5W9UroQ=="
+        "resolved": "8.1.1",
+        "contentHash": "GDLX/MpK4oa2nYC1N/zN2UidQTtVKLPF6gkdEmGb0RITEwpJG9Gu8olKqPYnKqVeFn44JZoCS0M2LGRKXP8B/A=="
       },
       "System.AppContext": {
         "type": "Transitive",
@@ -2101,7 +2101,7 @@
           "Serilog.Enrichers.CorrelationId": "[3.0.1, )",
           "Serilog.Sinks.ApplicationInsights": "[4.0.0, )",
           "SmartBreadcrumbs": "[3.6.1, )",
-          "Swashbuckle.AspNetCore": "[7.3.2, )"
+          "Swashbuckle.AspNetCore": "[8.1.1, )"
         }
       },
       "Azure.Identity": {
@@ -2294,14 +2294,14 @@
       },
       "Swashbuckle.AspNetCore": {
         "type": "CentralTransitive",
-        "requested": "[7.3.2, )",
-        "resolved": "7.3.2",
-        "contentHash": "WEkW7Cl8bexT75eURuqrqM/TQx+ftWKOWlCHzmw3Fl3oAmxiBO/lDVOuuqZsaBCHQIBcZxA6BbyiG5dv2mD2tw==",
+        "requested": "[8.1.1, )",
+        "resolved": "8.1.1",
+        "contentHash": "HJHexmU0PiYevgTLvKjYkxEtclF2w4O7iTd3Ef3p6KeT0kcYLpkFVgCw6glpGS57h8769anv8G+NFi9Kge+/yw==",
         "dependencies": {
           "Microsoft.Extensions.ApiDescription.Server": "6.0.5",
-          "Swashbuckle.AspNetCore.Swagger": "7.3.2",
-          "Swashbuckle.AspNetCore.SwaggerGen": "7.3.2",
-          "Swashbuckle.AspNetCore.SwaggerUI": "7.3.2"
+          "Swashbuckle.AspNetCore.Swagger": "8.1.1",
+          "Swashbuckle.AspNetCore.SwaggerGen": "8.1.1",
+          "Swashbuckle.AspNetCore.SwaggerUI": "8.1.1"
         }
       },
       "xunit.abstractions": {

--- a/web/tests/Web.Tests/Infrastructure/GivenAnEstablishmentApi.cs
+++ b/web/tests/Web.Tests/Infrastructure/GivenAnEstablishmentApi.cs
@@ -147,4 +147,15 @@ public class GivenAnEstablishmentApi(ITestOutputHelper testOutputHelper) : ApiCl
 
         VerifyCall(HttpMethod.Post, $"api/schools/search", request.ToJson(Formatting.None));
     }
+
+    [Fact]
+    public async Task SearchTrustsShouldCallCorrectUrl()
+    {
+        var api = new EstablishmentApi(HttpClient);
+        var request = new SearchRequest();
+
+        await api.SearchTrusts(request);
+
+        VerifyCall(HttpMethod.Post, $"api/trusts/search", request.ToJson(Formatting.None));
+    }
 }

--- a/web/tests/Web.Tests/Services/WhenSchoolSearchServiceIsCalled.cs
+++ b/web/tests/Web.Tests/Services/WhenSchoolSearchServiceIsCalled.cs
@@ -11,7 +11,7 @@ public class WhenSchoolSearchServiceIsCalled
 {
     private readonly Mock<IEstablishmentApi> _api = new();
 
-    public static TheoryData<string?, int?, int?, Dictionary<string, IEnumerable<string>>?, (string Field, string Order)?, SearchRequest?> WhenSendRequestData = new()
+    public static TheoryData<string?, int?, int?, SearchFilters?, SearchOrderBy?, SearchRequest?> WhenSendRequestData = new()
     {
         {
             "term",
@@ -25,7 +25,7 @@ public class WhenSchoolSearchServiceIsCalled
             "term",
             null,
             null,
-            new Dictionary<string, IEnumerable<string>>(),
+            new SearchFilters(),
             null,
             new SearchRequest { SearchText = "term" }
         },
@@ -33,11 +33,8 @@ public class WhenSchoolSearchServiceIsCalled
             "term",
             1,
             2,
-            new Dictionary<string, IEnumerable<string>>
-            {
-                { "field", ["value1", "value2"] }
-            },
-            ("field2", "value3"),
+            new SearchFilters("field", ["value1", "value2"]),
+            new SearchOrderBy("field2", "value3"),
             new SearchRequest
             {
                 SearchText = "term",
@@ -54,7 +51,7 @@ public class WhenSchoolSearchServiceIsCalled
 
     [Theory]
     [MemberData(nameof(WhenSendRequestData))]
-    public async Task ShouldSendRequest(string? term, int? pageSize = null, int? page = null, Dictionary<string, IEnumerable<string>>? filters = null, (string Field, string Order)? orderBy = null, SearchRequest? expected = null)
+    public async Task ShouldSendRequest(string? term, int? pageSize = null, int? page = null, SearchFilters? filters = null, SearchOrderBy? orderBy = null, SearchRequest? expected = null)
     {
         var response = new SearchResponse<SchoolSummary>();
 

--- a/web/tests/Web.Tests/Services/WhenTrustSearchServiceIsCalled.cs
+++ b/web/tests/Web.Tests/Services/WhenTrustSearchServiceIsCalled.cs
@@ -1,0 +1,64 @@
+﻿using Moq;
+using Web.App.Domain;
+using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Apis.Establishment;
+using Web.App.Services;
+using Xunit;
+
+namespace Web.Tests.Services;
+
+public class WhenTrustSearchServiceIsCalled
+{
+    private readonly Mock<IEstablishmentApi> _api = new();
+
+    public static TheoryData<string?, int?, int?, (string Field, string Order)?, SearchRequest?> WhenSendRequestData = new()
+    {
+        {
+            "term",
+            null,
+            null,
+            null,
+            new SearchRequest { SearchText = "term" }
+        },
+        {
+            "term",
+            null,
+            null,
+            null,
+            new SearchRequest { SearchText = "term" }
+        },
+        {
+            "term",
+            1,
+            2,
+            ("field2", "value3"),
+            new SearchRequest
+            {
+                SearchText = "term",
+                PageSize = 1,
+                Page = 2,
+                OrderBy = new OrderByCriteria { Field = "field2", Value = "value3"}
+            }
+        }
+    };
+
+    [Theory]
+    [MemberData(nameof(WhenSendRequestData))]
+    public async Task ShouldSendRequest(string? term, int? pageSize = null, int? page = null, (string Field, string Order)? orderBy = null, SearchRequest? expected = null)
+    {
+        var response = new SearchResponse<TrustSummary>();
+
+        SearchRequest? actualRequest = null;
+        _api.Setup(x => x.SearchTrusts(It.IsAny<SearchRequest>()))
+            .Callback<SearchRequest>(r =>
+            {
+                actualRequest = r;
+            })
+            .ReturnsAsync(ApiResult.Ok(response));
+
+        var service = new SearchService(_api.Object);
+
+        await service.TrustSearch(term, pageSize, page, orderBy);
+        Assert.Equivalent(expected, actualRequest);
+    }
+}

--- a/web/tests/Web.Tests/Services/WhenTrustSearchServiceIsCalled.cs
+++ b/web/tests/Web.Tests/Services/WhenTrustSearchServiceIsCalled.cs
@@ -11,7 +11,7 @@ public class WhenTrustSearchServiceIsCalled
 {
     private readonly Mock<IEstablishmentApi> _api = new();
 
-    public static TheoryData<string?, int?, int?, (string Field, string Order)?, SearchRequest?> WhenSendRequestData = new()
+    public static TheoryData<string?, int?, int?, SearchOrderBy?, SearchRequest?> WhenSendRequestData = new()
     {
         {
             "term",
@@ -31,7 +31,7 @@ public class WhenTrustSearchServiceIsCalled
             "term",
             1,
             2,
-            ("field2", "value3"),
+            new SearchOrderBy("field2", "value3"),
             new SearchRequest
             {
                 SearchText = "term",
@@ -44,7 +44,7 @@ public class WhenTrustSearchServiceIsCalled
 
     [Theory]
     [MemberData(nameof(WhenSendRequestData))]
-    public async Task ShouldSendRequest(string? term, int? pageSize = null, int? page = null, (string Field, string Order)? orderBy = null, SearchRequest? expected = null)
+    public async Task ShouldSendRequest(string? term, int? pageSize = null, int? page = null, SearchOrderBy? orderBy = null, SearchRequest? expected = null)
     {
         var response = new SearchResponse<TrustSummary>();
 

--- a/web/tests/Web.Tests/packages.lock.json
+++ b/web/tests/Web.Tests/packages.lock.json
@@ -620,8 +620,8 @@
       },
       "Microsoft.OpenApi": {
         "type": "Transitive",
-        "resolved": "1.6.22",
-        "contentHash": "aBvunmrdu/x+4CaA/UP1Jx4xWGwk4kymhoIRnn2Vp+zi5/KOPQJ9EkSXHRUr01WcGKtYl3Au7XfkPJbU1G2sjQ=="
+        "resolved": "1.6.23",
+        "contentHash": "tZ1I0KXnn98CWuV8cpI247A17jaY+ILS9vvF7yhI0uPPEqF4P1d7BWL5Uwtel10w9NucllHB3nTkfYTAcHAh8g=="
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
@@ -921,24 +921,24 @@
       },
       "Swashbuckle.AspNetCore.Swagger": {
         "type": "Transitive",
-        "resolved": "7.3.2",
-        "contentHash": "39Z2N3cLHDcDinu2IW5IaQO9wGPKTbc+vKbjIT/6gN3jFYypWY5U3O8i7Y9rmYDgxkm6niICnkcFZ3hEvikIHA==",
+        "resolved": "8.1.1",
+        "contentHash": "h+8D5jQtnl6X4f2hJQwf0Khj0SnCQANzirCELjXJ6quJ4C1aNNCvJrAsQ+4fOKAMqJkvW48cKj79ftG+YoGcRg==",
         "dependencies": {
-          "Microsoft.OpenApi": "1.6.22"
+          "Microsoft.OpenApi": "1.6.23"
         }
       },
       "Swashbuckle.AspNetCore.SwaggerGen": {
         "type": "Transitive",
-        "resolved": "7.3.2",
-        "contentHash": "x5famjpcgazpT/8eEIlpSYSTZDq6ojMARhuJgj6O67Uk+Yb1DdDM5yikdL7GK1pMk5rYBETUCRWYP6rp+vHnlA==",
+        "resolved": "8.1.1",
+        "contentHash": "2EuPzXSNleOOzYvziERWRLnk1Oz9i0Z1PimaUFy1SasBqeV/rG+eMfwFAMtTaf4W6gvVOzRcUCNRHvpBIIzr+A==",
         "dependencies": {
-          "Swashbuckle.AspNetCore.Swagger": "7.3.2"
+          "Swashbuckle.AspNetCore.Swagger": "8.1.1"
         }
       },
       "Swashbuckle.AspNetCore.SwaggerUI": {
         "type": "Transitive",
-        "resolved": "7.3.2",
-        "contentHash": "SNQuFjYin9KhkoCSVOD5/Y4VEyAjKBDeZkIqqY6x+oI21HMKzzVkeJA9V7tWFXf5df4m/+pTIlbKO7g5W9UroQ=="
+        "resolved": "8.1.1",
+        "contentHash": "GDLX/MpK4oa2nYC1N/zN2UidQTtVKLPF6gkdEmGb0RITEwpJG9Gu8olKqPYnKqVeFn44JZoCS0M2LGRKXP8B/A=="
       },
       "System.AppContext": {
         "type": "Transitive",
@@ -1873,7 +1873,7 @@
           "Serilog.Enrichers.CorrelationId": "[3.0.1, )",
           "Serilog.Sinks.ApplicationInsights": "[4.0.0, )",
           "SmartBreadcrumbs": "[3.6.1, )",
-          "Swashbuckle.AspNetCore": "[7.3.2, )"
+          "Swashbuckle.AspNetCore": "[8.1.1, )"
         }
       },
       "Azure.Identity": {
@@ -2089,14 +2089,14 @@
       },
       "Swashbuckle.AspNetCore": {
         "type": "CentralTransitive",
-        "requested": "[7.3.2, )",
-        "resolved": "7.3.2",
-        "contentHash": "WEkW7Cl8bexT75eURuqrqM/TQx+ftWKOWlCHzmw3Fl3oAmxiBO/lDVOuuqZsaBCHQIBcZxA6BbyiG5dv2mD2tw==",
+        "requested": "[8.1.1, )",
+        "resolved": "8.1.1",
+        "contentHash": "HJHexmU0PiYevgTLvKjYkxEtclF2w4O7iTd3Ef3p6KeT0kcYLpkFVgCw6glpGS57h8769anv8G+NFi9Kge+/yw==",
         "dependencies": {
           "Microsoft.Extensions.ApiDescription.Server": "6.0.5",
-          "Swashbuckle.AspNetCore.Swagger": "7.3.2",
-          "Swashbuckle.AspNetCore.SwaggerGen": "7.3.2",
-          "Swashbuckle.AspNetCore.SwaggerUI": "7.3.2"
+          "Swashbuckle.AspNetCore.Swagger": "8.1.1",
+          "Swashbuckle.AspNetCore.SwaggerGen": "8.1.1",
+          "Swashbuckle.AspNetCore.SwaggerUI": "8.1.1"
         }
       },
       "xunit.abstractions": {


### PR DESCRIPTION
### Context
[AB#250287](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/250287) [AB#257773](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/257773) #2263

### Change proposed in this pull request
- Wired up Trust Filtered Search to API
- Tidied up `ISearchService` arguments
- Bumped Web dependencies (including #2220)

### Guidance to review 
Intentionally resolves to `404` once form submitted successfully, even though search should be successful. Dependency on #2263.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

