### PR TITLE
Added `CancellationToken` support to Platform APIs

### DIFF
--- a/platform/src/abstractions/Platform.Functions/Extensions/HttpRequestDataExtensions.cs
+++ b/platform/src/abstractions/Platform.Functions/Extensions/HttpRequestDataExtensions.cs
@@ -28,12 +28,12 @@ public static class HttpRequestDataExtensions
         return guid;
     }
 
-    public static async Task<T> ReadAsJsonAsync<T>(this HttpRequestData req)
+    public static async Task<T> ReadAsJsonAsync<T>(this HttpRequestData req, CancellationToken cancellationToken = default)
     {
         var result = default(T);
         try
         {
-            result = await req.ReadFromJsonAsync<T>();
+            result = await req.ReadFromJsonAsync<T>(cancellationToken);
         }
         catch (Exception)
         {
@@ -56,25 +56,37 @@ public static class HttpRequestDataExtensions
         return parameters;
     }
 
-    public static async Task<HttpResponseData> CreateJsonResponseAsync(this HttpRequestData req, object obj, HttpStatusCode statusCode = HttpStatusCode.OK)
+    public static async Task<HttpResponseData> CreateJsonResponseAsync(
+        this HttpRequestData req,
+        object obj,
+        HttpStatusCode statusCode = HttpStatusCode.OK,
+        CancellationToken cancellationToken = default)
     {
         var response = req.CreateResponse(statusCode);
-        await response.WriteAsJsonAsync(obj);
+        await response.WriteAsJsonAsync(obj, cancellationToken);
         return response;
     }
 
-    public static async Task<HttpResponseData> CreateObjectResponseAsync(this HttpRequestData req, object obj, HttpStatusCode statusCode = HttpStatusCode.OK)
+    public static async Task<HttpResponseData> CreateObjectResponseAsync(
+        this HttpRequestData req,
+        object obj,
+        HttpStatusCode statusCode = HttpStatusCode.OK,
+        CancellationToken cancellationToken = default)
     {
         var response = req.CreateResponse(statusCode);
         var bytes = Encoding.UTF8.GetBytes(obj.ToString() ?? string.Empty);
         response.Headers.Add("Content-Type", ContentType.TextPlain);
-        await response.WriteBytesAsync(bytes);
+        await response.WriteBytesAsync(bytes, cancellationToken);
         return response;
     }
 
-    public static async Task<HttpResponseData> CreateValidationErrorsResponseAsync(this HttpRequestData req, IEnumerable<ValidationFailure> failures, HttpStatusCode statusCode = HttpStatusCode.BadRequest)
+    public static async Task<HttpResponseData> CreateValidationErrorsResponseAsync(
+        this HttpRequestData req,
+        IEnumerable<ValidationFailure> failures,
+        HttpStatusCode statusCode = HttpStatusCode.BadRequest,
+        CancellationToken cancellationToken = default)
     {
-        return await req.CreateJsonResponseAsync(failures.Select(e => new ValidationError(e.Severity, e.PropertyName, e.ErrorMessage)), statusCode);
+        return await req.CreateJsonResponseAsync(failures.Select(e => new ValidationError(e.Severity, e.PropertyName, e.ErrorMessage)), statusCode, cancellationToken: cancellationToken);
     }
 
     public static HttpResponseData CreateErrorResponse(this HttpRequestData req, int statusCode = (int)HttpStatusCode.InternalServerError) => req.CreateResponse((HttpStatusCode)statusCode);

--- a/platform/src/abstractions/Platform.Search/IndexClient.cs
+++ b/platform/src/abstractions/Platform.Search/IndexClient.cs
@@ -10,8 +10,8 @@ namespace Platform.Search;
 
 public interface IIndexClient
 {
-    Task<Response<SearchResults<T>>> SearchAsync<T>(string? searchText, SearchOptions options);
-    Task<Response<T>> GetDocumentAsync<T>(string? key);
+    Task<Response<SearchResults<T>>> SearchAsync<T>(string? searchText, SearchOptions options, CancellationToken cancellationToken = default);
+    Task<Response<T>> GetDocumentAsync<T>(string? key, CancellationToken cancellationToken = default);
     Task<Response<SuggestResults<T>>> SuggestAsync<T>(string? searchText, string? suggesterName, SuggestOptions options, CancellationToken cancellationToken = default);
 }
 
@@ -20,14 +20,14 @@ public abstract class IndexClient(Uri endpoint, AzureKeyCredential credential, s
 {
     private readonly SearchClient _client = new(endpoint, indexName, credential);
 
-    public async Task<Response<SearchResults<T>>> SearchAsync<T>(string? searchText, SearchOptions options)
+    public async Task<Response<SearchResults<T>>> SearchAsync<T>(string? searchText, SearchOptions options, CancellationToken cancellationToken = default)
     {
         var id = Guid.NewGuid();
 
         Response<SearchResults<T>> response;
         using (HttpPipeline.CreateClientRequestIdScope(id.ToString()))
         {
-            response = await _client.SearchAsync<T>(searchText, options);
+            response = await _client.SearchAsync<T>(searchText, options, cancellationToken);
         }
 
         var searchResults = response.Value;
@@ -37,8 +37,7 @@ public abstract class IndexClient(Uri endpoint, AzureKeyCredential credential, s
         return response;
     }
 
-
-    public Task<Response<T>> GetDocumentAsync<T>(string? key) => _client.GetDocumentAsync<T>(key);
+    public Task<Response<T>> GetDocumentAsync<T>(string? key, CancellationToken cancellationToken = default) => _client.GetDocumentAsync<T>(key, cancellationToken: cancellationToken);
 
     public async Task<Response<SuggestResults<T>>> SuggestAsync<T>(string? searchText, string? suggesterName, SuggestOptions options, CancellationToken cancellationToken = default)
     {

--- a/platform/src/abstractions/tests/Platform.Search.Tests/SearchSearchTests.cs
+++ b/platform/src/abstractions/tests/Platform.Search.Tests/SearchSearchTests.cs
@@ -31,7 +31,7 @@ public class SearchSearchTests
         var result = new TestType();
 
         _client
-            .Setup(c => c.GetDocumentAsync<TestType>(key))
+            .Setup(c => c.GetDocumentAsync<TestType>(key, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Response.FromValue(result, Mock.Of<Response>()));
 
         var results = await _service.CallLookUpAsync(key);
@@ -78,7 +78,7 @@ public class SearchSearchTests
                     && o.Skip == 0
                     && o.IncludeTotalCount == true
                     && o.Filter == nameof(filterBuilder)
-                    && o.QueryType == SearchQueryType.Simple)))
+                    && o.QueryType == SearchQueryType.Simple), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Response.FromValue(searchResults, Mock.Of<Response>()));
 
 
@@ -125,8 +125,8 @@ public class SearchSearchTests
                     && o.Skip == 0
                     && o.IncludeTotalCount == true
                     && o.Filter == null
-                    && o.QueryType == SearchQueryType.Simple)))
-            .Callback((string _, SearchOptions options) =>
+                    && o.QueryType == SearchQueryType.Simple), It.IsAny<CancellationToken>()))
+            .Callback((string _, SearchOptions options, CancellationToken _) =>
             {
                 capturedOptions = options;
             })
@@ -167,8 +167,8 @@ public class SearchSearchTests
                     && o.Skip == 0
                     && o.IncludeTotalCount == true
                     && o.Filter == null
-                    && o.QueryType == SearchQueryType.Simple)))
-            .Callback((string _, SearchOptions options) =>
+                    && o.QueryType == SearchQueryType.Simple), It.IsAny<CancellationToken>()))
+            .Callback((string _, SearchOptions options, CancellationToken _) =>
             {
                 capturedOptions = options;
             })
@@ -209,9 +209,7 @@ public class SearchSearchTests
         const string facetValue = nameof(facetValue);
         var facetResult = SearchModelFactory.FacetResult(facetCount, new Dictionary<string, object>
         {
-            {
-                "value", facetValue
-            }
+            { "value", facetValue }
         });
         var resultFacets = new Dictionary<string, IList<FacetResult>>
         {
@@ -242,7 +240,7 @@ public class SearchSearchTests
                     && o.IncludeTotalCount == true
                     && o.Filter == nameof(filterBuilder)
                     && o.QueryType == SearchQueryType.Simple
-                    && o.Facets[0] == facets[0])))
+                    && o.Facets[0] == facets[0]), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Response.FromValue(searchResults, Mock.Of<Response>()));
 
         var expectedFacets = new Dictionary<string, IList<FacetValueResponseModel>>
@@ -289,7 +287,7 @@ public class SearchSearchTests
                     o.Size == Size
                     && o.IncludeTotalCount == true
                     && o.Filter == filters
-                    && o.QueryType == SearchQueryType.Full)))
+                    && o.QueryType == SearchQueryType.Full), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Response.FromValue(searchResults, Mock.Of<Response>()));
 
         var (total, results) = await _service.CallSearchWithScoreAsync(Search, filters, Size);

--- a/platform/src/apis/Platform.Api.Benchmark/Features/ComparatorSets/DeleteSchoolUserDefinedComparatorSetFunction.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/Features/ComparatorSets/DeleteSchoolUserDefinedComparatorSetFunction.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -22,9 +23,10 @@ public class DeleteSchoolUserDefinedComparatorSetFunction(IComparatorSetsService
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "delete", Route = Routes.SchoolUserDefinedComparatorSetItem)] HttpRequestData req,
         string urn,
-        string identifier)
+        string identifier,
+        CancellationToken cancellationToken = default)
     {
-        var comparatorSet = await service.UserDefinedSchoolAsync(urn, identifier);
+        var comparatorSet = await service.UserDefinedSchoolAsync(urn, identifier, cancellationToken: cancellationToken);
         if (comparatorSet == null)
         {
             return req.CreateNotFoundResponse();

--- a/platform/src/apis/Platform.Api.Benchmark/Features/ComparatorSets/DeleteTrustUserDefinedComparatorSetFunction.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/Features/ComparatorSets/DeleteTrustUserDefinedComparatorSetFunction.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -22,9 +23,10 @@ public class DeleteTrustUserDefinedComparatorSetFunction(IComparatorSetsService 
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "delete", Route = Routes.TrustUserDefinedComparatorSetItem)] HttpRequestData req,
         string companyNumber,
-        string identifier)
+        string identifier,
+        CancellationToken cancellationToken = default)
     {
-        var comparatorSet = await service.UserDefinedTrustAsync(companyNumber, identifier);
+        var comparatorSet = await service.UserDefinedTrustAsync(companyNumber, identifier, cancellationToken: cancellationToken);
         if (comparatorSet == null)
         {
             return req.CreateNotFoundResponse();

--- a/platform/src/apis/Platform.Api.Benchmark/Features/ComparatorSets/GetSchoolCustomComparatorSetFunction.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/Features/ComparatorSets/GetSchoolCustomComparatorSetFunction.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -23,11 +24,12 @@ public class GetSchoolCustomComparatorSetFunction(IComparatorSetsService service
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "get", Route = Routes.SchoolCustomComparatorSet)] HttpRequestData req,
         string urn,
-        string identifier)
+        string identifier,
+        CancellationToken cancellationToken = default)
     {
-        var comparatorSet = await service.CustomSchoolAsync(identifier, urn);
+        var comparatorSet = await service.CustomSchoolAsync(identifier, urn, cancellationToken);
         return comparatorSet == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(comparatorSet);
+            : await req.CreateJsonResponseAsync(comparatorSet, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Benchmark/Features/ComparatorSets/GetSchoolDefaultComparatorSetFunction.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/Features/ComparatorSets/GetSchoolDefaultComparatorSetFunction.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -21,11 +22,12 @@ public class GetSchoolDefaultComparatorSetFunction(IComparatorSetsService servic
     [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "get", Route = Routes.SchoolDefaultComparatorSet)] HttpRequestData req,
-        string urn)
+        string urn,
+        CancellationToken cancellationToken = default)
     {
-        var comparatorSet = await service.DefaultSchoolAsync(urn);
+        var comparatorSet = await service.DefaultSchoolAsync(urn, cancellationToken);
         return comparatorSet == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(comparatorSet);
+            : await req.CreateJsonResponseAsync(comparatorSet, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Benchmark/Features/ComparatorSets/GetSchoolUserDefinedComparatorSetFunction.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/Features/ComparatorSets/GetSchoolUserDefinedComparatorSetFunction.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -23,11 +24,12 @@ public class GetSchoolUserDefinedComparatorSetFunction(IComparatorSetsService se
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "get", Route = Routes.SchoolUserDefinedComparatorSetItem)] HttpRequestData req,
         string urn,
-        string identifier)
+        string identifier,
+        CancellationToken cancellationToken = default)
     {
-        var comparatorSet = await service.UserDefinedSchoolAsync(urn, identifier);
+        var comparatorSet = await service.UserDefinedSchoolAsync(urn, identifier, cancellationToken: cancellationToken);
         return comparatorSet == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(comparatorSet);
+            : await req.CreateJsonResponseAsync(comparatorSet, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Benchmark/Features/ComparatorSets/GetTrustUserDefinedComparatorSetFunction.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/Features/ComparatorSets/GetTrustUserDefinedComparatorSetFunction.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -23,11 +24,12 @@ public class GetTrustUserDefinedComparatorSetFunction(IComparatorSetsService ser
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "get", Route = Routes.TrustUserDefinedComparatorSetItem)] HttpRequestData req,
         string companyNumber,
-        string identifier)
+        string identifier,
+        CancellationToken cancellationToken = default)
     {
-        var comparatorSet = await service.UserDefinedTrustAsync(companyNumber, identifier);
+        var comparatorSet = await service.UserDefinedTrustAsync(companyNumber, identifier, cancellationToken: cancellationToken);
         return comparatorSet == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(comparatorSet);
+            : await req.CreateJsonResponseAsync(comparatorSet, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Benchmark/Features/ComparatorSets/PostTrustUserDefinedComparatorSetFunction.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/Features/ComparatorSets/PostTrustUserDefinedComparatorSetFunction.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentValidation;
 using Microsoft.Azure.Functions.Worker;
@@ -26,9 +27,10 @@ public class PostTrustUserDefinedComparatorSetFunction(IComparatorSetsService se
     [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "post", Route = Routes.TrustUserDefinedComparatorSet)] HttpRequestData req,
-        string companyNumber)
+        string companyNumber,
+        CancellationToken cancellationToken = default)
     {
-        var body = await req.ReadAsJsonAsync<ComparatorSetUserDefinedRequest>();
+        var body = await req.ReadAsJsonAsync<ComparatorSetUserDefinedRequest>(cancellationToken);
         var identifier = Guid.NewGuid().ToString();
         var comparatorSet = new ComparatorSetUserDefinedTrust
         {
@@ -38,7 +40,7 @@ public class PostTrustUserDefinedComparatorSetFunction(IComparatorSetsService se
             CompanyNumber = companyNumber
         };
 
-        var validationResult = await trustValidator.ValidateAsync(comparatorSet);
+        var validationResult = await trustValidator.ValidateAsync(comparatorSet, cancellationToken);
         if (!validationResult.IsValid)
         {
             return req.CreateResponse(HttpStatusCode.BadRequest);

--- a/platform/src/apis/Platform.Api.Benchmark/Features/CustomData/DeleteSchoolCustomDataFunction.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/Features/CustomData/DeleteSchoolCustomDataFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -22,9 +23,10 @@ public class DeleteSchoolCustomDataFunction(ICustomDataService service)
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "delete", Route = Routes.SchoolCustomDataItem)] HttpRequestData req,
         string urn,
-        string identifier)
+        string identifier,
+        CancellationToken cancellationToken = default)
     {
-        var data = await service.CustomDataSchoolAsync(urn, identifier);
+        var data = await service.CustomDataSchoolAsync(urn, identifier, cancellationToken);
         if (data == null)
         {
             return req.CreateNotFoundResponse();

--- a/platform/src/apis/Platform.Api.Benchmark/Features/CustomData/GetSchoolCustomDataFunction.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/Features/CustomData/GetSchoolCustomDataFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -23,11 +24,12 @@ public class GetSchoolCustomDataFunction(ICustomDataService service)
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "get", Route = Routes.SchoolCustomDataItem)] HttpRequestData req,
         string urn,
-        string identifier)
+        string identifier,
+        CancellationToken cancellationToken = default)
     {
-        var data = await service.CustomDataSchoolAsync(urn, identifier);
+        var data = await service.CustomDataSchoolAsync(urn, identifier, cancellationToken);
         return data == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(data);
+            : await req.CreateJsonResponseAsync(data, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Benchmark/Features/CustomData/PostSchoolCustomDataFunction.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/Features/CustomData/PostSchoolCustomDataFunction.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -28,18 +29,19 @@ public class PostSchoolCustomDataFunction(ICustomDataService service)
     [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
     public async Task<MultiResponse> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "post", Route = Routes.SchoolCustomData)] HttpRequestData req,
-        string urn)
+        string urn,
+        CancellationToken cancellationToken = default)
     {
         var response = new MultiResponse();
 
-        var body = await req.ReadAsJsonAsync<CustomDataRequest>();
+        var body = await req.ReadAsJsonAsync<CustomDataRequest>(cancellationToken);
         var identifier = Guid.NewGuid().ToString();
         var data = body.CreateData(identifier, urn);
 
         await service.UpsertCustomDataAsync(data);
         await service.InsertNewAndDeactivateExistingUserDataAsync(CustomDataUserData.School(identifier, body.UserId, urn));
 
-        var year = await service.CurrentYearAsync();
+        var year = await service.CurrentYearAsync(cancellationToken);
 
         var message = new PipelineStartCustom
         {

--- a/platform/src/apis/Platform.Api.Benchmark/Features/FinancialPlans/DeleteFinancialPlanFunction.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/Features/FinancialPlans/DeleteFinancialPlanFunction.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -21,7 +22,8 @@ public class DeleteFinancialPlanFunction(IFinancialPlansService service)
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "delete", Route = Routes.FinancialPlan)] HttpRequestData req,
         string urn,
-        int year)
+        int year,
+        CancellationToken cancellationToken = default)
     {
         await service.DeleteAsync(urn, year);
         return req.CreateResponse(HttpStatusCode.OK);

--- a/platform/src/apis/Platform.Api.Benchmark/Features/FinancialPlans/GetDeploymentPlanFunction.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/Features/FinancialPlans/GetDeploymentPlanFunction.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -24,11 +25,12 @@ public class GetDeploymentPlanFunction(IFinancialPlansService service)
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "get", Route = Routes.DeploymentPlan)] HttpRequestData req,
         string urn,
-        int year)
+        int year,
+        CancellationToken cancellationToken = default)
     {
-        var plan = await service.DeploymentPlanAsync(urn, year);
+        var plan = await service.DeploymentPlanAsync(urn, year, cancellationToken);
         return plan != null
-            ? await req.CreateJsonResponseAsync(plan)
+            ? await req.CreateJsonResponseAsync(plan, cancellationToken: cancellationToken)
             : req.CreateNotFoundResponse();
     }
 }

--- a/platform/src/apis/Platform.Api.Benchmark/Features/FinancialPlans/GetFinancialPlanFunction.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/Features/FinancialPlans/GetFinancialPlanFunction.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -24,11 +25,12 @@ public class GetFinancialPlanFunction(IFinancialPlansService service)
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "get", Route = Routes.FinancialPlan)] HttpRequestData req,
         string urn,
-        int year)
+        int year,
+        CancellationToken cancellationToken = default)
     {
-        var plan = await service.DetailsAsync(urn, year);
+        var plan = await service.DetailsAsync(urn, year, cancellationToken);
         return plan != null
-            ? await req.CreateJsonResponseAsync(plan)
+            ? await req.CreateJsonResponseAsync(plan, cancellationToken: cancellationToken)
             : req.CreateNotFoundResponse();
     }
 }

--- a/platform/src/apis/Platform.Api.Benchmark/Features/FinancialPlans/GetFinancialPlansFunction.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/Features/FinancialPlans/GetFinancialPlansFunction.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -22,10 +23,11 @@ public class GetFinancialPlansFunction(IFinancialPlansService service)
     [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(IEnumerable<FinancialPlanSummary>))]
     [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, "get", Route = Routes.FinancialPlans)] HttpRequestData req)
+        [HttpTrigger(AuthorizationLevel.Admin, "get", Route = Routes.FinancialPlans)] HttpRequestData req,
+        CancellationToken cancellationToken = default)
     {
         var urns = req.Query["urns"]?.Split(",").Where(x => !string.IsNullOrEmpty(x)).ToArray() ?? [];
-        var plans = await service.QueryAsync(urns);
-        return await req.CreateJsonResponseAsync(plans);
+        var plans = await service.QueryAsync(urns, cancellationToken);
+        return await req.CreateJsonResponseAsync(plans, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Benchmark/Features/FinancialPlans/PutFinancialPlanFunction.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/Features/FinancialPlans/PutFinancialPlanFunction.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -26,9 +27,10 @@ public class PutFinancialPlanFunction(IFinancialPlansService service)
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "put", Route = Routes.FinancialPlan)] HttpRequestData req,
         string urn,
