### PR TITLE
Added `2 to 18 Population` as additional column in High needs benchmarking tables

### DIFF
--- a/front-end-components/src/components/charts/table-chart/component.tsx
+++ b/front-end-components/src/components/charts/table-chart/component.tsx
@@ -89,7 +89,7 @@ export const TableChart: React.FC<
               const { laName, schoolType, totalPupils, urn, value } = schoolRow;
               const { totalValue, schoolValue, centralValue, companyNumber } =
                 trustRow;
-              const { budget, laCode } = laRow;
+              const { budget, laCode, population } = laRow;
               const additionalData = schoolRow.urn
                 ? {
                     laName,
@@ -156,6 +156,11 @@ export const TableChart: React.FC<
                           })}
                         </td>
                       )}
+                      <td className="govuk-table__cell table-cell-value">
+                        {fullValueFormatter(population, {
+                          valueUnit: "amount",
+                        })}
+                      </td>
                     </>
                   ) : (
                     <td className="govuk-table__cell table-cell-value">

--- a/front-end-components/src/components/charts/table-chart/partials/table-cell-establishment-name.tsx
+++ b/front-end-components/src/components/charts/table-chart/partials/table-cell-establishment-name.tsx
@@ -26,6 +26,7 @@ export function TableCellEstablishmentName<
       className={classNames("govuk-table__cell", {
         "table-cell-warning":
           periodCoveredByReturn !== undefined && periodCoveredByReturn < 12,
+        "govuk-!-width-one-third": !!localAuthority,
       })}
     >
       <SelectedAnchor

--- a/front-end-components/src/components/charts/table-chart/types.tsx
+++ b/front-end-components/src/components/charts/table-chart/types.tsx
@@ -34,6 +34,7 @@ export type TrustChartData = {
 export type LaChartData = {
   laCode: string;
   laName: string;
+  population?: number;
   value?: number;
   outturn?: number;
   budget?: number;

--- a/front-end-components/src/composed/benchmark-chart-section-251/component.tsx
+++ b/front-end-components/src/composed/benchmark-chart-section-251/component.tsx
@@ -33,12 +33,18 @@ export function BenchmarkChartSection251<
             isNaN(budgetValue)
               ? undefined
               : budgetValue,
+          population: s.population2To18,
         });
       });
     }
 
     return {
-      tableHeadings: ["Local authority", "Outturn", "Budget"],
+      tableHeadings: [
+        "Local authority",
+        "Outturn",
+        "Budget",
+        "2 to 18 Population",
+      ],
       dataPoints,
     };
   }, [data, valueField]);

--- a/front-end-components/src/composed/benchmark-chart-send-2/component.tsx
+++ b/front-end-components/src/composed/benchmark-chart-send-2/component.tsx
@@ -22,12 +22,13 @@ export function BenchmarkChartSend2<
             value === undefined || value === null || isNaN(value)
               ? undefined
               : value,
+          population: s.population2To18,
         });
       });
     }
 
     return {
-      tableHeadings: ["Local authority", "Amount"],
+      tableHeadings: ["Local authority", "Amount", "2 to 18 Population"],
       dataPoints,
     };
   }, [data, valueField]);

--- a/front-end-components/src/services/types.tsx
+++ b/front-end-components/src/services/types.tsx
@@ -412,6 +412,7 @@ export type LocalAuthorityRank = {
 export type LocalAuthorityBenchmarkBase = {
   code: string;
   name: string;
+  population2To18?: number;
 };
 
 export type LocalAuthoritySection251Benchmark<

--- a/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsBenchmarking.feature
+++ b/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsBenchmarking.feature
@@ -33,15 +33,15 @@
         Given I am on local authority high needs benchmarking for local authority with code '201'
         When I click on view as table
         Then the table for 'High needs amount per head 2-18 population' contains the following S251 values:
-          | Name           | Actual  | Planned |
-          | City of London | £0.00   | £0.00   |
-          | Hackney        | £115.22 | £113.85 |
+          | Name           | Actual  | Planned | Population |
+          | City of London | £0.00   | £0.00   | 1,756      |
+          | Hackney        | £115.22 | £113.85 | 59,677     |
 
     @HighNeedsFlagEnabled
     Scenario: Can view local authority benchmarking table data for SEND2
         Given I am on local authority high needs benchmarking for local authority with code '201'
         When I click on view as table
         Then the table for 'Number aged up to 25 with SEN statement or EHC plan' contains the following SEND2 values:
-          | Name           | Amount |
-          | City of London | 10.82  |
-          | Hackney        | 51.31  |
+          | Name           | Amount | Population |
+          | City of London | 10.82  | 1,756      |
+          | Hackney        | 51.31  | 59,677     |

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsBenchmarkingPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsBenchmarkingPage.cs
@@ -72,11 +72,12 @@ public class HighNeedsBenchmarkingPage(IPage page)
             {
                 Name = await cells.ElementAt(0).InnerTextAsync(),
                 Actual = await cells.ElementAt(1).InnerTextAsync(),
-                Planned = await cells.ElementAt(2).InnerTextAsync()
+                Planned = await cells.ElementAt(2).InnerTextAsync(),
+                Population = await cells.ElementAt(3).InnerTextAsync()
             });
         }
 
-        expected.CompareToDynamicSet(set);
+        expected.CompareToDynamicSet(set, false);
     }
 
     public async Task TableContainsSend2(int index, DataTable expected)
@@ -92,7 +93,8 @@ public class HighNeedsBenchmarkingPage(IPage page)
             set.Add(new
             {
                 Name = await cells.ElementAt(0).InnerTextAsync(),
-                Amount = await cells.ElementAt(1).InnerTextAsync()
+                Amount = await cells.ElementAt(1).InnerTextAsync(),
+                Population = await cells.ElementAt(2).InnerTextAsync()
             });
         }
 

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsStartBenchmarking.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsStartBenchmarking.cs
@@ -163,7 +163,7 @@ public class WhenViewingHighNeedsStartBenchmarking(SchoolBenchmarkingWebAppClien
         var cancelButton = page.QuerySelector("a.govuk-link:contains('Cancel')") as IHtmlAnchorElement;
         Assert.NotNull(cancelButton);
 
-        page = await client.Follow(cancelButton);
+        page = await Client.Follow(cancelButton);
         if (referrer == "benchmarking")
         {
             DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeedsBenchmarking(authority.Code).ToAbsolute(), HttpStatusCode.NotFound);


### PR DESCRIPTION
### Context
[AB#258520](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/258520) [AB#258523](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/258523)

### Change proposed in this pull request
- Rendered `2 to 18 Population` as additional column in High needs tables
- E2E updates for validation of Population data in High needs benchmarking tables
- Fixed compiler warning on `WhenViewingHighNeedsHistoricData`

### Guidance to review 
`front-end` will need to be bumped in `Web` in order to validate changes and E2E to pass.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

