### PR TITLE
Wired up Web to Local Authority Search API

### DIFF
--- a/web/src/Web.App/Controllers/LocalAuthoritySearchController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthoritySearchController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.FeatureManagement.Mvc;
 using Web.App.Attributes.RequestTelemetry;
+using Web.App.Services;
 using Web.App.ViewModels.Search;
 
 namespace Web.App.Controllers;
@@ -9,7 +10,9 @@ namespace Web.App.Controllers;
 [Route("local-authority")]
 [LocalAuthorityRequestTelemetry(TrackedRequestFeature.Search)]
 [FeatureGate(FeatureFlags.FilteredSearch)]
-public class LocalAuthoritySearchController(ILogger<LocalAuthoritySearchController> logger)
+public class LocalAuthoritySearchController(
+    ILogger<LocalAuthoritySearchController> logger,
+    ISearchService searchService)
     : Controller
 {
     [HttpGet]
@@ -34,7 +37,7 @@ public class LocalAuthoritySearchController(ILogger<LocalAuthoritySearchControll
 
     [HttpGet]
     [Route("search")]
-    public IActionResult Search(
+    public async Task<IActionResult> Search(
         [FromQuery] string? term,
         [FromQuery] int? page,
         [FromQuery(Name = "sort")] string? orderBy
@@ -47,6 +50,8 @@ public class LocalAuthoritySearchController(ILogger<LocalAuthoritySearchControll
             orderBy
         }))
         {
+            var results = await searchService.LocalAuthoritySearch(term, 50, page, string.IsNullOrWhiteSpace(orderBy) ? null : new SearchOrderBy("LocalAuthorityNameSortable", orderBy));
+
             return NotFound();
         }
     }

--- a/web/src/Web.App/Infrastructure/Apis/Establishment/Api.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Establishment/Api.cs
@@ -11,6 +11,7 @@ public static class Api
         public static string TrustSearch => "api/trusts/search";
         public static string LocalAuthorities => "api/local-authorities";
         public static string LocalAuthoritySuggest => "api/local-authorities/suggest";
+        public static string LocalAuthoritySearch => "api/local-authorities/search";
         public static string LocalAuthorityNationalRank => "api/local-authorities/national-rank";
         public static string School(string? identifier)
         {

--- a/web/src/Web.App/Infrastructure/Apis/Establishment/EstablishmentApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Establishment/EstablishmentApi.cs
@@ -90,8 +90,12 @@ public class EstablishmentApi(HttpClient httpClient, string? key = default) : Ap
 
     public Task<ApiResult> SearchLocalAuthorities(SearchRequest request)
     {
-        // todo on follow-up task
-        throw new NotImplementedException();
+        return SendAsync(new HttpRequestMessage
+        {
+            Method = HttpMethod.Post,
+            RequestUri = new Uri(Api.Establishment.LocalAuthoritySearch, UriKind.Relative),
+            Content = new JsonContent(request)
+        });
     }
 }
 

--- a/web/src/Web.App/Services/SearchService.cs
+++ b/web/src/Web.App/Services/SearchService.cs
@@ -9,6 +9,7 @@ public interface ISearchService
 {
     Task<SearchResponse<SchoolSummary>> SchoolSearch(string? term, int? pageSize = null, int? page = null, SearchFilters? filters = null, SearchOrderBy? orderBy = null);
     Task<SearchResponse<TrustSummary>> TrustSearch(string? term, int? pageSize = null, int? page = null, SearchOrderBy? orderBy = null);
+    Task<SearchResponse<LocalAuthoritySummary>> LocalAuthoritySearch(string? term, int? pageSize = null, int? page = null, SearchOrderBy? orderBy = null);
 }
 
 public class SearchFilters : Dictionary<string, IEnumerable<string>>
@@ -44,5 +45,12 @@ public class SearchService(IEstablishmentApi establishmentApi) : ISearchService
         var request = SearchRequest.Create(term, pageSize, page, null, orderBy == null ? null : (orderBy.Field, orderBy.Order));
         return await establishmentApi.SearchTrusts(request)
             .GetResultOrThrow<SearchResponse<TrustSummary>>();
+    }
+
+    public async Task<SearchResponse<LocalAuthoritySummary>> LocalAuthoritySearch(string? term, int? pageSize = null, int? page = null, SearchOrderBy? orderBy = null)
+    {
+        var request = SearchRequest.Create(term, pageSize, page, null, orderBy == null ? null : (orderBy.Field, orderBy.Order));
+        return await establishmentApi.SearchLocalAuthorities(request)
+            .GetResultOrThrow<SearchResponse<LocalAuthoritySummary>>();
     }
 }