-        int year)
+        int year,
+        CancellationToken cancellationToken = default)
     {
-        var body = await req.ReadAsJsonAsync<FinancialPlanDetails>();
+        var body = await req.ReadAsJsonAsync<FinancialPlanDetails>(cancellationToken);
 
         //TODO : Consider adding request validator
         var result = await service.UpsertAsync(urn, year, body);

--- a/platform/src/apis/Platform.Api.Benchmark/Features/UserData/Services/UserDataService.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/Features/UserData/Services/UserDataService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 using Platform.Domain;
 using Platform.Sql;
@@ -15,7 +16,8 @@ public interface IUserDataService
         string? status = null,
         string? id = null,
         string? organisationId = null,
-        string? organisationType = null);
+        string? organisationType = null,
+        CancellationToken cancellationToken = default);
 }
 
 [ExcludeFromCodeCoverage]
@@ -27,7 +29,8 @@ public class UserDataService(IDatabaseFactory dbFactory) : IUserDataService
         string? status = null,
         string? id = null,
         string? organisationId = null,
-        string? organisationType = null)
+        string? organisationType = null,
+        CancellationToken cancellationToken = default)
     {
         var userDataBuilder = new UserDataQuery()
             .WhereUserIdEqual(userId)
@@ -60,6 +63,6 @@ public class UserDataService(IDatabaseFactory dbFactory) : IUserDataService
         }
 
         using var conn = await dbFactory.GetConnection();
-        return await conn.QueryAsync<Models.UserData>(userDataBuilder);
+        return await conn.QueryAsync<Models.UserData>(userDataBuilder, cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/GetLocalAuthoritiesFunction.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/GetLocalAuthoritiesFunction.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -19,9 +20,10 @@ public class GetLocalAuthoritiesFunction(ILocalAuthoritiesService service)
     [OpenApiOperation(nameof(GetLocalAuthoritiesFunction), Constants.Features.LocalAuthorities)]
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(IEnumerable<LocalAuthority>))]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.LocalAuthorities)] HttpRequestData req)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.LocalAuthorities)] HttpRequestData req,
+        CancellationToken cancellationToken = default)
     {
-        var response = await service.GetAllAsync();
-        return await req.CreateJsonResponseAsync(response);
+        var response = await service.GetAllAsync(cancellationToken);
+        return await req.CreateJsonResponseAsync(response, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/GetLocalAuthoritiesNationalRankFunction.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/GetLocalAuthoritiesNationalRankFunction.cs
@@ -27,16 +27,16 @@ public class GetLocalAuthoritiesNationalRankFunction(ILocalAuthorityRankingServi
     [OpenApiResponseWithBody(HttpStatusCode.BadRequest, ContentType.ApplicationJson, typeof(ValidationError[]))]
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.LocalAuthoritiesNationalRank)] HttpRequestData req,
-        CancellationToken token)
+        CancellationToken cancellationToken = default)
     {
         var queryParams = req.GetParameters<LocalAuthoritiesNationalRankParameters>();
-        var validationResult = await validator.ValidateAsync(queryParams, token);
+        var validationResult = await validator.ValidateAsync(queryParams, cancellationToken);
         if (!validationResult.IsValid)
         {
-            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors, cancellationToken: cancellationToken);
         }
 
-        var response = await service.GetRanking(queryParams.Ranking, queryParams.Sort, token);
-        return await req.CreateJsonResponseAsync(response);
+        var response = await service.GetRanking(queryParams.Ranking, queryParams.Sort, cancellationToken);
+        return await req.CreateJsonResponseAsync(response, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/GetLocalAuthorityFunction.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/GetLocalAuthorityFunction.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -20,16 +21,16 @@ public class GetLocalAuthorityFunction(ILocalAuthoritiesService service)
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(LocalAuthority))]
     [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.LocalAuthority)]
-        HttpRequestData req,
-        string identifier)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.LocalAuthority)] HttpRequestData req,
+        string identifier,
+        CancellationToken cancellationToken = default)
     {
-        var response = await service.GetAsync(identifier);
+        var response = await service.GetAsync(identifier, cancellationToken);
         if (response == null)
         {
             return req.CreateNotFoundResponse();
         }
 
-        return await req.CreateJsonResponseAsync(response);
+        return await req.CreateJsonResponseAsync(response, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/GetLocalAuthorityStatisticalNeighboursFunction.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/GetLocalAuthorityStatisticalNeighboursFunction.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -21,14 +22,15 @@ public class GetLocalAuthorityStatisticalNeighboursFunction(ILocalAuthoritiesSer
     [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.LocalAuthorityStatisticalNeighbours)] HttpRequestData req,
-        string identifier)
+        string identifier,
+        CancellationToken cancellationToken = default)
     {
-        var response = await service.GetStatisticalNeighboursAsync(identifier);
+        var response = await service.GetStatisticalNeighboursAsync(identifier, cancellationToken);
         if (response == null)
         {
             return req.CreateNotFoundResponse();
         }
 
-        return await req.CreateJsonResponseAsync(response);
+        return await req.CreateJsonResponseAsync(response, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/PostLocalAuthoritiesSearchFunction.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/PostLocalAuthoritiesSearchFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentValidation;
 using Microsoft.Azure.Functions.Worker;
@@ -25,17 +26,18 @@ public class PostLocalAuthoritiesSearchFunction(
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(SearchResponse<LocalAuthoritySummary>))]
     [OpenApiResponseWithBody(HttpStatusCode.BadRequest, ContentType.ApplicationJson, typeof(ValidationError[]))]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Post, Route = Routes.LocalAuthoritiesSearch)] HttpRequestData req)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Post, Route = Routes.LocalAuthoritiesSearch)] HttpRequestData req,
+        CancellationToken cancellationToken = default)
     {
-        var body = await req.ReadAsJsonAsync<SearchRequest>();
+        var body = await req.ReadAsJsonAsync<SearchRequest>(cancellationToken: cancellationToken);
 
-        var validationResult = await validator.ValidateAsync(body);
+        var validationResult = await validator.ValidateAsync(body, cancellationToken);
         if (!validationResult.IsValid)
         {
-            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors, cancellationToken: cancellationToken);
         }
 
-        var localAuthorities = await service.LocalAuthoritiesSearchAsync(body);
-        return await req.CreateJsonResponseAsync(localAuthorities);
+        var localAuthorities = await service.LocalAuthoritiesSearchAsync(body, cancellationToken);
+        return await req.CreateJsonResponseAsync(localAuthorities, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/PostLocalAuthoritiesSuggestFunction.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/PostLocalAuthoritiesSuggestFunction.cs
@@ -27,15 +27,15 @@ public class PostLocalAuthoritiesSuggestFunction(ILocalAuthoritiesService servic
         [HttpTrigger(AuthorizationLevel.Admin, MethodType.Post, Route = Routes.LocalAuthoritiesSuggest)] HttpRequestData req,
         CancellationToken cancellationToken = default)
     {
-        var body = await req.ReadAsJsonAsync<LocalAuthoritySuggestRequest>();
+        var body = await req.ReadAsJsonAsync<LocalAuthoritySuggestRequest>(cancellationToken: cancellationToken);
 
         var validationResult = await validator.ValidateAsync(body, cancellationToken);
         if (!validationResult.IsValid)
         {
-            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors, cancellationToken: cancellationToken);
         }
 
         var localAuthorities = await service.LocalAuthoritiesSuggestAsync(body, cancellationToken);
-        return await req.CreateJsonResponseAsync(localAuthorities);
+        return await req.CreateJsonResponseAsync(localAuthorities, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/Services/LocalAuthorityRankingService.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/LocalAuthorities/Services/LocalAuthorityRankingService.cs
@@ -9,18 +9,18 @@ namespace Platform.Api.Establishment.Features.LocalAuthorities.Services;
 
 public interface ILocalAuthorityRankingService
 {
-    Task<LocalAuthorityRanking> GetRanking(string ranking, string sort, CancellationToken token = default);
+    Task<LocalAuthorityRanking> GetRanking(string ranking, string sort, CancellationToken cancellationToken = default);
 }
 
 public class LocalAuthorityRankingService(IDatabaseFactory dbFactory) : ILocalAuthorityRankingService
 {
-    public async Task<LocalAuthorityRanking> GetRanking(string ranking, string sort, CancellationToken token)
+    public async Task<LocalAuthorityRanking> GetRanking(string ranking, string sort, CancellationToken cancellationToken = default)
     {
         var laBuilder = new LocalAuthorityFinancialDefaultCurrentRankingQuery(ranking, sort)
             .WhereValueIsNotNull();
 
         using var conn = await dbFactory.GetConnection();
-        var results = await conn.QueryAsync<LocalAuthorityRank>(laBuilder, token);
+        var results = await conn.QueryAsync<LocalAuthorityRank>(laBuilder, cancellationToken);
         return new LocalAuthorityRanking
         {
             Ranking = results.ToArray()

--- a/platform/src/apis/Platform.Api.Establishment/Features/Schools/GetSchoolFunction.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Schools/GetSchoolFunction.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -20,14 +21,14 @@ public class GetSchoolFunction(ISchoolsService service)
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(School))]
     [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.School)]
-        HttpRequestData req,
-        string identifier)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.School)] HttpRequestData req,
+        string identifier,
+        CancellationToken cancellationToken = default)
     {
-        var school = await service.GetAsync(identifier);
+        var school = await service.GetAsync(identifier, cancellationToken);
 
         return school == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(school);
+            : await req.CreateJsonResponseAsync(school, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Establishment/Features/Schools/PostSchoolComparatorsFunction.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Schools/PostSchoolComparatorsFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -6,9 +7,9 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Platform.Api.Establishment.Features.Schools.Models;
 using Platform.Api.Establishment.Features.Schools.Requests;
 using Platform.Api.Establishment.Features.Schools.Services;
+using Platform.Functions;
 using Platform.Functions.Extensions;
 using Platform.Functions.OpenApi;
-using Platform.Functions;
 
 namespace Platform.Api.Establishment.Features.Schools;
 
@@ -22,12 +23,12 @@ public class PostSchoolComparatorsFunction(ISchoolComparatorsService service)
     [OpenApiRequestBody(ContentType.ApplicationJson, typeof(SchoolComparatorsRequest), Description = "The comparator characteristics object")]
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(SchoolComparators))]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Post, Route = Routes.SchoolComparators)]
-        HttpRequestData req,
-        string identifier)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Post, Route = Routes.SchoolComparators)] HttpRequestData req,
+        string identifier,
+        CancellationToken cancellationToken = default)
     {
-        var body = await req.ReadAsJsonAsync<SchoolComparatorsRequest>();
-        var comparators = await service.ComparatorsAsync(identifier, body);
-        return await req.CreateJsonResponseAsync(comparators);
+        var body = await req.ReadAsJsonAsync<SchoolComparatorsRequest>(cancellationToken: cancellationToken);
+        var comparators = await service.ComparatorsAsync(identifier, body, cancellationToken);
+        return await req.CreateJsonResponseAsync(comparators, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Establishment/Features/Schools/PostSchoolsSuggestFunction.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Schools/PostSchoolsSuggestFunction.cs
@@ -27,15 +27,15 @@ public class PostSchoolsSuggestFunction(ISchoolsService service, IValidator<Sugg
         [HttpTrigger(AuthorizationLevel.Admin, MethodType.Post, Route = Routes.SchoolsSuggest)] HttpRequestData req,
         CancellationToken cancellationToken = default)
     {
-        var body = await req.ReadAsJsonAsync<SchoolSuggestRequest>();
+        var body = await req.ReadAsJsonAsync<SchoolSuggestRequest>(cancellationToken: cancellationToken);
 
         var validationResult = await validator.ValidateAsync(body, cancellationToken);
         if (!validationResult.IsValid)
         {
-            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors, cancellationToken: cancellationToken);
         }
 
         var schools = await service.SchoolsSuggestAsync(body, cancellationToken);
-        return await req.CreateJsonResponseAsync(schools);
+        return await req.CreateJsonResponseAsync(schools, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Establishment/Features/Schools/Services/SchoolComparatorsService.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Schools/Services/SchoolComparatorsService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Platform.Api.Establishment.Features.Schools.Models;
@@ -12,7 +13,7 @@ namespace Platform.Api.Establishment.Features.Schools.Services;
 
 public interface ISchoolComparatorsService
 {
-    Task<SchoolComparators> ComparatorsAsync(string urn, SchoolComparatorsRequest request);
+    Task<SchoolComparators> ComparatorsAsync(string urn, SchoolComparatorsRequest request, CancellationToken cancellationToken = default);
 }
 
 [ExcludeFromCodeCoverage]
@@ -20,12 +21,12 @@ public class SchoolComparatorsService(
     [FromKeyedServices(ResourceNames.Search.Indexes.SchoolComparators)] IIndexClient client)
     : SearchService<SchoolComparator>(client), ISchoolComparatorsService
 {
-    public async Task<SchoolComparators> ComparatorsAsync(string urn, SchoolComparatorsRequest request)
+    public async Task<SchoolComparators> ComparatorsAsync(string urn, SchoolComparatorsRequest request, CancellationToken cancellationToken = default)
     {
-        var school = await LookUpAsync(urn);
+        var school = await LookUpAsync(urn, cancellationToken);
 
         var filter = request.FilterExpression(urn);
-        var result = await SearchWithScoreAsync("*", filter, 100000);
+        var result = await SearchWithScoreAsync("*", filter, 100000, cancellationToken);
 
         return new SchoolComparators
         {

--- a/platform/src/apis/Platform.Api.Establishment/Features/Schools/Services/SchoolsService.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Schools/Services/SchoolsService.cs
@@ -14,8 +14,8 @@ namespace Platform.Api.Establishment.Features.Schools.Services;
 public interface ISchoolsService
 {
     Task<SuggestResponse<SchoolSummary>> SchoolsSuggestAsync(SchoolSuggestRequest request, CancellationToken cancellationToken = default);
-    Task<School?> GetAsync(string urn);
-    Task<SearchResponse<SchoolSummary>> SchoolsSearchAsync(SearchRequest request);
+    Task<School?> GetAsync(string urn, CancellationToken cancellationToken = default);
+    Task<SearchResponse<SchoolSummary>> SchoolsSearchAsync(SearchRequest request, CancellationToken cancellationToken = default);
 }
 
 [ExcludeFromCodeCoverage]
@@ -24,13 +24,13 @@ public class SchoolsService(
     IDatabaseFactory dbFactory)
     : SearchService<SchoolSummary>(client), ISchoolsService
 {
-    public async Task<School?> GetAsync(string urn)
+    public async Task<School?> GetAsync(string urn, CancellationToken cancellationToken = default)
     {
         var schoolBuilder = new SchoolQuery()
             .WhereUrnEqual(urn);
 
         using var conn = await dbFactory.GetConnection();
-        var school = await conn.QueryFirstOrDefaultAsync<School>(schoolBuilder);
+        var school = await conn.QueryFirstOrDefaultAsync<School>(schoolBuilder, cancellationToken);
 
         if (school == null || string.IsNullOrEmpty(school.FederationLeadURN))
         {
@@ -40,30 +40,17 @@ public class SchoolsService(
         var childSchoolsBuilder = new SchoolQuery()
             .WhereFederationLeadUrnEqual(urn);
 
-        school.FederationSchools = await conn.QueryAsync<School>(childSchoolsBuilder);
+        school.FederationSchools = await conn.QueryAsync<School>(childSchoolsBuilder, cancellationToken);
 
         return school;
     }
 
     public Task<SuggestResponse<SchoolSummary>> SchoolsSuggestAsync(SchoolSuggestRequest request, CancellationToken cancellationToken = default)
     {
-        var fields = new[]
-        {
-            nameof(SchoolSummary.SchoolName),
-            nameof(SchoolSummary.URN),
-            nameof(SchoolSummary.AddressStreet),
-            nameof(SchoolSummary.AddressLocality),
-            nameof(SchoolSummary.AddressLine3),
-            nameof(SchoolSummary.AddressTown),
-            nameof(SchoolSummary.AddressCounty),
-            nameof(SchoolSummary.AddressPostcode)
-        };
+        var fields = new[] { nameof(SchoolSummary.SchoolName), nameof(SchoolSummary.URN), nameof(SchoolSummary.AddressStreet), nameof(SchoolSummary.AddressLocality), nameof(SchoolSummary.AddressLine3), nameof(SchoolSummary.AddressTown), nameof(SchoolSummary.AddressCounty), nameof(SchoolSummary.AddressPostcode) };
 
         return SuggestAsync(request, request.FilterExpression, fields, cancellationToken);
     }
 
-    public Task<SearchResponse<SchoolSummary>> SchoolsSearchAsync(SearchRequest request)
-    {
-        return SearchAsync(request, request.FilterExpression);
-    }
+    public Task<SearchResponse<SchoolSummary>> SchoolsSearchAsync(SearchRequest request, CancellationToken cancellationToken = default) => SearchAsync(request, request.FilterExpression, cancellationToken: cancellationToken);
 }

--- a/platform/src/apis/Platform.Api.Establishment/Features/Trusts/GetTrustFunction.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Trusts/GetTrustFunction.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -20,16 +21,16 @@ public class GetTrustFunction(ITrustsService service)
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(Trust))]
     [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.Trust)]
-        HttpRequestData req,
-        string identifier)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.Trust)] HttpRequestData req,
+        string identifier,
+        CancellationToken cancellationToken = default)
     {
-        var response = await service.GetAsync(identifier);
+        var response = await service.GetAsync(identifier, cancellationToken);
         if (response == null)
         {
             return req.CreateNotFoundResponse();
         }
 
-        return await req.CreateJsonResponseAsync(response);
+        return await req.CreateJsonResponseAsync(response, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Establishment/Features/Trusts/PostTrustComparatorsFunction.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Trusts/PostTrustComparatorsFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -22,12 +23,12 @@ public class PostTrustComparatorsFunction(ITrustComparatorsService service)
     [OpenApiRequestBody(ContentType.ApplicationJson, typeof(TrustComparatorsRequest), Description = "The comparator characteristics object")]
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(TrustComparators))]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Post, Route = Routes.TrustComparators)]
-        HttpRequestData req,
-        string identifier)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Post, Route = Routes.TrustComparators)] HttpRequestData req,
+        string identifier,
+        CancellationToken cancellationToken = default)
     {
-        var body = await req.ReadAsJsonAsync<TrustComparatorsRequest>();
-        var comparators = await service.ComparatorsAsync(identifier, body);
-        return await req.CreateJsonResponseAsync(comparators);
+        var body = await req.ReadAsJsonAsync<TrustComparatorsRequest>(cancellationToken: cancellationToken);
+        var comparators = await service.ComparatorsAsync(identifier, body, cancellationToken);
+        return await req.CreateJsonResponseAsync(comparators, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Establishment/Features/Trusts/PostTrustsSearchFunction.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Trusts/PostTrustsSearchFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentValidation;
 using Microsoft.Azure.Functions.Worker;
@@ -25,17 +26,18 @@ public class PostTrustsSearchFunction(
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(SearchResponse<TrustSummary>))]
     [OpenApiResponseWithBody(HttpStatusCode.BadRequest, ContentType.ApplicationJson, typeof(ValidationError[]))]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Post, Route = Routes.TrustsSearch)] HttpRequestData req)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Post, Route = Routes.TrustsSearch)] HttpRequestData req,
+        CancellationToken cancellationToken = default)
     {
-        var body = await req.ReadAsJsonAsync<SearchRequest>();
+        var body = await req.ReadAsJsonAsync<SearchRequest>(cancellationToken: cancellationToken);
 
-        var validationResult = await validator.ValidateAsync(body);
+        var validationResult = await validator.ValidateAsync(body, cancellationToken);
         if (!validationResult.IsValid)
         {
-            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors, cancellationToken: cancellationToken);
         }
 
-        var trusts = await service.TrustsSearchAsync(body);
-        return await req.CreateJsonResponseAsync(trusts);
+        var trusts = await service.TrustsSearchAsync(body, cancellationToken);
+        return await req.CreateJsonResponseAsync(trusts, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Establishment/Features/Trusts/PostTrustsSuggestFunction.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Trusts/PostTrustsSuggestFunction.cs
@@ -24,19 +24,18 @@ public class PostTrustsSuggestFunction(ITrustsService service, IValidator<Sugges
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(SuggestResponse<TrustSummary>))]
     [OpenApiResponseWithBody(HttpStatusCode.BadRequest, ContentType.ApplicationJson, typeof(ValidationError[]))]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Post, Route = Routes.TrustsSuggest)]
