### PR TITLE
feat: update Revenue reserve calculations

### DIFF
--- a/data-pipeline/tests/unit/pre_processing/test_academies.py
+++ b/data-pipeline/tests/unit/pre_processing/test_academies.py
@@ -4,7 +4,91 @@ import pandas as pd
 from pipeline import pre_processing
 
 
-def test_revenue_reservce_part_year_academy():
+def test_revenue_reserve():
+    """
+    Academy `Revenue reserve` plus apportioned Central Services
+    `Revenue reserve`.
+    """
+    academies = pd.DataFrame(
+        [
+            {
+                "URN": 0,
+                "Trust UPIN": 0,
+                "Valid To": np.nan,
+                "Revenue reserve": 1.0,
+                "Number of pupils_pro_rata": 5.0,
+                "Total pupils in trust_pro_rata": 5.0,
+            },
+        ],
+        index=[0],
+    )
+    central_services = pd.DataFrame(
+        [
+            {
+                "Trust UPIN": 0,
+                "Revenue reserve": 10.0,
+            },
+        ]
+    )
+
+    result = pre_processing._trust_revenue_reserve(
+        academies,
+        central_services,
+    )
+
+    assert result.iloc[0]["Revenue reserve"] == 1.0 + (10.0 * (5.0 / 5.0))
+
+
+def test_share_revenue_reserve():
+    """
+    Sum of all Trust's Academies' `Revenue reserve` value, plus Central
+    Services `Revenue reserve`, apportioned back.
+    """
+    academies = pd.DataFrame(
+        [
+            {
+                "URN": 0,
+                "Trust UPIN": 0,
+                "Valid To": np.nan,
+                "Revenue reserve": 1.0,
+                "Number of pupils_pro_rata": 5.0,
+                "Total pupils in trust_pro_rata": 5.0,
+            },
+        ],
+        index=[0],
+    )
+    central_services = pd.DataFrame(
+        [
+            {
+                "Trust UPIN": 0,
+                "Revenue reserve": 10.0,
+            },
+        ]
+    )
+
+    result = pre_processing._trust_revenue_reserve(
+        academies,
+        central_services,
+    )
+
+    assert result.iloc[0]["Share Revenue reserve"] == ((1.0 + 10.0) * (5.0 / 5.0))
+
+
+def test_revenue_reserve_part_year_academy():
+    """
+    `Revenue reserve` will be the sum of:
+
+    - the Academy's `Revenue reserve`
+    - the apportioned (pro rata) Central Services `Revenue reserve` of
+      the Academy's _final_ Trust
+
+    `Shared Revenue reserve` will be the (pro rata) apportionment of:
+
+    - the sum of `Revenue reserve` for all Academies in the Trust
+      - or zero, in the case of an Academy moving _from_ a Trust
+    - the Central Services `Revenue reserve` for the Academy's _final_
+      Trust
+    """
     academies = pd.DataFrame(
         [
             {
@@ -54,13 +138,26 @@ def test_revenue_reservce_part_year_academy():
 
     assert result[(result["URN"] == 0) & (result["Trust UPIN"] == 0)].at[
         0, "Revenue reserve"
-    ] == 11.0 * (5.0 / 5.0)
+    ] == 1.0 + (10.0 * (5.0 / 5.0))
     assert (
         result[(result["URN"] == 0) & (result["Trust UPIN"] == 1)].at[
             1, "Revenue reserve"
         ]
-        == 0.0
+        == 0.0  # MUST be zero as leaving this Trust.
     )
     assert result[(result["URN"] == 1) & (result["Trust UPIN"] == 1)].at[
         2, "Revenue reserve"
+    ] == 1.0 + (20.0 * (10.0 / 15.0))
+
+    assert result[(result["URN"] == 0) & (result["Trust UPIN"] == 0)].at[
+        0, "Share Revenue reserve"
+    ] == 11.0 * (5.0 / 5.0)
+    assert (
+        result[(result["URN"] == 0) & (result["Trust UPIN"] == 1)].at[
+            1, "Share Revenue reserve"
+        ]
+        == 0.0  # MUST be zero as leaving this Trust.
+    )
+    assert result[(result["URN"] == 1) & (result["Trust UPIN"] == 1)].at[
+        2, "Share Revenue reserve"
     ] == 21.0 * (10.0 / 15.0)


### PR DESCRIPTION
### Context

The current `Revenue reserve` calculations manage apportioment somewhat different to elsewhere: this updates that value to be consistent while retaining the current calculation as `Share Revenu reserve`.

### Change proposed in this pull request

- persist existing Academy/Trust `Revenue reserve` calculation as `Share revenue reserve`
- add `Revenue reserve` value as the original Academy submission _plus_ the apportioned Central Services value
  - for Academies leaving a Trust, this must be zero

### Guidance to review 

WIP: need to persist to DB.

### Checklist (add/remove as appropriate)

- [ ] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally
- [ ] You have reviewed with UX/Design

