### PR TITLE
Removed `-T` suffix from cost codes

### DIFF
--- a/web/src/Web.App/Domain/CostCodes.cs
+++ b/web/src/Web.App/Domain/CostCodes.cs
@@ -3,54 +3,54 @@
 public class CostCodes(bool isPartOfTrust)
 {
     // TeachingStaffCostCodes
-    private string TeachingStaffCostCode { get; } = isPartOfTrust ? "BAE010-T" : "E01";
-    private string SupplyTeachingStaffCostCode { get; } = isPartOfTrust ? "BAE020-T" : "E02";
-    private string AgencySupplyTeachingStaffCostCode { get; } = isPartOfTrust ? "BAE240-T" : "E26";
-    private string EducationSupportStaffCostCode { get; } = isPartOfTrust ? "BAE030-T" : "E03";
-    private string EducationalConsultancyCostCode { get; } = isPartOfTrust ? "BAE230-T" : "E27";
+    private string TeachingStaffCostCode { get; } = isPartOfTrust ? "BAE010" : "E01";
+    private string SupplyTeachingStaffCostCode { get; } = isPartOfTrust ? "BAE020" : "E02";
+    private string AgencySupplyTeachingStaffCostCode { get; } = isPartOfTrust ? "BAE240" : "E26";
+    private string EducationSupportStaffCostCode { get; } = isPartOfTrust ? "BAE030" : "E03";
+    private string EducationalConsultancyCostCode { get; } = isPartOfTrust ? "BAE230" : "E27";
 
     // NonEducationalSupportStaffCostCodes
-    private string AdministrativeClericalStaffCostCode { get; } = isPartOfTrust ? "BAE040-T" : "E05";
-    private string AuditorsCostCode { get; } = isPartOfTrust ? "BAE260-T" : "";
-    private string OtherStaffCostCode { get; } = isPartOfTrust ? "BAE070-T" : "E07";
-    private string ProfessionalServicesNonCurriculumCostCode { get; } = isPartOfTrust ? "BAE300-T" : "E28a";
+    private string AdministrativeClericalStaffCostCode { get; } = isPartOfTrust ? "BAE040" : "E05";
+    private string AuditorsCostCode { get; } = isPartOfTrust ? "BAE260" : "";
+    private string OtherStaffCostCode { get; } = isPartOfTrust ? "BAE070" : "E07";
+    private string ProfessionalServicesNonCurriculumCostCode { get; } = isPartOfTrust ? "BAE300" : "E28a";
 
     // EducationalSuppliesCostCodes
-    private string ExaminationFeesCostCode { get; } = isPartOfTrust ? "BAE220-T" : "E21";
-    private string LearningResourcesNonIctCostsCode { get; } = isPartOfTrust ? "BAE200-T" : "E19";
+    private string ExaminationFeesCostCode { get; } = isPartOfTrust ? "BAE220" : "E21";
+    private string LearningResourcesNonIctCostsCode { get; } = isPartOfTrust ? "BAE200" : "E19";
 
     // EducationalIctCostCodes
-    private string LearningResourcesIctCostCode { get; } = isPartOfTrust ? "BAE210-T" : "E20";
+    private string LearningResourcesIctCostCode { get; } = isPartOfTrust ? "BAE210" : "E20";
 
     // PremisesStaffServicesCostCodes
-    private string CleaningCaretakingCostCode { get; } = isPartOfTrust ? "BAE130-T" : "E14";
-    private string MaintenancePremisesCostCode { get; } = isPartOfTrust ? "BAE120-T" : "E12";
-    private string OtherOccupationCostCode { get; } = isPartOfTrust ? "BAE180-T" : "E18";
-    private string PremisesStaffCostCode { get; } = isPartOfTrust ? "BAE050-T" : "E04";
+    private string CleaningCaretakingCostCode { get; } = isPartOfTrust ? "BAE130" : "E14";
+    private string MaintenancePremisesCostCode { get; } = isPartOfTrust ? "BAE120" : "E12";
+    private string OtherOccupationCostCode { get; } = isPartOfTrust ? "BAE180" : "E18";
+    private string PremisesStaffCostCode { get; } = isPartOfTrust ? "BAE050" : "E04";
 
     // UtilitiesCostCodes
-    private string EnergyCostCode { get; } = isPartOfTrust ? "BAE150-T" : "E16";
-    private string WaterSewerageCostCode { get; } = isPartOfTrust ? "BAE140-T" : "E15";
+    private string EnergyCostCode { get; } = isPartOfTrust ? "BAE150" : "E16";
+    private string WaterSewerageCostCode { get; } = isPartOfTrust ? "BAE140" : "E15";
 
     // AdministrativeSuppliesCostCodes
-    private string AdministrativeSuppliesNonEducationalCostCode { get; } = isPartOfTrust ? "BAE280-T" : "E22";
+    private string AdministrativeSuppliesNonEducationalCostCode { get; } = isPartOfTrust ? "BAE280" : "E22";
 
     // CateringStaffServicesCostCodes
-    private string CateringStaffCostCode { get; } = isPartOfTrust ? "BAE060-T" : "E06";
-    private string CateringSuppliesCostCode { get; } = isPartOfTrust ? "BAE250-T" : "E25";
+    private string CateringStaffCostCode { get; } = isPartOfTrust ? "BAE060" : "E06";
+    private string CateringSuppliesCostCode { get; } = isPartOfTrust ? "BAE250" : "E25";
 
     // OtherCostCodes
-    private string DirectRevenueFinancingCostCode { get; } = isPartOfTrust ? "BAE290-T" : "E30";
-    private string GroundsMaintenanceCostCode { get; } = isPartOfTrust ? "BAE320-T" : "E13";
-    private string IndirectEmployeeExpensesCostCode { get; } = isPartOfTrust ? "BAE080-T" : "E08";
-    private string InterestChargesLoanBankCostCode { get; } = isPartOfTrust ? "BAE320-T" : "E29";
-    private string OtherInsurancePremiumsCostCode { get; } = isPartOfTrust ? "BAE270-T" : "E23";
-    private string PrivateFinanceInitiativeChargesCostCode { get; } = isPartOfTrust ? "BAE310-T" : "E28b";
-    private string RentRatesCostCode { get; } = isPartOfTrust ? "BAE160-T" : "E17";
-    private string SpecialFacilitiesCostCode { get; } = isPartOfTrust ? "BAE190-T" : "E24";
-    private string StaffDevelopmentTrainingCostCode { get; } = isPartOfTrust ? "BAE090-T" : "E09";
-    private string StaffRelatedInsuranceCostCode { get; } = isPartOfTrust ? "BAE110-T" : "E11";
-    private string SupplyTeacherInsurableCostCode { get; } = isPartOfTrust ? "BAE100-T" : "E10";
+    private string DirectRevenueFinancingCostCode { get; } = isPartOfTrust ? "BAE290" : "E30";
+    private string GroundsMaintenanceCostCode { get; } = isPartOfTrust ? "BAE320" : "E13";
+    private string IndirectEmployeeExpensesCostCode { get; } = isPartOfTrust ? "BAE080" : "E08";
+    private string InterestChargesLoanBankCostCode { get; } = isPartOfTrust ? "BAE320" : "E29";
+    private string OtherInsurancePremiumsCostCode { get; } = isPartOfTrust ? "BAE270" : "E23";
+    private string PrivateFinanceInitiativeChargesCostCode { get; } = isPartOfTrust ? "BAE310" : "E28b";
+    private string RentRatesCostCode { get; } = isPartOfTrust ? "BAE160" : "E17";
+    private string SpecialFacilitiesCostCode { get; } = isPartOfTrust ? "BAE190" : "E24";
+    private string StaffDevelopmentTrainingCostCode { get; } = isPartOfTrust ? "BAE090" : "E09";
+    private string StaffRelatedInsuranceCostCode { get; } = isPartOfTrust ? "BAE110" : "E11";
+    private string SupplyTeacherInsurableCostCode { get; } = isPartOfTrust ? "BAE100" : "E10";
     private string CommunityFocusedSchoolCostCode { get; } = isPartOfTrust ? "" : "E32";
     private string CommunityFocusedSchoolStaffCostCode { get; } = isPartOfTrust ? "" : "E31";
 

--- a/web/tests/Web.Tests/Domain/GivenASubCategoryCostCodes.cs
+++ b/web/tests/Web.Tests/Domain/GivenASubCategoryCostCodes.cs
@@ -1,17 +1,133 @@
 ﻿using Web.App.Domain;
 using Xunit;
+
 namespace Web.Tests.Domain;
 
 public class GivenASubCategoryCostCodes
 {
     [Theory]
+    [InlineData(SubCostCategories.TeachingStaff.TeachingStaffCosts, false, "E01")]
+    [InlineData(SubCostCategories.TeachingStaff.TeachingStaffCosts, true, "BAE010")]
+    [InlineData(SubCostCategories.TeachingStaff.SupplyTeachingStaffCosts, false, "E02")]
+    [InlineData(SubCostCategories.TeachingStaff.SupplyTeachingStaffCosts, true, "BAE020")]
+    [InlineData(SubCostCategories.TeachingStaff.AgencySupplyTeachingStaffCosts, false, "E26")]
+    [InlineData(SubCostCategories.TeachingStaff.AgencySupplyTeachingStaffCosts, true, "BAE240")]
+    [InlineData(SubCostCategories.TeachingStaff.EducationSupportStaffCosts, false, "E03")]
+    [InlineData(SubCostCategories.TeachingStaff.EducationSupportStaffCosts, true, "BAE030")]
+    [InlineData(SubCostCategories.TeachingStaff.EducationalConsultancyCosts, false, "E27")]
+    [InlineData(SubCostCategories.TeachingStaff.EducationalConsultancyCosts, true, "BAE230")]
+    public void GetsCorrectCostCodeForTeachingStaff(string subCategory, bool isPartOfTrust, string? expectedCostCode)
+    {
+        AssertCodeEqual(subCategory, isPartOfTrust, expectedCostCode);
+    }
+
+    [Theory]
+    [InlineData(SubCostCategories.NonEducationalSupportStaff.AdministrativeClericalStaffCosts, false, "E05")]
+    [InlineData(SubCostCategories.NonEducationalSupportStaff.AdministrativeClericalStaffCosts, true, "BAE040")]
     [InlineData(SubCostCategories.NonEducationalSupportStaff.AuditorsCosts, false, null)]
-    [InlineData(SubCostCategories.NonEducationalSupportStaff.AuditorsCosts, true, "BAE260-T")]
-    [InlineData(SubCostCategories.Other.CommunityFocusedSchoolCosts, false, "E32")]
-    [InlineData(SubCostCategories.Other.CommunityFocusedSchoolCosts, true, null)]
+    [InlineData(SubCostCategories.NonEducationalSupportStaff.AuditorsCosts, true, "BAE260")]
+    [InlineData(SubCostCategories.NonEducationalSupportStaff.OtherStaffCosts, false, "E07")]
+    [InlineData(SubCostCategories.NonEducationalSupportStaff.OtherStaffCosts, true, "BAE070")]
+    [InlineData(SubCostCategories.NonEducationalSupportStaff.ProfessionalServicesNonCurriculumCosts, false, "E28a")]
+    [InlineData(SubCostCategories.NonEducationalSupportStaff.ProfessionalServicesNonCurriculumCosts, true, "BAE300")]
+    public void GetsCorrectCostCodeForNonEducationalSupportStaff(string subCategory, bool isPartOfTrust, string? expectedCostCode)
+    {
+        AssertCodeEqual(subCategory, isPartOfTrust, expectedCostCode);
+    }
+
+    [Theory]
+    [InlineData(SubCostCategories.EducationalSupplies.ExaminationFeesCosts, false, "E21")]
+    [InlineData(SubCostCategories.EducationalSupplies.ExaminationFeesCosts, true, "BAE220")]
+    [InlineData(SubCostCategories.EducationalSupplies.LearningResourcesNonIctCosts, false, "E19")]
+    [InlineData(SubCostCategories.EducationalSupplies.LearningResourcesNonIctCosts, true, "BAE200")]
+    public void GetsCorrectCostCodeForEducationalSupplies(string subCategory, bool isPartOfTrust, string? expectedCostCode)
+    {
+        AssertCodeEqual(subCategory, isPartOfTrust, expectedCostCode);
+    }
+
+    [Theory]
+    [InlineData(SubCostCategories.EducationalIct.LearningResourcesIctCosts, false, "E20")]
+    [InlineData(SubCostCategories.EducationalIct.LearningResourcesIctCosts, true, "BAE210")]
+    public void GetsCorrectCostCodeFoEducationalIct(string subCategory, bool isPartOfTrust, string? expectedCostCode)
+    {
+        AssertCodeEqual(subCategory, isPartOfTrust, expectedCostCode);
+    }
+
+    [Theory]
+    [InlineData(SubCostCategories.PremisesStaffServices.CleaningCaretakingCosts, false, "E14")]
+    [InlineData(SubCostCategories.PremisesStaffServices.CleaningCaretakingCosts, true, "BAE130")]
+    [InlineData(SubCostCategories.PremisesStaffServices.MaintenancePremisesCosts, false, "E12")]
+    [InlineData(SubCostCategories.PremisesStaffServices.MaintenancePremisesCosts, true, "BAE120")]
+    [InlineData(SubCostCategories.PremisesStaffServices.OtherOccupationCosts, false, "E18")]
+    [InlineData(SubCostCategories.PremisesStaffServices.OtherOccupationCosts, true, "BAE180")]
+    [InlineData(SubCostCategories.PremisesStaffServices.PremisesStaffCosts, false, "E04")]
+    [InlineData(SubCostCategories.PremisesStaffServices.PremisesStaffCosts, true, "BAE050")]
+    public void GetsCorrectCostCodeForPremisesStaffServices(string subCategory, bool isPartOfTrust, string? expectedCostCode)
+    {
+        AssertCodeEqual(subCategory, isPartOfTrust, expectedCostCode);
+    }
+
+    [Theory]
+    [InlineData(SubCostCategories.Utilities.EnergyCosts, false, "E16")]
+    [InlineData(SubCostCategories.Utilities.EnergyCosts, true, "BAE150")]
+    [InlineData(SubCostCategories.Utilities.WaterSewerageCosts, false, "E15")]
+    [InlineData(SubCostCategories.Utilities.WaterSewerageCosts, true, "BAE140")]
+    public void GetsCorrectCostCodeForUtilities(string subCategory, bool isPartOfTrust, string? expectedCostCode)
+    {
+        AssertCodeEqual(subCategory, isPartOfTrust, expectedCostCode);
+    }
+
+    [Theory]
+    [InlineData(SubCostCategories.AdministrativeSupplies.AdministrativeSuppliesNonEducationalCosts, false, "E22")]
+    [InlineData(SubCostCategories.AdministrativeSupplies.AdministrativeSuppliesNonEducationalCosts, true, "BAE280")]
+    public void GetsCorrectCostCodeForAdministrativeSupplies(string subCategory, bool isPartOfTrust, string? expectedCostCode)
+    {
+        AssertCodeEqual(subCategory, isPartOfTrust, expectedCostCode);
+    }
+
+    [Theory]
+    [InlineData(SubCostCategories.CateringStaffServices.CateringStaffCosts, false, "E06")]
+    [InlineData(SubCostCategories.CateringStaffServices.CateringStaffCosts, true, "BAE060")]
+    [InlineData(SubCostCategories.CateringStaffServices.CateringSuppliesCosts, false, "E25")]
+    [InlineData(SubCostCategories.CateringStaffServices.CateringSuppliesCosts, true, "BAE250")]
+    public void GetsCorrectCostCodeForCateringStaffServices(string subCategory, bool isPartOfTrust, string? expectedCostCode)
+    {
+        AssertCodeEqual(subCategory, isPartOfTrust, expectedCostCode);
+    }
+
+    [Theory]
+    [InlineData(SubCostCategories.Other.DirectRevenueFinancingCosts, false, "E30")]
+    [InlineData(SubCostCategories.Other.DirectRevenueFinancingCosts, true, "BAE290")]
+    [InlineData(SubCostCategories.Other.GroundsMaintenanceCosts, false, "E13")]
+    [InlineData(SubCostCategories.Other.GroundsMaintenanceCosts, true, "BAE320")]
+    [InlineData(SubCostCategories.Other.IndirectEmployeeExpenses, false, "E08")]
+    [InlineData(SubCostCategories.Other.IndirectEmployeeExpenses, true, "BAE080")]
+    [InlineData(SubCostCategories.Other.InterestChargesLoanBank, false, "E29")]
+    [InlineData(SubCostCategories.Other.InterestChargesLoanBank, true, "BAE320")]
+    [InlineData(SubCostCategories.Other.OtherInsurancePremiumsCosts, false, "E23")]
+    [InlineData(SubCostCategories.Other.OtherInsurancePremiumsCosts, true, "BAE270")]
+    [InlineData(SubCostCategories.Other.PrivateFinanceInitiativeCharges, false, "E28b")]
+    [InlineData(SubCostCategories.Other.PrivateFinanceInitiativeCharges, true, "BAE310")]
+    [InlineData(SubCostCategories.Other.RentRatesCosts, false, "E17")]
+    [InlineData(SubCostCategories.Other.RentRatesCosts, true, "BAE160")]
+    [InlineData(SubCostCategories.Other.SpecialFacilitiesCosts, false, "E24")]
+    [InlineData(SubCostCategories.Other.SpecialFacilitiesCosts, true, "BAE190")]
+    [InlineData(SubCostCategories.Other.StaffDevelopmentTrainingCosts, false, "E09")]
+    [InlineData(SubCostCategories.Other.StaffDevelopmentTrainingCosts, true, "BAE090")]
+    [InlineData(SubCostCategories.Other.StaffRelatedInsuranceCosts, false, "E11")]
+    [InlineData(SubCostCategories.Other.StaffRelatedInsuranceCosts, true, "BAE110")]
+    [InlineData(SubCostCategories.Other.SupplyTeacherInsurableCosts, false, "E10")]
+    [InlineData(SubCostCategories.Other.SupplyTeacherInsurableCosts, true, "BAE100")]
     [InlineData(SubCostCategories.Other.CommunityFocusedSchoolStaff, false, "E31")]
     [InlineData(SubCostCategories.Other.CommunityFocusedSchoolStaff, true, null)]
-    public void GetsCorrectCostCode(string subCategory, bool isPartOfTrust, string? expectedCostCode)
+    [InlineData(SubCostCategories.Other.CommunityFocusedSchoolCosts, false, "E32")]
+    [InlineData(SubCostCategories.Other.CommunityFocusedSchoolCosts, true, null)]
+    public void GetsCorrectCostCodeForOther(string subCategory, bool isPartOfTrust, string? expectedCostCode)
+    {
+        AssertCodeEqual(subCategory, isPartOfTrust, expectedCostCode);
+    }
+
+    private static void AssertCodeEqual(string subCategory, bool isPartOfTrust, string? expectedCostCode)
     {
         var costCodes = new CostCodes(isPartOfTrust);
 


### PR DESCRIPTION
### Context
[AB#258439](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/258439) [AB#258226](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/258226)

### Change proposed in this pull request
- Updated cost codes
- Additional unit tests

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