-        HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Post, Route = Routes.TrustsSuggest)] HttpRequestData req,
         CancellationToken cancellationToken = default)
     {
-        var body = await req.ReadAsJsonAsync<TrustSuggestRequest>();
+        var body = await req.ReadAsJsonAsync<TrustSuggestRequest>(cancellationToken: cancellationToken);
 
         var validationResult = await validator.ValidateAsync(body, cancellationToken);
         if (!validationResult.IsValid)
         {
-            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors, cancellationToken: cancellationToken);
         }
 
         var trusts = await service.TrustsSuggestAsync(body, cancellationToken);
-        return await req.CreateJsonResponseAsync(trusts);
+        return await req.CreateJsonResponseAsync(trusts, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Establishment/Features/Trusts/Services/TrustComparatorsService.cs
+++ b/platform/src/apis/Platform.Api.Establishment/Features/Trusts/Services/TrustComparatorsService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Platform.Api.Establishment.Features.Trusts.Models;
@@ -11,7 +12,7 @@ namespace Platform.Api.Establishment.Features.Trusts.Services;
 
 public interface ITrustComparatorsService
 {
-    Task<TrustComparators> ComparatorsAsync(string companyNumber, TrustComparatorsRequest request);
+    Task<TrustComparators> ComparatorsAsync(string companyNumber, TrustComparatorsRequest request, CancellationToken cancellationToken = default);
 }
 
 //TODO : Lookup target trust and add comparators ordering
@@ -20,13 +21,13 @@ public class TrustComparatorsService(
     [FromKeyedServices(ResourceNames.Search.Indexes.TrustComparators)] IIndexClient client)
     : SearchService<TrustComparator>(client), ITrustComparatorsService
 {
-    public async Task<TrustComparators> ComparatorsAsync(string companyNumber, TrustComparatorsRequest request)
+    public async Task<TrustComparators> ComparatorsAsync(string companyNumber, TrustComparatorsRequest request, CancellationToken cancellationToken = default)
     {
         //var trust = await connection.LookUpAsync(request.Target);
 
         var filter = request.FilterExpression(companyNumber);
         var search = request.SearchExpression();
-        var result = await SearchWithScoreAsync(search, filter, 100000);
+        var result = await SearchWithScoreAsync(search, filter, 100000, cancellationToken);
 
         return new TrustComparators
         {

--- a/platform/src/apis/Platform.Api.Insight/Features/Balance/GetBalanceSchoolFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Balance/GetBalanceSchoolFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -20,13 +21,13 @@ public class GetBalanceSchoolFunction(IBalanceService service)
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(BalanceSchoolResponse))]
     [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.School)]
-        HttpRequestData req,
-        string urn)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.School)] HttpRequestData req,
+        string urn,
+        CancellationToken cancellationToken = default)
     {
-        var result = await service.GetSchoolAsync(urn);
+        var result = await service.GetSchoolAsync(urn, cancellationToken);
         return result == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(result.MapToApiResponse());
+            : await req.CreateJsonResponseAsync(result.MapToApiResponse(), cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Balance/GetBalanceSchoolHistoryFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Balance/GetBalanceSchoolHistoryFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -25,15 +26,15 @@ public class GetBalanceSchoolHistoryFunction(IBalanceService service)
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(BalanceHistoryResponse))]
     [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.SchoolHistory)]
-        HttpRequestData req,
-        string urn)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.SchoolHistory)] HttpRequestData req,
+        string urn,
+        CancellationToken cancellationToken = default)
     {
         var queryParams = req.GetParameters<BalanceParameters>();
 
-        var (years, rows) = await service.GetSchoolHistoryAsync(urn, queryParams.Dimension);
+        var (years, rows) = await service.GetSchoolHistoryAsync(urn, queryParams.Dimension, cancellationToken);
         return years == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(years.MapToApiResponse(rows));
+            : await req.CreateJsonResponseAsync(years.MapToApiResponse(rows), cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Balance/GetBalanceTrustFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Balance/GetBalanceTrustFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -20,13 +21,13 @@ public class GetBalanceTrustFunction(IBalanceService service)
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(BalanceTrustResponse))]
     [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.Trust)]
-        HttpRequestData req,
-        string companyNumber)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.Trust)] HttpRequestData req,
+        string companyNumber,
+        CancellationToken cancellationToken = default)
     {
-        var result = await service.GetTrustAsync(companyNumber);
+        var result = await service.GetTrustAsync(companyNumber, cancellationToken);
         return result == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(result.MapToApiResponse());
+            : await req.CreateJsonResponseAsync(result.MapToApiResponse(), cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Balance/GetBalanceTrustHistoryFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Balance/GetBalanceTrustHistoryFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -24,15 +25,15 @@ public class GetBalanceTrustHistoryFunction(IBalanceService service)
     [OpenApiParameter("dimension", In = ParameterLocation.Query, Description = "Dimension for response values", Type = typeof(string), Example = typeof(ExampleDimensionFinance))]
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(BalanceHistoryResponse))]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.TrustHistory)]
-        HttpRequestData req,
-        string companyNumber)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.TrustHistory)] HttpRequestData req,
+        string companyNumber,
+        CancellationToken cancellationToken = default)
     {
         var queryParams = req.GetParameters<BalanceParameters>();
 
-        var (years, rows) = await service.GetTrustHistoryAsync(companyNumber, queryParams.Dimension);
+        var (years, rows) = await service.GetTrustHistoryAsync(companyNumber, queryParams.Dimension, cancellationToken);
         return years == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(years.MapToApiResponse(rows));
+            : await req.CreateJsonResponseAsync(years.MapToApiResponse(rows), cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Balance/GetBalanceTrustsFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Balance/GetBalanceTrustsFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -25,12 +26,12 @@ public class GetBalanceTrustsFunction(IBalanceService service)
     [OpenApiParameter("dimension", In = ParameterLocation.Query, Description = "Value dimension", Type = typeof(string), Required = true, Example = typeof(ExampleDimensionFinance))]
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(BalanceTrustResponse[]))]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.Trusts)]
-        HttpRequestData req)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.Trusts)] HttpRequestData req,
+        CancellationToken cancellationToken = default)
     {
         var queryParams = req.GetParameters<BalanceQueryTrustsParameters>();
 
-        var result = await service.QueryTrustsAsync(queryParams.Trusts, queryParams.Dimension);
-        return await req.CreateJsonResponseAsync(result.MapToApiResponse());
+        var result = await service.QueryTrustsAsync(queryParams.Trusts, queryParams.Dimension, cancellationToken);
+        return await req.CreateJsonResponseAsync(result.MapToApiResponse(), cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/BudgetForecast/GetBudgetForecastCurrentYearFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/BudgetForecast/GetBudgetForecastCurrentYearFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -24,14 +25,15 @@ public class GetBudgetForecastCurrentYearFunction(IBudgetForecastService service
     [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "get", Route = Routes.CurrentYear)] HttpRequestData req,
-        string companyNumber)
+        string companyNumber,
+        CancellationToken cancellationToken = default)
     {
-        var year = await service.GetBudgetForecastCurrentYearAsync();
+        var year = await service.GetBudgetForecastCurrentYearAsync(cancellationToken);
         if (year == null)
         {
             return req.CreateNotFoundResponse();
         }
 
-        return await req.CreateJsonResponseAsync(year);
+        return await req.CreateJsonResponseAsync(year, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/BudgetForecast/GetBudgetForecastMetricsFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/BudgetForecast/GetBudgetForecastMetricsFunction.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -22,9 +23,10 @@ public class GetBudgetForecastMetricsFunction(IBudgetForecastService service)
     [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "get", Route = Routes.Metrics)] HttpRequestData req,
-        string companyNumber)
+        string companyNumber,
+        CancellationToken cancellationToken = default)
     {
-        var result = await service.GetBudgetForecastReturnMetricsAsync(companyNumber, Pipeline.RunType.Default);
-        return await req.CreateJsonResponseAsync(result.Select(Mapper.MapToApiResponse));
+        var result = await service.GetBudgetForecastReturnMetricsAsync(companyNumber, Pipeline.RunType.Default, cancellationToken);
+        return await req.CreateJsonResponseAsync(result.Select(Mapper.MapToApiResponse), cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/BudgetForecast/GetBudgetForecastReturnFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/BudgetForecast/GetBudgetForecastReturnFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -26,21 +27,15 @@ public class GetBudgetForecastReturnFunction(IBudgetForecastService service)
     [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "get", Route = Routes.Return)] HttpRequestData req,
-        string companyNumber)
+        string companyNumber,
+        CancellationToken cancellationToken = default)
     {
         var queryParams = req.GetParameters<BudgetForecastReturnParameters>();
 
-        var bfr = await service.GetBudgetForecastReturnsAsync(
-            companyNumber,
-            queryParams.RunType,
-            queryParams.Category,
-            queryParams.RunId);
+        var bfr = await service.GetBudgetForecastReturnsAsync(companyNumber, queryParams.RunType, queryParams.Category, queryParams.RunId, cancellationToken);
 
-        var ar = await service.GetActualReturnsAsync(
-            companyNumber,
-            queryParams.Category,
-            queryParams.RunId);
+        var ar = await service.GetActualReturnsAsync(companyNumber, queryParams.Category, queryParams.RunId, cancellationToken);
 
-        return await req.CreateJsonResponseAsync(Mapper.MapToApiResponse(bfr, ar));
+        return await req.CreateJsonResponseAsync(Mapper.MapToApiResponse(bfr, ar), cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Census/GetCensusFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Census/GetCensusFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -20,13 +21,13 @@ public class GetCensusFunction(ICensusService service)
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(CensusResponse))]
     [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.School)]
-        HttpRequestData req,
-        string urn)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.School)] HttpRequestData req,
+        string urn,
+        CancellationToken cancellationToken = default)
     {
-        var result = await service.GetAsync(urn);
+        var result = await service.GetAsync(urn, cancellationToken);
         return result == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(result.MapToApiResponse());
+            : await req.CreateJsonResponseAsync(result.MapToApiResponse(), cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Census/GetCensusHistoryComparatorSetAverageFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Census/GetCensusHistoryComparatorSetAverageFunction.cs
@@ -26,22 +26,21 @@ public class GetCensusHistoryComparatorSetAverageFunctions(ICensusService servic
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(CensusHistoryResponse))]
     [OpenApiResponseWithBody(HttpStatusCode.BadRequest, ContentType.ApplicationJson, typeof(ValidationError[]))]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.SchoolHistoryComparatorSetAverage)]
-        HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.SchoolHistoryComparatorSetAverage)] HttpRequestData req,
         string urn,
-        CancellationToken token)
+        CancellationToken cancellationToken = default)
     {
         var queryParams = req.GetParameters<CensusParameters>();
 
-        var validationResult = await validator.ValidateAsync(queryParams, token);
+        var validationResult = await validator.ValidateAsync(queryParams, cancellationToken);
         if (!validationResult.IsValid)
         {
-            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors, cancellationToken: cancellationToken);
         }
 
-        var (years, rows) = await service.GetComparatorAveHistoryAsync(urn, queryParams.Dimension, token);
+        var (years, rows) = await service.GetComparatorAveHistoryAsync(urn, queryParams.Dimension, cancellationToken);
         return years == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(years.MapToApiResponse(rows));
+            : await req.CreateJsonResponseAsync(years.MapToApiResponse(rows), cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Census/GetCensusHistoryFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Census/GetCensusHistoryFunction.cs
@@ -27,22 +27,21 @@ public class GetCensusHistoryFunction(ICensusService service, IValidator<CensusP
     [OpenApiResponseWithBody(HttpStatusCode.BadRequest, ContentType.ApplicationJson, typeof(ValidationError[]))]
     [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.SchoolHistory)]
-        HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.SchoolHistory)] HttpRequestData req,
         string urn,
-        CancellationToken token)
+        CancellationToken cancellationToken = default)
     {
         var queryParams = req.GetParameters<CensusParameters>();
 
-        var validationResult = await validator.ValidateAsync(queryParams, token);
+        var validationResult = await validator.ValidateAsync(queryParams, cancellationToken);
         if (!validationResult.IsValid)
         {
-            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors, cancellationToken: cancellationToken);
         }
 
-        var (years, rows) = await service.GetSchoolHistoryAsync(urn, queryParams.Dimension, token);
+        var (years, rows) = await service.GetSchoolHistoryAsync(urn, queryParams.Dimension, cancellationToken);
         return years == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(years.MapToApiResponse(rows));
+            : await req.CreateJsonResponseAsync(years.MapToApiResponse(rows), cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Census/GetCensusHistoryNationalAverageFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Census/GetCensusHistoryNationalAverageFunction.cs
@@ -28,22 +28,21 @@ public class GetCensusHistoryNationalAverageFunction(ICensusService service, IVa
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(CensusHistoryResponse))]
     [OpenApiResponseWithBody(HttpStatusCode.BadRequest, ContentType.ApplicationJson, typeof(ValidationError[]))]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.SchoolHistoryNationalAverage)]
-        HttpRequestData req,
-        CancellationToken token)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.SchoolHistoryNationalAverage)] HttpRequestData req,
+        CancellationToken cancellationToken = default)
     {
         var queryParams = req.GetParameters<CensusNationalAvgParameters>();
 
-        var validationResult = await validator.ValidateAsync(queryParams, token);
+        var validationResult = await validator.ValidateAsync(queryParams, cancellationToken);
         if (!validationResult.IsValid)
         {
-            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors, cancellationToken: cancellationToken);
         }
 
         var (years, rows) = await service.GetNationalAvgHistoryAsync(queryParams.OverallPhase, queryParams.FinanceType,
-            queryParams.Dimension, token);
+            queryParams.Dimension, cancellationToken);
         return years == null
-            ? await req.CreateJsonResponseAsync(new CensusHistoryResponse())
-            : await req.CreateJsonResponseAsync(years.MapToApiResponse(rows));
+            ? await req.CreateJsonResponseAsync(new CensusHistoryResponse(), cancellationToken: cancellationToken)
+            : await req.CreateJsonResponseAsync(years.MapToApiResponse(rows), cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Census/Services/CensusService.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Census/Services/CensusService.cs
@@ -14,10 +14,10 @@ namespace Platform.Api.Insight.Features.Census.Services;
 
 public interface ICensusService
 {
-    Task<CensusSchoolModel?> GetAsync(string urn);
+    Task<CensusSchoolModel?> GetAsync(string urn, CancellationToken cancellationToken = default);
     Task<(YearsModel?, IEnumerable<CensusHistoryModel>)> GetSchoolHistoryAsync(string urn, string dimension, CancellationToken cancellationToken = default);
-    Task<CensusSchoolModel?> GetCustomAsync(string urn, string identifier, string dimension);
-    Task<IEnumerable<CensusSchoolModel>> QueryAsync(string[] urns, string? companyNumber, string? laCode, string? phase, string dimension);
+    Task<CensusSchoolModel?> GetCustomAsync(string urn, string identifier, string dimension, CancellationToken cancellationToken = default);
+    Task<IEnumerable<CensusSchoolModel>> QueryAsync(string[] urns, string? companyNumber, string? laCode, string? phase, string dimension, CancellationToken cancellationToken = default);
     Task<(YearsModel?, IEnumerable<CensusHistoryModel>)> GetComparatorAveHistoryAsync(string urn, string dimension, CancellationToken cancellationToken = default);
     Task<(YearsModel?, IEnumerable<CensusHistoryModel>)> GetNationalAvgHistoryAsync(string overallPhase, string financeType, string dimension, CancellationToken cancellationToken = default);
 }
@@ -25,13 +25,13 @@ public interface ICensusService
 [ExcludeFromCodeCoverage]
 public class CensusService(IDatabaseFactory dbFactory, ICacheKeyFactory cacheKeyFactory, IDistributedCache cache) : ICensusService
 {
-    public async Task<CensusSchoolModel?> GetAsync(string urn)
+    public async Task<CensusSchoolModel?> GetAsync(string urn, CancellationToken cancellationToken = default)
     {
         var builder = new CensusSchoolDefaultCurrentQuery(Dimensions.Census.Total)
             .WhereUrnEqual(urn);
 
         using var conn = await dbFactory.GetConnection();
-        return await conn.QueryFirstOrDefaultAsync<CensusSchoolModel>(builder);
+        return await conn.QueryFirstOrDefaultAsync<CensusSchoolModel>(builder, cancellationToken);
     }
 
     public async Task<(YearsModel?, IEnumerable<CensusHistoryModel>)> GetSchoolHistoryAsync(string urn, string dimension, CancellationToken cancellationToken = default)
@@ -41,7 +41,7 @@ public class CensusService(IDatabaseFactory dbFactory, ICacheKeyFactory cacheKey
 
         if (years == null)
         {
-            return (null, Array.Empty<CensusHistoryModel>());
+            return (null, []);
         }
 
         var historyBuilder = new CensusSchoolDefaultQuery(dimension)
@@ -51,17 +51,17 @@ public class CensusService(IDatabaseFactory dbFactory, ICacheKeyFactory cacheKey
         return (years, await conn.QueryAsync<CensusHistoryModel>(historyBuilder, cancellationToken));
     }
 
-    public async Task<CensusSchoolModel?> GetCustomAsync(string urn, string identifier, string dimension)
+    public async Task<CensusSchoolModel?> GetCustomAsync(string urn, string identifier, string dimension, CancellationToken cancellationToken = default)
     {
         var builder = new CensusSchoolCustomQuery(dimension)
             .WhereUrnEqual(urn)
             .WhereRunIdEqual(identifier);
 
         using var conn = await dbFactory.GetConnection();
-        return await conn.QueryFirstOrDefaultAsync<CensusSchoolModel>(builder);
+        return await conn.QueryFirstOrDefaultAsync<CensusSchoolModel>(builder, cancellationToken);
     }
 
-    public async Task<IEnumerable<CensusSchoolModel>> QueryAsync(string[] urns, string? companyNumber, string? laCode, string? phase, string dimension)
+    public async Task<IEnumerable<CensusSchoolModel>> QueryAsync(string[] urns, string? companyNumber, string? laCode, string? phase, string dimension, CancellationToken cancellationToken = default)
     {
         var builder = new CensusSchoolDefaultCurrentQuery(dimension);
         if (urns.Length != 0)
@@ -86,7 +86,7 @@ public class CensusService(IDatabaseFactory dbFactory, ICacheKeyFactory cacheKey
         }
 
         using var conn = await dbFactory.GetConnection();
-        return await conn.QueryAsync<CensusSchoolModel>(builder);
+        return await conn.QueryAsync<CensusSchoolModel>(builder, cancellationToken);
     }
 
     public async Task<(YearsModel?, IEnumerable<CensusHistoryModel>)> GetComparatorAveHistoryAsync(string urn, string dimension, CancellationToken cancellationToken = default)
@@ -96,7 +96,7 @@ public class CensusService(IDatabaseFactory dbFactory, ICacheKeyFactory cacheKey
 
         if (years == null)
         {
-            return (null, Array.Empty<CensusHistoryModel>());
+            return (null, []);
         }
 
         var historyBuilder = new CensusSchoolDefaultComparatorAveQuery(dimension)
@@ -113,7 +113,7 @@ public class CensusService(IDatabaseFactory dbFactory, ICacheKeyFactory cacheKey
 
         if (years == null)
         {
-            return (null, Array.Empty<CensusHistoryModel>());
+            return (null, []);
         }
 
         var cacheKey = cacheKeyFactory.CreateCensusHistoryNationalAverageCacheKey(years.EndYear, overallPhase, financeType, dimension);
@@ -121,7 +121,7 @@ public class CensusService(IDatabaseFactory dbFactory, ICacheKeyFactory cacheKey
         return (years, history);
     }
 
-    private static async Task<IEnumerable<CensusHistoryModel>> GetNationalAvgHistoryAsync(IDatabaseConnection conn, YearsModel years, string overallPhase, string financeType, string dimension, CancellationToken cancellationToken)
+    private static async Task<IEnumerable<CensusHistoryModel>> GetNationalAvgHistoryAsync(IDatabaseConnection conn, YearsModel years, string overallPhase, string financeType, string dimension, CancellationToken cancellationToken = default)
     {
         var historyBuilder = new CensusSchoolDefaultNationalAveQuery(dimension)
             .WhereOverallPhaseEqual(overallPhase)

--- a/platform/src/apis/Platform.Api.Insight/Features/Expenditure/GetExpenditureSchoolCustomFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Expenditure/GetExpenditureSchoolCustomFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentValidation;
 using Microsoft.Azure.Functions.Worker;
@@ -28,22 +29,22 @@ public class GetExpenditureSchoolCustomFunction(IExpenditureService service, IVa
     [OpenApiResponseWithBody(HttpStatusCode.BadRequest, ContentType.ApplicationJson, typeof(ValidationError[]))]
     [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.SchoolCustom)]
-        HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.SchoolCustom)] HttpRequestData req,
         string urn,
-        string identifier)
+        string identifier,
+        CancellationToken cancellationToken = default)
     {
         var queryParams = req.GetParameters<ExpenditureParameters>();
 
-        var validationResult = await validator.ValidateAsync(queryParams);
+        var validationResult = await validator.ValidateAsync(queryParams, cancellationToken);
         if (!validationResult.IsValid)
         {
-            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors, cancellationToken: cancellationToken);
         }
 
-        var result = await service.GetCustomSchoolAsync(urn, identifier, queryParams.Dimension);
+        var result = await service.GetCustomSchoolAsync(urn, identifier, queryParams.Dimension, cancellationToken);
         return result == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(result.MapToApiResponse(queryParams.Category));
+            : await req.CreateJsonResponseAsync(result.MapToApiResponse(queryParams.Category), cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Expenditure/GetExpenditureSchoolFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Expenditure/GetExpenditureSchoolFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentValidation;
 using Microsoft.Azure.Functions.Worker;
@@ -27,21 +28,21 @@ public class GetExpenditureSchoolFunction(IExpenditureService service, IValidato
     [OpenApiResponseWithBody(HttpStatusCode.BadRequest, ContentType.ApplicationJson, typeof(ValidationError[]))]
     [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.School)]
-        HttpRequestData req,
-        string urn)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.School)] HttpRequestData req,
+        string urn,
+        CancellationToken cancellationToken = default)
     {
         var queryParams = req.GetParameters<ExpenditureParameters>();
 
-        var validationResult = await validator.ValidateAsync(queryParams);
+        var validationResult = await validator.ValidateAsync(queryParams, cancellationToken);
         if (!validationResult.IsValid)
         {
-            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors, cancellationToken: cancellationToken);
         }
 
