### PR TITLE
Added optional `CancellationToken` to all proxy endpoints and API-calling service methods

### DIFF
--- a/web/src/Web.App/Controllers/Api/EducationHealthCarePlansProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/EducationHealthCarePlansProxyController.cs
@@ -6,7 +6,6 @@ using Web.App.Domain.NonFinancial;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.NonFinancial;
 using Web.App.Infrastructure.Extensions;
-using Web.App.Services;
 
 namespace Web.App.Controllers.Api;
 
@@ -54,7 +53,7 @@ public class EducationHealthCarePlansProxyController(
     [ProducesResponseType<EducationHealthCarePlansHistoryResponse[]>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Route("history")]
-    public async Task<IActionResult> History([FromQuery] string code, CancellationToken cancellationToken)
+    public async Task<IActionResult> History([FromQuery] string code, CancellationToken cancellationToken = default)
     {
         try
         {

--- a/web/src/Web.App/Controllers/Api/IncomeProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/IncomeProxyController.cs
@@ -4,6 +4,7 @@ using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.Insight;
 using Web.App.Infrastructure.Extensions;
+
 namespace Web.App.Controllers.Api;
 
 [ApiController]
@@ -13,6 +14,7 @@ public class IncomeProxyController(ILogger<IncomeProxyController> logger, IIncom
     /// <param name="type" example="school"></param>
     /// <param name="id" example="140565"></param>
     /// <param name="dimension" example="PerUnit"></param>
+    /// <param name="cancellationToken"></param>
     [HttpGet]
     [Produces("application/json")]
     [ProducesResponseType<IncomeHistoryRows>(StatusCodes.Status200OK)]
@@ -21,7 +23,8 @@ public class IncomeProxyController(ILogger<IncomeProxyController> logger, IIncom
     public async Task<IActionResult> History(
         [FromQuery] string type,
         [FromQuery] string id,
-        [FromQuery] string dimension)
+        [FromQuery] string dimension,
+        CancellationToken cancellationToken = default)
     {
         using (logger.BeginScope(new
         {
@@ -36,8 +39,8 @@ public class IncomeProxyController(ILogger<IncomeProxyController> logger, IIncom
 
                 var result = type.ToLower() switch
                 {
-                    OrganisationTypes.School => await api.SchoolHistory(id, query).GetResultOrDefault<IncomeHistoryRows>(),
-                    OrganisationTypes.Trust => await api.TrustHistory(id, query).GetResultOrDefault<IncomeHistoryRows>(),
+                    OrganisationTypes.School => await api.SchoolHistory(id, query, cancellationToken).GetResultOrDefault<IncomeHistoryRows>(),
+                    OrganisationTypes.Trust => await api.TrustHistory(id, query, cancellationToken).GetResultOrDefault<IncomeHistoryRows>(),
                     _ => throw new ArgumentOutOfRangeException(nameof(type))
                 };
 

--- a/web/src/Web.App/Controllers/Api/NationalRankProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/NationalRankProxyController.cs
@@ -20,7 +20,7 @@ public class NationalRankProxyController(
     [Produces("application/json")]
     [ProducesResponseType<LocalAuthorityRanking>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> Query([FromQuery] string ranking, [FromQuery] string? sort, CancellationToken cancellationToken)
+    public async Task<IActionResult> Query([FromQuery] string ranking, [FromQuery] string? sort, CancellationToken cancellationToken = default)
     {
         try
         {

--- a/web/src/Web.App/Controllers/Api/UserDataProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/UserDataProxyController.cs
@@ -17,7 +17,7 @@ public class UserDataProxyController(ILogger<UserDataProxyController> logger, IU
     [ProducesResponseType<UserData>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> SchoolUserData(string urn)
+    public async Task<IActionResult> SchoolUserData(string urn, CancellationToken cancellationToken = default)
     {
         using (logger.BeginScope(new
         {
@@ -26,7 +26,7 @@ public class UserDataProxyController(ILogger<UserDataProxyController> logger, IU
         {
             try
             {
-                var userSet = await userDataService.GetSchoolComparatorSetActiveAsync(User, urn);
+                var userSet = await userDataService.GetSchoolComparatorSetActiveAsync(User, urn, cancellationToken);
                 if (userSet == null)
                 {
                     return new NotFoundResult();
@@ -45,7 +45,7 @@ public class UserDataProxyController(ILogger<UserDataProxyController> logger, IU
     [HttpGet]
     [Route("trust/{companyNumber}")]
     [Produces("application/json")]
-    public async Task<IActionResult> TrustUserData(string companyNumber)
+    public async Task<IActionResult> TrustUserData(string companyNumber, CancellationToken cancellationToken = default)
     {
         using (logger.BeginScope(new
         {
@@ -54,7 +54,7 @@ public class UserDataProxyController(ILogger<UserDataProxyController> logger, IU
         {
             try
             {
-                var userSet = await userDataService.GetTrustComparatorSetAsync(User, companyNumber);
+                var userSet = await userDataService.GetTrustComparatorSetAsync(User, companyNumber, cancellationToken);
                 if (userSet == null)
                 {
                     return new NotFoundResult();
@@ -76,7 +76,7 @@ public class UserDataProxyController(ILogger<UserDataProxyController> logger, IU
     [ProducesResponseType<UserData>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> SchoolCustomDataUserData(string urn)
+    public async Task<IActionResult> SchoolCustomDataUserData(string urn, CancellationToken cancellationToken = default)
     {
         using (logger.BeginScope(new
         {
@@ -85,7 +85,7 @@ public class UserDataProxyController(ILogger<UserDataProxyController> logger, IU
         {
             try
             {
-                var userData = await userDataService.GetCustomDataActiveAsync(User, urn);
+                var userData = await userDataService.GetCustomDataActiveAsync(User, urn, cancellationToken);
                 if (userData == null)
                 {
                     return new NotFoundResult();

--- a/web/src/Web.App/Controllers/TrustForecastController.cs
+++ b/web/src/Web.App/Controllers/TrustForecastController.cs
@@ -6,9 +6,11 @@ using Web.App.Attributes.RequestTelemetry;
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.Establishment;
+using Web.App.Infrastructure.Apis.Insight;
 using Web.App.Infrastructure.Extensions;
 using Web.App.TagHelpers;
 using Web.App.ViewModels;
+
 namespace Web.App.Controllers;
 
 [Controller]

--- a/web/src/Web.App/Infrastructure/Apis/Benchmark/ComparatorSetApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Benchmark/ComparatorSetApi.cs
@@ -2,24 +2,55 @@
 
 public class ComparatorSetApi(HttpClient httpClient, string? key = default) : ApiBase(httpClient, key), IComparatorSetApi
 {
-    public async Task<ApiResult> GetDefaultSchoolAsync(string urn) => await GetAsync(Api.ComparatorSet.SchoolDefault(urn));
-    public async Task<ApiResult> GetCustomSchoolAsync(string urn, string identifier) => await GetAsync(Api.ComparatorSet.SchoolCustom(urn, identifier));
-    public async Task<ApiResult> RemoveUserDefinedSchoolAsync(string urn, string? identifier) => await DeleteAsync(Api.ComparatorSet.SchoolUserDefined(urn, identifier));
-    public async Task<ApiResult> UpsertUserDefinedSchoolAsync(string urn, PostComparatorSetUserDefinedRequest request) => await PostAsync(Api.ComparatorSet.SchoolUserDefined(urn), new JsonContent(request));
-    public async Task<ApiResult> GetUserDefinedTrustAsync(string companyNumber, string? identifier) => await GetAsync(Api.ComparatorSet.TrustUserDefined(companyNumber, identifier));
-    public async Task<ApiResult> RemoveUserDefinedTrustAsync(string companyNumber, string? identifier) => await DeleteAsync(Api.ComparatorSet.TrustUserDefined(companyNumber, identifier));
-    public async Task<ApiResult> UpsertUserDefinedTrustAsync(string companyNumber, PostComparatorSetUserDefinedRequest request) => await PostAsync(Api.ComparatorSet.TrustUserDefined(companyNumber), new JsonContent(request));
-    public async Task<ApiResult> GetUserDefinedSchoolAsync(string urn, string? identifier) => await GetAsync(Api.ComparatorSet.SchoolUserDefined(urn, identifier));
+    public async Task<ApiResult> GetDefaultSchoolAsync(string urn, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync(Api.ComparatorSet.SchoolDefault(urn), cancellationToken);
+    }
+
+    public async Task<ApiResult> GetCustomSchoolAsync(string urn, string identifier, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync(Api.ComparatorSet.SchoolCustom(urn, identifier), cancellationToken);
+    }
+
+    public async Task<ApiResult> RemoveUserDefinedSchoolAsync(string urn, string? identifier)
+    {
+        return await DeleteAsync(Api.ComparatorSet.SchoolUserDefined(urn, identifier));
+    }
+
+    public async Task<ApiResult> UpsertUserDefinedSchoolAsync(string urn, PostComparatorSetUserDefinedRequest request)
+    {
+        return await PostAsync(Api.ComparatorSet.SchoolUserDefined(urn), new JsonContent(request));
+    }
+
+    public async Task<ApiResult> GetUserDefinedTrustAsync(string companyNumber, string? identifier, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync(Api.ComparatorSet.TrustUserDefined(companyNumber, identifier), cancellationToken);
+    }
+
+    public async Task<ApiResult> RemoveUserDefinedTrustAsync(string companyNumber, string? identifier)
+    {
+        return await DeleteAsync(Api.ComparatorSet.TrustUserDefined(companyNumber, identifier));
+    }
+
+    public async Task<ApiResult> UpsertUserDefinedTrustAsync(string companyNumber, PostComparatorSetUserDefinedRequest request)
+    {
+        return await PostAsync(Api.ComparatorSet.TrustUserDefined(companyNumber), new JsonContent(request));
+    }
+
+    public async Task<ApiResult> GetUserDefinedSchoolAsync(string urn, string? identifier, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync(Api.ComparatorSet.SchoolUserDefined(urn, identifier), cancellationToken);
+    }
 }
 
 public interface IComparatorSetApi
 {
-    Task<ApiResult> GetDefaultSchoolAsync(string urn);
-    Task<ApiResult> GetCustomSchoolAsync(string urn, string identifier);
-    Task<ApiResult> GetUserDefinedSchoolAsync(string urn, string? identifier);
+    Task<ApiResult> GetDefaultSchoolAsync(string urn, CancellationToken cancellationToken = default);
+    Task<ApiResult> GetCustomSchoolAsync(string urn, string identifier, CancellationToken cancellationToken = default);
+    Task<ApiResult> GetUserDefinedSchoolAsync(string urn, string? identifier, CancellationToken cancellationToken = default);
     Task<ApiResult> UpsertUserDefinedSchoolAsync(string urn, PostComparatorSetUserDefinedRequest request);
     Task<ApiResult> RemoveUserDefinedSchoolAsync(string urn, string? identifier);
-    Task<ApiResult> GetUserDefinedTrustAsync(string companyNumber, string? identifier);
+    Task<ApiResult> GetUserDefinedTrustAsync(string companyNumber, string? identifier, CancellationToken cancellationToken = default);
     Task<ApiResult> RemoveUserDefinedTrustAsync(string companyNumber, string? identifier);
     Task<ApiResult> UpsertUserDefinedTrustAsync(string companyNumber, PostComparatorSetUserDefinedRequest request);
 }

--- a/web/src/Web.App/Infrastructure/Apis/Benchmark/UserDataApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Benchmark/UserDataApi.cs
@@ -2,13 +2,13 @@
 
 public class UserDataApi(HttpClient httpClient, string? key = default) : ApiBase(httpClient, key), IUserDataApi
 {
-    public async Task<ApiResult> GetAsync(ApiQuery? query = null)
+    public async Task<ApiResult> GetAsync(ApiQuery? query = null, CancellationToken cancellationToken = default)
     {
-        return await GetAsync($"{Api.UserData.All}{query?.ToQueryString()}");
+        return await GetAsync($"{Api.UserData.All}{query?.ToQueryString()}", cancellationToken);
     }
 }
 
 public interface IUserDataApi
 {
-    Task<ApiResult> GetAsync(ApiQuery? query = null);
+    Task<ApiResult> GetAsync(ApiQuery? query = null, CancellationToken cancellationToken = default);
 }

--- a/web/src/Web.App/Infrastructure/Apis/Establishment/EstablishmentApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Establishment/EstablishmentApi.cs
@@ -2,24 +2,24 @@ namespace Web.App.Infrastructure.Apis.Establishment;
 
 public class EstablishmentApi(HttpClient httpClient, string? key = default) : ApiBase(httpClient, key), IEstablishmentApi
 {
-    public Task<ApiResult> GetSchool(string? identifier)
+    public Task<ApiResult> GetSchool(string? identifier, CancellationToken cancellationToken = default)
     {
-        return GetAsync(Api.Establishment.School(identifier));
+        return GetAsync(Api.Establishment.School(identifier), cancellationToken);
     }
 
-    public Task<ApiResult> GetTrust(string? identifier)
+    public Task<ApiResult> GetTrust(string? identifier, CancellationToken cancellationToken = default)
     {
-        return GetAsync(Api.Establishment.Trust(identifier));
+        return GetAsync(Api.Establishment.Trust(identifier), cancellationToken);
     }
 
-    public Task<ApiResult> GetLocalAuthority(string? identifier)
+    public Task<ApiResult> GetLocalAuthority(string? identifier, CancellationToken cancellationToken = default)
     {
-        return GetAsync(Api.Establishment.LocalAuthority(identifier));
+        return GetAsync(Api.Establishment.LocalAuthority(identifier), cancellationToken);
     }
 
-    public Task<ApiResult> GetLocalAuthorityStatisticalNeighbours(string? identifier)
+    public Task<ApiResult> GetLocalAuthorityStatisticalNeighbours(string? identifier, CancellationToken cancellationToken = default)
     {
-        return GetAsync(Api.Establishment.LocalAuthorityStatisticalNeighbours(identifier));
+        return GetAsync(Api.Establishment.LocalAuthorityStatisticalNeighbours(identifier), cancellationToken);
     }
 
     public Task<ApiResult> GetLocalAuthoritiesNationalRank(ApiQuery? query = null, CancellationToken cancellationToken = default)
@@ -27,9 +27,9 @@ public class EstablishmentApi(HttpClient httpClient, string? key = default) : Ap
         return GetAsync($"{Api.Establishment.LocalAuthorityNationalRank}{query?.ToQueryString()}", cancellationToken);
     }
 
-    public Task<ApiResult> GetLocalAuthorities()
+    public Task<ApiResult> GetLocalAuthorities(CancellationToken cancellationToken = default)
     {
-        return GetAsync(Api.Establishment.LocalAuthorities);
+        return GetAsync(Api.Establishment.LocalAuthorities, cancellationToken);
     }
 
     public Task<ApiResult> SuggestSchools(string search, string[]? exclude = null, bool? excludeMissingFinancialData = null, CancellationToken cancellationToken = default)
@@ -68,49 +68,49 @@ public class EstablishmentApi(HttpClient httpClient, string? key = default) : Ap
         }, cancellationToken);
     }
 
-    public Task<ApiResult> SearchSchools(SearchRequest request)
+    public Task<ApiResult> SearchSchools(SearchRequest request, CancellationToken cancellationToken = default)
     {
         return SendAsync(new HttpRequestMessage
         {
             Method = HttpMethod.Post,
             RequestUri = new Uri(Api.Establishment.SchoolSearch, UriKind.Relative),
             Content = new JsonContent(request)
-        });
+        }, cancellationToken);
     }
 
-    public Task<ApiResult> SearchTrusts(SearchRequest request)
+    public Task<ApiResult> SearchTrusts(SearchRequest request, CancellationToken cancellationToken = default)
     {
         return SendAsync(new HttpRequestMessage
         {
             Method = HttpMethod.Post,
             RequestUri = new Uri(Api.Establishment.TrustSearch, UriKind.Relative),
             Content = new JsonContent(request)
-        });
+        }, cancellationToken);
     }
 
-    public Task<ApiResult> SearchLocalAuthorities(SearchRequest request)
+    public Task<ApiResult> SearchLocalAuthorities(SearchRequest request, CancellationToken cancellationToken = default)
     {
         return SendAsync(new HttpRequestMessage
         {
             Method = HttpMethod.Post,
             RequestUri = new Uri(Api.Establishment.LocalAuthoritySearch, UriKind.Relative),
             Content = new JsonContent(request)
-        });
+        }, cancellationToken);
     }
 }
 
 public interface IEstablishmentApi
 {
-    Task<ApiResult> GetSchool(string? identifier);
-    Task<ApiResult> GetTrust(string? identifier);
-    Task<ApiResult> GetLocalAuthority(string? identifier);
-    Task<ApiResult> GetLocalAuthorityStatisticalNeighbours(string? identifier);
+    Task<ApiResult> GetSchool(string? identifier, CancellationToken cancellationToken = default);
+    Task<ApiResult> GetTrust(string? identifier, CancellationToken cancellationToken = default);
+    Task<ApiResult> GetLocalAuthority(string? identifier, CancellationToken cancellationToken = default);
+    Task<ApiResult> GetLocalAuthorityStatisticalNeighbours(string? identifier, CancellationToken cancellationToken = default);
     Task<ApiResult> GetLocalAuthoritiesNationalRank(ApiQuery? query = null, CancellationToken cancellationToken = default);
-    Task<ApiResult> GetLocalAuthorities();
+    Task<ApiResult> GetLocalAuthorities(CancellationToken cancellationToken = default);
     Task<ApiResult> SuggestSchools(string search, string[]? exclude = null, bool? excludeMissingFinancialData = null, CancellationToken cancellationToken = default);
     Task<ApiResult> SuggestTrusts(string search, string[]? exclude = null, CancellationToken cancellationToken = default);
     Task<ApiResult> SuggestLocalAuthorities(string search, string[]? exclude = null, CancellationToken cancellationToken = default);
-    Task<ApiResult> SearchSchools(SearchRequest request);
-    Task<ApiResult> SearchTrusts(SearchRequest request);
-    Task<ApiResult> SearchLocalAuthorities(SearchRequest request);
+    Task<ApiResult> SearchSchools(SearchRequest request, CancellationToken cancellationToken = default);
+    Task<ApiResult> SearchTrusts(SearchRequest request, CancellationToken cancellationToken = default);
+    Task<ApiResult> SearchLocalAuthorities(SearchRequest request, CancellationToken cancellationToken = default);
 }

--- a/web/src/Web.App/Infrastructure/Apis/Insight/BalanceApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Insight/BalanceApi.cs
@@ -2,22 +2,37 @@
 
 public interface IBalanceApi
 {
-    Task<ApiResult> School(string? urn, ApiQuery? query = null);
-    Task<ApiResult> Trust(string? companyNo, ApiQuery? query = null);
-    Task<ApiResult> SchoolHistory(string? urn, ApiQuery? query = null);
-    Task<ApiResult> TrustHistory(string? companyNo, ApiQuery? query = null);
-    Task<ApiResult> QueryTrusts(ApiQuery? query = null);
+    Task<ApiResult> School(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default);
+    Task<ApiResult> Trust(string? companyNo, ApiQuery? query = null, CancellationToken cancellationToken = default);
+    Task<ApiResult> SchoolHistory(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default);
+    Task<ApiResult> TrustHistory(string? companyNo, ApiQuery? query = null, CancellationToken cancellationToken = default);
+    Task<ApiResult> QueryTrusts(ApiQuery? query = null, CancellationToken cancellationToken = default);
 }
 
 public class BalanceApi(HttpClient httpClient, string? key = default) : ApiBase(httpClient, key), IBalanceApi
 {
-    public async Task<ApiResult> School(string? urn, ApiQuery? query = null) => await GetAsync($"{Api.Balance.School(urn)}{query?.ToQueryString()}");
+    public async Task<ApiResult> School(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"{Api.Balance.School(urn)}{query?.ToQueryString()}", cancellationToken);
+    }
 
-    public async Task<ApiResult> SchoolHistory(string? urn, ApiQuery? query = null) => await GetAsync($"{Api.Balance.SchoolHistory(urn)}{query?.ToQueryString()}");
+    public async Task<ApiResult> SchoolHistory(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"{Api.Balance.SchoolHistory(urn)}{query?.ToQueryString()}", cancellationToken);
+    }
 
-    public async Task<ApiResult> Trust(string? companyNo, ApiQuery? query = null) => await GetAsync($"{Api.Balance.Trust(companyNo)}{query?.ToQueryString()}");
+    public async Task<ApiResult> Trust(string? companyNo, ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"{Api.Balance.Trust(companyNo)}{query?.ToQueryString()}", cancellationToken);
+    }
 
-    public async Task<ApiResult> TrustHistory(string? companyNo, ApiQuery? query = null) => await GetAsync($"{Api.Balance.TrustHistory(companyNo)}{query?.ToQueryString()}");
+    public async Task<ApiResult> TrustHistory(string? companyNo, ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"{Api.Balance.TrustHistory(companyNo)}{query?.ToQueryString()}", cancellationToken);
+    }
 
-    public async Task<ApiResult> QueryTrusts(ApiQuery? query = null) => await GetAsync($"{Api.Balance.Trusts}{query?.ToQueryString()}");
+    public async Task<ApiResult> QueryTrusts(ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"{Api.Balance.Trusts}{query?.ToQueryString()}", cancellationToken);
+    }
 }

--- a/web/src/Web.App/Infrastructure/Apis/Insight/BudgetForecastApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Insight/BudgetForecastApi.cs
@@ -1,20 +1,26 @@
-﻿namespace Web.App.Infrastructure.Apis;
+﻿namespace Web.App.Infrastructure.Apis.Insight;
 
 public interface IBudgetForecastApi
 {
-    Task<ApiResult> BudgetForecastReturns(string? companyNo, ApiQuery? query = null);
-    Task<ApiResult> BudgetForecastReturnsMetrics(string? companyNo, ApiQuery? query = null);
-    Task<ApiResult> GetCurrentBudgetForecastYear(string? companyNo, ApiQuery? query = null);
+    Task<ApiResult> BudgetForecastReturns(string? companyNo, ApiQuery? query = null, CancellationToken cancellationToken = default);
+    Task<ApiResult> BudgetForecastReturnsMetrics(string? companyNo, ApiQuery? query = null, CancellationToken cancellationToken = default);
+    Task<ApiResult> GetCurrentBudgetForecastYear(string? companyNo, ApiQuery? query = null, CancellationToken cancellationToken = default);
 }
 
 public class BudgetForecastApi(HttpClient httpClient, string? key = default) : ApiBase(httpClient, key), IBudgetForecastApi
 {
-    public async Task<ApiResult> BudgetForecastReturns(string? companyNo, ApiQuery? query = null) =>
-        await GetAsync($"api/budget-forecast/{companyNo}{query?.ToQueryString()}");
+    public async Task<ApiResult> BudgetForecastReturns(string? companyNo, ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"api/budget-forecast/{companyNo}{query?.ToQueryString()}", cancellationToken);
+    }
 
-    public async Task<ApiResult> BudgetForecastReturnsMetrics(string? companyNo, ApiQuery? query = null) =>
-        await GetAsync($"api/budget-forecast/{companyNo}/metrics{query?.ToQueryString()}");
+    public async Task<ApiResult> BudgetForecastReturnsMetrics(string? companyNo, ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"api/budget-forecast/{companyNo}/metrics{query?.ToQueryString()}", cancellationToken);
+    }
 
-    public async Task<ApiResult> GetCurrentBudgetForecastYear(string? companyNo, ApiQuery? query = null) =>
-        await GetAsync($"api/budget-forecast/{companyNo}/current-year{query?.ToQueryString()}");
+    public async Task<ApiResult> GetCurrentBudgetForecastYear(string? companyNo, ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"api/budget-forecast/{companyNo}/current-year{query?.ToQueryString()}", cancellationToken);
+    }
 }

--- a/web/src/Web.App/Infrastructure/Apis/Insight/CensusApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Insight/CensusApi.cs
@@ -2,20 +2,43 @@
 
 public interface ICensusApi
 {
-    Task<ApiResult> Get(string? urn, ApiQuery? query = null);
-    Task<ApiResult> GetCustom(string? urn, string? identifier, ApiQuery? query = null);
+    Task<ApiResult> Get(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default);
+    Task<ApiResult> GetCustom(string? urn, string? identifier, ApiQuery? query = null, CancellationToken cancellationToken = default);
     Task<ApiResult> SchoolHistory(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default);
     Task<ApiResult> SchoolHistoryComparatorSetAverage(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default);
     Task<ApiResult> SchoolHistoryNationalAverage(ApiQuery? query = null, CancellationToken cancellationToken = default);
-    Task<ApiResult> Query(ApiQuery? query = null);
+    Task<ApiResult> Query(ApiQuery? query = null, CancellationToken cancellationToken = default);
 }
 
 public class CensusApi(HttpClient httpClient, string? key = default) : ApiBase(httpClient, key), ICensusApi
 {
-    public async Task<ApiResult> Get(string? urn, ApiQuery? query = null) => await GetAsync($"{Api.Census.School(urn)}{query?.ToQueryString()}");
-    public async Task<ApiResult> GetCustom(string? urn, string? identifier, ApiQuery? query = null) => await GetAsync($"{Api.Census.SchoolCustom(urn, identifier)}{query?.ToQueryString()}");
-    public async Task<ApiResult> SchoolHistory(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default) => await GetAsync($"{Api.Census.SchoolHistory(urn)}{query?.ToQueryString()}", cancellationToken);
-    public async Task<ApiResult> SchoolHistoryComparatorSetAverage(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default) => await GetAsync($"{Api.Census.SchoolHistoryComparatorSetAverage(urn)}{query?.ToQueryString()}", cancellationToken);
-    public async Task<ApiResult> SchoolHistoryNationalAverage(ApiQuery? query = null, CancellationToken cancellationToken = default) => await GetAsync($"{Api.Census.SchoolHistoryNationalAverage}{query?.ToQueryString()}", cancellationToken);
-    public async Task<ApiResult> Query(ApiQuery? query = null) => await GetAsync($"{Api.Census.Schools}{query?.ToQueryString()}");
+    public async Task<ApiResult> Get(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"{Api.Census.School(urn)}{query?.ToQueryString()}", cancellationToken);
+    }
+
+    public async Task<ApiResult> GetCustom(string? urn, string? identifier, ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"{Api.Census.SchoolCustom(urn, identifier)}{query?.ToQueryString()}", cancellationToken);
+    }
+
+    public async Task<ApiResult> SchoolHistory(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"{Api.Census.SchoolHistory(urn)}{query?.ToQueryString()}", cancellationToken);
+    }
+
+    public async Task<ApiResult> SchoolHistoryComparatorSetAverage(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"{Api.Census.SchoolHistoryComparatorSetAverage(urn)}{query?.ToQueryString()}", cancellationToken);
+    }
+
+    public async Task<ApiResult> SchoolHistoryNationalAverage(ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"{Api.Census.SchoolHistoryNationalAverage}{query?.ToQueryString()}", cancellationToken);
+    }
+
+    public async Task<ApiResult> Query(ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"{Api.Census.Schools}{query?.ToQueryString()}", cancellationToken);
+    }
 }

--- a/web/src/Web.App/Infrastructure/Apis/Insight/ExpenditureApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Insight/ExpenditureApi.cs
@@ -2,26 +2,59 @@
 
 public interface IExpenditureApi
 {
-    Task<ApiResult> School(string? urn, ApiQuery? query = null);
-    Task<ApiResult> SchoolCustom(string? urn, string? identifier, ApiQuery? query = null);
-    Task<ApiResult> Trust(string? companyNo, ApiQuery? query = null);
+    Task<ApiResult> School(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default);
+    Task<ApiResult> SchoolCustom(string? urn, string? identifier, ApiQuery? query = null, CancellationToken cancellationToken = default);
+    Task<ApiResult> Trust(string? companyNo, ApiQuery? query = null, CancellationToken cancellationToken = default);
     Task<ApiResult> SchoolHistory(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default);
     Task<ApiResult> SchoolHistoryComparatorSetAverage(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default);
     Task<ApiResult> SchoolHistoryNationalAverage(ApiQuery? query = null, CancellationToken cancellationToken = default);
-    Task<ApiResult> TrustHistory(string? companyNo, ApiQuery? query = null);
-    Task<ApiResult> QuerySchools(ApiQuery? query = null);
-    Task<ApiResult> QueryTrusts(ApiQuery? query = null);
+    Task<ApiResult> TrustHistory(string? companyNo, ApiQuery? query = null, CancellationToken cancellationToken = default);
+    Task<ApiResult> QuerySchools(ApiQuery? query = null, CancellationToken cancellationToken = default);
+    Task<ApiResult> QueryTrusts(ApiQuery? query = null, CancellationToken cancellationToken = default);
 }
 
 public class ExpenditureApi(HttpClient httpClient, string? key = default) : ApiBase(httpClient, key), IExpenditureApi
 {
-    public async Task<ApiResult> QuerySchools(ApiQuery? query = null) => await GetAsync($"{Api.Expenditure.Schools}{query?.ToQueryString()}");
-    public async Task<ApiResult> School(string? urn, ApiQuery? query = null) => await GetAsync($"{Api.Expenditure.School(urn)}{query?.ToQueryString()}");
-    public async Task<ApiResult> SchoolCustom(string? urn, string? identifier, ApiQuery? query = null) => await GetAsync($"{Api.Expenditure.SchoolCustom(urn, identifier)}{query?.ToQueryString()}");
-    public async Task<ApiResult> SchoolHistory(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default) => await GetAsync($"{Api.Expenditure.SchoolHistory(urn)}{query?.ToQueryString()}", cancellationToken);
-    public async Task<ApiResult> SchoolHistoryComparatorSetAverage(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default) => await GetAsync($"{Api.Expenditure.SchoolHistoryComparatorSetAverage(urn)}{query?.ToQueryString()}", cancellationToken);
-    public async Task<ApiResult> SchoolHistoryNationalAverage(ApiQuery? query = null, CancellationToken cancellationToken = default) => await GetAsync($"{Api.Expenditure.SchoolHistoryNationalAverage}{query?.ToQueryString()}", cancellationToken);
-    public async Task<ApiResult> Trust(string? companyNo, ApiQuery? query = null) => await GetAsync($"{Api.Expenditure.Trust(companyNo)}{query?.ToQueryString()}");
-    public async Task<ApiResult> TrustHistory(string? companyNo, ApiQuery? query = null) => await GetAsync($"{Api.Expenditure.TrustHistory(companyNo)}{query?.ToQueryString()}");
-    public async Task<ApiResult> QueryTrusts(ApiQuery? query = null) => await GetAsync($"{Api.Expenditure.Trusts}{query?.ToQueryString()}");
+    public async Task<ApiResult> QuerySchools(ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"{Api.Expenditure.Schools}{query?.ToQueryString()}", cancellationToken);
+    }
+
+    public async Task<ApiResult> School(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"{Api.Expenditure.School(urn)}{query?.ToQueryString()}", cancellationToken);
+    }
+
+    public async Task<ApiResult> SchoolCustom(string? urn, string? identifier, ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"{Api.Expenditure.SchoolCustom(urn, identifier)}{query?.ToQueryString()}", cancellationToken);
+    }
+
+    public async Task<ApiResult> SchoolHistory(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"{Api.Expenditure.SchoolHistory(urn)}{query?.ToQueryString()}", cancellationToken);
+    }
+    public async Task<ApiResult> SchoolHistoryComparatorSetAverage(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"{Api.Expenditure.SchoolHistoryComparatorSetAverage(urn)}{query?.ToQueryString()}", cancellationToken);
+    }
+    public async Task<ApiResult> SchoolHistoryNationalAverage(ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"{Api.Expenditure.SchoolHistoryNationalAverage}{query?.ToQueryString()}", cancellationToken);
+    }
+
+    public async Task<ApiResult> Trust(string? companyNo, ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"{Api.Expenditure.Trust(companyNo)}{query?.ToQueryString()}", cancellationToken);
+    }
+
+    public async Task<ApiResult> TrustHistory(string? companyNo, ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"{Api.Expenditure.TrustHistory(companyNo)}{query?.ToQueryString()}", cancellationToken);
+    }
+
+    public async Task<ApiResult> QueryTrusts(ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"{Api.Expenditure.Trusts}{query?.ToQueryString()}", cancellationToken);
+    }
 }

--- a/web/src/Web.App/Infrastructure/Apis/Insight/IncomeApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Insight/IncomeApi.cs
@@ -2,25 +2,25 @@
 
 public interface IIncomeApi
 {
-    Task<ApiResult> School(string? urn, ApiQuery? query = null);
-    Task<ApiResult> SchoolHistory(string? urn, ApiQuery? query = null);
-    Task<ApiResult> TrustHistory(string? companyNo, ApiQuery? query = null);
+    Task<ApiResult> School(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default);
+    Task<ApiResult> SchoolHistory(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default);
+    Task<ApiResult> TrustHistory(string? companyNo, ApiQuery? query = null, CancellationToken cancellationToken = default);
 }
 
 public class IncomeApi(HttpClient httpClient, string? key = default) : ApiBase(httpClient, key), IIncomeApi
 {
-    public async Task<ApiResult> School(string? urn, ApiQuery? query = null)
+    public async Task<ApiResult> School(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default)
     {
-        return await GetAsync($"{Api.Income.School(urn)}{query?.ToQueryString()}");
+        return await GetAsync($"{Api.Income.School(urn)}{query?.ToQueryString()}", cancellationToken);
     }
 
-    public async Task<ApiResult> SchoolHistory(string? urn, ApiQuery? query = null)
+    public async Task<ApiResult> SchoolHistory(string? urn, ApiQuery? query = null, CancellationToken cancellationToken = default)
     {
-        return await GetAsync($"{Api.Income.SchoolHistory(urn)}{query?.ToQueryString()}");
+        return await GetAsync($"{Api.Income.SchoolHistory(urn)}{query?.ToQueryString()}", cancellationToken);
     }
 
-    public async Task<ApiResult> TrustHistory(string? companyNo, ApiQuery? query = null)
+    public async Task<ApiResult> TrustHistory(string? companyNo, ApiQuery? query = null, CancellationToken cancellationToken = default)
     {
-        return await GetAsync($"{Api.Income.TrustHistory(companyNo)}{query?.ToQueryString()}");
+        return await GetAsync($"{Api.Income.TrustHistory(companyNo)}{query?.ToQueryString()}", cancellationToken);
     }
 }

--- a/web/src/Web.App/Services/SchoolComparatorSetService.cs
+++ b/web/src/Web.App/Services/SchoolComparatorSetService.cs
@@ -8,9 +8,9 @@ namespace Web.App.Services;
 
 public interface ISchoolComparatorSetService
 {
-    Task<SchoolComparatorSet?> ReadComparatorSet(string urn);
-    Task<SchoolComparatorSet?> ReadComparatorSet(string urn, string identifier);
-    Task<UserDefinedSchoolComparatorSet?> ReadUserDefinedComparatorSet(string urn, string identifier);
+    Task<SchoolComparatorSet?> ReadComparatorSet(string urn, CancellationToken cancellationToken = default);
+    Task<SchoolComparatorSet?> ReadComparatorSet(string urn, string identifier, CancellationToken cancellationToken = default);
+    Task<UserDefinedSchoolComparatorSet?> ReadUserDefinedComparatorSet(string urn, string identifier, CancellationToken cancellationToken = default);
     UserDefinedSchoolComparatorSet ReadUserDefinedComparatorSetFromSession(string urn);
     UserDefinedSchoolComparatorSet SetUserDefinedComparatorSetInSession(string urn, UserDefinedSchoolComparatorSet set);
     void ClearUserDefinedComparatorSetFromSession(string urn, string? identifier = null);
@@ -21,17 +21,23 @@ public interface ISchoolComparatorSetService
 
 public class SchoolComparatorSetService(IHttpContextAccessor httpContextAccessor, IComparatorSetApi api) : ISchoolComparatorSetService
 {
-    public async Task<SchoolComparatorSet?> ReadComparatorSet(string urn) =>
+    public async Task<SchoolComparatorSet?> ReadComparatorSet(string urn, CancellationToken cancellationToken = default)
+    {
         //Do not add to session state. Locking on session state blocks requests
-        await api.GetDefaultSchoolAsync(urn).GetResultOrDefault<SchoolComparatorSet>();
+        return await api.GetDefaultSchoolAsync(urn, cancellationToken).GetResultOrDefault<SchoolComparatorSet>();
+    }
 
-    public async Task<SchoolComparatorSet?> ReadComparatorSet(string urn, string identifier) =>
+    public async Task<SchoolComparatorSet?> ReadComparatorSet(string urn, string identifier, CancellationToken cancellationToken = default)
+    {
         //Do not add to session state. Locking on session state blocks requests
-        await api.GetCustomSchoolAsync(urn, identifier).GetResultOrDefault<SchoolComparatorSet>();
+        return await api.GetCustomSchoolAsync(urn, identifier, cancellationToken).GetResultOrDefault<SchoolComparatorSet>();
+    }
 
-    public async Task<UserDefinedSchoolComparatorSet?> ReadUserDefinedComparatorSet(string urn, string identifier) =>
+    public async Task<UserDefinedSchoolComparatorSet?> ReadUserDefinedComparatorSet(string urn, string identifier, CancellationToken cancellationToken = default)
+    {
         //Do not add to session state. Locking on session state blocks requests
-        await api.GetUserDefinedSchoolAsync(urn, identifier).GetResultOrDefault<UserDefinedSchoolComparatorSet>();
+        return await api.GetUserDefinedSchoolAsync(urn, identifier, cancellationToken).GetResultOrDefault<UserDefinedSchoolComparatorSet>();
+    }
 
     public UserDefinedSchoolComparatorSet ReadUserDefinedComparatorSetFromSession(string urn)
     {

--- a/web/src/Web.App/Services/TrustComparatorSetService.cs
+++ b/web/src/Web.App/Services/TrustComparatorSetService.cs
@@ -8,7 +8,7 @@ namespace Web.App.Services;
 
 public interface ITrustComparatorSetService
 {
-    Task<UserDefinedTrustComparatorSet> ReadUserDefinedComparatorSet(string companyNumber, string identifier);
+    Task<UserDefinedTrustComparatorSet> ReadUserDefinedComparatorSet(string companyNumber, string identifier, CancellationToken cancellationToken = default);
     UserDefinedTrustComparatorSet ReadUserDefinedComparatorSetFromSession(string companyNumber);
     UserDefinedTrustComparatorSet SetUserDefinedComparatorSetInSession(string companyNumber, UserDefinedTrustComparatorSet set);
     void ClearUserDefinedComparatorSetFromSession(string companyNumber, string? identifier = null);
@@ -19,9 +19,11 @@ public interface ITrustComparatorSetService
 
 public class TrustComparatorSetService(IHttpContextAccessor httpContextAccessor, IComparatorSetApi api) : ITrustComparatorSetService
 {
-    public async Task<UserDefinedTrustComparatorSet> ReadUserDefinedComparatorSet(string companyNumber, string identifier) =>
+    public async Task<UserDefinedTrustComparatorSet> ReadUserDefinedComparatorSet(string companyNumber, string identifier, CancellationToken cancellationToken = default)
+    {
         //Do not add to session state. Locking on session state blocks requests
-        await api.GetUserDefinedTrustAsync(companyNumber, identifier).GetResultOrThrow<UserDefinedTrustComparatorSet>();
+        return await api.GetUserDefinedTrustAsync(companyNumber, identifier, cancellationToken).GetResultOrThrow<UserDefinedTrustComparatorSet>();
+    }
 
     public UserDefinedTrustComparatorSet ReadUserDefinedComparatorSetFromSession(string companyNumber)
     {

--- a/web/src/Web.App/Services/UserDataService.cs
+++ b/web/src/Web.App/Services/UserDataService.cs
@@ -9,11 +9,11 @@ namespace Web.App.Services;
 
 public interface IUserDataService
 {
-    Task<UserData?> GetSchoolComparatorSetActiveAsync(ClaimsPrincipal user, string urn);
-    Task<UserData?> GetCustomDataActiveAsync(ClaimsPrincipal user, string urn);
-    Task<UserData?> GetTrustComparatorSetAsync(ClaimsPrincipal user, string companyNumber);
-    Task<(string? CustomData, string? ComparatorSet)> GetSchoolDataAsync(ClaimsPrincipal user, string urn);
-    Task<(string? CustomData, string? ComparatorSet)> GetTrustDataAsync(ClaimsPrincipal user, string companyNumber);
+    Task<UserData?> GetSchoolComparatorSetActiveAsync(ClaimsPrincipal user, string urn, CancellationToken cancellationToken = default);
+    Task<UserData?> GetCustomDataActiveAsync(ClaimsPrincipal user, string urn, CancellationToken cancellationToken = default);
+    Task<UserData?> GetTrustComparatorSetAsync(ClaimsPrincipal user, string companyNumber, CancellationToken cancellationToken = default);
+    Task<(string? CustomData, string? ComparatorSet)> GetSchoolDataAsync(ClaimsPrincipal user, string urn, CancellationToken cancellationToken = default);
+    Task<(string? CustomData, string? ComparatorSet)> GetTrustDataAsync(ClaimsPrincipal user, string companyNumber, CancellationToken cancellationToken = default);
 }
 
 public class UserDataService(IUserDataApi api, ILogger<UserDataService> logger) : IUserDataService
@@ -23,7 +23,7 @@ public class UserDataService(IUserDataApi api, ILogger<UserDataService> logger) 
     private const string ComparatorSet = "comparator-set";
     private const string CustomData = "custom-data";
 
-    public async Task<UserData?> GetSchoolComparatorSetActiveAsync(ClaimsPrincipal user, string urn)
+    public async Task<UserData?> GetSchoolComparatorSetActiveAsync(ClaimsPrincipal user, string urn, CancellationToken cancellationToken = default)
     {
         if (user.Identity is not { IsAuthenticated: true })
         {
@@ -36,7 +36,7 @@ public class UserDataService(IUserDataApi api, ILogger<UserDataService> logger) 
             .AddIfNotNull("organisationType", OrganisationSchool)
             .AddIfNotNull("organisationId", urn);
 
-        var userSets = await api.GetAsync(query).GetResultOrDefault<UserData[]>();
+        var userSets = await api.GetAsync(query, cancellationToken).GetResultOrDefault<UserData[]>();
         if (userSets?.Length > 1)
         {
             logger.LogWarning(
@@ -51,7 +51,7 @@ public class UserDataService(IUserDataApi api, ILogger<UserDataService> logger) 
         return userSets?.FirstOrDefault();
     }
 
-    public async Task<UserData?> GetCustomDataActiveAsync(ClaimsPrincipal user, string urn)
+    public async Task<UserData?> GetCustomDataActiveAsync(ClaimsPrincipal user, string urn, CancellationToken cancellationToken = default)
     {
         if (user.Identity is not { IsAuthenticated: true })
         {
@@ -64,7 +64,7 @@ public class UserDataService(IUserDataApi api, ILogger<UserDataService> logger) 
             .AddIfNotNull("organisationType", OrganisationSchool)
             .AddIfNotNull("organisationId", urn);
 
-        var userSets = await api.GetAsync(query).GetResultOrDefault<UserData[]>();
+        var userSets = await api.GetAsync(query, cancellationToken).GetResultOrDefault<UserData[]>();
         if (userSets?.Length > 1)
         {
             logger.LogWarning(
@@ -79,7 +79,7 @@ public class UserDataService(IUserDataApi api, ILogger<UserDataService> logger) 
         return userSets?.FirstOrDefault();
     }
 
-    public async Task<UserData?> GetTrustComparatorSetAsync(ClaimsPrincipal user, string companyNumber)
+    public async Task<UserData?> GetTrustComparatorSetAsync(ClaimsPrincipal user, string companyNumber, CancellationToken cancellationToken = default)
     {
         if (user.Identity is not { IsAuthenticated: true })
         {
@@ -92,7 +92,7 @@ public class UserDataService(IUserDataApi api, ILogger<UserDataService> logger) 
             .AddIfNotNull("organisationType", OrganisationTrust)
             .AddIfNotNull("organisationId", companyNumber);
 
-        var userSets = await api.GetAsync(query).GetResultOrDefault<UserData[]>();
+        var userSets = await api.GetAsync(query, cancellationToken).GetResultOrDefault<UserData[]>();
         if (userSets?.Length > 1)
         {
             logger.LogWarning(
@@ -107,7 +107,7 @@ public class UserDataService(IUserDataApi api, ILogger<UserDataService> logger) 
         return userSets?.FirstOrDefault();
     }
 
-    public async Task<(string? CustomData, string? ComparatorSet)> GetSchoolDataAsync(ClaimsPrincipal user, string urn)
+    public async Task<(string? CustomData, string? ComparatorSet)> GetSchoolDataAsync(ClaimsPrincipal user, string urn, CancellationToken cancellationToken = default)
     {
         if (user.Identity is not { IsAuthenticated: true })
         {
@@ -120,13 +120,13 @@ public class UserDataService(IUserDataApi api, ILogger<UserDataService> logger) 
             .AddIfNotNull("organisationType", OrganisationSchool)
             .AddIfNotNull("organisationId", urn);
 
-        var userSets = await api.GetAsync(query).GetResultOrDefault<UserData[]>();
+        var userSets = await api.GetAsync(query, cancellationToken).GetResultOrDefault<UserData[]>();
         return (userSets?.FirstOrDefault(x => x.Type == CustomData)?.Id,
             userSets?.FirstOrDefault(x => x.Type == ComparatorSet)?.Id);
     }
 
     public async Task<(string? CustomData, string? ComparatorSet)> GetTrustDataAsync(ClaimsPrincipal user,
-        string companyNumber)
+        string companyNumber, CancellationToken cancellationToken = default)
     {
         if (user.Identity is not { IsAuthenticated: true })
         {
@@ -138,7 +138,7 @@ public class UserDataService(IUserDataApi api, ILogger<UserDataService> logger) 
             .AddIfNotNull("organisationType", OrganisationTrust)
             .AddIfNotNull("organisationId", companyNumber);
 
-        var userSets = await api.GetAsync(query).GetResultOrDefault<UserData[]>();
+        var userSets = await api.GetAsync(query, cancellationToken).GetResultOrDefault<UserData[]>();
         return (userSets?.FirstOrDefault(x => x.Type == CustomData)?.Id,
             userSets?.FirstOrDefault(x => x.Type == ComparatorSet)?.Id);
     }

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -155,14 +155,14 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     public BenchmarkingWebAppClient SetupEstablishment(School school)
     {
         EstablishmentApi.Reset();
-        EstablishmentApi.Setup(api => api.GetSchool(school.URN)).ReturnsAsync(ApiResult.Ok(school));
+        EstablishmentApi.Setup(api => api.GetSchool(school.URN, It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(school));
         return this;
     }
 
     public BenchmarkingWebAppClient SetupEstablishment(Trust trust)
     {
         EstablishmentApi.Reset();
-        EstablishmentApi.Setup(api => api.GetTrust(trust.CompanyNumber)).ReturnsAsync(ApiResult.Ok(trust));
+        EstablishmentApi.Setup(api => api.GetTrust(trust.CompanyNumber, It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(trust));
         return this;
     }
 
@@ -170,14 +170,14 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     {
         EstablishmentApi.Reset();
         trust.Schools = schools;
-        EstablishmentApi.Setup(api => api.GetTrust(trust.CompanyNumber)).ReturnsAsync(ApiResult.Ok(trust));
+        EstablishmentApi.Setup(api => api.GetTrust(trust.CompanyNumber, It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(trust));
         return this;
     }
 
     public BenchmarkingWebAppClient SetupEstablishment(LocalAuthority authority)
     {
         EstablishmentApi.Reset();
-        EstablishmentApi.Setup(api => api.GetLocalAuthority(authority.Code)).ReturnsAsync(ApiResult.Ok(authority));
+        EstablishmentApi.Setup(api => api.GetLocalAuthority(authority.Code, It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(authority));
         return this;
     }
 
@@ -185,7 +185,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     {
         EstablishmentApi.Reset();
         authority.Schools = schools;
-        EstablishmentApi.Setup(api => api.GetLocalAuthority(authority.Code)).ReturnsAsync(ApiResult.Ok(authority));
+        EstablishmentApi.Setup(api => api.GetLocalAuthority(authority.Code, It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(authority));
         return this;
     }
 
@@ -197,79 +197,79 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     {
         SetupEstablishment(authority, []);
         EstablishmentApi.Setup(api => api.GetLocalAuthoritiesNationalRank(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(ranking));
-        EstablishmentApi.Setup(api => api.GetLocalAuthorityStatisticalNeighbours(authority.Code)).ReturnsAsync(ApiResult.Ok(statisticalNeighbours));
-        EstablishmentApi.Setup(api => api.GetLocalAuthorities()).ReturnsAsync(ApiResult.Ok(authorities));
+        EstablishmentApi.Setup(api => api.GetLocalAuthorityStatisticalNeighbours(authority.Code, It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(statisticalNeighbours));
+        EstablishmentApi.Setup(api => api.GetLocalAuthorities(It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(authorities));
         return this;
     }
 
     public BenchmarkingWebAppClient SetupEstablishment(LocalAuthorityStatisticalNeighbours authority, LocalAuthority[] authorities)
     {
         EstablishmentApi.Reset();
-        EstablishmentApi.Setup(api => api.GetLocalAuthorityStatisticalNeighbours(authority.Code)).ReturnsAsync(ApiResult.Ok(authority));
-        EstablishmentApi.Setup(api => api.GetLocalAuthorities()).ReturnsAsync(ApiResult.Ok(authorities));
-        EstablishmentApi.Setup(api => api.GetLocalAuthority(It.IsAny<string>())).ReturnsAsync(ApiResult.Ok(authorities.First()));
+        EstablishmentApi.Setup(api => api.GetLocalAuthorityStatisticalNeighbours(authority.Code, It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(authority));
+        EstablishmentApi.Setup(api => api.GetLocalAuthorities(It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(authorities));
+        EstablishmentApi.Setup(api => api.GetLocalAuthority(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(authorities.First()));
         return this;
     }
 
     public BenchmarkingWebAppClient SetupEstablishmentWithNotFound()
     {
         EstablishmentApi.Reset();
-        EstablishmentApi.Setup(api => api.GetSchool(It.IsAny<string>())).ReturnsAsync(ApiResult.NotFound);
-        EstablishmentApi.Setup(api => api.GetTrust(It.IsAny<string>())).ReturnsAsync(ApiResult.NotFound);
-        EstablishmentApi.Setup(api => api.GetLocalAuthority(It.IsAny<string>())).ReturnsAsync(ApiResult.NotFound);
-        EstablishmentApi.Setup(api => api.GetLocalAuthorityStatisticalNeighbours(It.IsAny<string>())).ReturnsAsync(ApiResult.NotFound);
+        EstablishmentApi.Setup(api => api.GetSchool(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.NotFound);
+        EstablishmentApi.Setup(api => api.GetTrust(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.NotFound);
+        EstablishmentApi.Setup(api => api.GetLocalAuthority(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.NotFound);
+        EstablishmentApi.Setup(api => api.GetLocalAuthorityStatisticalNeighbours(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.NotFound);
         return this;
     }
 
     public BenchmarkingWebAppClient SetupEstablishmentWithException()
     {
         EstablishmentApi.Reset();
-        EstablishmentApi.Setup(api => api.GetSchool(It.IsAny<string>())).Throws(new Exception());
-        EstablishmentApi.Setup(api => api.GetTrust(It.IsAny<string>())).Throws(new Exception());
-        EstablishmentApi.Setup(api => api.GetLocalAuthority(It.IsAny<string>())).Throws(new Exception());
-        EstablishmentApi.Setup(api => api.GetLocalAuthorityStatisticalNeighbours(It.IsAny<string>())).Throws(new Exception());
-        EstablishmentApi.Setup(api => api.GetLocalAuthorities()).Throws(new Exception());
+        EstablishmentApi.Setup(api => api.GetSchool(It.IsAny<string>(), It.IsAny<CancellationToken>())).Throws(new Exception());
+        EstablishmentApi.Setup(api => api.GetTrust(It.IsAny<string>(), It.IsAny<CancellationToken>())).Throws(new Exception());
+        EstablishmentApi.Setup(api => api.GetLocalAuthority(It.IsAny<string>(), It.IsAny<CancellationToken>())).Throws(new Exception());
+        EstablishmentApi.Setup(api => api.GetLocalAuthorityStatisticalNeighbours(It.IsAny<string>(), It.IsAny<CancellationToken>())).Throws(new Exception());
+        EstablishmentApi.Setup(api => api.GetLocalAuthorities(It.IsAny<CancellationToken>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.SuggestSchools(It.IsAny<string>(), It.IsAny<string[]?>(), It.IsAny<bool?>(), It.IsAny<CancellationToken>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.SuggestTrusts(It.IsAny<string>(), It.IsAny<string[]?>(), It.IsAny<CancellationToken>())).Throws(new Exception());
         EstablishmentApi.Setup(api => api.SuggestLocalAuthorities(It.IsAny<string>(), It.IsAny<string[]?>(), It.IsAny<CancellationToken>())).Throws(new Exception());
-        EstablishmentApi.Setup(api => api.SearchSchools(It.IsAny<SearchRequest>())).Throws(new Exception());
-        EstablishmentApi.Setup(api => api.SearchTrusts(It.IsAny<SearchRequest>())).Throws(new Exception());
-        EstablishmentApi.Setup(api => api.SearchLocalAuthorities(It.IsAny<SearchRequest>())).Throws(new Exception());
+        EstablishmentApi.Setup(api => api.SearchSchools(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>())).Throws(new Exception());
+        EstablishmentApi.Setup(api => api.SearchTrusts(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>())).Throws(new Exception());
+        EstablishmentApi.Setup(api => api.SearchLocalAuthorities(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>())).Throws(new Exception());
         return this;
     }
 
     public BenchmarkingWebAppClient SetupEstablishment(SearchResponse<SchoolSummary> schools)
     {
         EstablishmentApi.Reset();
-        EstablishmentApi.Setup(api => api.SearchSchools(It.IsAny<SearchRequest>())).ReturnsAsync(ApiResult.Ok(schools));
+        EstablishmentApi.Setup(api => api.SearchSchools(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(schools));
         return this;
     }
 
     public BenchmarkingWebAppClient SetupEstablishment(SearchResponse<TrustSummary> trusts)
     {
         EstablishmentApi.Reset();
-        EstablishmentApi.Setup(api => api.SearchTrusts(It.IsAny<SearchRequest>())).ReturnsAsync(ApiResult.Ok(trusts));
+        EstablishmentApi.Setup(api => api.SearchTrusts(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(trusts));
         return this;
     }
 
     public BenchmarkingWebAppClient SetupEstablishment(SearchResponse<LocalAuthoritySummary> localAuthorities)
     {
         EstablishmentApi.Reset();
-        EstablishmentApi.Setup(api => api.SearchLocalAuthorities(It.IsAny<SearchRequest>())).ReturnsAsync(ApiResult.Ok(localAuthorities));
+        EstablishmentApi.Setup(api => api.SearchLocalAuthorities(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(localAuthorities));
         return this;
     }
 
     public BenchmarkingWebAppClient SetupCensus(School school, Census census)
     {
         CensusApi.Reset();
-        CensusApi.Setup(api => api.Get(school.URN, It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(census));
+        CensusApi.Setup(api => api.Get(school.URN, It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(census));
         return this;
     }
 
     public BenchmarkingWebAppClient SetupCensus(Census[] censuses)
     {
         CensusApi.Reset();
-        CensusApi.Setup(api => api.Query(It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(censuses));
+        CensusApi.Setup(api => api.Query(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(censuses));
         return this;
     }
 
@@ -292,9 +292,9 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     {
         CensusApi.Reset();
         CensusApi
-            .Setup(api => api.SchoolHistory(It.IsAny<string?>(), It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
+            .Setup(api => api.SchoolHistory(It.IsAny<string>(), It.IsAny<ApiQuery>(), It.IsAny<CancellationToken>()))
             .Throws(new Exception());
-        CensusApi.Setup(api => api.Query(It.IsAny<ApiQuery?>())).Throws(new Exception());
+        CensusApi.Setup(api => api.Query(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>())).Throws(new Exception());
         return this;
     }
 
@@ -331,7 +331,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     public BenchmarkingWebAppClient SetupIncome(School school, SchoolIncome? income = null)
     {
         IncomeApi.Reset();
-        IncomeApi.Setup(api => api.School(school.URN, It.IsAny<ApiQuery?>()))
+        IncomeApi.Setup(api => api.School(school.URN, It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ApiResult.Ok(income));
         return this;
     }
@@ -339,14 +339,14 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     public BenchmarkingWebAppClient SetupBalance(School school, SchoolBalance? balance = null)
     {
         BalanceApi.Reset();
-        BalanceApi.Setup(api => api.School(school.URN, It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(balance ?? new SchoolBalance()));
+        BalanceApi.Setup(api => api.School(school.URN, It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(balance ?? new SchoolBalance()));
         return this;
     }
 
     public BenchmarkingWebAppClient SetupBalance(Trust trust, TrustBalance? balance = null)
     {
         BalanceApi.Reset();
-        BalanceApi.Setup(api => api.Trust(trust.CompanyNumber, It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(balance ?? new TrustBalance()));
+        BalanceApi.Setup(api => api.Trust(trust.CompanyNumber, It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(balance ?? new TrustBalance()));
         return this;
     }
 
@@ -357,9 +357,9 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         int? currentYear = null)
     {
         BudgetForecastApi.Reset();
-        BudgetForecastApi.Setup(api => api.BudgetForecastReturns(trust.CompanyNumber, It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(returns ?? []));
-        BudgetForecastApi.Setup(api => api.BudgetForecastReturnsMetrics(trust.CompanyNumber, It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(metrics ?? []));
-        BudgetForecastApi.Setup(api => api.GetCurrentBudgetForecastYear(trust.CompanyNumber, It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(currentYear ?? 2022));
+        BudgetForecastApi.Setup(api => api.BudgetForecastReturns(trust.CompanyNumber, It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(returns ?? []));
+        BudgetForecastApi.Setup(api => api.BudgetForecastReturnsMetrics(trust.CompanyNumber, It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(metrics ?? []));
+        BudgetForecastApi.Setup(api => api.GetCurrentBudgetForecastYear(trust.CompanyNumber, It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(currentYear ?? 2022));
         return this;
     }
 
@@ -381,7 +381,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     {
         BalanceApi.Reset();
 
-        BalanceApi.Setup(api => api.School(It.IsAny<string?>(), It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(balance ?? new SchoolBalance
+        BalanceApi.Setup(api => api.School(It.IsAny<string?>(), It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(balance ?? new SchoolBalance
         {
             PeriodCoveredByReturn = 12
         }));
@@ -393,7 +393,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     {
         MetricRagRatingApi.Reset();
 
-        MetricRagRatingApi.Setup(api => api.GetDefaultAsync(It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(ratings ?? Array.Empty<RagRating>()));
+        MetricRagRatingApi.Setup(api => api.GetDefaultAsync(It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(ratings ?? []));
 
         return this;
     }
@@ -401,7 +401,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     public BenchmarkingWebAppClient SetupMetricRagRatingUserDefined(IEnumerable<RagRating>? ratings = null)
     {
         MetricRagRatingApi.Reset();
-        MetricRagRatingApi.Setup(api => api.UserDefinedAsync(It.IsAny<string>())).ReturnsAsync(ApiResult.Ok(ratings ?? Array.Empty<RagRating>()));
+        MetricRagRatingApi.Setup(api => api.UserDefinedAsync(It.IsAny<string>())).ReturnsAsync(ApiResult.Ok(ratings ?? []));
         return this;
     }
 
@@ -409,7 +409,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     {
         MetricRagRatingApi.Reset();
 
-        MetricRagRatingApi.Setup(api => api.GetDefaultAsync(It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(originalRatings ?? Array.Empty<RagRating>()));
+        MetricRagRatingApi.Setup(api => api.GetDefaultAsync(It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(originalRatings ?? []));
         MetricRagRatingApi.Setup(api => api.CustomAsync(customData)).ReturnsAsync(ApiResult.Ok(customRatings));
 
         return this;
@@ -419,7 +419,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     {
         ExpenditureApi.Reset();
         ExpenditureApi
-            .Setup(api => api.School(school.URN, It.IsAny<ApiQuery?>()))
+            .Setup(api => api.School(school.URN, It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ApiResult.Ok(expenditure ?? new SchoolExpenditure
             {
                 PeriodCoveredByReturn = 12
@@ -431,7 +431,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     {
         ExpenditureApi.Reset();
         ExpenditureApi
-            .Setup(api => api.QuerySchools(It.IsAny<ApiQuery?>()))
+            .Setup(api => api.QuerySchools(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ApiResult.Ok(expenditures));
         return this;
     }
@@ -440,7 +440,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     {
         ExpenditureApi.Reset();
         ExpenditureApi
-            .Setup(api => api.SchoolCustom(school.URN, identifier, It.IsAny<ApiQuery?>()))
+            .Setup(api => api.SchoolCustom(school.URN, identifier, It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ApiResult.Ok(expenditure));
         return this;
     }
@@ -449,7 +449,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     {
         ExpenditureApi.Reset();
         ExpenditureApi
-            .Setup(api => api.QueryTrusts(It.IsAny<ApiQuery?>()))
+            .Setup(api => api.QueryTrusts(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ApiResult.Ok(expenditure));
         return this;
     }
@@ -490,14 +490,14 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     public BenchmarkingWebAppClient SetupSchoolInsight(IEnumerable<SchoolCharacteristic>? characteristics = null)
     {
         SchoolInsightApi.Reset();
-        SchoolInsightApi.Setup(api => api.GetCharacteristicsAsync(It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(characteristics ?? Array.Empty<SchoolCharacteristic>()));
+        SchoolInsightApi.Setup(api => api.GetCharacteristicsAsync(It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(characteristics ?? []));
         return this;
     }
 
     public BenchmarkingWebAppClient SetupTrustInsightApi(IEnumerable<TrustCharacteristic>? characteristics = null)
     {
         TrustInsightApi.Reset();
-        TrustInsightApi.Setup(api => api.GetCharacteristicsAsync(It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(characteristics ?? Array.Empty<TrustCharacteristic>()));
+        TrustInsightApi.Setup(api => api.GetCharacteristicsAsync(It.IsAny<ApiQuery?>())).ReturnsAsync(ApiResult.Ok(characteristics ?? []));
         return this;
     }
 
@@ -522,21 +522,21 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     public BenchmarkingWebAppClient SetupComparatorSetApi(UserDefinedTrustComparatorSet trustComparatorSet)
     {
         ComparatorApi.Reset();
-        ComparatorSetApi.Setup(api => api.GetUserDefinedTrustAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(ApiResult.Ok(trustComparatorSet));
+        ComparatorSetApi.Setup(api => api.GetUserDefinedTrustAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(trustComparatorSet));
         return this;
     }
 
     public BenchmarkingWebAppClient SetupComparatorSetApiWithException()
     {
         ComparatorSetApi.Reset();
-        ComparatorSetApi.Setup(api => api.GetDefaultSchoolAsync(It.IsAny<string>())).Throws(new Exception());
+        ComparatorSetApi.Setup(api => api.GetDefaultSchoolAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Throws(new Exception());
         return this;
     }
 
     public BenchmarkingWebAppClient SetupComparatorSet(School school, SchoolComparatorSet? comparatorSet)
     {
         ComparatorSetApi.Reset();
-        ComparatorSetApi.Setup(api => api.GetDefaultSchoolAsync(school.URN!)).ReturnsAsync(ApiResult.Ok(comparatorSet));
+        ComparatorSetApi.Setup(api => api.GetDefaultSchoolAsync(school.URN!, It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(comparatorSet));
         return this;
     }
 
@@ -598,7 +598,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     public BenchmarkingWebAppClient SetupUserData(UserData[]? data = null)
     {
         UserDataApi.Reset();
-        UserDataApi.Setup(api => api.GetAsync(It.IsAny<ApiQuery>())).ReturnsAsync(ApiResult.Ok(data ?? []));
+        UserDataApi.Setup(api => api.GetAsync(It.IsAny<ApiQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(data ?? []));
         return this;
     }
 

--- a/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingSpending.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingSpending.cs
@@ -6,6 +6,7 @@ using Moq;
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
 using Xunit;
+
 namespace Web.Integration.Tests.Pages.Schools;
 
 public class WhenViewingSpending(SchoolBenchmarkingWebAppClient client)
@@ -171,7 +172,7 @@ public class WhenViewingSpending(SchoolBenchmarkingWebAppClient client)
         if (comparatorSet != null)
         {
             client.SetupComparatorSet(school, comparatorSet);
-            var setup = client.ExpenditureApi.SetupSequence(api => api.QuerySchools(It.IsAny<ApiQuery?>()));
+            var setup = client.ExpenditureApi.SetupSequence(api => api.QuerySchools(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()));
             if (comparatorSet.Pupil.Length > 0 && comparatorSet.Building.Length == 0 || comparatorSet.Pupil.Length == 0 && comparatorSet.Building.Length > 0)
             {
                 setup.ReturnsAsync(ApiResult.Ok(expenditures));
@@ -209,13 +210,13 @@ public class WhenViewingSpending(SchoolBenchmarkingWebAppClient client)
             var expectedCostCodeList = new Dictionary<string, int>
             {
                 { "Teaching and Teaching support staff", 5 },
-                { "Non-educational support staff", financeType == EstablishmentTypes.Maintained ? 3 : 4  },
+                { "Non-educational support staff", financeType == EstablishmentTypes.Maintained ? 3 : 4 },
                 { "Educational supplies", 2 },
                 { "Educational ICT", 1 },
                 { "Premises staff and services", 4 },
                 { "Utilities", 2 },
                 { "Administrative supplies", 1 },
-                { "Catering staff and supplies", 2 },
+                { "Catering staff and supplies", 2 }
             };
 
             Assert.NotNull(costCodeList);

--- a/web/tests/Web.Tests/Controllers/Api/BudgetForecast/WhenBudgetForecastApiReceivesRequest.cs
+++ b/web/tests/Web.Tests/Controllers/Api/BudgetForecast/WhenBudgetForecastApiReceivesRequest.cs
@@ -4,7 +4,9 @@ using Moq;
 using Web.App.Controllers.Api;
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Apis.Insight;
 using Xunit;
+
 namespace Web.Tests.Controllers.Api.BudgetForecast;
 
 public class WhenBudgetForecastApiReceivesRequest
@@ -43,11 +45,11 @@ public class WhenBudgetForecastApiReceivesRequest
         var actualQuery = string.Empty;
 
         _budgetForecastApi
-            .Setup(e => e.BudgetForecastReturnsMetrics(companyNumber, null))
+            .Setup(e => e.BudgetForecastReturnsMetrics(companyNumber, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(ApiResult.Ok(metrics));
         _budgetForecastApi
-            .Setup(e => e.BudgetForecastReturns(companyNumber, It.IsAny<ApiQuery?>()))
-            .Callback<string, ApiQuery?>((_, query) =>
+            .Setup(e => e.BudgetForecastReturns(companyNumber, It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, ApiQuery?, CancellationToken>((_, query, _) =>
             {
                 actualQuery = query?.ToQueryString();
             })

--- a/web/tests/Web.Tests/Controllers/Api/Census/WhenCensusApiReceivesHistoryComparisonRequest.cs
+++ b/web/tests/Web.Tests/Controllers/Api/Census/WhenCensusApiReceivesHistoryComparisonRequest.cs
@@ -9,6 +9,7 @@ using Web.App.Infrastructure.Apis.Establishment;
 using Web.App.Infrastructure.Apis.Insight;
 using Web.App.Services;
 using Xunit;
+
 namespace Web.Tests.Controllers.Api.Census;
 
 public class WhenCensusApiReceivesHistoryComparisonRequest
@@ -34,15 +35,15 @@ public class WhenCensusApiReceivesHistoryComparisonRequest
         // arrange
         var results = new CensusHistoryRows();
         var actualQuery = string.Empty;
+        var cancellationToken = CancellationToken.None;
 
         var school = _fixture.Build<School>()
             .With(s => s.URN, urn)
             .Create();
         _establishmentApi
-            .Setup(e => e.GetSchool(urn))
+            .Setup(e => e.GetSchool(urn, cancellationToken))
             .ReturnsAsync(ApiResult.Ok(school));
 
-        var cancellationToken = CancellationToken.None;
         SetupCensusHistory(urn, results, q => actualQuery = q, cancellationToken);
 
         // act
@@ -61,16 +62,16 @@ public class WhenCensusApiReceivesHistoryComparisonRequest
         // arrange
         var results = new CensusHistoryRows();
         var actualQuery = string.Empty;
+        var cancellationToken = CancellationToken.None;
 
         var school = _fixture.Build<School>()
             .With(s => s.URN, urn)
             .Create();
         _establishmentApi
-            .Setup(e => e.GetSchool(urn))
+            .Setup(e => e.GetSchool(urn, cancellationToken))
             .ReturnsAsync(ApiResult.Ok(school));
 
-        SetupCensusHistory(urn);
-        var cancellationToken = CancellationToken.None;
+        SetupCensusHistory(urn, cancellationToken: cancellationToken);
         _censusApi
             .Setup(e => e.SchoolHistoryComparatorSetAverage(urn, It.IsAny<ApiQuery?>(), cancellationToken))
             .Callback<string, ApiQuery?, CancellationToken>((_, query, _) =>
@@ -98,6 +99,7 @@ public class WhenCensusApiReceivesHistoryComparisonRequest
         // arrange
         var results = new CensusHistoryRows();
         var actualQuery = string.Empty;
+        var cancellationToken = CancellationToken.None;
 
         var school = new School
         {
@@ -106,11 +108,10 @@ public class WhenCensusApiReceivesHistoryComparisonRequest
             OverallPhase = schoolOverallPhase
         };
         _establishmentApi
-            .Setup(e => e.GetSchool(urn))
+            .Setup(e => e.GetSchool(urn, cancellationToken))
             .ReturnsAsync(ApiResult.Ok(school));
 
-        SetupCensusHistory(urn);
-        var cancellationToken = CancellationToken.None;
+        SetupCensusHistory(urn, cancellationToken: cancellationToken);
         _censusApi
             .Setup(e => e.SchoolHistoryNationalAverage(It.IsAny<ApiQuery?>(), cancellationToken))
             .Callback<ApiQuery?, CancellationToken>((query, _) =>

--- a/web/tests/Web.Tests/Controllers/Api/Census/WhenCensusApiReceivesQueryRequest.cs
+++ b/web/tests/Web.Tests/Controllers/Api/Census/WhenCensusApiReceivesQueryRequest.cs
@@ -8,6 +8,7 @@ using Web.App.Infrastructure.Apis.Establishment;
 using Web.App.Infrastructure.Apis.Insight;
 using Web.App.Services;
 using Xunit;
+
 namespace Web.Tests.Controllers.Api.Census;
 
 public class WhenCensusApiReceivesQueryRequest
@@ -33,8 +34,8 @@ public class WhenCensusApiReceivesQueryRequest
         var actualQuery = string.Empty;
 
         _censusApi
-            .Setup(e => e.Query(It.IsAny<ApiQuery?>()))
-            .Callback<ApiQuery?>(c =>
+            .Setup(e => e.Query(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
+            .Callback<ApiQuery?, CancellationToken>((c, _) =>
             {
                 actualQuery = c?.ToQueryString();
             })
@@ -58,8 +59,8 @@ public class WhenCensusApiReceivesQueryRequest
         var actualQuery = string.Empty;
 
         _censusApi
-            .Setup(e => e.Query(It.IsAny<ApiQuery?>()))
-            .Callback<ApiQuery?>(c =>
+            .Setup(e => e.Query(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
+            .Callback<ApiQuery?, CancellationToken>((c, _) =>
             {
                 actualQuery = c?.ToQueryString();
             })

--- a/web/tests/Web.Tests/Controllers/Api/Expenditure/WhenExpenditureApiReceivesHistoryComparisonRequest.cs
+++ b/web/tests/Web.Tests/Controllers/Api/Expenditure/WhenExpenditureApiReceivesHistoryComparisonRequest.cs
@@ -10,6 +10,7 @@ using Web.App.Infrastructure.Apis.Establishment;
 using Web.App.Infrastructure.Apis.Insight;
 using Web.App.Services;
 using Xunit;
+
 namespace Web.Tests.Controllers.Api.Expenditure;
 
 public class WhenExpenditureApiReceivesHistoryComparisonRequest
@@ -36,15 +37,15 @@ public class WhenExpenditureApiReceivesHistoryComparisonRequest
         // arrange
         var results = new ExpenditureHistoryRows();
         var actualQuery = string.Empty;
+        var cancellationToken = CancellationToken.None;
 
         var school = _fixture.Build<School>()
             .With(s => s.URN, urn)
             .Create();
         _establishmentApi
-            .Setup(e => e.GetSchool(urn))
+            .Setup(e => e.GetSchool(urn, cancellationToken))
             .ReturnsAsync(ApiResult.Ok(school));
 
-        var cancellationToken = CancellationToken.None;
         SetupExpenditureHistory(urn, results, q => actualQuery = q, cancellationToken);
 
         // act
@@ -63,16 +64,17 @@ public class WhenExpenditureApiReceivesHistoryComparisonRequest
         // arrange
         var results = new ExpenditureHistoryRows();
         var actualQuery = string.Empty;
+        var cancellationToken = CancellationToken.None;
 
         var school = _fixture.Build<School>()
             .With(s => s.URN, urn)
             .Create();
+
         _establishmentApi
-            .Setup(e => e.GetSchool(urn))
+            .Setup(e => e.GetSchool(urn, cancellationToken))
             .ReturnsAsync(ApiResult.Ok(school));
 
-        SetupExpenditureHistory(urn);
-        var cancellationToken = CancellationToken.None;
+        SetupExpenditureHistory(urn, cancellationToken: cancellationToken);
         _expenditureApi
             .Setup(e => e.SchoolHistoryComparatorSetAverage(urn, It.IsAny<ApiQuery?>(), cancellationToken))
             .Callback<string, ApiQuery?, CancellationToken>((_, query, _) =>
@@ -100,6 +102,7 @@ public class WhenExpenditureApiReceivesHistoryComparisonRequest
         // arrange
         var results = new ExpenditureHistoryRows();
         var actualQuery = string.Empty;
+        var cancellationToken = CancellationToken.None;
 
         var school = new School
         {
@@ -107,12 +110,12 @@ public class WhenExpenditureApiReceivesHistoryComparisonRequest
             FinanceType = schoolFinanceType,
             OverallPhase = schoolOverallPhase
         };
+
         _establishmentApi
-            .Setup(e => e.GetSchool(urn))
+            .Setup(e => e.GetSchool(urn, cancellationToken))
             .ReturnsAsync(ApiResult.Ok(school));
 
-        SetupExpenditureHistory(urn);
-        var cancellationToken = CancellationToken.None;
+        SetupExpenditureHistory(urn, cancellationToken: cancellationToken);
         _expenditureApi
             .Setup(e => e.SchoolHistoryNationalAverage(It.IsAny<ApiQuery?>(), cancellationToken))
             .Callback<ApiQuery?, CancellationToken>((query, _) =>

--- a/web/tests/Web.Tests/Controllers/Api/Expenditure/WhenExpenditureApiReceivesHistoryRequest.cs
+++ b/web/tests/Web.Tests/Controllers/Api/Expenditure/WhenExpenditureApiReceivesHistoryRequest.cs
@@ -9,6 +9,7 @@ using Web.App.Infrastructure.Apis.Establishment;
 using Web.App.Infrastructure.Apis.Insight;
 using Web.App.Services;
 using Xunit;
+
 namespace Web.Tests.Controllers.Api.Expenditure;
 
 public class WhenExpenditureApiReceivesHistoryRequest
@@ -60,8 +61,8 @@ public class WhenExpenditureApiReceivesHistoryRequest
         var actualQuery = string.Empty;
 
         _expenditureApi
-            .Setup(e => e.TrustHistory(companyNumber, It.IsAny<ApiQuery?>()))
-            .Callback<string, ApiQuery?>((_, query) =>
+            .Setup(e => e.TrustHistory(companyNumber, It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, ApiQuery?, CancellationToken>((_, query, _) =>
             {
                 actualQuery = query?.ToQueryString();
             })

--- a/web/tests/Web.Tests/Controllers/Api/Expenditure/WhenExpenditureApiReceivesQueryRequest.cs
+++ b/web/tests/Web.Tests/Controllers/Api/Expenditure/WhenExpenditureApiReceivesQueryRequest.cs
@@ -9,6 +9,7 @@ using Web.App.Infrastructure.Apis.Establishment;
 using Web.App.Infrastructure.Apis.Insight;
 using Web.App.Services;
 using Xunit;
+
 namespace Web.Tests.Controllers.Api.Expenditure;
 
 public class WhenExpenditureApiReceivesQueryRequest
@@ -40,11 +41,11 @@ public class WhenExpenditureApiReceivesQueryRequest
         var actualQuery = string.Empty;
 
         _establishmentApi
-            .Setup(e => e.GetTrust(companyNumber))
+            .Setup(e => e.GetTrust(companyNumber, It.IsAny<CancellationToken>()))
             .ReturnsAsync(ApiResult.Ok(trust));
         _expenditureApi
-            .Setup(e => e.QuerySchools(It.IsAny<ApiQuery?>()))
-            .Callback<ApiQuery?>(c =>
+            .Setup(e => e.QuerySchools(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
+            .Callback<ApiQuery?, CancellationToken>((c, _) =>
             {
                 actualQuery = c?.ToQueryString();
             })
@@ -73,11 +74,11 @@ public class WhenExpenditureApiReceivesQueryRequest
         var actualQuery = string.Empty;
 
         _establishmentApi
-            .Setup(e => e.GetLocalAuthority(laCode))
+            .Setup(e => e.GetLocalAuthority(laCode, It.IsAny<CancellationToken>()))
             .ReturnsAsync(ApiResult.Ok(la));
         _expenditureApi
-            .Setup(e => e.QuerySchools(It.IsAny<ApiQuery?>()))
-            .Callback<ApiQuery?>(c =>
+            .Setup(e => e.QuerySchools(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
+            .Callback<ApiQuery?, CancellationToken>((c, _) =>
             {
                 actualQuery = c?.ToQueryString();
             })

--- a/web/tests/Web.Tests/Services/WhenClaimsIdentifierServiceIsCalled.cs
+++ b/web/tests/Web.Tests/Services/WhenClaimsIdentifierServiceIsCalled.cs
@@ -1,10 +1,10 @@
 ﻿using Moq;
-using Xunit;
-using Web.App.Services;
-using Web.App.Infrastructure.Apis.Establishment;
 using Web.App.Domain;
 using Web.App.Identity.Models;
 using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Apis.Establishment;
+using Web.App.Services;
+using Xunit;
 
 namespace Web.Tests.Services;
 
@@ -22,14 +22,14 @@ public class WhenClaimsIdentifierServiceIsCalled
         var organisation = new Organisation
         {
             Category = organisationItem,
-            CompanyRegistrationNumber = 12345678,
+            CompanyRegistrationNumber = 12345678
         };
         var response = new Trust
         {
-            Schools = [new TrustSchool { URN = "123456" }],
+            Schools = [new TrustSchool { URN = "123456" }]
         };
 
-        _mockApi.Setup(api => api.GetTrust(It.IsAny<string>()))
+        _mockApi.Setup(api => api.GetTrust(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ApiResult.Ok(response));
         var service = new ClaimsIdentifierService(_mockApi.Object);
 
@@ -51,17 +51,18 @@ public class WhenClaimsIdentifierServiceIsCalled
         var organisation = new Organisation
         {
             Category = organisationItem,
-            CompanyRegistrationNumber = 12345678,
+            CompanyRegistrationNumber = 12345678
         };
         var response = new Trust
         {
-            Schools = [
+            Schools =
+            [
                 new TrustSchool { URN = "123456" },
                 new TrustSchool { URN = "987654" }
-            ],
+            ]
         };
 
-        _mockApi.Setup(api => api.GetTrust(It.IsAny<string>()))
+        _mockApi.Setup(api => api.GetTrust(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ApiResult.Ok(response));
         var service = new ClaimsIdentifierService(_mockApi.Object);
 
@@ -84,16 +85,17 @@ public class WhenClaimsIdentifierServiceIsCalled
         var organisation = new Organisation
         {
             Category = organisationItem,
-            EstablishmentNumber = 123,
+            EstablishmentNumber = 123
         };
         var response = new LocalAuthority
         {
-            Schools = [
+            Schools =
+            [
                 new LocalAuthoritySchool { URN = "123456" },
                 new LocalAuthoritySchool { URN = "987654" }
-            ],
+            ]
         };
-        _mockApi.Setup(api => api.GetLocalAuthority(It.IsAny<string>()))
+        _mockApi.Setup(api => api.GetLocalAuthority(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ApiResult.Ok(response));
         var service = new ClaimsIdentifierService(_mockApi.Object);
 
@@ -108,7 +110,7 @@ public class WhenClaimsIdentifierServiceIsCalled
     [Fact]
     public async Task ShouldReturnCorrectlyWhenAcademy()
     {
-        var organisationItem = new OrganisationItem()
+        var organisationItem = new OrganisationItem
         {
             Id = "001"
         };
@@ -119,7 +121,7 @@ public class WhenClaimsIdentifierServiceIsCalled
         };
 
         var response = new School { URN = "123456", TrustCompanyNumber = "12345678" };
-        _mockApi.Setup(api => api.GetSchool(organisation.URN.ToString()))
+        _mockApi.Setup(api => api.GetSchool(organisation.URN.ToString(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ApiResult.Ok(response));
         var service = new ClaimsIdentifierService(_mockApi.Object);
 
@@ -134,7 +136,7 @@ public class WhenClaimsIdentifierServiceIsCalled
     [Fact]
     public async Task ShouldReturnCorrectlyWhenNotAcademy()
     {
-        var organisationItem = new OrganisationItem()
+        var organisationItem = new OrganisationItem
         {
             Id = "001"
         };
@@ -145,7 +147,7 @@ public class WhenClaimsIdentifierServiceIsCalled
         };
         var response = new School { URN = "123456" };
 
-        _mockApi.Setup(api => api.GetSchool(organisation.URN.ToString()))
+        _mockApi.Setup(api => api.GetSchool(organisation.URN.ToString(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ApiResult.Ok(response));
         var service = new ClaimsIdentifierService(_mockApi.Object);
 
@@ -160,13 +162,13 @@ public class WhenClaimsIdentifierServiceIsCalled
     public async Task ShouldReturnCorrectlyWhenOrganisationIsNull()
     {
         Organisation? organisation = null;
-        _mockApi.Setup(api => api.GetSchool(It.IsAny<string>()))
+        _mockApi.Setup(api => api.GetSchool(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ApiResult.Ok());
 
-        _mockApi.Setup(api => api.GetTrust(It.IsAny<string>()))
+        _mockApi.Setup(api => api.GetTrust(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ApiResult.Ok());
 
-        _mockApi.Setup(api => api.GetLocalAuthority(It.IsAny<string>()))
+        _mockApi.Setup(api => api.GetLocalAuthority(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ApiResult.Ok());
         var service = new ClaimsIdentifierService(_mockApi.Object);
 
@@ -174,8 +176,8 @@ public class WhenClaimsIdentifierServiceIsCalled
 
         Assert.Empty(schools);
         Assert.Empty(trusts);
-        _mockApi.Verify(api => api.GetSchool(It.IsAny<string>()), Times.Never);
-        _mockApi.Verify(api => api.GetTrust(It.IsAny<string>()), Times.Never);
-        _mockApi.Verify(api => api.GetLocalAuthority(It.IsAny<string>()), Times.Never);
+        _mockApi.Verify(api => api.GetSchool(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockApi.Verify(api => api.GetTrust(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockApi.Verify(api => api.GetLocalAuthority(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/web/tests/Web.Tests/Services/WhenLocalAuthoritySearchServiceIsCalled.cs
+++ b/web/tests/Web.Tests/Services/WhenLocalAuthoritySearchServiceIsCalled.cs
@@ -9,7 +9,6 @@ namespace Web.Tests.Services;
 
 public class WhenLocalAuthoritySearchServiceIsCalled
 {
-    private readonly Mock<IEstablishmentApi> _api = new();
 
     public static TheoryData<string?, int?, int?, SearchOrderBy?, SearchRequest?> WhenSendRequestData = new()
     {
@@ -37,10 +36,12 @@ public class WhenLocalAuthoritySearchServiceIsCalled
                 SearchText = "term",
                 PageSize = 1,
                 Page = 2,
-                OrderBy = new OrderByCriteria { Field = "field2", Value = "value3"}
+                OrderBy = new OrderByCriteria { Field = "field2", Value = "value3" }
             }
         }
     };
+
+    private readonly Mock<IEstablishmentApi> _api = new();
 
     [Theory]
     [MemberData(nameof(WhenSendRequestData))]
@@ -49,8 +50,8 @@ public class WhenLocalAuthoritySearchServiceIsCalled
         var response = new SearchResponse<LocalAuthoritySummary>();
 
         SearchRequest? actualRequest = null;
-        _api.Setup(x => x.SearchLocalAuthorities(It.IsAny<SearchRequest>()))
-            .Callback<SearchRequest>(r =>
+        _api.Setup(x => x.SearchLocalAuthorities(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<SearchRequest, CancellationToken>((r, _) =>
             {
                 actualRequest = r;
             })

--- a/web/tests/Web.Tests/Services/WhenSchoolSearchServiceIsCalled.cs
+++ b/web/tests/Web.Tests/Services/WhenSchoolSearchServiceIsCalled.cs
@@ -9,7 +9,6 @@ namespace Web.Tests.Services;
 
 public class WhenSchoolSearchServiceIsCalled
 {
-    private readonly Mock<IEstablishmentApi> _api = new();
 
     public static TheoryData<string?, int?, int?, SearchFilters?, SearchOrderBy?, SearchRequest?> WhenSendRequestData = new()
     {
@@ -40,14 +39,17 @@ public class WhenSchoolSearchServiceIsCalled
                 SearchText = "term",
                 PageSize = 1,
                 Page = 2,
-                Filters = [
-                    new FilterCriteria { Field = "field", Value = "value1"},
-                    new FilterCriteria { Field = "field", Value = "value2"}
+                Filters =
+                [
+                    new FilterCriteria { Field = "field", Value = "value1" },
+                    new FilterCriteria { Field = "field", Value = "value2" }
                 ],
-                OrderBy = new OrderByCriteria { Field = "field2", Value = "value3"}
+                OrderBy = new OrderByCriteria { Field = "field2", Value = "value3" }
             }
         }
     };
+
+    private readonly Mock<IEstablishmentApi> _api = new();
 
     [Theory]
     [MemberData(nameof(WhenSendRequestData))]
@@ -56,8 +58,8 @@ public class WhenSchoolSearchServiceIsCalled
         var response = new SearchResponse<SchoolSummary>();
 
         SearchRequest? actualRequest = null;
-        _api.Setup(x => x.SearchSchools(It.IsAny<SearchRequest>()))
-            .Callback<SearchRequest>(r =>
+        _api.Setup(x => x.SearchSchools(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<SearchRequest, CancellationToken>((r, _) =>
             {
                 actualRequest = r;
             })

--- a/web/tests/Web.Tests/Services/WhenTrustSearchServiceIsCalled.cs
+++ b/web/tests/Web.Tests/Services/WhenTrustSearchServiceIsCalled.cs
@@ -9,7 +9,6 @@ namespace Web.Tests.Services;
 
 public class WhenTrustSearchServiceIsCalled
 {
-    private readonly Mock<IEstablishmentApi> _api = new();
 
     public static TheoryData<string?, int?, int?, SearchOrderBy?, SearchRequest?> WhenSendRequestData = new()
     {
@@ -37,10 +36,12 @@ public class WhenTrustSearchServiceIsCalled
                 SearchText = "term",
                 PageSize = 1,
                 Page = 2,
-                OrderBy = new OrderByCriteria { Field = "field2", Value = "value3"}
+                OrderBy = new OrderByCriteria { Field = "field2", Value = "value3" }
             }
         }
     };
+
+    private readonly Mock<IEstablishmentApi> _api = new();
 
     [Theory]
     [MemberData(nameof(WhenSendRequestData))]
@@ -49,8 +50,8 @@ public class WhenTrustSearchServiceIsCalled
         var response = new SearchResponse<TrustSummary>();
 
         SearchRequest? actualRequest = null;
-        _api.Setup(x => x.SearchTrusts(It.IsAny<SearchRequest>()))
-            .Callback<SearchRequest>(r =>
+        _api.Setup(x => x.SearchTrusts(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<SearchRequest, CancellationToken>((r, _) =>
             {
                 actualRequest = r;
             })

--- a/web/tests/Web.Tests/Services/WhenUserDataServiceIsCalled.cs
+++ b/web/tests/Web.Tests/Services/WhenUserDataServiceIsCalled.cs
@@ -2,21 +2,21 @@
 using AutoFixture;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
-using Xunit;
-using Web.App.Services;
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.Benchmark;
+using Web.App.Services;
+using Xunit;
 
 namespace Web.Tests.Services;
 
 public class WhenUserDataServiceIsCalled
 {
-    private readonly Fixture _fixture = new();
-    private readonly Mock<IUserDataApi> _api = new();
-    private readonly NullLogger<UserDataService> _logger = new();
     private static readonly string UserGuid = Guid.NewGuid().ToString();
+    private readonly Mock<IUserDataApi> _api = new();
     private readonly ClaimsPrincipal _authUser = new(new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, UserGuid)], "authenticated"));
+    private readonly Fixture _fixture = new();
+    private readonly NullLogger<UserDataService> _logger = new();
 
     [Fact]
     public async Task ShouldReturnUserDataWhenGettingSchoolComparatorSetActive()
@@ -25,8 +25,8 @@ public class WhenUserDataServiceIsCalled
         string? actualQuery = null;
         var response = _fixture.Build<UserData>().CreateMany().ToArray();
 
-        _api.Setup(api => api.GetAsync(It.IsAny<ApiQuery?>()))
-            .Callback<ApiQuery?>(q =>
+        _api.Setup(api => api.GetAsync(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
+            .Callback<ApiQuery?, CancellationToken>((q, _) =>
             {
                 actualQuery = q?.ToQueryString();
             })
@@ -46,8 +46,8 @@ public class WhenUserDataServiceIsCalled
         string? actualQuery = null;
         var response = _fixture.Build<UserData>().CreateMany().ToArray();
 
-        _api.Setup(api => api.GetAsync(It.IsAny<ApiQuery?>()))
-            .Callback<ApiQuery?>(q =>
+        _api.Setup(api => api.GetAsync(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
+            .Callback<ApiQuery?, CancellationToken>((q, _) =>
             {
                 actualQuery = q?.ToQueryString();
             })
@@ -67,8 +67,8 @@ public class WhenUserDataServiceIsCalled
         string? actualQuery = null;
         var response = _fixture.Build<UserData>().CreateMany().ToArray();
 
-        _api.Setup(api => api.GetAsync(It.IsAny<ApiQuery?>()))
-            .Callback<ApiQuery?>(q =>
+        _api.Setup(api => api.GetAsync(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
+            .Callback<ApiQuery?, CancellationToken>((q, _) =>
             {
                 actualQuery = q?.ToQueryString();
             })
@@ -92,8 +92,8 @@ public class WhenUserDataServiceIsCalled
         response.First().Type = "comparator-set";
         response.Last().Type = "custom-data";
 
-        _api.Setup(api => api.GetAsync(It.IsAny<ApiQuery?>()))
-            .Callback<ApiQuery?>(q =>
+        _api.Setup(api => api.GetAsync(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
+            .Callback<ApiQuery?, CancellationToken>((q, _) =>
             {
                 actualQuery = q?.ToQueryString();
             })
@@ -118,8 +118,8 @@ public class WhenUserDataServiceIsCalled
         response.First().Type = "comparator-set";
         response.Last().Type = "custom-data";
 
-        _api.Setup(api => api.GetAsync(It.IsAny<ApiQuery?>()))
-            .Callback<ApiQuery?>(q =>
+        _api.Setup(api => api.GetAsync(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
+            .Callback<ApiQuery?, CancellationToken>((q, _) =>
             {
                 actualQuery = q?.ToQueryString();
             })


### PR DESCRIPTION
### Context
[AB#258443](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/258443) [AB#259789](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/259789)

### Change proposed in this pull request
- Added `CancellationToken` support to proxy API controller actions
- Added `CancellationToken` support to services and APIs in Web
- Updated unit tests

### Guidance to review 
From the user's perspective, this is a non-functional change. Unit, integration and E2E tests should continue to pass. Additional changes required as part of other work items to complete the wiring up of this feature.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