--- a/web/tests/Web.Tests/Infrastructure/GivenAnEstablishmentApi.cs
+++ b/web/tests/Web.Tests/Infrastructure/GivenAnEstablishmentApi.cs
@@ -158,4 +158,15 @@ public class GivenAnEstablishmentApi(ITestOutputHelper testOutputHelper) : ApiCl
 
         VerifyCall(HttpMethod.Post, $"api/trusts/search", request.ToJson(Formatting.None));
     }
+
+    [Fact]
+    public async Task SearchLocalAuthoritiesShouldCallCorrectUrl()
+    {
+        var api = new EstablishmentApi(HttpClient);
+        var request = new SearchRequest();
+
+        await api.SearchLocalAuthorities(request);
+
+        VerifyCall(HttpMethod.Post, $"api/local-authorities/search", request.ToJson(Formatting.None));
+    }
 }

--- a/web/tests/Web.Tests/Services/WhenLocalAuthoritySearchServiceIsCalled.cs
+++ b/web/tests/Web.Tests/Services/WhenLocalAuthoritySearchServiceIsCalled.cs
@@ -1,0 +1,64 @@
+﻿using Moq;
+using Web.App.Domain;
+using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Apis.Establishment;
+using Web.App.Services;
+using Xunit;
+
+namespace Web.Tests.Services;
+
+public class WhenLocalAuthoritySearchServiceIsCalled
+{
+    private readonly Mock<IEstablishmentApi> _api = new();
+
+    public static TheoryData<string?, int?, int?, SearchOrderBy?, SearchRequest?> WhenSendRequestData = new()
+    {
+        {
+            "term",
+            null,
+            null,
+            null,
+            new SearchRequest { SearchText = "term" }
+        },
+        {
+            "term",
+            null,
+            null,
+            null,
+            new SearchRequest { SearchText = "term" }
+        },
+        {
+            "term",
+            1,
+            2,
+            new SearchOrderBy("field2", "value3"),
+            new SearchRequest
+            {
+                SearchText = "term",
+                PageSize = 1,
+                Page = 2,
+                OrderBy = new OrderByCriteria { Field = "field2", Value = "value3"}
+            }
+        }
+    };
+
+    [Theory]
+    [MemberData(nameof(WhenSendRequestData))]
+    public async Task ShouldSendRequest(string? term, int? pageSize = null, int? page = null, SearchOrderBy? orderBy = null, SearchRequest? expected = null)
+    {
+        var response = new SearchResponse<LocalAuthoritySummary>();
+
+        SearchRequest? actualRequest = null;
+        _api.Setup(x => x.SearchLocalAuthorities(It.IsAny<SearchRequest>()))
+            .Callback<SearchRequest>(r =>
+            {
+                actualRequest = r;
+            })
+            .ReturnsAsync(ApiResult.Ok(response));
+
+        var service = new SearchService(_api.Object);
+
+        await service.LocalAuthoritySearch(term, pageSize, page, orderBy);
+        Assert.Equivalent(expected, actualRequest);
+    }
+}


### PR DESCRIPTION
### Context
[AB#250286](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/250286) [AB#257779](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/257779) #2279

### Change proposed in this pull request
- Consume LA search endpoint (but do nothing with the response in this PR)
- Unit test coverage

### Guidance to review 
Dependency on #2279. API call should succeed when searching, but `404` still displayed. This will be resolved in follow-up work.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