-        var result = await service.GetSchoolAsync(urn, queryParams.Dimension);
+        var result = await service.GetSchoolAsync(urn, queryParams.Dimension, cancellationToken);
         return result == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(result.MapToApiResponse(queryParams.Category));
+            : await req.CreateJsonResponseAsync(result.MapToApiResponse(queryParams.Category), cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Expenditure/GetExpenditureSchoolHistoryComparatorSetAverageFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Expenditure/GetExpenditureSchoolHistoryComparatorSetAverageFunction.cs
@@ -27,22 +27,21 @@ public class GetExpenditureSchoolHistoryComparatorSetAverageFunction(IExpenditur
     [OpenApiResponseWithBody(HttpStatusCode.BadRequest, ContentType.ApplicationJson, typeof(ValidationError[]))]
     [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.SchoolHistoryComparatorSetAverage)]
-        HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.SchoolHistoryComparatorSetAverage)] HttpRequestData req,
         string urn,
-        CancellationToken token)
+        CancellationToken cancellationToken = default)
     {
         var queryParams = req.GetParameters<ExpenditureParameters>();
 
-        var validationResult = await validator.ValidateAsync(queryParams, token);
+        var validationResult = await validator.ValidateAsync(queryParams, cancellationToken);
         if (!validationResult.IsValid)
         {
-            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors, cancellationToken: cancellationToken);
         }
 
-        var (years, rows) = await service.GetComparatorAveHistoryAsync(urn, queryParams.Dimension, token);
+        var (years, rows) = await service.GetComparatorAveHistoryAsync(urn, queryParams.Dimension, cancellationToken);
         return years == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(years.MapToApiResponse(rows));
+            : await req.CreateJsonResponseAsync(years.MapToApiResponse(rows), cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Expenditure/GetExpenditureSchoolHistoryFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Expenditure/GetExpenditureSchoolHistoryFunction.cs
@@ -27,22 +27,21 @@ public class GetExpenditureSchoolHistoryFunction(IExpenditureService service, IV
     [OpenApiResponseWithBody(HttpStatusCode.BadRequest, ContentType.ApplicationJson, typeof(ValidationError[]))]
     [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.SchoolHistory)]
-        HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.SchoolHistory)] HttpRequestData req,
         string urn,
-        CancellationToken token)
+        CancellationToken cancellationToken = default)
     {
         var queryParams = req.GetParameters<ExpenditureParameters>();
 
-        var validationResult = await validator.ValidateAsync(queryParams, token);
+        var validationResult = await validator.ValidateAsync(queryParams, cancellationToken);
         if (!validationResult.IsValid)
         {
-            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors, cancellationToken: cancellationToken);
         }
 
-        var (years, rows) = await service.GetSchoolHistoryAsync(urn, queryParams.Dimension, token);
+        var (years, rows) = await service.GetSchoolHistoryAsync(urn, queryParams.Dimension, cancellationToken);
         return years == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(years.MapToApiResponse(rows));
+            : await req.CreateJsonResponseAsync(years.MapToApiResponse(rows), cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Expenditure/GetExpenditureSchoolHistoryNationalAverageFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Expenditure/GetExpenditureSchoolHistoryNationalAverageFunction.cs
@@ -29,22 +29,21 @@ public class GetExpenditureSchoolHistoryNationalAverageFunction(IExpenditureServ
     [OpenApiResponseWithBody(HttpStatusCode.BadRequest, ContentType.ApplicationJson, typeof(ValidationError[]))]
     [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.SchoolHistoryNationalAverage)]
-        HttpRequestData req,
-        CancellationToken token)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.SchoolHistoryNationalAverage)] HttpRequestData req,
+        CancellationToken cancellationToken = default)
     {
         var queryParams = req.GetParameters<ExpenditureNationalAvgParameters>();
 
-        var validationResult = await validator.ValidateAsync(queryParams, token);
+        var validationResult = await validator.ValidateAsync(queryParams, cancellationToken);
         if (!validationResult.IsValid)
         {
-            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors, cancellationToken: cancellationToken);
         }
 
         var (years, rows) = await service.GetNationalAvgHistoryAsync(queryParams.OverallPhase, queryParams.FinanceType,
-            queryParams.Dimension, token);
+            queryParams.Dimension, cancellationToken);
         return years == null
-            ? await req.CreateJsonResponseAsync(new ExpenditureHistoryResponse())
-            : await req.CreateJsonResponseAsync(years.MapToApiResponse(rows));
+            ? await req.CreateJsonResponseAsync(new ExpenditureHistoryResponse(), cancellationToken: cancellationToken)
+            : await req.CreateJsonResponseAsync(years.MapToApiResponse(rows), cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Expenditure/GetExpenditureTrustFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Expenditure/GetExpenditureTrustFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentValidation;
 using Microsoft.Azure.Functions.Worker;
@@ -27,21 +28,21 @@ public class GetExpenditureTrustFunction(IExpenditureService service, IValidator
     [OpenApiResponseWithBody(HttpStatusCode.BadRequest, ContentType.ApplicationJson, typeof(ValidationError[]))]
     [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.Trust)]
-        HttpRequestData req,
-        string companyNumber)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.Trust)] HttpRequestData req,
+        string companyNumber,
+        CancellationToken cancellationToken = default)
     {
         var queryParams = req.GetParameters<ExpenditureParameters>();
 
-        var validationResult = await validator.ValidateAsync(queryParams);
+        var validationResult = await validator.ValidateAsync(queryParams, cancellationToken);
         if (!validationResult.IsValid)
         {
-            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors, cancellationToken: cancellationToken);
         }
 
-        var result = await service.GetTrustAsync(companyNumber, queryParams.Dimension);
+        var result = await service.GetTrustAsync(companyNumber, queryParams.Dimension, cancellationToken);
         return result == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(result.MapToApiResponse(queryParams.Category));
+            : await req.CreateJsonResponseAsync(result.MapToApiResponse(queryParams.Category), cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Files/GetTransparencyFilesFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Files/GetTransparencyFilesFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -18,9 +19,10 @@ public class GetTransparencyFilesFunction(IFilesService service)
     [OpenApiOperation(nameof(GetTransparencyFilesFunction), Constants.Features.Files)]
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(FileResponse[]))]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.Transparency)] HttpRequestData req)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.Transparency)] HttpRequestData req,
+        CancellationToken cancellationToken = default)
     {
-        var result = await service.GetActiveFilesByType("transparency-aar", "transparency-cfr");
-        return await req.CreateJsonResponseAsync(result.MapToApiResponse());
+        var result = await service.GetActiveFilesByType(cancellationToken, "transparency-aar", "transparency-cfr");
+        return await req.CreateJsonResponseAsync(result.MapToApiResponse(), cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Files/Services/FilesService.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Files/Services/FilesService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 using Platform.Api.Insight.Features.Files.Models;
 using Platform.Sql;
@@ -9,18 +10,18 @@ namespace Platform.Api.Insight.Features.Files.Services;
 
 public interface IFilesService
 {
-    Task<IEnumerable<FileModel>> GetActiveFilesByType(params string[] types);
+    Task<IEnumerable<FileModel>> GetActiveFilesByType(CancellationToken cancellationToken = default, params string[] types);
 }
 
 [ExcludeFromCodeCoverage]
 public class FilesService(IDatabaseFactory dbFactory) : IFilesService
 {
-    public async Task<IEnumerable<FileModel>> GetActiveFilesByType(params string[] types)
+    public async Task<IEnumerable<FileModel>> GetActiveFilesByType(CancellationToken cancellationToken = default, params string[] types)
     {
         using var conn = await dbFactory.GetConnection();
         var filesBuilder = new ActiveFilesQuery(FileModel.Fields)
             .WhereTypeIn(types);
 
-        return await conn.QueryAsync<FileModel>(filesBuilder);
+        return await conn.QueryAsync<FileModel>(filesBuilder, cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Income/GetIncomeSchoolFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Income/GetIncomeSchoolFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -20,13 +21,13 @@ public class GetIncomeSchoolFunction(IIncomeService service)
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(IncomeSchoolResponse))]
     [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.School)]
-        HttpRequestData req,
-        string urn)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.School)] HttpRequestData req,
+        string urn,
+        CancellationToken cancellationToken = default)
     {
-        var result = await service.GetSchoolAsync(urn);
+        var result = await service.GetSchoolAsync(urn, cancellationToken);
         return result == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(result.MapToApiResponse());
+            : await req.CreateJsonResponseAsync(result.MapToApiResponse(), cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Income/GetIncomeTrustHistoryFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Income/GetIncomeTrustHistoryFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentValidation;
 using Microsoft.Azure.Functions.Worker;
@@ -26,21 +27,21 @@ public class GetIncomeTrustHistoryFunction(IIncomeService service, IValidator<In
     [OpenApiResponseWithBody(HttpStatusCode.BadRequest, ContentType.ApplicationJson, typeof(ValidationError[]))]
     [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.TrustHistory)]
-        HttpRequestData req,
-        string companyNumber)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.TrustHistory)] HttpRequestData req,
+        string companyNumber,
+        CancellationToken cancellationToken = default)
     {
         var queryParams = req.GetParameters<IncomeParameters>();
 
-        var validationResult = await validator.ValidateAsync(queryParams);
+        var validationResult = await validator.ValidateAsync(queryParams, cancellationToken);
         if (!validationResult.IsValid)
         {
-            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors, cancellationToken: cancellationToken);
         }
 
-        var (years, rows) = await service.GetTrustHistoryAsync(companyNumber, queryParams.Dimension);
+        var (years, rows) = await service.GetTrustHistoryAsync(companyNumber, queryParams.Dimension, cancellationToken);
         return years == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(years.MapToApiResponse(rows));
+            : await req.CreateJsonResponseAsync(years.MapToApiResponse(rows), cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Income/Services/IncomeService.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Income/Services/IncomeService.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 using Platform.Api.Insight.Features.Income.Models;
 using Platform.Api.Insight.Shared;
@@ -12,54 +12,54 @@ namespace Platform.Api.Insight.Features.Income.Services;
 
 public interface IIncomeService
 {
-    Task<IncomeSchoolModel?> GetSchoolAsync(string urn);
-    Task<(YearsModel? years, IEnumerable<IncomeHistoryModel> rows)> GetSchoolHistoryAsync(string urn, string dimension);
-    Task<(YearsModel?, IEnumerable<IncomeHistoryModel>)> GetTrustHistoryAsync(string companyNumber, string dimension);
+    Task<IncomeSchoolModel?> GetSchoolAsync(string urn, CancellationToken cancellationToken = default);
+    Task<(YearsModel? years, IEnumerable<IncomeHistoryModel> rows)> GetSchoolHistoryAsync(string urn, string dimension, CancellationToken cancellationToken = default);
+    Task<(YearsModel?, IEnumerable<IncomeHistoryModel>)> GetTrustHistoryAsync(string companyNumber, string dimension, CancellationToken cancellationToken = default);
 }
 
 [ExcludeFromCodeCoverage]
 public class IncomeService(IDatabaseFactory dbFactory) : IIncomeService
 {
-    public async Task<IncomeSchoolModel?> GetSchoolAsync(string urn)
+    public async Task<IncomeSchoolModel?> GetSchoolAsync(string urn, CancellationToken cancellationToken = default)
     {
         var builder = new IncomeSchoolDefaultCurrentQuery(Dimensions.Finance.Actuals)
             .WhereUrnEqual(urn);
 
         using var conn = await dbFactory.GetConnection();
-        return await conn.QueryFirstOrDefaultAsync<IncomeSchoolModel>(builder);
+        return await conn.QueryFirstOrDefaultAsync<IncomeSchoolModel>(builder, cancellationToken);
     }
 
-    public async Task<(YearsModel?, IEnumerable<IncomeHistoryModel>)> GetSchoolHistoryAsync(string urn, string dimension)
+    public async Task<(YearsModel?, IEnumerable<IncomeHistoryModel>)> GetSchoolHistoryAsync(string urn, string dimension, CancellationToken cancellationToken = default)
     {
         using var conn = await dbFactory.GetConnection();
-        var years = await conn.QueryYearsSchoolAsync(urn);
+        var years = await conn.QueryYearsSchoolAsync(urn, cancellationToken);
 
         if (years == null)
         {
-            return (null, Array.Empty<IncomeHistoryModel>());
+            return (null, []);
         }
 
         var historyBuilder = new IncomeSchoolDefaultQuery(dimension)
             .WhereUrnEqual(urn)
             .WhereRunIdBetween(years.StartYear, years.EndYear);
 
-        return (years, await conn.QueryAsync<IncomeHistoryModel>(historyBuilder));
+        return (years, await conn.QueryAsync<IncomeHistoryModel>(historyBuilder, cancellationToken));
     }
 
-    public async Task<(YearsModel?, IEnumerable<IncomeHistoryModel>)> GetTrustHistoryAsync(string companyNumber, string dimension)
+    public async Task<(YearsModel?, IEnumerable<IncomeHistoryModel>)> GetTrustHistoryAsync(string companyNumber, string dimension, CancellationToken cancellationToken = default)
     {
         using var conn = await dbFactory.GetConnection();
-        var years = await conn.QueryYearsTrustAsync(companyNumber);
+        var years = await conn.QueryYearsTrustAsync(companyNumber, cancellationToken);
 
         if (years == null)
         {
-            return (null, Array.Empty<IncomeHistoryModel>());
+            return (null, []);
         }
 
         var historyBuilder = new IncomeTrustDefaultQuery(dimension)
             .WhereCompanyNumberEqual(companyNumber)
             .WhereRunIdBetween(years.StartYear, years.EndYear);
 
-        return (years, await conn.QueryAsync<IncomeHistoryModel>(historyBuilder));
+        return (years, await conn.QueryAsync<IncomeHistoryModel>(historyBuilder, cancellationToken));
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/MetricRagRatings/GetUserDefinedMetricRagRatingsFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/MetricRagRatings/GetUserDefinedMetricRagRatingsFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -23,11 +24,12 @@ public class GetUserDefinedMetricRagRatingsFunction(IMetricRagRatingsService ser
     [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "get", Route = Routes.UserDefined)] HttpRequestData req,
-        string identifier)
+        string identifier,
+        CancellationToken cancellationToken = default)
     {
         var queryParams = req.GetParameters<MetricRagRatingParameters>();
 
-        var result = await service.UserDefinedAsync(identifier, queryParams.DataContext);
-        return await req.CreateJsonResponseAsync(result);
+        var result = await service.UserDefinedAsync(identifier, queryParams.DataContext, cancellationToken: cancellationToken);
+        return await req.CreateJsonResponseAsync(result, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Schools/GetSchoolCharacteristicsFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Schools/GetSchoolCharacteristicsFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -20,11 +21,12 @@ public class GetSchoolCharacteristicsFunction(ISchoolsService service)
     [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, "get", Route = Routes.SchoolCharacteristics)] HttpRequestData req,
-        string urn)
+        string urn,
+        CancellationToken cancellationToken = default)
     {
-        var result = await service.CharacteristicAsync(urn);
+        var result = await service.CharacteristicAsync(urn, cancellationToken);
         return result == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(result);
+            : await req.CreateJsonResponseAsync(result, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Schools/GetSchoolsCharacteristicsFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Schools/GetSchoolsCharacteristicsFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -21,11 +22,12 @@ public class GetSchoolsCharacteristicsFunction(ISchoolsService service)
     [OpenApiResponseWithBody(HttpStatusCode.OK, "application/json", typeof(SchoolCharacteristic[]))]
     [OpenApiResponseWithoutBody(HttpStatusCode.InternalServerError)]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, "get", Route = Routes.SchoolsCharacteristics)] HttpRequestData req)
