### PR TITLE
Included `Population2To18` in local authority High needs Web proxy responses

### DIFF
--- a/web/src/Web.App/Controllers/Api/HighNeedsProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/HighNeedsProxyController.cs
@@ -41,7 +41,7 @@ public class HighNeedsProxyController(
         }
         catch (Exception e)
         {
-            logger.LogError(e, "An error getting local authority high needs history data: {DisplayUrl}", Request.GetDisplayUrl());
+            logger.LogError(e, "An error getting local authority high needs data: {DisplayUrl}", Request.GetDisplayUrl());
             return StatusCode(500);
         }
     }

--- a/web/src/Web.App/Controllers/Api/Mappers/EducationHealthCarePlansHistoryResponseMapper.cs
+++ b/web/src/Web.App/Controllers/Api/Mappers/EducationHealthCarePlansHistoryResponseMapper.cs
@@ -11,6 +11,7 @@ public static class EducationHealthCarePlansResponseMapper
         {
             Code = item.Code,
             Name = item.Name,
+            Population2To18 = item.Population2To18,
             Total = item.Total,
             Mainstream = item.Mainstream,
             Resourced = item.Resourced,

--- a/web/src/Web.App/Controllers/Api/Mappers/LocalAuthorityHighNeedsResponseMapper.cs
+++ b/web/src/Web.App/Controllers/Api/Mappers/LocalAuthorityHighNeedsResponseMapper.cs
@@ -11,6 +11,7 @@ public static class LocalAuthorityHighNeedsResponseMapper
         {
             Code = l.Code,
             Name = l.Name,
+            Population2To18 = l.Population2To18,
             Outturn = l.Outturn?.MapToApiResponse(),
             Budget = l.Budget?.MapToApiResponse()
         });

--- a/web/src/Web.App/Controllers/Api/Responses/EducationHealthCarePlansResponse.cs
+++ b/web/src/Web.App/Controllers/Api/Responses/EducationHealthCarePlansResponse.cs
@@ -11,6 +11,7 @@ public record EducationHealthCarePlansComparisonResponse : EducationHealthCarePl
 {
     public string? Code { get; set; }
     public string? Name { get; set; }
+    public double? Population2To18 { get; set; }
 }
 
 public record EducationHealthCarePlansResponse

--- a/web/src/Web.App/Controllers/Api/Responses/LocalAuthorityHighNeedsResponse.cs
+++ b/web/src/Web.App/Controllers/Api/Responses/LocalAuthorityHighNeedsResponse.cs
@@ -14,6 +14,7 @@ public record LocalAuthorityHighNeedsComparisonResponse
 {
     public string? Code { get; init; }
     public string? Name { get; init; }
+    public double? Population2To18 { get; init; }
     public LocalAuthorityHighNeedsApiResponse? Outturn { get; init; }
     public LocalAuthorityHighNeedsApiResponse? Budget { get; init; }
 }

--- a/web/src/Web.App/Domain/LocalAuthorities/LocalAuthority.cs
+++ b/web/src/Web.App/Domain/LocalAuthorities/LocalAuthority.cs
@@ -1,9 +1,12 @@
+// ReSharper disable ClassNeverInstantiated.Global
+// ReSharper disable UnusedAutoPropertyAccessor.Global
 namespace Web.App.Domain.LocalAuthorities;
 
 public record LocalAuthority<T>
 {
     public string? Code { get; set; }
     public string? Name { get; set; }
+    public double? Population2To18 { get; set; }
     public T? Outturn { get; set; }
     public T? Budget { get; set; }
 }

--- a/web/src/Web.App/Domain/NonFinancial/LocalAuthorityNumberOfPlans.cs
+++ b/web/src/Web.App/Domain/NonFinancial/LocalAuthorityNumberOfPlans.cs
@@ -7,6 +7,7 @@ public record LocalAuthorityNumberOfPlans
 {
     public string? Code { get; set; }
     public string? Name { get; set; }
+    public double? Population2To18 { get; set; }
     public decimal? Total { get; set; }
     public decimal? Mainstream { get; set; }
     public decimal? Resourced { get; set; }

--- a/web/tests/Web.Integration.Tests/Proxy/WhenRequestingEducationHealthCarePlansComparison.cs
+++ b/web/tests/Web.Integration.Tests/Proxy/WhenRequestingEducationHealthCarePlansComparison.cs
@@ -43,6 +43,7 @@ public class WhenEducationHealthCarePlansComparison(SchoolBenchmarkingWebAppClie
 
             Assert.Equal(expected.Code, actual.Code);
             Assert.Equal(expected.Name, actual.Name);
+            Assert.Equal(expected.Population2To18, actual.Population2To18);
             Assert.Equal(expected.Total, actual.Total);
             Assert.Equal(expected.Mainstream, actual.Mainstream);
             Assert.Equal(expected.Resourced, actual.Resourced);

--- a/web/tests/Web.Integration.Tests/Proxy/WhenRequestingHighNeedsComparison.cs
+++ b/web/tests/Web.Integration.Tests/Proxy/WhenRequestingHighNeedsComparison.cs
@@ -44,6 +44,7 @@ public class WhenRequestingHighNeedsComparison(SchoolBenchmarkingWebAppClient cl
 
             Assert.Equal(expected.Code, actual.Code);
             Assert.Equal(expected.Name, actual.Name);
+            Assert.Equal(expected.Population2To18, actual.Population2To18);
         }
     }
 

--- a/web/tests/Web.Tests/Controllers/Api/Mappers/WhenEducationHealthCarePlansComparisonResponseMapperMaps.cs
+++ b/web/tests/Web.Tests/Controllers/Api/Mappers/WhenEducationHealthCarePlansComparisonResponseMapperMaps.cs
@@ -29,6 +29,7 @@ public class WhenEducationHealthCarePlansComparisonResponseMapperMaps
 
             Assert.Equal(expected.Code, actual.Code);
             Assert.Equal(expected.Name, actual.Name);
+            Assert.Equal(expected.Population2To18, actual.Population2To18);
             Assert.Equal(expected.Total, actual.Total);
             Assert.Equal(expected.Mainstream, actual.Mainstream);
             Assert.Equal(expected.Resourced, actual.Resourced);

--- a/web/tests/Web.Tests/Controllers/Api/Mappers/WhenLocalAuthorityHighNeedsComparisonResponseMapperMapsToApi.cs
+++ b/web/tests/Web.Tests/Controllers/Api/Mappers/WhenLocalAuthorityHighNeedsComparisonResponseMapperMapsToApi.cs
@@ -30,6 +30,7 @@ public class WhenLocalAuthorityHighNeedsComparisonResponseMapperMapsToApi
 
             Assert.Equal(expected.Code, actual.Code);
             Assert.Equal(expected.Name, actual.Name);
+            Assert.Equal(expected.Population2To18, actual.Population2To18);
             AssertFieldsMapped(expected.Outturn!, actual.Outturn);
             AssertFieldsMapped(expected.Budget!, actual.Budget);
         }


### PR DESCRIPTION
### Context
[AB#258520](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/258520) [AB#258522](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/258522) #2270

### Change proposed in this pull request
- Added `Population2To18` to `GET /api/local-authorities/education-health-care-plans/comparison` response
- Added `Population2To18` to `GET /api/local-authorities/high-needs/comparison` response
- Unit and integration test updates

### Guidance to review 
Dependency on #2270 

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

