### PR TITLE
Added `rel="canonical"` `Link` header to all responses

### DIFF
--- a/web/src/Web.App/Middleware/CanonicalHeaderMiddleware.cs
+++ b/web/src/Web.App/Middleware/CanonicalHeaderMiddleware.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.Options;
+
+namespace Web.App.Middleware;
+
+public class CanonicalHeaderMiddleware(IOptions<MiddlewareOptions> options) : IMiddleware
+{
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        var canonicalHostName = options.Value.CanonicalHostName;
+        if (!string.IsNullOrWhiteSpace(canonicalHostName))
+        {
+            var scheme = context.Request.Scheme;
+            var path = context.Request.Path;
+            var query = QueryString.Create(context.Request.Query).ToString();
+
+            // https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#rel-canonical-header-method
+            context.Response.Headers.Link = $"<{scheme}://{canonicalHostName}{path}{query}>; rel=\"canonical\"";
+        }
+
+        await next(context);
+    }
+}

--- a/web/src/Web.App/Middleware/MiddlewareOptions.cs
+++ b/web/src/Web.App/Middleware/MiddlewareOptions.cs
@@ -1,0 +1,7 @@
+// ReSharper disable PropertyCanBeMadeInitOnly.Global
+namespace Web.App.Middleware;
+
+public record MiddlewareOptions
+{
+    public string? CanonicalHostName { get; set; }
+}