+        [HttpTrigger(AuthorizationLevel.Admin, "get", Route = Routes.SchoolsCharacteristics)] HttpRequestData req,
+        CancellationToken cancellationToken = default)
     {
         var queryParams = req.GetParameters<SchoolsParameters>();
 
-        var schools = await service.QueryCharacteristicAsync(queryParams.Schools);
-        return await req.CreateJsonResponseAsync(schools);
+        var schools = await service.QueryCharacteristicAsync(queryParams.Schools, cancellationToken);
+        return await req.CreateJsonResponseAsync(schools, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Schools/Services/SchoolsService.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Schools/Services/SchoolsService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Platform.Api.Insight.Features.Schools.Models;
 using Platform.Sql;
@@ -7,13 +8,13 @@ namespace Platform.Api.Insight.Features.Schools.Services;
 
 public interface ISchoolsService
 {
-    Task<IEnumerable<SchoolCharacteristic>> QueryCharacteristicAsync(string[] urns);
-    Task<SchoolCharacteristic?> CharacteristicAsync(string urn);
+    Task<IEnumerable<SchoolCharacteristic>> QueryCharacteristicAsync(string[] urns, CancellationToken cancellationToken = default);
+    Task<SchoolCharacteristic?> CharacteristicAsync(string urn, CancellationToken cancellationToken = default);
 }
 
 public class SchoolsService(IDatabaseFactory dbFactory) : ISchoolsService
 {
-    public async Task<IEnumerable<SchoolCharacteristic>> QueryCharacteristicAsync(string[] urns)
+    public async Task<IEnumerable<SchoolCharacteristic>> QueryCharacteristicAsync(string[] urns, CancellationToken cancellationToken = default)
     {
         using var conn = await dbFactory.GetConnection();
         const string sql = "SELECT * FROM SchoolCharacteristic WHERE URN IN @URNS";
@@ -22,10 +23,10 @@ public class SchoolsService(IDatabaseFactory dbFactory) : ISchoolsService
             URNS = urns
         };
 
-        return await conn.QueryAsync<SchoolCharacteristic>(sql, parameters);
+        return await conn.QueryAsync<SchoolCharacteristic>(sql, parameters, cancellationToken);
     }
 
-    public async Task<SchoolCharacteristic?> CharacteristicAsync(string urn)
+    public async Task<SchoolCharacteristic?> CharacteristicAsync(string urn, CancellationToken cancellationToken = default)
     {
         using var conn = await dbFactory.GetConnection();
         const string sql = "SELECT * FROM SchoolCharacteristic WHERE URN = @URN";
@@ -34,6 +35,6 @@ public class SchoolsService(IDatabaseFactory dbFactory) : ISchoolsService
             URN = urn
         };
 
-        return await conn.QueryFirstOrDefaultAsync<SchoolCharacteristic>(sql, parameters);
+        return await conn.QueryFirstOrDefaultAsync<SchoolCharacteristic>(sql, parameters, cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Trusts/GetTrustsCharacteristicsFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Trusts/GetTrustsCharacteristicsFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -23,12 +24,12 @@ public class GetTrustsCharacteristicsFunction(ITrustsService service)
     [OpenApiParameter("companyNumbers", In = ParameterLocation.Query, Description = "List of trust company numbers", Type = typeof(string[]), Required = true)]
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(TrustCharacteristic[]))]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.Characteristics)]
-        HttpRequestData req)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.Characteristics)] HttpRequestData req,
+        CancellationToken cancellationToken = default)
     {
         var queryParams = req.GetParameters<TrustsParameters>();
 
-        var trusts = await service.QueryAsync(queryParams.Trusts);
-        return await req.CreateJsonResponseAsync(trusts);
+        var trusts = await service.QueryAsync(queryParams.Trusts, cancellationToken);
+        return await req.CreateJsonResponseAsync(trusts, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Trusts/Services/TrustsService.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Trusts/Services/TrustsService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 using Platform.Api.Insight.Features.Trusts.Models;
 using Platform.Sql;
@@ -9,18 +10,18 @@ namespace Platform.Api.Insight.Features.Trusts.Services;
 
 public interface ITrustsService
 {
-    Task<IEnumerable<TrustCharacteristic>> QueryAsync(string[] companyNumbers);
+    Task<IEnumerable<TrustCharacteristic>> QueryAsync(string[] companyNumbers, CancellationToken cancellationToken = default);
 }
 
 [ExcludeFromCodeCoverage]
 public class TrustsService(IDatabaseFactory dbFactory) : ITrustsService
 {
-    public async Task<IEnumerable<TrustCharacteristic>> QueryAsync(string[] companyNumbers)
+    public async Task<IEnumerable<TrustCharacteristic>> QueryAsync(string[] companyNumbers, CancellationToken cancellationToken = default)
     {
         using var conn = await dbFactory.GetConnection();
         var builder = new TrustCharacteristicsQuery()
             .WhereCompanyNumberIn(companyNumbers);
 
-        return await conn.QueryAsync<TrustCharacteristic>(builder);
+        return await conn.QueryAsync<TrustCharacteristic>(builder, cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/Years/GetCurrentReturnYearsFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/Years/GetCurrentReturnYearsFunction.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -19,16 +20,30 @@ public class GetCurrentReturnYearsFunction(IDatabaseFactory dbFactory)
     [OpenApiOperation(nameof(GetCurrentReturnYearsFunction), Constants.Features.Years)]
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(object))]
     public async Task<HttpResponseData> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.CurrentReturn)]
-        HttpRequestData req)
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.CurrentReturn)] HttpRequestData req,
+        CancellationToken cancellationToken = default)
     {
         using var conn = await dbFactory.GetConnection();
         const string sql = "SELECT Value FROM Parameters WHERE Name = @Name";
 
-        var aar = await conn.QueryFirstOrDefaultAsync<string>(sql, new { Name = "LatestAARYear" });
-        var cfr = await conn.QueryFirstOrDefaultAsync<string>(sql, new { Name = "LatestCFRYear" });
-        var s251 = await conn.QueryFirstOrDefaultAsync<string>(sql, new { Name = "LatestS251Year" });
+        var aar = await conn.QueryFirstOrDefaultAsync<string>(sql, new
+        {
+            Name = "LatestAARYear"
+        }, cancellationToken);
+        var cfr = await conn.QueryFirstOrDefaultAsync<string>(sql, new
+        {
+            Name = "LatestCFRYear"
+        }, cancellationToken);
+        var s251 = await conn.QueryFirstOrDefaultAsync<string>(sql, new
+        {
+            Name = "LatestS251Year"
+        }, cancellationToken);
 
-        return await req.CreateJsonResponseAsync(new { aar, cfr, s251 });
+        return await req.CreateJsonResponseAsync(new
+        {
+            aar,
+            cfr,
+            s251
+        }, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Shared/DatabaseExtensions.cs
+++ b/platform/src/apis/Platform.Api.Insight/Shared/DatabaseExtensions.cs
@@ -12,28 +12,28 @@ public static class DatabaseExtensions
     public static async Task<YearsModel?> QueryYearsSchoolAsync(
         this IDatabaseConnection conn,
         string urn,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
         var builder = new YearsSchoolQuery(urn);
-        return await conn.QueryFirstOrDefaultAsync<YearsModel>(builder, token);
+        return await conn.QueryFirstOrDefaultAsync<YearsModel>(builder, cancellationToken);
     }
 
     public static async Task<YearsModel?> QueryYearsTrustAsync(
         this IDatabaseConnection conn,
         string companyNumber,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
         var builder = new YearsTrustQuery(companyNumber);
-        return await conn.QueryFirstOrDefaultAsync<YearsModel>(builder, token);
+        return await conn.QueryFirstOrDefaultAsync<YearsModel>(builder, cancellationToken);
     }
 
     public static async Task<YearsModel?> QueryYearsOverallPhaseAsync(
         this IDatabaseConnection conn,
         string overallPhase,
         string financeType,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
         var builder = new YearsOverallPhaseQuery(overallPhase, financeType);
-        return await conn.QueryFirstOrDefaultAsync<YearsModel>(builder, token);
+        return await conn.QueryFirstOrDefaultAsync<YearsModel>(builder, cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/GetHighNeedsFunction.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/GetHighNeedsFunction.cs
@@ -35,10 +35,10 @@ public class GetHighNeedsFunction(IHighNeedsService service, IValidator<HighNeed
         var validationResult = await validator.ValidateAsync(queryParams, cancellationToken);
         if (!validationResult.IsValid)
         {
-            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors, cancellationToken: cancellationToken);
         }
 
         var highNeeds = await service.Get(queryParams.Codes, queryParams.Dimension, cancellationToken);
-        return await req.CreateJsonResponseAsync(highNeeds);
+        return await req.CreateJsonResponseAsync(highNeeds, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/GetHighNeedsFunction.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/GetHighNeedsFunction.cs
@@ -28,17 +28,17 @@ public class GetHighNeedsFunction(IHighNeedsService service, IValidator<HighNeed
     [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.HighNeeds)] HttpRequestData req,
-        CancellationToken token)
+        CancellationToken cancellationToken = default)
     {
         var queryParams = req.GetParameters<HighNeedsDimensionedParameters>();
 
-        var validationResult = await validator.ValidateAsync(queryParams, token);
+        var validationResult = await validator.ValidateAsync(queryParams, cancellationToken);
         if (!validationResult.IsValid)
         {
             return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
         }
 
-        var highNeeds = await service.Get(queryParams.Codes, queryParams.Dimension, token);
+        var highNeeds = await service.Get(queryParams.Codes, queryParams.Dimension, cancellationToken);
         return await req.CreateJsonResponseAsync(highNeeds);
     }
 }

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/GetHighNeedsHistoryFunction.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/GetHighNeedsHistoryFunction.cs
@@ -35,12 +35,12 @@ public class GetHighNeedsHistoryFunction(IHighNeedsService service, IValidator<H
         var validationResult = await validator.ValidateAsync(queryParams, cancellationToken);
         if (!validationResult.IsValid)
         {
-            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors, cancellationToken: cancellationToken);
         }
 
         var history = await service.GetHistory(queryParams.Codes, queryParams.Dimension, cancellationToken);
         return history == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(history);
+            : await req.CreateJsonResponseAsync(history, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/GetHighNeedsHistoryFunction.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Features/HighNeeds/GetHighNeedsHistoryFunction.cs
@@ -28,17 +28,17 @@ public class GetHighNeedsHistoryFunction(IHighNeedsService service, IValidator<H
     [OpenApiResponseWithoutBody(HttpStatusCode.NotFound)]
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.HighNeedsHistory)] HttpRequestData req,
-        CancellationToken token)
+        CancellationToken cancellationToken = default)
     {
         var queryParams = req.GetParameters<HighNeedsDimensionedParameters>();
 
-        var validationResult = await validator.ValidateAsync(queryParams, token);
+        var validationResult = await validator.ValidateAsync(queryParams, cancellationToken);
         if (!validationResult.IsValid)
         {
             return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
         }
 
-        var history = await service.GetHistory(queryParams.Codes, queryParams.Dimension, token);
+        var history = await service.GetHistory(queryParams.Codes, queryParams.Dimension, cancellationToken);
         return history == null
             ? req.CreateNotFoundResponse()
             : await req.CreateJsonResponseAsync(history);

--- a/platform/src/apis/Platform.Api.LocalAuthorityFinances/Shared/DatabaseExtensions.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthorityFinances/Shared/DatabaseExtensions.cs
@@ -12,9 +12,9 @@ public static class DatabaseExtensions
     public static async Task<YearsModel?> QueryYearsLocalAuthorityAsync(
         this IDatabaseConnection conn,
         string code,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
         var builder = new YearsLocalAuthorityQuery(code);
-        return await conn.QueryFirstOrDefaultAsync<YearsModel>(builder, token);
+        return await conn.QueryFirstOrDefaultAsync<YearsModel>(builder, cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.NonFinancial/Features/EducationHealthCarePlans/GetEducationHealthCarePlansLocalAuthoritiesFunction.cs
+++ b/platform/src/apis/Platform.Api.NonFinancial/Features/EducationHealthCarePlans/GetEducationHealthCarePlansLocalAuthoritiesFunction.cs
@@ -36,10 +36,10 @@ public class GetEducationHealthCarePlansLocalAuthoritiesFunction(
         var validationResult = await validator.ValidateAsync(queryParams, cancellationToken);
         if (!validationResult.IsValid)
         {
-            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors, cancellationToken: cancellationToken);
         }
 
         var result = await service.Get(queryParams.Codes, queryParams.Dimension, cancellationToken);
-        return await req.CreateJsonResponseAsync(result);
+        return await req.CreateJsonResponseAsync(result, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.NonFinancial/Features/EducationHealthCarePlans/GetEducationHealthCarePlansLocalAuthoritiesFunction.cs
+++ b/platform/src/apis/Platform.Api.NonFinancial/Features/EducationHealthCarePlans/GetEducationHealthCarePlansLocalAuthoritiesFunction.cs
@@ -29,17 +29,17 @@ public class GetEducationHealthCarePlansLocalAuthoritiesFunction(
     [OpenApiResponseWithoutBody(HttpStatusCode.BadRequest)]
     public async Task<HttpResponseData> EducationHealthCarePlans(
         [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.LocalAuthorities)] HttpRequestData req,
-        CancellationToken token)
+        CancellationToken cancellationToken = default)
     {
         var queryParams = req.GetParameters<EducationHealthCarePlansDimensionedParameters>();
 
-        var validationResult = await validator.ValidateAsync(queryParams, token);
+        var validationResult = await validator.ValidateAsync(queryParams, cancellationToken);
         if (!validationResult.IsValid)
         {
             return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
         }
 
-        var result = await service.Get(queryParams.Codes, queryParams.Dimension, token);
+        var result = await service.Get(queryParams.Codes, queryParams.Dimension, cancellationToken);
         return await req.CreateJsonResponseAsync(result);
     }
 }

--- a/platform/src/apis/Platform.Api.NonFinancial/Features/EducationHealthCarePlans/GetEducationHealthCarePlansLocalAuthoritiesHistoryFunction.cs
+++ b/platform/src/apis/Platform.Api.NonFinancial/Features/EducationHealthCarePlans/GetEducationHealthCarePlansLocalAuthoritiesHistoryFunction.cs
@@ -36,12 +36,12 @@ public class GetEducationHealthCarePlansLocalAuthoritiesHistoryFunction(
         var validationResult = await validator.ValidateAsync(queryParams, cancellationToken);
         if (!validationResult.IsValid)
         {
-            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
+            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors, cancellationToken: cancellationToken);
         }
 
         var result = await service.GetHistory(queryParams.Codes, queryParams.Dimension, cancellationToken);
         return result == null
             ? req.CreateNotFoundResponse()
-            : await req.CreateJsonResponseAsync(result);
+            : await req.CreateJsonResponseAsync(result, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.NonFinancial/Features/EducationHealthCarePlans/GetEducationHealthCarePlansLocalAuthoritiesHistoryFunction.cs
+++ b/platform/src/apis/Platform.Api.NonFinancial/Features/EducationHealthCarePlans/GetEducationHealthCarePlansLocalAuthoritiesHistoryFunction.cs
@@ -29,17 +29,17 @@ public class GetEducationHealthCarePlansLocalAuthoritiesHistoryFunction(
     [OpenApiResponseWithoutBody(HttpStatusCode.BadRequest)]
     public async Task<HttpResponseData> EducationHealthCarePlans(
         [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.LocalAuthoritiesHistory)] HttpRequestData req,
-        CancellationToken token)
+        CancellationToken cancellationToken = default)
     {
         var queryParams = req.GetParameters<EducationHealthCarePlansDimensionedParameters>();
 
-        var validationResult = await validator.ValidateAsync(queryParams, token);
+        var validationResult = await validator.ValidateAsync(queryParams, cancellationToken);
         if (!validationResult.IsValid)
         {
             return await req.CreateValidationErrorsResponseAsync(validationResult.Errors);
         }
 
-        var result = await service.GetHistory(queryParams.Codes, queryParams.Dimension, token);
+        var result = await service.GetHistory(queryParams.Codes, queryParams.Dimension, cancellationToken);
         return result == null
             ? req.CreateNotFoundResponse()
             : await req.CreateJsonResponseAsync(result);

--- a/platform/src/apis/Platform.Api.NonFinancial/Shared/DatabaseExtensions.cs
+++ b/platform/src/apis/Platform.Api.NonFinancial/Shared/DatabaseExtensions.cs
@@ -12,9 +12,9 @@ public static class DatabaseExtensions
     public static async Task<YearsModel?> QueryYearsLocalAuthorityAsync(
         this IDatabaseConnection conn,
         string code,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
         var builder = new YearsLocalAuthorityQuery(code);
-        return await conn.QueryFirstOrDefaultAsync<YearsModel>(builder, token);
+        return await conn.QueryFirstOrDefaultAsync<YearsModel>(builder, cancellationToken);
     }
 }

--- a/platform/tests/Platform.Benchmark.Tests/ComparatorSets/WhenDeleteSchoolUserDefinedComparatorSetRuns.cs
+++ b/platform/tests/Platform.Benchmark.Tests/ComparatorSets/WhenDeleteSchoolUserDefinedComparatorSetRuns.cs
@@ -26,7 +26,7 @@ public class WhenDeleteSchoolUserDefinedComparatorSetRuns : FunctionsTestBase
         const string runType = "default";
 
         _service
-            .Setup(d => d.UserDefinedSchoolAsync(urn, identifier, runType))
+            .Setup(d => d.UserDefinedSchoolAsync(urn, identifier, runType, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ComparatorSetUserDefinedSchool());
 
         _service
@@ -51,7 +51,7 @@ public class WhenDeleteSchoolUserDefinedComparatorSetRuns : FunctionsTestBase
         const string runType = "default";
 
         _service
-            .Setup(d => d.UserDefinedSchoolAsync(urn, identifier, runType))
+            .Setup(d => d.UserDefinedSchoolAsync(urn, identifier, runType, It.IsAny<CancellationToken>()))
             .ReturnsAsync((ComparatorSetUserDefinedSchool?)null);
 
         _service

--- a/platform/tests/Platform.Benchmark.Tests/ComparatorSets/WhenDeleteTrustUserDefinedComparatorSetRuns.cs
+++ b/platform/tests/Platform.Benchmark.Tests/ComparatorSets/WhenDeleteTrustUserDefinedComparatorSetRuns.cs
@@ -26,7 +26,7 @@ public class WhenDeleteTrustUserDefinedComparatorSetRuns : FunctionsTestBase
         const string runType = "default";
 
         _service
-            .Setup(d => d.UserDefinedTrustAsync(urn, identifier, runType))
+            .Setup(d => d.UserDefinedTrustAsync(urn, identifier, runType, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ComparatorSetUserDefinedTrust());
 
         _service
@@ -51,7 +51,7 @@ public class WhenDeleteTrustUserDefinedComparatorSetRuns : FunctionsTestBase
         const string runType = "default";
 
         _service
-            .Setup(d => d.UserDefinedTrustAsync(urn, identifier, runType))
+            .Setup(d => d.UserDefinedTrustAsync(urn, identifier, runType, It.IsAny<CancellationToken>()))
             .ReturnsAsync((ComparatorSetUserDefinedTrust?)null);
 
         _service

--- a/platform/tests/Platform.Benchmark.Tests/ComparatorSets/WhenGetSchoolCustomComparatorSetRuns.cs
+++ b/platform/tests/Platform.Benchmark.Tests/ComparatorSets/WhenGetSchoolCustomComparatorSetRuns.cs
@@ -25,7 +25,7 @@ public class WhenGetSchoolCustomComparatorSetRuns : FunctionsTestBase
         const string identifier = nameof(identifier);
 
         _service
-            .Setup(d => d.CustomSchoolAsync(identifier, urn))
+            .Setup(d => d.CustomSchoolAsync(identifier, urn, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ComparatorSetSchool());
 
         var response =

--- a/platform/tests/Platform.Benchmark.Tests/ComparatorSets/WhenGetSchoolDefaultComparatorSetRuns.cs
+++ b/platform/tests/Platform.Benchmark.Tests/ComparatorSets/WhenGetSchoolDefaultComparatorSetRuns.cs
@@ -24,7 +24,7 @@ public class WhenGetSchoolDefaultComparatorSetRuns : FunctionsTestBase
         const string urn = nameof(urn);
 
         _service
-            .Setup(d => d.DefaultSchoolAsync(urn))
+            .Setup(d => d.DefaultSchoolAsync(urn, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ComparatorSetSchool());
 
         var response =

--- a/platform/tests/Platform.Benchmark.Tests/ComparatorSets/WhenGetSchoolUserDefinedComparatorSetRuns.cs
+++ b/platform/tests/Platform.Benchmark.Tests/ComparatorSets/WhenGetSchoolUserDefinedComparatorSetRuns.cs
@@ -26,7 +26,7 @@ public class WhenGetSchoolUserDefinedComparatorSetRuns : FunctionsTestBase
         const string runType = "default";
 
         _service
-            .Setup(d => d.UserDefinedSchoolAsync(urn, identifier, runType))
+            .Setup(d => d.UserDefinedSchoolAsync(urn, identifier, runType, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ComparatorSetUserDefinedSchool());
 
         var response =

--- a/platform/tests/Platform.Benchmark.Tests/ComparatorSets/WhenGetTrustUserDefinedComparatorSetRuns.cs
+++ b/platform/tests/Platform.Benchmark.Tests/ComparatorSets/WhenGetTrustUserDefinedComparatorSetRuns.cs
@@ -26,7 +26,7 @@ public class WhenGetTrustUserDefinedComparatorSetRuns : FunctionsTestBase
         const string runType = "default";
 
         _service
-            .Setup(d => d.UserDefinedTrustAsync(urn, identifier, runType))
+            .Setup(d => d.UserDefinedTrustAsync(urn, identifier, runType, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ComparatorSetUserDefinedTrust());
 
         var response =
@@ -45,7 +45,7 @@ public class WhenGetTrustUserDefinedComparatorSetRuns : FunctionsTestBase
         const string runType = "default";
 
         _service
-            .Setup(d => d.UserDefinedTrustAsync(urn, identifier, runType))
+            .Setup(d => d.UserDefinedTrustAsync(urn, identifier, runType, It.IsAny<CancellationToken>()))
             .ReturnsAsync((ComparatorSetUserDefinedTrust?)null);
 
         var response =

--- a/platform/tests/Platform.Benchmark.Tests/ComparatorSets/WhenPostSchoolUserDefinedComparatorSetRuns.cs
+++ b/platform/tests/Platform.Benchmark.Tests/ComparatorSets/WhenPostSchoolUserDefinedComparatorSetRuns.cs
@@ -39,7 +39,7 @@ public class WhenPostSchoolUserDefinedComparatorSetRuns : FunctionsTestBase
                 It.IsAny<ComparatorSetUserDefinedSchool>()));
 
         _service
-            .Setup(d => d.CurrentYearAsync())
+            .Setup(d => d.CurrentYearAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync("2024");
 
         _schoolValidator
@@ -79,7 +79,7 @@ public class WhenPostSchoolUserDefinedComparatorSetRuns : FunctionsTestBase
 
         const int year = 2024;
         _service
-            .Setup(d => d.CurrentYearAsync())
+            .Setup(d => d.CurrentYearAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(year.ToString());
 
         _schoolValidator
@@ -126,7 +126,7 @@ public class WhenPostSchoolUserDefinedComparatorSetRuns : FunctionsTestBase
                 It.IsAny<ComparatorSetUserDefinedSchool>()));
 
         _service
-            .Setup(d => d.CurrentYearAsync())
+            .Setup(d => d.CurrentYearAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync("2024");
 
         _schoolValidator

--- a/platform/tests/Platform.Benchmark.Tests/CustomData/WhenDeleteSchoolCustomDataFunctionRuns.cs
+++ b/platform/tests/Platform.Benchmark.Tests/CustomData/WhenDeleteSchoolCustomDataFunctionRuns.cs
@@ -26,7 +26,7 @@ public class WhenDeleteSchoolCustomDataFunctionRuns : FunctionsTestBase
         const string identifier = nameof(identifier);
 
         _service
-            .Setup(d => d.CustomDataSchoolAsync(urn, identifier))
+            .Setup(d => d.CustomDataSchoolAsync(urn, identifier, It.IsAny<CancellationToken>()))
             .ReturnsAsync(data)
             .Verifiable();
 
@@ -49,7 +49,7 @@ public class WhenDeleteSchoolCustomDataFunctionRuns : FunctionsTestBase
         const string identifier = nameof(identifier);
 
         _service
-            .Setup(d => d.CustomDataSchoolAsync(urn, identifier))
+            .Setup(d => d.CustomDataSchoolAsync(urn, identifier, It.IsAny<CancellationToken>()))
             .ReturnsAsync(data)
             .Verifiable();
 

--- a/platform/tests/Platform.Benchmark.Tests/CustomData/WhenGetSchoolCustomDataFunctionRuns.cs
+++ b/platform/tests/Platform.Benchmark.Tests/CustomData/WhenGetSchoolCustomDataFunctionRuns.cs
@@ -28,7 +28,7 @@ public class WhenGetSchoolCustomDataFunctionRuns : FunctionsTestBase
         var result = _fixture.Create<CustomDataSchool>();
 
         _service
-            .Setup(d => d.CustomDataSchoolAsync(urn, identifier))
+            .Setup(d => d.CustomDataSchoolAsync(urn, identifier, It.IsAny<CancellationToken>()))
             .ReturnsAsync(result);
 
         var response =

--- a/platform/tests/Platform.Benchmark.Tests/CustomData/WhenPostSchoolCustomDataFunctionRuns.cs
+++ b/platform/tests/Platform.Benchmark.Tests/CustomData/WhenPostSchoolCustomDataFunctionRuns.cs
@@ -32,7 +32,7 @@ public class WhenPostSchoolCustomDataFunctionRuns : FunctionsTestBase
 
         const int year = 2024;
         _service
-            .Setup(d => d.CurrentYearAsync())
+            .Setup(d => d.CurrentYearAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(year.ToString());
 
         const string urn = "123321";

--- a/platform/tests/Platform.Benchmark.Tests/FinancialPlans/WhenGetDeploymentPlanFunctionRuns.cs
+++ b/platform/tests/Platform.Benchmark.Tests/FinancialPlans/WhenGetDeploymentPlanFunctionRuns.cs
@@ -25,7 +25,7 @@ public class WhenGetDeploymentPlanFunctionRuns : FunctionsTestBase
         const int year = 2021;
 
         _service
-            .Setup(d => d.DeploymentPlanAsync(urn, year))
+            .Setup(d => d.DeploymentPlanAsync(urn, year, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new FinancialPlanDeployment());
 
         var result = await _function.RunAsync(CreateHttpRequestData(), urn, year);
@@ -41,7 +41,7 @@ public class WhenGetDeploymentPlanFunctionRuns : FunctionsTestBase
         const int year = 2021;
 
         _service
-            .Setup(d => d.DeploymentPlanAsync(urn, year))
+            .Setup(d => d.DeploymentPlanAsync(urn, year, It.IsAny<CancellationToken>()))
             .ReturnsAsync((FinancialPlanDeployment?)null);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), urn, year);

--- a/platform/tests/Platform.Benchmark.Tests/FinancialPlans/WhenGetFinancialPlanFunctionRuns.cs
+++ b/platform/tests/Platform.Benchmark.Tests/FinancialPlans/WhenGetFinancialPlanFunctionRuns.cs
@@ -25,7 +25,7 @@ public class WhenGetFinancialPlanFunctionRuns : FunctionsTestBase
         const int year = 2021;
 
         _service
-            .Setup(d => d.DetailsAsync(urn, year))
+            .Setup(d => d.DetailsAsync(urn, year, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new FinancialPlanDetails());
 
         var result = await _function.RunAsync(CreateHttpRequestData(), urn, year);
@@ -41,7 +41,7 @@ public class WhenGetFinancialPlanFunctionRuns : FunctionsTestBase
         const int year = 2021;
 
         _service
-            .Setup(d => d.DetailsAsync(urn, year))
+            .Setup(d => d.DetailsAsync(urn, year, It.IsAny<CancellationToken>()))
             .ReturnsAsync((FinancialPlanDetails?)null);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), urn, year);

--- a/platform/tests/Platform.Benchmark.Tests/FinancialPlans/WhenGetFinancialPlansRuns.cs
+++ b/platform/tests/Platform.Benchmark.Tests/FinancialPlans/WhenGetFinancialPlansRuns.cs
@@ -33,7 +33,7 @@ public class WhenGetFinancialPlansRuns : FunctionsTestBase
         var data = _fixture.Build<FinancialPlanSummary>().CreateMany();
 
         _service
-            .Setup(d => d.QueryAsync(urns))
+            .Setup(d => d.QueryAsync(urns, It.IsAny<CancellationToken>()))
             .ReturnsAsync(data);
 
         var result = await _function.RunAsync(CreateHttpRequestData(query));

--- a/platform/tests/Platform.Benchmark.Tests/UserData/WhenGetUserDataFunctionRuns.cs
+++ b/platform/tests/Platform.Benchmark.Tests/UserData/WhenGetUserDataFunctionRuns.cs
@@ -45,7 +45,7 @@ public class WhenGetUserDataFunctionRuns : FunctionsTestBase
         var userData = _fixture.CreateMany<Api.Benchmark.Features.UserData.Models.UserData>();
 
         _service
-            .Setup(d => d.QueryAsync(userId, type, status, id, organisationId, organisationType))
+            .Setup(d => d.QueryAsync(userId, type, status, id, organisationId, organisationType, It.IsAny<CancellationToken>()))
             .ReturnsAsync(userData)
             .Verifiable(Times.Once);
 
@@ -86,7 +86,7 @@ public class WhenGetUserDataFunctionRuns : FunctionsTestBase
         Assert.Contains(values, p => p.PropertyName == nameof(UserDataParameters.UserId));
 
         _service
-            .Setup(d => d.QueryAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .Setup(d => d.QueryAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .Verifiable(Times.Never);
     }
 }

--- a/platform/tests/Platform.Establishment.Tests/LocalAuthorities/GetLocalAuthoritiesFunctionTests.cs
+++ b/platform/tests/Platform.Establishment.Tests/LocalAuthorities/GetLocalAuthoritiesFunctionTests.cs
@@ -32,7 +32,7 @@ public class GetLocalAuthoritiesFunctionTests : FunctionsTestBase
     public async Task ShouldReturn200OnValidRequest()
     {
         _service
-            .Setup(d => d.GetAllAsync())
+            .Setup(d => d.GetAllAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(_localAuthorities);
 
         var result = await _function.RunAsync(CreateHttpRequestData());

--- a/platform/tests/Platform.Establishment.Tests/LocalAuthorities/GetLocalAuthorityFunctionTests.cs
+++ b/platform/tests/Platform.Establishment.Tests/LocalAuthorities/GetLocalAuthorityFunctionTests.cs
@@ -13,9 +13,9 @@ namespace Platform.Establishment.Tests.LocalAuthorities;
 
 public class GetLocalAuthorityFunctionTests : FunctionsTestBase
 {
+    private readonly GetLocalAuthorityFunction _function;
     private readonly string _laCode;
     private readonly LocalAuthority _localAuthority;
-    private readonly GetLocalAuthorityFunction _function;
     private readonly Mock<ILocalAuthoritiesService> _service;
 
     public GetLocalAuthorityFunctionTests()
@@ -40,7 +40,7 @@ public class GetLocalAuthorityFunctionTests : FunctionsTestBase
     public async Task ShouldReturn200OnValidRequest()
     {
         _service
-            .Setup(d => d.GetAsync(_laCode))
+            .Setup(d => d.GetAsync(_laCode, It.IsAny<CancellationToken>()))
             .ReturnsAsync(_localAuthority);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), _laCode);
@@ -58,7 +58,7 @@ public class GetLocalAuthorityFunctionTests : FunctionsTestBase
     public async Task ShouldReturn404OnInvalidRequest()
     {
         _service
-            .Setup(d => d.GetAsync(_laCode))
+            .Setup(d => d.GetAsync(_laCode, It.IsAny<CancellationToken>()))
             .ReturnsAsync((LocalAuthority?)null);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), _laCode);

--- a/platform/tests/Platform.Establishment.Tests/LocalAuthorities/GetLocalAuthorityStatisticalNeighboursFunctionTests.cs
+++ b/platform/tests/Platform.Establishment.Tests/LocalAuthorities/GetLocalAuthorityStatisticalNeighboursFunctionTests.cs
@@ -35,7 +35,7 @@ public class GetLocalAuthorityStatisticalNeighboursFunctionTests : FunctionsTest
     public async Task ShouldReturn200OnValidRequest()
     {
         _service
-            .Setup(d => d.GetStatisticalNeighboursAsync(_laCode))
+            .Setup(d => d.GetStatisticalNeighboursAsync(_laCode, It.IsAny<CancellationToken>()))
             .ReturnsAsync(_neighboursResponse);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), _laCode);
@@ -53,7 +53,7 @@ public class GetLocalAuthorityStatisticalNeighboursFunctionTests : FunctionsTest
     public async Task ShouldReturn404OnInvalidRequest()
     {
         _service
-            .Setup(d => d.GetAsync(_laCode))
+            .Setup(d => d.GetAsync(_laCode, It.IsAny<CancellationToken>()))
             .ReturnsAsync((LocalAuthority?)null);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), _laCode);

--- a/platform/tests/Platform.Establishment.Tests/LocalAuthorities/PostLocalAuthoritiesSearchFunctionTests.cs
+++ b/platform/tests/Platform.Establishment.Tests/LocalAuthorities/PostLocalAuthoritiesSearchFunctionTests.cs
@@ -30,7 +30,7 @@ public class PostLocalAuthoritiesSearchFunctionTests : FunctionsTestBase
     public async Task ShouldReturn200OnValidRequest()
     {
         _service
-            .Setup(d => d.LocalAuthoritiesSearchAsync(It.IsAny<SearchRequest>()))
+            .Setup(d => d.LocalAuthoritiesSearchAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new SearchResponse<LocalAuthoritySummary>());
 
         _validator
@@ -68,6 +68,6 @@ public class PostLocalAuthoritiesSearchFunctionTests : FunctionsTestBase
         Assert.Contains(values, p => p.PropertyName == nameof(SearchRequest.SearchText));
 
         _service
-            .Verify(d => d.LocalAuthoritiesSearchAsync(It.IsAny<SearchRequest>()), Times.Never);
+            .Verify(d => d.LocalAuthoritiesSearchAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/platform/tests/Platform.Establishment.Tests/LocalAuthorities/Services/WhenLocalAuthoritiesServiceSearches.cs
+++ b/platform/tests/Platform.Establishment.Tests/LocalAuthorities/Services/WhenLocalAuthoritiesServiceSearches.cs
@@ -33,9 +33,10 @@ public class WhenLocalAuthoritiesServiceSearches
                 "SearchAsync",
                 ItExpr.IsAny<SearchRequest>(),
                 ItExpr.IsAny<Func<string?>>(),
-                ItExpr.IsAny<string[]?>()
+                ItExpr.IsAny<string[]?>(),
+                ItExpr.IsAny<CancellationToken>()
             )
-            .Callback((SearchRequest _, Func<string?> _, string[] facets) =>
+            .Callback((SearchRequest _, Func<string?> _, string[] facets, CancellationToken _) =>
             {
                 capturedFacets = facets;
             })
@@ -58,9 +59,10 @@ public class WhenLocalAuthoritiesServiceSearches
                 "SearchAsync",
                 ItExpr.IsAny<SearchRequest>(),
                 ItExpr.IsAny<Func<string?>>(),
-                ItExpr.IsAny<string[]?>()
+                ItExpr.IsAny<string[]?>(),
+                ItExpr.IsAny<CancellationToken>()
             )
-            .Callback((SearchRequest request, Func<string?> _, string[] _) =>
+            .Callback((SearchRequest request, Func<string?> _, string[] _, CancellationToken _) =>
             {
                 capturedRequest = request;
             })

--- a/platform/tests/Platform.Establishment.Tests/Schools/GetSchoolFunctionTests.cs
+++ b/platform/tests/Platform.Establishment.Tests/Schools/GetSchoolFunctionTests.cs
@@ -25,7 +25,7 @@ public class GetSchoolFunctionTests : FunctionsTestBase
     public async Task ShouldReturn200OnValidRequest()
     {
         _service
-            .Setup(d => d.GetAsync(It.IsAny<string>()))
+            .Setup(d => d.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new School());
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1");
@@ -41,9 +41,8 @@ public class GetSchoolFunctionTests : FunctionsTestBase
     [Fact]
     public async Task ShouldReturn404OnInvalidRequest()
     {
-
         _service
-            .Setup(d => d.GetAsync(It.IsAny<string>()))
+            .Setup(d => d.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((School?)null);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1");

--- a/platform/tests/Platform.Establishment.Tests/Schools/PostSchoolComparatorsFunctionTests.cs
+++ b/platform/tests/Platform.Establishment.Tests/Schools/PostSchoolComparatorsFunctionTests.cs
@@ -14,11 +14,11 @@ namespace Platform.Establishment.Tests.Schools;
 
 public class PostSchoolComparatorsFunctionTests : FunctionsTestBase
 {
-    private readonly string _urn;
     private readonly SchoolComparators _comparators;
-    private readonly SchoolComparatorsRequest _request;
     private readonly PostSchoolComparatorsFunction _function;
+    private readonly SchoolComparatorsRequest _request;
     private readonly Mock<ISchoolComparatorsService> _service;
+    private readonly string _urn;
 
     public PostSchoolComparatorsFunctionTests()
     {
@@ -36,7 +36,7 @@ public class PostSchoolComparatorsFunctionTests : FunctionsTestBase
     public async Task ShouldReturn200OnValidRequest()
     {
         _service
-            .Setup(d => d.ComparatorsAsync(_urn, It.IsAny<SchoolComparatorsRequest>()))
+            .Setup(d => d.ComparatorsAsync(_urn, It.IsAny<SchoolComparatorsRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_comparators);
 
         var result = await _function.RunAsync(CreateHttpRequestDataWithBody(_request), _urn);

--- a/platform/tests/Platform.Establishment.Tests/Schools/PostSchoolsSearchFunctionTests.cs
+++ b/platform/tests/Platform.Establishment.Tests/Schools/PostSchoolsSearchFunctionTests.cs
@@ -30,7 +30,7 @@ public class PostSchoolsSearchFunctionTests : FunctionsTestBase
     public async Task ShouldReturn200OnValidRequest()
     {
         _service
-            .Setup(d => d.SchoolsSearchAsync(It.IsAny<SearchRequest>()))
+            .Setup(d => d.SchoolsSearchAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new SearchResponse<SchoolSummary>());
 
         _validator
@@ -68,6 +68,6 @@ public class PostSchoolsSearchFunctionTests : FunctionsTestBase
         Assert.Contains(values, p => p.PropertyName == nameof(SearchRequest.SearchText));
 
         _service
-            .Verify(d => d.SchoolsSearchAsync(It.IsAny<SearchRequest>()), Times.Never);
+            .Verify(d => d.SchoolsSearchAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/platform/tests/Platform.Establishment.Tests/Schools/Services/WhenSchoolsServiceSearches.cs
+++ b/platform/tests/Platform.Establishment.Tests/Schools/Services/WhenSchoolsServiceSearches.cs
@@ -33,9 +33,10 @@ public class WhenSchoolsServiceSearches
                 "SearchAsync",
                 ItExpr.IsAny<SearchRequest>(),
                 ItExpr.IsAny<Func<string?>>(),
-                ItExpr.IsAny<string[]?>()
+                ItExpr.IsAny<string[]?>(),
+                ItExpr.IsAny<CancellationToken>()
             )
-            .Callback((SearchRequest _, Func<string?> _, string[] facets) =>
+            .Callback((SearchRequest _, Func<string?> _, string[] facets, CancellationToken _) =>
             {
                 capturedFacets = facets;
             })
@@ -58,9 +59,10 @@ public class WhenSchoolsServiceSearches
                 "SearchAsync",
                 ItExpr.IsAny<SearchRequest>(),
                 ItExpr.IsAny<Func<string?>>(),
-                ItExpr.IsAny<string[]?>()
+                ItExpr.IsAny<string[]?>(),
+                ItExpr.IsAny<CancellationToken>()
             )
-            .Callback((SearchRequest request, Func<string?> _, string[] _) =>
+            .Callback((SearchRequest request, Func<string?> _, string[] _, CancellationToken _) =>
             {
                 capturedRequest = request;
             })

--- a/platform/tests/Platform.Establishment.Tests/Trusts/GetTrustFunctionTests.cs
+++ b/platform/tests/Platform.Establishment.Tests/Trusts/GetTrustFunctionTests.cs
@@ -14,9 +14,9 @@ namespace Platform.Establishment.Tests.Trusts;
 public class GetTrustFunctionTests : FunctionsTestBase
 {
     private readonly string _companyNumber;
-    private readonly Trust _trust;
     private readonly GetTrustFunction _function;
     private readonly Mock<ITrustsService> _service;
+    private readonly Trust _trust;
 
     public GetTrustFunctionTests()
     {
@@ -40,7 +40,7 @@ public class GetTrustFunctionTests : FunctionsTestBase
     public async Task ShouldReturn200OnValidRequest()
     {
         _service
-            .Setup(d => d.GetAsync(_companyNumber))
+            .Setup(d => d.GetAsync(_companyNumber, It.IsAny<CancellationToken>()))
             .ReturnsAsync(_trust);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), _companyNumber);
@@ -58,7 +58,7 @@ public class GetTrustFunctionTests : FunctionsTestBase
     public async Task ShouldReturn404OnInvalidRequest()
     {
         _service
-            .Setup(d => d.GetAsync(_companyNumber))
+            .Setup(d => d.GetAsync(_companyNumber, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Trust?)null);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), _companyNumber);

--- a/platform/tests/Platform.Establishment.Tests/Trusts/PostTrustComparatorsFunctionTests.cs
+++ b/platform/tests/Platform.Establishment.Tests/Trusts/PostTrustComparatorsFunctionTests.cs
@@ -15,8 +15,8 @@ public class PostTrustComparatorsFunctionTests : FunctionsTestBase
 {
     private readonly string _companyNumber;
     private readonly TrustComparators _comparators;
-    private readonly TrustComparatorsRequest _request;
     private readonly PostTrustComparatorsFunction _function;
+    private readonly TrustComparatorsRequest _request;
     private readonly Mock<ITrustComparatorsService> _service;
 
     public PostTrustComparatorsFunctionTests()
@@ -35,7 +35,7 @@ public class PostTrustComparatorsFunctionTests : FunctionsTestBase
     public async Task ShouldReturn200OnValidRequest()
     {
         _service
-            .Setup(d => d.ComparatorsAsync(_companyNumber, It.IsAny<TrustComparatorsRequest>()))
+            .Setup(d => d.ComparatorsAsync(_companyNumber, It.IsAny<TrustComparatorsRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_comparators);
 
         var result = await _function.RunAsync(CreateHttpRequestDataWithBody(_request), _companyNumber);

--- a/platform/tests/Platform.Establishment.Tests/Trusts/PostTrustsSearchFunctionTests.cs
+++ b/platform/tests/Platform.Establishment.Tests/Trusts/PostTrustsSearchFunctionTests.cs
@@ -30,7 +30,7 @@ public class PostTrustsSearchFunctionTests : FunctionsTestBase
     public async Task ShouldReturn200OnValidRequest()
     {
         _service
-            .Setup(d => d.TrustsSearchAsync(It.IsAny<SearchRequest>()))
+            .Setup(d => d.TrustsSearchAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new SearchResponse<TrustSummary>());
 
         _validator
@@ -68,6 +68,6 @@ public class PostTrustsSearchFunctionTests : FunctionsTestBase
         Assert.Contains(values, p => p.PropertyName == nameof(SearchRequest.SearchText));
 
         _service
-            .Verify(d => d.TrustsSearchAsync(It.IsAny<SearchRequest>()), Times.Never);
+            .Verify(d => d.TrustsSearchAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/platform/tests/Platform.Establishment.Tests/Trusts/Services/WhenTrustsServiceSearches.cs
+++ b/platform/tests/Platform.Establishment.Tests/Trusts/Services/WhenTrustsServiceSearches.cs
@@ -33,9 +33,10 @@ public class WhenTrustsServiceSearches
                 "SearchAsync",
                 ItExpr.IsAny<SearchRequest>(),
                 ItExpr.IsAny<Func<string?>>(),
-                ItExpr.IsAny<string[]?>()
+                ItExpr.IsAny<string[]?>(),
+                ItExpr.IsAny<CancellationToken>()
             )
-            .Callback((SearchRequest _, Func<string?> _, string[] facets) =>
+            .Callback((SearchRequest _, Func<string?> _, string[] facets, CancellationToken _) =>
             {
                 capturedFacets = facets;
             })
@@ -58,9 +59,10 @@ public class WhenTrustsServiceSearches
                 "SearchAsync",
                 ItExpr.IsAny<SearchRequest>(),
                 ItExpr.IsAny<Func<string?>>(),
-                ItExpr.IsAny<string[]?>()
+                ItExpr.IsAny<string[]?>(),
+                ItExpr.IsAny<CancellationToken>()
             )
-            .Callback((SearchRequest request, Func<string?> _, string[] _) =>
+            .Callback((SearchRequest request, Func<string?> _, string[] _, CancellationToken _) =>
             {
                 capturedRequest = request;
             })

--- a/platform/tests/Platform.Insight.Tests/Balance/GetBalanceSchoolFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Balance/GetBalanceSchoolFunctionTests.cs
@@ -14,9 +14,9 @@ namespace Platform.Insight.Tests.Balance;
 
 public class GetBalanceSchoolFunctionTests : FunctionsTestBase
 {
+    private readonly Fixture _fixture;
     private readonly GetBalanceSchoolFunction _function;
     private readonly Mock<IBalanceService> _service;
-    private readonly Fixture _fixture;
 
     public GetBalanceSchoolFunctionTests()
     {
@@ -31,7 +31,7 @@ public class GetBalanceSchoolFunctionTests : FunctionsTestBase
         var model = _fixture.Build<BalanceSchoolModel>().Create();
 
         _service
-            .Setup(d => d.GetSchoolAsync(It.IsAny<string>()))
+            .Setup(d => d.GetSchoolAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(model);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1");
@@ -48,7 +48,7 @@ public class GetBalanceSchoolFunctionTests : FunctionsTestBase
     public async Task ShouldReturn404OnNotFound()
     {
         _service
-            .Setup(d => d.GetSchoolAsync(It.IsAny<string>()))
+            .Setup(d => d.GetSchoolAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((BalanceSchoolModel?)null);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1");

--- a/platform/tests/Platform.Insight.Tests/Balance/GetBalanceSchoolHistoryFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Balance/GetBalanceSchoolHistoryFunctionTests.cs
@@ -15,9 +15,9 @@ namespace Platform.Insight.Tests.Balance;
 
 public class GetBalanceSchoolHistoryFunctionTests : FunctionsTestBase
 {
+    private readonly Fixture _fixture;
     private readonly GetBalanceSchoolHistoryFunction _function;
     private readonly Mock<IBalanceService> _service;
-    private readonly Fixture _fixture;
 
     public GetBalanceSchoolHistoryFunctionTests()
     {
@@ -30,10 +30,14 @@ public class GetBalanceSchoolHistoryFunctionTests : FunctionsTestBase
     public async Task ShouldReturn200OnValidRequest()
     {
         var history = _fixture.CreateMany<BalanceHistoryModel>(5);
-        var years = new YearsModel { StartYear = 2019, EndYear = 2023 };
+        var years = new YearsModel
+        {
+            StartYear = 2019,
+            EndYear = 2023
+        };
 
         _service
-            .Setup(d => d.GetSchoolHistoryAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(d => d.GetSchoolHistoryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((years, history));
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1");
@@ -50,8 +54,8 @@ public class GetBalanceSchoolHistoryFunctionTests : FunctionsTestBase
     public async Task ShouldReturn404OnNotFound()
     {
         _service
-            .Setup(d => d.GetSchoolHistoryAsync(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((null, Array.Empty<BalanceHistoryModel>()));
+            .Setup(d => d.GetSchoolHistoryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((null, []));
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1");
 

--- a/platform/tests/Platform.Insight.Tests/Balance/GetBalanceTrustFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Balance/GetBalanceTrustFunctionTests.cs
@@ -14,9 +14,9 @@ namespace Platform.Insight.Tests.Balance;
 
 public class GetBalanceTrustFunctionTests : FunctionsTestBase
 {
+    private readonly Fixture _fixture;
     private readonly GetBalanceTrustFunction _function;
     private readonly Mock<IBalanceService> _service;
-    private readonly Fixture _fixture;
 
     public GetBalanceTrustFunctionTests()
     {
@@ -31,7 +31,7 @@ public class GetBalanceTrustFunctionTests : FunctionsTestBase
         var model = _fixture.Build<BalanceTrustModel>().Create();
 
         _service
-            .Setup(d => d.GetTrustAsync(It.IsAny<string>()))
+            .Setup(d => d.GetTrustAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(model);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1");
@@ -48,7 +48,7 @@ public class GetBalanceTrustFunctionTests : FunctionsTestBase
     public async Task ShouldReturn404OnNotFound()
     {
         _service
-            .Setup(d => d.GetTrustAsync(It.IsAny<string>()))
+            .Setup(d => d.GetTrustAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((BalanceTrustModel?)null);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1");

--- a/platform/tests/Platform.Insight.Tests/Balance/GetBalanceTrustHistoryFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Balance/GetBalanceTrustHistoryFunctionTests.cs
@@ -15,9 +15,9 @@ namespace Platform.Insight.Tests.Balance;
 
 public class GetBalanceTrustHistoryFunctionTests : FunctionsTestBase
 {
+    private readonly Fixture _fixture;
     private readonly GetBalanceTrustHistoryFunction _function;
     private readonly Mock<IBalanceService> _service;
-    private readonly Fixture _fixture;
 
     public GetBalanceTrustHistoryFunctionTests()
     {
@@ -30,10 +30,14 @@ public class GetBalanceTrustHistoryFunctionTests : FunctionsTestBase
     public async Task ShouldReturn200OnValidRequest()
     {
         var history = _fixture.CreateMany<BalanceHistoryModel>(5);
-        var years = new YearsModel { StartYear = 2019, EndYear = 2023 };
+        var years = new YearsModel
+        {
+            StartYear = 2019,
+            EndYear = 2023
+        };
 
         _service
-            .Setup(d => d.GetTrustHistoryAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(d => d.GetTrustHistoryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((years, history));
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1");
@@ -50,8 +54,8 @@ public class GetBalanceTrustHistoryFunctionTests : FunctionsTestBase
     public async Task ShouldReturn404OnNotFound()
     {
         _service
-            .Setup(d => d.GetTrustHistoryAsync(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((null, Array.Empty<BalanceHistoryModel>()));
+            .Setup(d => d.GetTrustHistoryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((null, []));
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1");
 

--- a/platform/tests/Platform.Insight.Tests/Balance/GetBalanceTrustsFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Balance/GetBalanceTrustsFunctionTests.cs
@@ -14,9 +14,9 @@ namespace Platform.Insight.Tests.Balance;
 
 public class GetBalanceTrustsFunctionTests : FunctionsTestBase
 {
+    private readonly Fixture _fixture;
     private readonly GetBalanceTrustsFunction _function;
     private readonly Mock<IBalanceService> _service;
-    private readonly Fixture _fixture;
 
     public GetBalanceTrustsFunctionTests()
     {
@@ -31,7 +31,7 @@ public class GetBalanceTrustsFunctionTests : FunctionsTestBase
         var trusts = _fixture.CreateMany<BalanceTrustModel>(5);
 
         _service
-            .Setup(d => d.QueryTrustsAsync(It.IsAny<string[]>(), It.IsAny<string>()))
+            .Setup(d => d.QueryTrustsAsync(It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(trusts);
 
         var result = await _function.RunAsync(CreateHttpRequestData());

--- a/platform/tests/Platform.Insight.Tests/BudgetForecast/WhenGetBudgetForecastCurrentYearFunctionRuns.cs
+++ b/platform/tests/Platform.Insight.Tests/BudgetForecast/WhenGetBudgetForecastCurrentYearFunctionRuns.cs
@@ -2,10 +2,7 @@ using System.Net;
 using AutoFixture;
 using Moq;
 using Platform.Api.Insight.Features.BudgetForecast;
-using Platform.Api.Insight.Features.BudgetForecast.Models;
-using Platform.Api.Insight.Features.BudgetForecast.Responses;
 using Platform.Api.Insight.Features.BudgetForecast.Services;
-using Platform.Domain;
 using Platform.Functions;
 using Platform.Test;
 using Platform.Test.Extensions;
@@ -31,7 +28,7 @@ public class WhenGetBudgetForecastCurrentYearFunctionRuns : FunctionsTestBase
         const int year = 2021;
 
         _service
-            .Setup(d => d.GetBudgetForecastCurrentYearAsync())
+            .Setup(d => d.GetBudgetForecastCurrentYearAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(year);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), companyNumber);
@@ -51,7 +48,7 @@ public class WhenGetBudgetForecastCurrentYearFunctionRuns : FunctionsTestBase
         int? year = null;
 
         _service
-            .Setup(d => d.GetBudgetForecastCurrentYearAsync())
+            .Setup(d => d.GetBudgetForecastCurrentYearAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(year);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), companyNumber);

--- a/platform/tests/Platform.Insight.Tests/BudgetForecast/WhenGetBudgetForecastMetricsFunctionRuns.cs
+++ b/platform/tests/Platform.Insight.Tests/BudgetForecast/WhenGetBudgetForecastMetricsFunctionRuns.cs
@@ -31,7 +31,7 @@ public class WhenGetBudgetForecastMetricsFunctionRuns : FunctionsTestBase
         var results = Fixture.Build<BudgetForecastReturnMetricModel>().CreateMany().ToArray();
 
         _service
-            .Setup(d => d.GetBudgetForecastReturnMetricsAsync(companyNumber, Pipeline.RunType.Default))
+            .Setup(d => d.GetBudgetForecastReturnMetricsAsync(companyNumber, Pipeline.RunType.Default, It.IsAny<CancellationToken>()))
             .ReturnsAsync(results);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), companyNumber);

--- a/platform/tests/Platform.Insight.Tests/BudgetForecast/WhenGetBudgetForecastReturnFunctionRuns.cs
+++ b/platform/tests/Platform.Insight.Tests/BudgetForecast/WhenGetBudgetForecastReturnFunctionRuns.cs
@@ -7,7 +7,6 @@ using Platform.Api.Insight.Features.BudgetForecast.Models;
 using Platform.Api.Insight.Features.BudgetForecast.Parameters;
 using Platform.Api.Insight.Features.BudgetForecast.Responses;
 using Platform.Api.Insight.Features.BudgetForecast.Services;
-using Platform.Domain;
 using Platform.Functions;
 using Platform.Test;
 using Platform.Test.Extensions;
@@ -41,11 +40,11 @@ public class WhenGetBudgetForecastReturnFunctionRuns : FunctionsTestBase
         var ar = Fixture.Build<ActualReturnModel>().CreateMany().ToArray();
 
         _service
-            .Setup(d => d.GetBudgetForecastReturnsAsync(companyNumber, QueryParams.RunType, QueryParams.Category, QueryParams.RunId))
+            .Setup(d => d.GetBudgetForecastReturnsAsync(companyNumber, QueryParams.RunType, QueryParams.Category, QueryParams.RunId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(bfr);
 
         _service
-            .Setup(d => d.GetActualReturnsAsync(companyNumber, QueryParams.Category, QueryParams.RunId))
+            .Setup(d => d.GetActualReturnsAsync(companyNumber, QueryParams.Category, QueryParams.RunId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(ar);
 
         var result = await _function.RunAsync(CreateHttpRequestData(_query), companyNumber);

--- a/platform/tests/Platform.Insight.Tests/Census/GetCensusCustomFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Census/GetCensusCustomFunctionTests.cs
@@ -17,10 +17,10 @@ namespace Platform.Insight.Tests.Census;
 public class GetCensusCustomFunctionTests : FunctionsTestBase
 {
     private const string Urn = "URN";
+    private readonly Fixture _fixture;
     private readonly GetCensusCustomFunction _function;
     private readonly Mock<ICensusService> _service;
     private readonly Mock<IValidator<CensusParameters>> _validator;
-    private readonly Fixture _fixture;
 
     public GetCensusCustomFunctionTests()
     {
@@ -40,7 +40,7 @@ public class GetCensusCustomFunctionTests : FunctionsTestBase
             .ReturnsAsync(new ValidationResult());
 
         _service
-            .Setup(d => d.GetCustomAsync(Urn, It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(d => d.GetCustomAsync(Urn, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(model);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), Urn, Guid.Empty.ToString());
@@ -61,7 +61,7 @@ public class GetCensusCustomFunctionTests : FunctionsTestBase
             .ReturnsAsync(new ValidationResult());
 
         _service
-            .Setup(d => d.GetCustomAsync(Urn, It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(d => d.GetCustomAsync(Urn, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((CensusSchoolModel?)null);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), Urn, Guid.Empty.ToString());
@@ -90,6 +90,6 @@ public class GetCensusCustomFunctionTests : FunctionsTestBase
         Assert.Contains(values, p => p.PropertyName == nameof(CensusParameters.Dimension));
 
         _service
-            .Verify(d => d.GetCustomAsync(Urn, It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            .Verify(d => d.GetCustomAsync(Urn, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/platform/tests/Platform.Insight.Tests/Census/GetCensusFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Census/GetCensusFunctionTests.cs
@@ -15,9 +15,9 @@ namespace Platform.Insight.Tests.Census;
 public class GetCensusFunctionTests : FunctionsTestBase
 {
     private const string Urn = "URN";
+    private readonly Fixture _fixture;
     private readonly GetCensusFunction _function;
     private readonly Mock<ICensusService> _service;
-    private readonly Fixture _fixture;
 
     public GetCensusFunctionTests()
     {
@@ -32,7 +32,7 @@ public class GetCensusFunctionTests : FunctionsTestBase
         var model = _fixture.Build<CensusSchoolModel>().Create();
 
         _service
-            .Setup(d => d.GetAsync(Urn))
+            .Setup(d => d.GetAsync(Urn, It.IsAny<CancellationToken>()))
             .ReturnsAsync(model);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), Urn);
@@ -49,7 +49,7 @@ public class GetCensusFunctionTests : FunctionsTestBase
     public async Task ShouldReturn404OnNotFound()
     {
         _service
-            .Setup(d => d.GetAsync(Urn))
+            .Setup(d => d.GetAsync(Urn, It.IsAny<CancellationToken>()))
             .ReturnsAsync((CensusSchoolModel?)null);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), Urn);

--- a/platform/tests/Platform.Insight.Tests/Census/GetCensusHistoryComparatorSetAverageFunctionsTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Census/GetCensusHistoryComparatorSetAverageFunctionsTests.cs
@@ -19,10 +19,10 @@ namespace Platform.Insight.Tests.Census;
 public class GetCensusHistoryComparatorSetAverageFunctionsTests : FunctionsTestBase
 {
     private readonly CancellationToken _cancellationToken = CancellationToken.None;
+    private readonly Fixture _fixture;
     private readonly GetCensusHistoryComparatorSetAverageFunctions _function;
     private readonly Mock<ICensusService> _service;
     private readonly Mock<IValidator<CensusParameters>> _validator;
-    private readonly Fixture _fixture;
 
     public GetCensusHistoryComparatorSetAverageFunctionsTests()
     {
@@ -36,7 +36,11 @@ public class GetCensusHistoryComparatorSetAverageFunctionsTests : FunctionsTestB
     public async Task ShouldReturn200OnValidRequest()
     {
         var history = _fixture.CreateMany<CensusHistoryModel>(5);
-        var years = new YearsModel { StartYear = 2019, EndYear = 2023 };
+        var years = new YearsModel
+        {
+            StartYear = 2019,
+            EndYear = 2023
+        };
 
         _validator
             .Setup(v => v.ValidateAsync(It.IsAny<CensusParameters>(), It.IsAny<CancellationToken>()))
@@ -65,7 +69,7 @@ public class GetCensusHistoryComparatorSetAverageFunctionsTests : FunctionsTestB
 
         _service
             .Setup(d => d.GetComparatorAveHistoryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((null, Array.Empty<CensusHistoryModel>()));
+            .ReturnsAsync((null, []));
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1", _cancellationToken);
 

--- a/platform/tests/Platform.Insight.Tests/Census/GetCensusHistoryFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Census/GetCensusHistoryFunctionTests.cs
@@ -19,10 +19,10 @@ namespace Platform.Insight.Tests.Census;
 public class GetCensusHistoryFunctionTests : FunctionsTestBase
 {
     private readonly CancellationToken _cancellationToken = CancellationToken.None;
+    private readonly Fixture _fixture;
     private readonly GetCensusHistoryFunction _function;
     private readonly Mock<ICensusService> _service;
     private readonly Mock<IValidator<CensusParameters>> _validator;
-    private readonly Fixture _fixture;
 
     public GetCensusHistoryFunctionTests()
     {
@@ -35,7 +35,11 @@ public class GetCensusHistoryFunctionTests : FunctionsTestBase
     public async Task ShouldReturn200OnValidRequest()
     {
         var history = _fixture.CreateMany<CensusHistoryModel>(5);
-        var years = new YearsModel { StartYear = 2019, EndYear = 2023 };
+        var years = new YearsModel
+        {
+            StartYear = 2019,
+            EndYear = 2023
+        };
 
         _validator
             .Setup(v => v.ValidateAsync(It.IsAny<CensusParameters>(), It.IsAny<CancellationToken>()))
@@ -64,7 +68,7 @@ public class GetCensusHistoryFunctionTests : FunctionsTestBase
 
         _service
             .Setup(d => d.GetSchoolHistoryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((null, Array.Empty<CensusHistoryModel>()));
+            .ReturnsAsync((null, []));
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1", _cancellationToken);
 

--- a/platform/tests/Platform.Insight.Tests/Census/GetCensusQueryFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Census/GetCensusQueryFunctionTests.cs
@@ -3,7 +3,6 @@ using FluentValidation;
 using FluentValidation.Results;
 using Moq;
 using Platform.Api.Insight.Features.Census;
-using Platform.Api.Insight.Features.Census.Models;
 using Platform.Api.Insight.Features.Census.Parameters;
 using Platform.Api.Insight.Features.Census.Services;
 using Platform.Functions;
@@ -34,8 +33,8 @@ public class GetCensusQueryFunctionTests : FunctionsTestBase
             .ReturnsAsync(new ValidationResult());
 
         _service
-            .Setup(d => d.QueryAsync(It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(Array.Empty<CensusSchoolModel>());
+            .Setup(d => d.QueryAsync(It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
 
         var result = await _function.RunAsync(CreateHttpRequestData());
 
@@ -53,8 +52,8 @@ public class GetCensusQueryFunctionTests : FunctionsTestBase
             ]));
 
         _service
-            .Setup(d => d.QueryAsync(It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(Array.Empty<CensusSchoolModel>());
+            .Setup(d => d.QueryAsync(It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
 
         var result = await _function.RunAsync(CreateHttpRequestData());
 
@@ -67,6 +66,6 @@ public class GetCensusQueryFunctionTests : FunctionsTestBase
         Assert.Contains(values, p => p.PropertyName == nameof(CensusQuerySchoolsParameters.Dimension));
 
         _service
-            .Verify(x => x.QueryAsync(It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            .Verify(x => x.QueryAsync(It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never());
     }
 }

--- a/platform/tests/Platform.Insight.Tests/Expenditure/GetExpenditureSchoolCustomFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Expenditure/GetExpenditureSchoolCustomFunctionTests.cs
@@ -18,10 +18,10 @@ namespace Platform.Insight.Tests.Expenditure;
 public class GetExpenditureSchoolCustomFunctionTests : FunctionsTestBase
 {
     private const string Urn = "URN";
+    private readonly Fixture _fixture;
     private readonly GetExpenditureSchoolCustomFunction _function;
     private readonly Mock<IExpenditureService> _service;
     private readonly Mock<IValidator<ExpenditureParameters>> _validator;
-    private readonly Fixture _fixture;
 
     public GetExpenditureSchoolCustomFunctionTests()
     {
@@ -40,7 +40,7 @@ public class GetExpenditureSchoolCustomFunctionTests : FunctionsTestBase
             .ReturnsAsync(new ValidationResult());
 
         _service
-            .Setup(d => d.GetCustomSchoolAsync(Urn, It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(d => d.GetCustomSchoolAsync(Urn, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(model);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), Urn, "id");
@@ -61,7 +61,7 @@ public class GetExpenditureSchoolCustomFunctionTests : FunctionsTestBase
             .ReturnsAsync(new ValidationResult());
 
         _service
-            .Setup(d => d.GetCustomSchoolAsync(Urn, It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(d => d.GetCustomSchoolAsync(Urn, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((ExpenditureSchoolModel?)null);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), Urn, "id");
@@ -90,6 +90,6 @@ public class GetExpenditureSchoolCustomFunctionTests : FunctionsTestBase
         Assert.Contains(values, p => p.PropertyName == nameof(ExpenditureParameters.Dimension));
 
         _service
-            .Verify(d => d.GetCustomSchoolAsync(Urn, It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            .Verify(d => d.GetCustomSchoolAsync(Urn, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/platform/tests/Platform.Insight.Tests/Expenditure/GetExpenditureSchoolFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Expenditure/GetExpenditureSchoolFunctionTests.cs
@@ -18,10 +18,10 @@ namespace Platform.Insight.Tests.Expenditure;
 public class GetExpenditureSchoolFunctionTests : FunctionsTestBase
 {
     private const string Urn = "URN";
+    private readonly Fixture _fixture;
     private readonly GetExpenditureSchoolFunction _function;
     private readonly Mock<IExpenditureService> _service;
     private readonly Mock<IValidator<ExpenditureParameters>> _validator;
-    private readonly Fixture _fixture;
 
     public GetExpenditureSchoolFunctionTests()
     {
@@ -40,7 +40,7 @@ public class GetExpenditureSchoolFunctionTests : FunctionsTestBase
             .ReturnsAsync(new ValidationResult());
 
         _service
-            .Setup(d => d.GetSchoolAsync(Urn, It.IsAny<string>()))
+            .Setup(d => d.GetSchoolAsync(Urn, It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(model);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), Urn);
@@ -61,7 +61,7 @@ public class GetExpenditureSchoolFunctionTests : FunctionsTestBase
             .ReturnsAsync(new ValidationResult());
 
         _service
-            .Setup(d => d.GetSchoolAsync(Urn, It.IsAny<string>()))
+            .Setup(d => d.GetSchoolAsync(Urn, It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((ExpenditureSchoolModel?)null);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), Urn);
@@ -90,6 +90,6 @@ public class GetExpenditureSchoolFunctionTests : FunctionsTestBase
         Assert.Contains(values, p => p.PropertyName == nameof(ExpenditureParameters.Dimension));
 
         _service
-            .Verify(d => d.GetSchoolAsync(Urn, It.IsAny<string>()), Times.Never);
+            .Verify(d => d.GetSchoolAsync(Urn, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/platform/tests/Platform.Insight.Tests/Expenditure/GetExpenditureSchoolHistoryComparatorSetAverageFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Expenditure/GetExpenditureSchoolHistoryComparatorSetAverageFunctionTests.cs
@@ -3,7 +3,6 @@ using FluentValidation;
 using FluentValidation.Results;
 using Moq;
 using Platform.Api.Insight.Features.Expenditure;
-using Platform.Api.Insight.Features.Expenditure.Models;
 using Platform.Api.Insight.Features.Expenditure.Parameters;
 using Platform.Api.Insight.Features.Expenditure.Responses;
 using Platform.Api.Insight.Features.Expenditure.Services;
@@ -38,7 +37,7 @@ public class GetExpenditureSchoolHistoryComparatorSetAverageFunctionTests : Func
 
         _service
             .Setup(d => d.GetComparatorAveHistoryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((new YearsModel(), Array.Empty<ExpenditureHistoryModel>()));
+            .ReturnsAsync((new YearsModel(), []));
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1", _cancellationToken);
 
@@ -59,7 +58,7 @@ public class GetExpenditureSchoolHistoryComparatorSetAverageFunctionTests : Func
 
         _service
             .Setup(d => d.GetComparatorAveHistoryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((null, Array.Empty<ExpenditureHistoryModel>()));
+            .ReturnsAsync((null, []));
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1", _cancellationToken);
 

--- a/platform/tests/Platform.Insight.Tests/Expenditure/GetExpenditureSchoolHistoryFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Expenditure/GetExpenditureSchoolHistoryFunctionTests.cs
@@ -3,7 +3,6 @@ using FluentValidation;
 using FluentValidation.Results;
 using Moq;
 using Platform.Api.Insight.Features.Expenditure;
-using Platform.Api.Insight.Features.Expenditure.Models;
 using Platform.Api.Insight.Features.Expenditure.Parameters;
 using Platform.Api.Insight.Features.Expenditure.Responses;
 using Platform.Api.Insight.Features.Expenditure.Services;
@@ -38,7 +37,7 @@ public class GetExpenditureSchoolHistoryFunctionTests : FunctionsTestBase
 
         _service
             .Setup(d => d.GetSchoolHistoryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((new YearsModel(), Array.Empty<ExpenditureHistoryModel>()));
+            .ReturnsAsync((new YearsModel(), []));
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1", _cancellationToken);
 
@@ -59,7 +58,7 @@ public class GetExpenditureSchoolHistoryFunctionTests : FunctionsTestBase
 
         _service
             .Setup(d => d.GetSchoolHistoryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((null, Array.Empty<ExpenditureHistoryModel>()));
+            .ReturnsAsync((null, []));
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1", _cancellationToken);
 

--- a/platform/tests/Platform.Insight.Tests/Expenditure/GetExpenditureSchoolHistoryNationalAverageFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Expenditure/GetExpenditureSchoolHistoryNationalAverageFunctionTests.cs
@@ -3,7 +3,6 @@ using FluentValidation;
 using FluentValidation.Results;
 using Moq;
 using Platform.Api.Insight.Features.Expenditure;
-using Platform.Api.Insight.Features.Expenditure.Models;
 using Platform.Api.Insight.Features.Expenditure.Parameters;
 using Platform.Api.Insight.Features.Expenditure.Services;
 using Platform.Api.Insight.Shared;
@@ -35,7 +34,7 @@ public class GetExpenditureSchoolHistoryNationalAverageFunctionTests : Functions
 
         _service
             .Setup(d => d.GetNationalAvgHistoryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((new YearsModel(), Array.Empty<ExpenditureHistoryModel>()));
+            .ReturnsAsync((new YearsModel(), []));
 
         var result = await _function.RunAsync(CreateHttpRequestData(), _cancellationToken);
 

--- a/platform/tests/Platform.Insight.Tests/Expenditure/GetExpenditureSchoolsFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Expenditure/GetExpenditureSchoolsFunctionTests.cs
@@ -17,10 +17,10 @@ namespace Platform.Insight.Tests.Expenditure;
 
 public class GetExpenditureSchoolsFunctionTests : FunctionsTestBase
 {
+    private readonly Fixture _fixture;
     private readonly GetExpenditureSchoolsFunction _function;
     private readonly Mock<IExpenditureService> _service;
     private readonly Mock<IValidator<ExpenditureQuerySchoolParameters>> _validator;
-    private readonly Fixture _fixture;
 
     public GetExpenditureSchoolsFunctionTests()
     {
@@ -39,7 +39,7 @@ public class GetExpenditureSchoolsFunctionTests : FunctionsTestBase
             .ReturnsAsync(new ValidationResult());
 
         _service
-            .Setup(d => d.QuerySchoolsAsync(It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(d => d.QuerySchoolsAsync(It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(model);
 
         var result = await _function.RunAsync(CreateHttpRequestData());
@@ -72,6 +72,6 @@ public class GetExpenditureSchoolsFunctionTests : FunctionsTestBase
         Assert.Contains(values, p => p.PropertyName == nameof(ExpenditureParameters.Dimension));
 
         _service
-            .Verify(d => d.QuerySchoolsAsync(It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            .Verify(d => d.QuerySchoolsAsync(It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never());
     }
 }

--- a/platform/tests/Platform.Insight.Tests/Expenditure/GetExpenditureTrustFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Expenditure/GetExpenditureTrustFunctionTests.cs
@@ -17,10 +17,10 @@ namespace Platform.Insight.Tests.Expenditure;
 
 public class GetExpenditureTrustFunctionTests : FunctionsTestBase
 {
+    private readonly Fixture _fixture;
     private readonly GetExpenditureTrustFunction _function;
     private readonly Mock<IExpenditureService> _service;
     private readonly Mock<IValidator<ExpenditureParameters>> _validator;
-    private readonly Fixture _fixture;
 
     public GetExpenditureTrustFunctionTests()
     {
@@ -39,7 +39,7 @@ public class GetExpenditureTrustFunctionTests : FunctionsTestBase
             .ReturnsAsync(new ValidationResult());
 
         _service
-            .Setup(d => d.GetTrustAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(d => d.GetTrustAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(model);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1");
@@ -60,7 +60,7 @@ public class GetExpenditureTrustFunctionTests : FunctionsTestBase
             .ReturnsAsync(new ValidationResult());
 
         _service
-            .Setup(d => d.GetTrustAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(d => d.GetTrustAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((ExpenditureTrustModel?)null);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1");
@@ -89,6 +89,6 @@ public class GetExpenditureTrustFunctionTests : FunctionsTestBase
         Assert.Contains(values, p => p.PropertyName == nameof(ExpenditureParameters.Dimension));
 
         _service.Verify(
-            x => x.GetTrustAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            x => x.GetTrustAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never());
     }
 }

--- a/platform/tests/Platform.Insight.Tests/Expenditure/GetExpenditureTrustHistoryFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Expenditure/GetExpenditureTrustHistoryFunctionTests.cs
@@ -3,7 +3,6 @@ using FluentValidation;
 using FluentValidation.Results;
 using Moq;
 using Platform.Api.Insight.Features.Expenditure;
-using Platform.Api.Insight.Features.Expenditure.Models;
 using Platform.Api.Insight.Features.Expenditure.Parameters;
 using Platform.Api.Insight.Features.Expenditure.Responses;
 using Platform.Api.Insight.Features.Expenditure.Services;
@@ -36,8 +35,8 @@ public class GetExpenditureTrustHistoryFunctionTests : FunctionsTestBase
             .ReturnsAsync(new ValidationResult());
 
         _service
-            .Setup(d => d.GetTrustHistoryAsync(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((new YearsModel(), Array.Empty<ExpenditureHistoryModel>()));
+            .Setup(d => d.GetTrustHistoryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new YearsModel(), []));
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1");
 
@@ -57,8 +56,8 @@ public class GetExpenditureTrustHistoryFunctionTests : FunctionsTestBase
             .ReturnsAsync(new ValidationResult());
 
         _service
-            .Setup(d => d.GetTrustHistoryAsync(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((null, Array.Empty<ExpenditureHistoryModel>()));
+            .Setup(d => d.GetTrustHistoryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((null, []));
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1");
 

--- a/platform/tests/Platform.Insight.Tests/Expenditure/GetExpenditureTrustsFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Expenditure/GetExpenditureTrustsFunctionTests.cs
@@ -17,10 +17,10 @@ namespace Platform.Insight.Tests.Expenditure;
 
 public class GetExpenditureTrustsFunctionTests : FunctionsTestBase
 {
+    private readonly Fixture _fixture;
     private readonly GetExpenditureTrustsFunction _function;
     private readonly Mock<IExpenditureService> _service;
     private readonly Mock<IValidator<ExpenditureQueryTrustParameters>> _validator;
-    private readonly Fixture _fixture;
 
     public GetExpenditureTrustsFunctionTests()
     {
@@ -39,7 +39,7 @@ public class GetExpenditureTrustsFunctionTests : FunctionsTestBase
             .ReturnsAsync(new ValidationResult());
 
         _service
-            .Setup(d => d.QueryTrustsAsync(It.IsAny<string[]>(), It.IsAny<string>()))
+            .Setup(d => d.QueryTrustsAsync(It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(model);
 
         var result = await _function.RunAsync(CreateHttpRequestData());
@@ -72,6 +72,6 @@ public class GetExpenditureTrustsFunctionTests : FunctionsTestBase
         Assert.Contains(values, p => p.PropertyName == nameof(ExpenditureQueryTrustParameters.Dimension));
 
         _service.Verify(
-            x => x.QueryTrustsAsync(It.IsAny<string[]>(), It.IsAny<string>()), Times.Never());
+            x => x.QueryTrustsAsync(It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never());
     }
 }

--- a/platform/tests/Platform.Insight.Tests/Files/GetTransparencyFilesFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Files/GetTransparencyFilesFunctionTests.cs
@@ -31,7 +31,7 @@ public class GetTransparencyFilesFunctionTests : FunctionsTestBase
         var models = _fixture.CreateMany<FileModel>();
 
         _service
-            .Setup(d => d.GetActiveFilesByType("transparency-aar", "transparency-cfr"))
+            .Setup(d => d.GetActiveFilesByType(It.IsAny<CancellationToken>(), "transparency-aar", "transparency-cfr"))
             .ReturnsAsync(models);
 
         var result = await _function.RunAsync(CreateHttpRequestData());

--- a/platform/tests/Platform.Insight.Tests/Income/GetIncomeSchoolFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Income/GetIncomeSchoolFunctionTests.cs
@@ -26,7 +26,7 @@ public class GetIncomeSchoolFunctionTests : FunctionsTestBase
     public async Task ShouldReturn200OnValidRequest()
     {
         _service
-            .Setup(d => d.GetSchoolAsync(It.IsAny<string>()))
+            .Setup(d => d.GetSchoolAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new IncomeSchoolModel());
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1");
@@ -43,7 +43,7 @@ public class GetIncomeSchoolFunctionTests : FunctionsTestBase
     public async Task ShouldReturn404OnNotFound()
     {
         _service
-            .Setup(d => d.GetSchoolAsync(It.IsAny<string>()))
+            .Setup(d => d.GetSchoolAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IncomeSchoolModel?)null);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1");

--- a/platform/tests/Platform.Insight.Tests/Income/GetIncomeSchoolHistoryFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Income/GetIncomeSchoolHistoryFunctionTests.cs
@@ -3,7 +3,6 @@ using FluentValidation;
 using FluentValidation.Results;
 using Moq;
 using Platform.Api.Insight.Features.Income;
-using Platform.Api.Insight.Features.Income.Models;
 using Platform.Api.Insight.Features.Income.Parameters;
 using Platform.Api.Insight.Features.Income.Responses;
 using Platform.Api.Insight.Features.Income.Services;
@@ -36,8 +35,8 @@ public class GetIncomeSchoolHistoryFunctionTests : FunctionsTestBase
             .ReturnsAsync(new ValidationResult());
 
         _service
-            .Setup(d => d.GetSchoolHistoryAsync(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((new YearsModel(), Array.Empty<IncomeHistoryModel>()));
+            .Setup(d => d.GetSchoolHistoryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new YearsModel(), []));
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1");
 
@@ -57,8 +56,8 @@ public class GetIncomeSchoolHistoryFunctionTests : FunctionsTestBase
             .ReturnsAsync(new ValidationResult());
 
         _service
-            .Setup(d => d.GetSchoolHistoryAsync(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((null, Array.Empty<IncomeHistoryModel>()));
+            .Setup(d => d.GetSchoolHistoryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((null, []));
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1");
 
@@ -86,6 +85,6 @@ public class GetIncomeSchoolHistoryFunctionTests : FunctionsTestBase
         Assert.Contains(values, p => p.PropertyName == nameof(IncomeParameters.Dimension));
 
         _service
-            .Verify(d => d.GetSchoolHistoryAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            .Verify(d => d.GetSchoolHistoryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/platform/tests/Platform.Insight.Tests/Income/GetIncomeTrustHistoryFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Income/GetIncomeTrustHistoryFunctionTests.cs
@@ -3,7 +3,6 @@ using FluentValidation;
 using FluentValidation.Results;
 using Moq;
 using Platform.Api.Insight.Features.Income;
-using Platform.Api.Insight.Features.Income.Models;
 using Platform.Api.Insight.Features.Income.Parameters;
 using Platform.Api.Insight.Features.Income.Responses;
 using Platform.Api.Insight.Features.Income.Services;
@@ -36,8 +35,8 @@ public class GetIncomeTrustHistoryFunctionTests : FunctionsTestBase
             .ReturnsAsync(new ValidationResult());
 
         _service
-            .Setup(d => d.GetTrustHistoryAsync(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((new YearsModel(), Array.Empty<IncomeHistoryModel>()));
+            .Setup(d => d.GetTrustHistoryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new YearsModel(), []));
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1");
 
@@ -57,8 +56,8 @@ public class GetIncomeTrustHistoryFunctionTests : FunctionsTestBase
             .ReturnsAsync(new ValidationResult());
 
         _service
-            .Setup(d => d.GetTrustHistoryAsync(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((null, Array.Empty<IncomeHistoryModel>()));
+            .Setup(d => d.GetTrustHistoryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((null, []));
 
         var result = await _function.RunAsync(CreateHttpRequestData(), "1");
 
@@ -86,6 +85,6 @@ public class GetIncomeTrustHistoryFunctionTests : FunctionsTestBase
         Assert.Contains(values, p => p.PropertyName == nameof(IncomeParameters.Dimension));
 
         _service
-            .Verify(d => d.GetTrustHistoryAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            .Verify(d => d.GetTrustHistoryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/platform/tests/Platform.Insight.Tests/MetricRagRatings/WhenGetDefaultMetricRagRatingsFunctionRuns.cs
+++ b/platform/tests/Platform.Insight.Tests/MetricRagRatings/WhenGetDefaultMetricRagRatingsFunctionRuns.cs
@@ -47,7 +47,7 @@ public class WhenGetDefaultMetricRagRatingsFunctionRuns : FunctionsTestBase
             .ReturnsAsync(new ValidationResult());
 
         _service
-            .Setup(d => d.QueryAsync(QueryParams.Urns, QueryParams.Categories, QueryParams.Statuses, QueryParams.CompanyNumber, QueryParams.LaCode, QueryParams.Phase, It.IsAny<string>(), It.IsAny<bool>()))
+            .Setup(d => d.QueryAsync(QueryParams.Urns, QueryParams.Categories, QueryParams.Statuses, QueryParams.CompanyNumber, QueryParams.LaCode, QueryParams.Phase, It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(results);
 
         var result = await _function.RunAsync(CreateHttpRequestData(_query));
@@ -81,6 +81,6 @@ public class WhenGetDefaultMetricRagRatingsFunctionRuns : FunctionsTestBase
         Assert.Contains(values, p => p.PropertyName == nameof(MetricRagRatingsParameters.Categories));
 
         _service.Verify(
-            x => x.QueryAsync(It.IsAny<string[]>(), It.IsAny<string[]>(), It.IsAny<string[]>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never());
+            x => x.QueryAsync(It.IsAny<string[]>(), It.IsAny<string[]>(), It.IsAny<string[]>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never());
     }
 }

--- a/platform/tests/Platform.Insight.Tests/MetricRagRatings/WhenGetUserDefinedMetricRagRatingsFunctionRuns.cs
+++ b/platform/tests/Platform.Insight.Tests/MetricRagRatings/WhenGetUserDefinedMetricRagRatingsFunctionRuns.cs
@@ -30,7 +30,7 @@ public class WhenGetUserDefinedMetricRagRatingsFunctionRuns : FunctionsTestBase
         const string identifier = nameof(identifier);
 
         _service
-            .Setup(d => d.UserDefinedAsync(identifier, Pipeline.RunType.Default, It.IsAny<bool>()))
+            .Setup(d => d.UserDefinedAsync(identifier, Pipeline.RunType.Default, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(results);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), identifier);

--- a/platform/tests/Platform.Insight.Tests/Schools/WhenGetSchoolCharacteristicsFunctionRuns.cs
+++ b/platform/tests/Platform.Insight.Tests/Schools/WhenGetSchoolCharacteristicsFunctionRuns.cs
@@ -29,7 +29,7 @@ public class WhenGetSchoolCharacteristicsFunctionRuns : FunctionsTestBase
         var results = Fixture.Create<SchoolCharacteristic>();
 
         _service
-            .Setup(d => d.CharacteristicAsync(urn))
+            .Setup(d => d.CharacteristicAsync(urn, It.IsAny<CancellationToken>()))
             .ReturnsAsync(results);
 
         var result = await _function.RunAsync(CreateHttpRequestData(), urn);

--- a/platform/tests/Platform.Insight.Tests/Schools/WhenGetSchoolsCharacteristicsFunctionRuns.cs
+++ b/platform/tests/Platform.Insight.Tests/Schools/WhenGetSchoolsCharacteristicsFunctionRuns.cs
@@ -35,7 +35,7 @@ public class WhenGetSchoolsCharacteristicsFunctionRuns : FunctionsTestBase
         var results = Fixture.Build<SchoolCharacteristic>().CreateMany().ToArray();
 
         _service
-            .Setup(d => d.QueryCharacteristicAsync(QueryParams.Schools))
+            .Setup(d => d.QueryCharacteristicAsync(QueryParams.Schools, It.IsAny<CancellationToken>()))
             .ReturnsAsync(results);
 
         var result = await _function.RunAsync(CreateHttpRequestData(_query));

--- a/platform/tests/Platform.Insight.Tests/Trusts/GetTrustsCharacteristicsFunctionTests.cs
+++ b/platform/tests/Platform.Insight.Tests/Trusts/GetTrustsCharacteristicsFunctionTests.cs
@@ -13,9 +13,9 @@ namespace Platform.Insight.Tests.Trusts;
 
 public class GetTrustsCharacteristicsFunctionTests : FunctionsTestBase
 {
+    private readonly Fixture _fixture;
     private readonly GetTrustsCharacteristicsFunction _function;
     private readonly Mock<ITrustsService> _service;
-    private readonly Fixture _fixture;
 
     public GetTrustsCharacteristicsFunctionTests()
     {
@@ -33,7 +33,7 @@ public class GetTrustsCharacteristicsFunctionTests : FunctionsTestBase
             .CreateMany(5);
 
         _service
-            .Setup(d => d.QueryAsync(It.IsAny<string[]>()))
+            .Setup(d => d.QueryAsync(It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(model);
 
         var result = await _function.RunAsync(CreateHttpRequestData());


### PR DESCRIPTION
### Context
[AB#258443](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/258443) [AB#259846](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/259846)

### Change proposed in this pull request
- Function `CancellationToken` support
- Service layer `CancellationToken` support

### Guidance to review 
From the user's perspective, this is a non-functional change. Unit and API tests should continue to pass. Additional changes required as part of other work items to complete the wiring up of this feature.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

