### PR TITLE
feat: adds section 251 line codes to high needs benchmarking charts

### DIFF
--- a/front-end-components/src/components/context-codes-list/component.tsx
+++ b/front-end-components/src/components/context-codes-list/component.tsx
@@ -1,0 +1,17 @@
+import { ContextCodesListProps } from "src/components/context-codes-list";
+
+export const ContextCodesList: React.FC<ContextCodesListProps> = (props) => {
+  const { codes } = props;
+
+  return (
+    codes && (
+      <ul className="app-cost-code-list">
+        {codes.map((code) => (
+          <li key={code}>
+            <strong className="govuk-tag">{code}</strong>
+          </li>
+        ))}
+      </ul>
+    )
+  );
+};

--- a/front-end-components/src/components/context-codes-list/index.tsx
+++ b/front-end-components/src/components/context-codes-list/index.tsx
@@ -1,0 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
+export * from "src/components/context-codes-list/types";
+export * from "src/components/context-codes-list/component";

--- a/front-end-components/src/components/context-codes-list/types.tsx
+++ b/front-end-components/src/components/context-codes-list/types.tsx
@@ -1,0 +1,3 @@
+export type ContextCodesListProps = {
+  codes: string[];
+};

--- a/front-end-components/src/components/cost-codes-list/component.tsx
+++ b/front-end-components/src/components/cost-codes-list/component.tsx
@@ -1,4 +1,5 @@
 import { CostCodesListProps } from "src/components/cost-codes-list";