--- a/web/src/Web.App/Program.cs
+++ b/web/src/Web.App/Program.cs
@@ -69,6 +69,10 @@ builder.Services.Configure<CacheOptions>(builder.Configuration.GetSection("Cache
 
 builder.AddSessionService();
 
+builder.Services
+    .Configure<MiddlewareOptions>(builder.Configuration.GetSection("Middleware"))
+    .AddTransient<CanonicalHeaderMiddleware>();
+
 if (!builder.Environment.IsIntegration())
 {
     builder.Services.AddDfeSignIn(options =>
@@ -143,6 +147,7 @@ app
     })
     .UseForwardedHeaders()
     .UseMiddleware<CustomResponseHeadersMiddleware>()
+    .UseMiddleware<CanonicalHeaderMiddleware>()
     .UseStatusCodePagesWithReExecute("/error/{0}")
     .UseHttpsRedirection()
     .UseRouting()

--- a/web/src/Web.App/appsettings.Development.json
+++ b/web/src/Web.App/appsettings.Development.json
@@ -43,6 +43,9 @@
     "ContainerName": "sessions",
     "DatabaseName": "session-data"
   },
+  "Middleware": {
+    "CanonicalHostName": "localhost:7095"
+  },
   "Serilog": {
     "Using": [
       "Serilog.Sinks.Console",

--- a/web/terraform/app-service.tf
+++ b/web/terraform/app-service.tf
@@ -107,6 +107,7 @@ resource "azurerm_windows_web_app" "education-benchmarking-as" {
     "Storage__ReturnsContainer"                               = azurerm_storage_container.return-container.name
     "CacheOptions__ReturnYears__SlidingExpiration"            = var.configuration[var.environment].CacheOptions.ReturnYears.SlidingExpiration
     "CacheOptions__ReturnYears__AbsoluteExpiration"           = var.configuration[var.environment].CacheOptions.ReturnYears.AbsoluteExpiration
+    "Middleware__CanonicalHostName"                           = local.host_name
   }
   tags = local.common-tags
 }

--- a/web/tests/Web.E2ETests/Features/HomePage.feature
+++ b/web/tests/Web.E2ETests/Features/HomePage.feature
@@ -1,0 +1,10 @@
+﻿Feature: Home page
+
+    Scenario: Go to find organisation
+        Given I am on home page
+        When I click Start now button
+        Then the find organisation page is disabled
+
+    Scenario: Canonical link is in response headers
+        Given I am on home page
+        Then the canonical link should be present in headers

--- a/web/tests/Web.E2ETests/Pages/HomePage.cs
+++ b/web/tests/Web.E2ETests/Pages/HomePage.cs
@@ -1,14 +1,19 @@
 ﻿using Microsoft.Playwright;
+
 namespace Web.E2ETests.Pages;
 
 public class HomePage(IPage page) : BasePage(page)
 {
-    private readonly IPage _page = page;
-
     private ILocator DataSourcesLink =>
-        _page.Locator(Selectors.GovFooterLink, new PageLocatorOptions
+        page.Locator(Selectors.GovFooterLink, new PageLocatorOptions
         {
             HasText = "Data Sources"
+        });
+
+    private ILocator StartNowButton =>
+        page.Locator(Selectors.GovButton, new PageLocatorOptions
+        {
+            HasText = "Start now"
         });
 
     public override async Task IsDisplayed()
@@ -19,6 +24,12 @@ public class HomePage(IPage page) : BasePage(page)
     public async Task<DataSourcesPage> ClickDataSourcesLink()
     {
         await DataSourcesLink.ClickAsync();
-        return new DataSourcesPage(_page);
+        return new DataSourcesPage(page);
+    }
+
+    public async Task<FindOrganisationPage> ClickStartNowButton()
+    {
+        await StartNowButton.ClickAsync();
+        return new FindOrganisationPage(page);
     }
 }

--- a/web/tests/Web.E2ETests/Steps/HomePageSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/HomePageSteps.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.Playwright;
+using Web.E2ETests.Drivers;
+using Web.E2ETests.Pages;
+using Xunit;
+
+namespace Web.E2ETests.Steps;
+
+[Binding]
+[Scope(Feature = "Home page")]
+public class HomePageSteps(PageDriver driver)
+{
+    private FindOrganisationPage? _findOrganisationPage;
+    private HomePage? _homePage;
+    private IResponse? _response;
+
+    [Given("I am on home page")]
+    public async Task GivenIAmOnHomePage()
+    {
+        var url = HomePageUrl();
+        var page = await driver.Current;
+        _response = await page.GotoAndWaitForLoadAsync(url);
+
+        _homePage = new HomePage(page);
+        await _homePage.IsDisplayed();
+    }
+
+    [When("I click Start now button")]
+    public async Task WhenIClickStartNowButton()
+    {
+        Assert.NotNull(_homePage);
+        _findOrganisationPage = await _homePage.ClickStartNowButton();
+    }
+
+    [Then("the find organisation page is disabled")]
+    public async Task ThenTheFindOrganisationPageIsDisabled()
+    {
+        Assert.NotNull(_findOrganisationPage);
+        await _findOrganisationPage.IsDisplayed();
+    }
+
+    [Then("the canonical link should be present in headers")]
+    public async Task ThenTheCanonicalLinkShouldBePresentInHeaders()
+    {
+        Assert.NotNull(_homePage);
+        Assert.NotNull(_response);
+        var linkHeader = await _response.HeaderValueAsync("Link");
+        Assert.Equal($"<{HomePageUrl()}>; rel=\"canonical\"", linkHeader);
+    }
+
+    private static string HomePageUrl()
+    {
+        return $"{TestConfiguration.ServiceUrl}/";
+    }
+}

--- a/web/tests/Web.Tests/Middleware/WhenCanonicalHeaderMiddlewareInvokes.cs
+++ b/web/tests/Web.Tests/Middleware/WhenCanonicalHeaderMiddlewareInvokes.cs
@@ -1,0 +1,57 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using Web.App.Middleware;
+using Xunit;
+
+namespace Web.Tests.Middleware;
+
+public class WhenCanonicalHeaderMiddlewareInvokes
+{
+    public static TheoryData<string, string, string, Dictionary<string, StringValues>, string?> LinkResponseHeaderTestData = new()
+    {
+        {
+            "", "https", "/", new Dictionary<string, StringValues>(), null
+        },
+        {
+            "host.name", "https", "/", new Dictionary<string, StringValues>(), "<https://host.name/>; rel=\"canonical\""
+        },
+        {
+            "host.name", "https", "/path", new Dictionary<string, StringValues>(), "<https://host.name/path>; rel=\"canonical\""
+        },
+        {
+            "host.name",
+            "https",
+            "/path",
+            new Dictionary<string, StringValues> { { "query", "value" } },
+            "<https://host.name/path?query=value>; rel=\"canonical\""
+        }
+    };
+
+    [Theory]
+    [MemberData(nameof(LinkResponseHeaderTestData))]
+    public async Task ShouldSetLinkResponseHeader(string canonicalHostName, string scheme, string path, Dictionary<string, StringValues> query, string? expected)
+    {
+        var options = new Mock<IOptions<MiddlewareOptions>>();
+        options
+            .SetupGet(o => o.Value)
+            .Returns(new MiddlewareOptions { CanonicalHostName = canonicalHostName });
+
+        var middleware = new CanonicalHeaderMiddleware(options.Object);
+
+        var context = new DefaultHttpContext
+        {
+            Request =
+            {
+                Scheme = scheme,
+                Path = path,
+                Query = new QueryCollection(query)
+            }
+        };
+
+        await middleware.InvokeAsync(context, _ => Task.CompletedTask);
+
+        Assert.Equal(expected, context.Response.Headers.Link);
+    }
+}


### PR DESCRIPTION
### Context
[AB#258781](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/258781) [AB#258789](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/258789)

### Change proposed in this pull request
- Added header via custom middleware
- Included new configuration in app service Terraform
- Unit and E2E test coverage 

### Guidance to review 
If new configuration is resolved then new header should be observable in all responses from the web app, e.g.:

![image](https://github.com/user-attachments/assets/43743668-7a02-4abb-8cb5-be4fd3cfdb7a)

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