+import { ContextCodesList } from "src/components/context-codes-list";
 import { useCostCodeMapContext } from "src/contexts/hooks";
 
 export const CostCodesList: React.FC<CostCodesListProps> = (props) => {
@@ -6,15 +7,5 @@ export const CostCodesList: React.FC<CostCodesListProps> = (props) => {
 
   const { categoryCostCodes } = useCostCodeMapContext(category);
 
-  return (
-    categoryCostCodes && (
-      <ul className="app-cost-code-list">
-        {categoryCostCodes.map((costCode) => (
-          <li key={costCode}>
-            <strong className="govuk-tag">{costCode}</strong>
-          </li>
-        ))}
-      </ul>
-    )
-  );
+  return categoryCostCodes && <ContextCodesList codes={categoryCostCodes} />;
 };

--- a/front-end-components/src/composed/benchmark-chart-section-251/component.tsx
+++ b/front-end-components/src/composed/benchmark-chart-section-251/component.tsx
@@ -9,7 +9,12 @@ import { DataWarning } from "src/components/charts/data-warning";
 
 export function BenchmarkChartSection251<
   TData extends LocalAuthoritySection251,
->({ chartTitle, data, valueField }: BenchmarkChartSection251Props<TData>) {
+>({
+  chartTitle,
+  data,
+  valueField,
+  lineCodes,
+}: BenchmarkChartSection251Props<TData>) {
   const mergedData = useMemo(() => {
     const dataPoints: LaChartData[] = [];
 
@@ -76,6 +81,7 @@ export function BenchmarkChartSection251<
       seriesLabelField="laName"
       showCopyImageButton
       valueUnit="currency"
+      lineCodes={lineCodes}
     >
       <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{chartTitle}</h3>
       {missingDataKeys.length > 0 && (

--- a/front-end-components/src/composed/benchmark-chart-section-251/types.tsx
+++ b/front-end-components/src/composed/benchmark-chart-section-251/types.tsx
@@ -10,4 +10,5 @@ export interface BenchmarkChartSection251Props<
   chartTitle: string;
   data: LocalAuthoritySection251Benchmark<TData>[] | undefined;
   valueField: ResolvedStatProps<TData>["valueField"];
+  lineCodes?: string[];
 }

--- a/front-end-components/src/composed/horizontal-bar-chart-multi-series/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-multi-series/composed.tsx
@@ -28,6 +28,7 @@ export function HorizontalBarChartMultiSeries<TData extends LaChartData>({
   showCopyImageButton,
   xAxisLabel,
   valueUnit,
+  lineCodes,
 }: HorizontalBarChartMultiSeriesProps<TData>) {
   const { chartMode } = useChartModeContext();
   const selectedEstabishment = useContext(SelectedEstablishmentContext);
@@ -91,6 +92,15 @@ export function HorizontalBarChartMultiSeries<TData extends LaChartData>({
         >
           {hasData ? (
             <>
+              {lineCodes && lineCodes.length > 0 && (
+                <ul className="app-cost-code-list">
+                  {lineCodes.map((code) => (
+                    <li key={code}>
+                      <strong className="govuk-tag">{code}</strong>
+                    </li>
+                  ))}
+                </ul>
+              )}
               {chartMode == ChartModeChart && (
                 <HorizontalBarChart
                   barCategoryGap={5}

--- a/front-end-components/src/composed/horizontal-bar-chart-multi-series/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-multi-series/composed.tsx
@@ -7,6 +7,7 @@ import {
 } from "src/contexts";
 import { Loading } from "src/components/loading";
 import { HorizontalBarChartMultiSeriesProps } from "src/composed/horizontal-bar-chart-multi-series";
+import { ContextCodesList } from "src/components/context-codes-list";
 import {
   ChartModeChart,
   ChartModeTable,
@@ -93,13 +94,7 @@ export function HorizontalBarChartMultiSeries<TData extends LaChartData>({
           {hasData ? (
             <>
               {lineCodes && lineCodes.length > 0 && (
-                <ul className="app-cost-code-list">
-                  {lineCodes.map((code) => (
-                    <li key={code}>
-                      <strong className="govuk-tag">{code}</strong>
-                    </li>
-                  ))}
-                </ul>
+                <ContextCodesList codes={lineCodes} />
               )}
               {chartMode == ChartModeChart && (
                 <HorizontalBarChart

--- a/front-end-components/src/composed/horizontal-bar-chart-multi-series/types.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-multi-series/types.tsx
@@ -15,6 +15,7 @@ export type HorizontalBarChartMultiSeriesProps<TData extends LaChartData> =
     children?: React.ReactNode[] | React.ReactNode;
     data: HorizontalBarChartMultiSeriesPropsData<TData>;
     xAxisLabel?: string;
+    lineCodes?: string[];
   };
 
 export type HorizontalBarChartMultiSeriesPropsData<TData extends LaChartData> =

--- a/front-end-components/src/views/benchmark-data-high-needs/partials/index.tsx
+++ b/front-end-components/src/views/benchmark-data-high-needs/partials/index.tsx
@@ -19,30 +19,37 @@ export const section251Sections: BenchmarkChartSection251Section<LocalAuthorityS
         {
           name: "Total place funding for special schools and AP/PRUs",
           field: "highNeedsAmountTotalPlaceFunding",
+          lineCodes: ["1.0.2"],
         },
         {
           name: "Top up funding (maintained schools, academies, free schools and colleges)",
           field: "highNeedsAmountTopUpFundingMaintained",
+          lineCodes: ["1.2.1", "1.2.2", "1.2.4", "1.2.11"],
         },
         {
           name: "Top up funding (non-maintained and independent schools and colleges)",
           field: "highNeedsAmountTopUpFundingNonMaintained",
+          lineCodes: ["1.2.3"],
         },
         {
           name: "SEN support and inclusion services",
           field: "highNeedsAmountSenServices",
+          lineCodes: ["1.2.5", "1.2.8", "1.2.9"],
         },
         {
           name: "Alternative provision services",
           field: "highNeedsAmountAlternativeProvisionServices",
+          lineCodes: ["1.2.7"],
         },
         {
           name: "Hospital education services",
           field: "highNeedsAmountHospitalServices",
+          lineCodes: ["1.2.6"],
         },
         {
           name: "Therapies and other health related services",
           field: "highNeedsAmountOtherHealthServices",
+          lineCodes: ["1.2.13"],
         },
       ],
     },
@@ -53,18 +60,22 @@ export const section251Sections: BenchmarkChartSection251Section<LocalAuthorityS
         {
           name: "Primary place funding per head 2-18 population",
           field: "placeFundingPrimary",
+          lineCodes: ["1.0.2"],
         },
         {
           name: "Secondary place funding per head 2-18 population",
           field: "placeFundingSecondary",
+          lineCodes: ["1.0.2"],
         },
         {
           name: "Special place funding per head 2-18 population",
           field: "placeFundingSpecial",
+          lineCodes: ["1.0.2"],
         },
         {
           name: "PRU and alternative provision place funding per head 2-18",
           field: "placeFundingAlternativeProvision",
+          lineCodes: ["1.0.2"],
         },
       ],
     },
@@ -75,30 +86,37 @@ export const section251Sections: BenchmarkChartSection251Section<LocalAuthorityS
         {
           name: "Early years top up funding per head 2-18 population (maintained)",
           field: "maintainedEarlyYears",
+          lineCodes: ["1.2.1", "1.2.2", "1.2.4", "1.2.11"],
         },
         {
           name: "Primary top up funding per head 2-18 population (maintained)",
           field: "maintainedPrimary",
+          lineCodes: ["1.2.1", "1.2.2", "1.2.4", "1.2.11"],
         },
         {
           name: "Secondary top up funding per head 2-18 population (maintained)",
           field: "maintainedSecondary",
+          lineCodes: ["1.2.1", "1.2.2", "1.2.4", "1.2.11"],
         },
         {
           name: "Special top up funding per head 2-18 population (maintained)",
           field: "maintainedSpecial",
+          lineCodes: ["1.2.1", "1.2.2", "1.2.4", "1.2.11"],
         },
         {
           name: "Alternative provision top up funding per head 2-18 population (maintained)",
           field: "maintainedAlternativeProvision",
+          lineCodes: ["1.2.1", "1.2.2", "1.2.4", "1.2.11"],
         },
         {
           name: "Post-school top up funding per head 2-18 population (maintained)",
           field: "maintainedPostSchool",
+          lineCodes: ["1.2.1", "1.2.2", "1.2.4", "1.2.11"],
         },
         {
           name: "Top up funding income per head 2-18 population (maintained)",
           field: "maintainedIncome",
+          lineCodes: ["1.2.1", "1.2.2", "1.2.4", "1.2.11"],
         },
       ],
     },
@@ -109,30 +127,37 @@ export const section251Sections: BenchmarkChartSection251Section<LocalAuthorityS
         {
           name: "Early years top up funding per head 2-18 population (non-maintained)",
           field: "nonMaintainedEarlyYears",
+          lineCodes: ["1.2.3"],
         },
         {
           name: "Primary top up funding per head 2-18 population (non-maintained)",
           field: "nonMaintainedPrimary",
+          lineCodes: ["1.2.3"],
         },
         {
           name: "Secondary top up funding per head 2-18 population (non-maintained)",
           field: "nonMaintainedSecondary",
+          lineCodes: ["1.2.3"],
         },
         {
           name: "Special top up funding per head 2-18 population (non-maintained)",
           field: "nonMaintainedSpecial",
+          lineCodes: ["1.2.3"],
         },
         {
           name: "Alternative provision top up funding per head 2-18 population (non-maintained)",
           field: "nonMaintainedAlternativeProvision",
+          lineCodes: ["1.2.3"],
         },
         {
           name: "Post-school top up funding per head 2-18 population (non-maintained)",
           field: "nonMaintainedPostSchool",
+          lineCodes: ["1.2.3"],
         },
         {
           name: "Top up funding income per head 2-18 population (non-maintained)",
           field: "nonMaintainedIncome",
+          lineCodes: ["1.2.3"],
         },
       ],
     },

--- a/front-end-components/src/views/benchmark-data-high-needs/partials/section-251-section.tsx
+++ b/front-end-components/src/views/benchmark-data-high-needs/partials/section-251-section.tsx
@@ -23,6 +23,7 @@ export const Section251Section: React.FC<
                 chartTitle={chart.name}
                 data={data}
                 valueField={chart.field}
+                lineCodes={chart.lineCodes}
               />
             </section>
           ))}

--- a/front-end-components/src/views/benchmark-data-high-needs/types.tsx
+++ b/front-end-components/src/views/benchmark-data-high-needs/types.tsx
@@ -35,6 +35,7 @@ export type BenchmarkDataHighNeedsSection251Chart<
     label: string;
     content: ReactNode;
   };
+  lineCodes?: string[];
 };
 
 export type BenchmarkChartSend2Section<


### PR DESCRIPTION
### Context
[AB#258519](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/258519) - [AB#258528](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/258528)

### Change proposed in this pull request
Adds section 251 line codes to the section 251 charts on high needs benchmarking following the existing pattern used for schools as govuk tag components
Also a refactor of the component used for the schools cost codes so it can be reused.

### Guidance to review 
Validate the codes are correct as per the ticket description.
Copy front-end assets to web locally to run and validate the codes appear correct on the high needs benchmarking page and there is no change to the schools spending priorities and comparison pages

E2E tests will follow on a separate PR after a bump to front end


### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

