### PR TITLE
Added abort signal support to `fetch` calls

### DIFF
--- a/front-end-components/src/components/modals/modal-save-images/modal-save-images-modal/component.tsx
+++ b/front-end-components/src/components/modals/modal-save-images/modal-save-images-modal/component.tsx
@@ -7,6 +7,7 @@ import {
 } from "src/hooks/useDownloadImage";
 import { ElementSelector } from "src/components/element-selector";
 import { ProgressWithAria } from "src/components/progress-with-aria";
+import { useAbort } from "src/hooks/useAbort";
 
 export function ModalSaveImagesModal({
   all,
@@ -23,9 +24,7 @@ export function ModalSaveImagesModal({
 }: ModalSaveImagesModalProps) {
   const [imagesLoading, setImagesLoading] = useState<boolean>();
   const [progress, setProgress] = useState<number>();
-  const [cancelSignal, setCancelSignal] = useState<AbortController>(
-    new AbortController()
-  );
+  const { abort, signal } = useAbort();
   const [cancelMode, setCancelMode] = useState(false);
   const modalRef = useRef<ModalHandler>(null);
   const [allElements, setAllElements] = useState<ElementAndAttributes[]>([]);
@@ -47,7 +46,7 @@ export function ModalSaveImagesModal({
     onImagesLoading: setImagesLoading,
     onProgress: handleProgress,
     showTitles,
-    signal: cancelSignal.signal,
+    signal,
   });
 
   useEffect(() => {
@@ -74,17 +73,16 @@ export function ModalSaveImagesModal({
   }, [elementClassName, elementTitleAttr, costCodesAttr]);
 
   const handleCloseModal = useCallback(
-    (abort: boolean) => {
-      if (imagesLoading && abort) {
-        cancelSignal.abort();
-        setCancelSignal(new AbortController());
+    (shouldAbort: boolean) => {
+      if (imagesLoading && shouldAbort) {
+        abort();
       }
 
       setProgress(undefined);
       setCancelMode(false);
       onCloseModal();
     },
-    [cancelSignal, imagesLoading, onCloseModal]
+    [abort, imagesLoading, onCloseModal]
   );
 
   const handleDownloadStart = async () => {

--- a/front-end-components/src/hooks/useAbort.ts
+++ b/front-end-components/src/hooks/useAbort.ts
@@ -1,0 +1,16 @@
+import { useState, useCallback } from "react";
+
+// wrapper around `AbortController` to re-initialise after each `abort()` called
+export function useAbort() {
+  const [controller, setController] = useState<AbortController>(
+    new AbortController()
+  );
+
+  const abort = useCallback(() => {
+    controller.abort();
+    setController(new AbortController());
+  }, [controller]);
+
+  const signal = controller.signal;
+  return { abort, signal };
+}

--- a/front-end-components/src/services/balance-api.tsx
+++ b/front-end-components/src/services/balance-api.tsx
@@ -9,7 +9,8 @@ export class BalanceApi {
   static async history(
     type: string,
     id: string,
-    dimension: string
+    dimension: string,
+    signals?: AbortSignal[]
   ): Promise<BalanceHistoryRows> {
     const params = new URLSearchParams({
       type: type,
@@ -24,6 +25,7 @@ export class BalanceApi {
         "Content-Type": "application/json",
         "X-Correlation-ID": uuidv4(),
       },
+      signal: signals?.length ? AbortSignal.any(signals) : undefined,
     });
 
     const json = await response.json();
@@ -37,7 +39,8 @@ export class BalanceApi {
   static async trust(
     id: string,
     dimension: string,
-    excludeCentralServices?: boolean
+    excludeCentralServices?: boolean,
+    signals?: AbortSignal[]
   ): Promise<TrustBalance[]> {
     const params = new URLSearchParams({
       type: "trust",
@@ -59,6 +62,7 @@ export class BalanceApi {
         "Content-Type": "application/json",
         "X-Correlation-ID": uuidv4(),
       },
+      signal: signals?.length ? AbortSignal.any(signals) : undefined,
     })
       .then((res) => res.json())
       .then((res) => {
@@ -71,7 +75,8 @@ export class BalanceApi {
   }
 
   static async budgetForecastReturns(
-    id: string
+    id: string,
+    signals?: AbortSignal[]
   ): Promise<BudgetForecastReturn[]> {
     const params = new URLSearchParams({
       companyNumber: id,
@@ -84,6 +89,7 @@ export class BalanceApi {
         "Content-Type": "application/json",
         "X-Correlation-ID": uuidv4(),
       },
+      signal: signals?.length ? AbortSignal.any(signals) : undefined,
     })
       .then((res) => res.json())
       .then((res) => {

--- a/front-end-components/src/services/budget-forecast-api.tsx
+++ b/front-end-components/src/services/budget-forecast-api.tsx
@@ -3,7 +3,8 @@ import { v4 as uuidv4 } from "uuid";
 
 export class BudgetForecastApi {
   static async budgetForecastReturns(
-    id: string
+    id: string,
+    signals?: AbortSignal[]
   ): Promise<BudgetForecastReturn[]> {
     const params = new URLSearchParams({
       companyNumber: id,
@@ -16,6 +17,7 @@ export class BudgetForecastApi {
         "Content-Type": "application/json",
         "X-Correlation-ID": uuidv4(),
       },
+      signal: signals?.length ? AbortSignal.any(signals) : undefined,
     })
       .then((res) => res.json())
       .then((res) => {

--- a/front-end-components/src/services/census-api.tsx
+++ b/front-end-components/src/services/census-api.tsx
@@ -9,7 +9,8 @@ import { v4 as uuidv4 } from "uuid";
 export class CensusApi {
   static async history(
     id: string,
-    dimension: string
+    dimension: string,
+    signals?: AbortSignal[]
   ): Promise<CensusHistoryRows> {
     const response = await fetch(
       "/api/census/history?" +
@@ -21,6 +22,7 @@ export class CensusApi {
           "Content-Type": "application/json",
           "X-Correlation-ID": uuidv4(),
         },
+        signal: signals?.length ? AbortSignal.any(signals) : undefined,
       }
     );
 
@@ -70,7 +72,8 @@ export class CensusApi {
     dimension: string,
     category: string,
     phase?: string,
-    customDataId?: string
+    customDataId?: string,
+    signals?: AbortSignal[]
   ): Promise<Census[]> {
     const params = new URLSearchParams({
       type: type,
@@ -94,6 +97,7 @@ export class CensusApi {
         "Content-Type": "application/json",
         "X-Correlation-ID": uuidv4(),
       },
+      signal: signals?.length ? AbortSignal.any(signals) : undefined,
     })
       .then((res) => res.json())
       .then((res) => {

--- a/front-end-components/src/services/expenditure-api.tsx
+++ b/front-end-components/src/services/expenditure-api.tsx
@@ -11,7 +11,8 @@ export class ExpenditureApi {
   static async history(
     type: string,
     id: string,
-    dimension: string
+    dimension: string,
+    signals?: AbortSignal[]
   ): Promise<ExpenditureHistoryRows> {
     const params = new URLSearchParams({
       type: type,
@@ -26,6 +27,7 @@ export class ExpenditureApi {
         "Content-Type": "application/json",
         "X-Correlation-ID": uuidv4(),
       },
+      signal: signals?.length ? AbortSignal.any(signals) : undefined,
     });
 
     const json = await response.json();
@@ -79,7 +81,8 @@ export class ExpenditureApi {
     dimension: string,
     category: string,
     phase?: string,
-    customDataId?: string
+    customDataId?: string,
+    signals?: AbortSignal[]
   ): Promise<T[]> {
     const params = new URLSearchParams({
       type: type,
@@ -103,6 +106,7 @@ export class ExpenditureApi {
         "Content-Type": "application/json",
         "X-Correlation-ID": uuidv4(),
       },
+      signal: signals?.length ? AbortSignal.any(signals) : undefined,
     })
       .then((res) => res.json())
       .then((res) => {
@@ -118,7 +122,8 @@ export class ExpenditureApi {
     id: string,
     dimension: string,
     category: string,
-    excludeCentralServices?: boolean
+    excludeCentralServices?: boolean,
+    signals?: AbortSignal[]
   ): Promise<T[]> {
     const params = new URLSearchParams({
       type: "trust",
@@ -141,6 +146,7 @@ export class ExpenditureApi {
         "Content-Type": "application/json",
         "X-Correlation-ID": uuidv4(),
       },
+      signal: signals?.length ? AbortSignal.any(signals) : undefined,
     })
       .then((res) => res.json())
       .then((res) => {

--- a/front-end-components/src/services/history-service.ts
+++ b/front-end-components/src/services/history-service.ts
@@ -17,26 +17,29 @@ export class HistoryService {
   static async getBalanceHistory(
     type: string,
     id: string,
-    dimension: string
+    dimension: string,
+    signals?: AbortSignal[]
   ): Promise<BalanceHistoryItem[]> {
-    const historyRows = await BalanceApi.history(type, id, dimension);
+    const historyRows = await BalanceApi.history(type, id, dimension, signals);
     return HistoryService.populateHistoricYears(historyRows);
   }
 
   static async getIncomeHistory(
     type: string,
     id: string,
-    dimension: string
+    dimension: string,
+    signals?: AbortSignal[]
   ): Promise<IncomeHistoryItem[]> {
-    const historyRows = await IncomeApi.history(type, id, dimension);
+    const historyRows = await IncomeApi.history(type, id, dimension, signals);
     return HistoryService.populateHistoricYears(historyRows);
   }
 
   static async getCensusHistory(
     id: string,
-    dimension: string
+    dimension: string,
+    signals?: AbortSignal[]
   ): Promise<CensusHistoryItem[]> {
-    const historyRows = await CensusApi.history(id, dimension);
+    const historyRows = await CensusApi.history(id, dimension, signals);
     return HistoryService.populateHistoricYears(historyRows);
   }
 
@@ -87,9 +90,15 @@ export class HistoryService {
   static async getExpenditureHistory(
     type: string,
     id: string,
-    dimension: string
+    dimension: string,
+    signals?: AbortSignal[]
   ): Promise<ExpenditureHistoryItem[]> {
-    const historyRows = await ExpenditureApi.history(type, id, dimension);
+    const historyRows = await ExpenditureApi.history(
+      type,
+      id,
+      dimension,
+      signals
+    );
     return HistoryService.populateHistoricYears(historyRows);
   }
 

--- a/front-end-components/src/services/income-api.tsx
+++ b/front-end-components/src/services/income-api.tsx
@@ -5,7 +5,8 @@ export class IncomeApi {
   static async history(
     type: string,
     id: string,
-    dimension: string
+    dimension: string,
+    signals?: AbortSignal[]
   ): Promise<IncomeHistoryRows> {
     const params = new URLSearchParams({
       type: type,
@@ -20,6 +21,7 @@ export class IncomeApi {
         "Content-Type": "application/json",
         "X-Correlation-ID": uuidv4(),
       },
+      signal: signals?.length ? AbortSignal.any(signals) : undefined,
     });
 
     const json = await response.json();

--- a/front-end-components/src/services/national-rank-api.tsx
+++ b/front-end-components/src/services/national-rank-api.tsx
@@ -4,7 +4,8 @@ import { v4 as uuidv4 } from "uuid";
 export class NationalRankApi {
   static async get(
     ranking: "SpendAsPercentageOfBudget",
-    sort?: "asc" | "desc"
+    sort?: "asc" | "desc",
+    signals?: AbortSignal[]
   ): Promise<LocalAuthorityRanking> {
     const params: { ranking: string; sort?: string } = { ranking };
     if (sort) {
@@ -19,6 +20,7 @@ export class NationalRankApi {
           "Content-Type": "application/json",
           "X-Correlation-ID": uuidv4(),
         },
+        signal: signals?.length ? AbortSignal.any(signals) : undefined,
       }
     );
 

--- a/front-end-components/src/views/compare-your-census/partials/auxiliary-staff.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/auxiliary-staff.tsx
@@ -11,6 +11,7 @@ import { AuxiliaryStaffData } from "src/views/compare-your-census/partials";
 import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { Census, CensusApi } from "src/services";
 import { DimensionedChart } from "src/composed/dimensioned-chart";
+import { useAbort } from "src/hooks/useAbort";
 
 export const AuxiliaryStaff: React.FC<{ type: string; id: string }> = ({
   type,
@@ -20,6 +21,7 @@ export const AuxiliaryStaff: React.FC<{ type: string; id: string }> = ({
   const customDataId = useContext(CustomDataContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
   const [data, setData] = useState<Census[] | null>();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await CensusApi.query(
@@ -28,9 +30,10 @@ export const AuxiliaryStaff: React.FC<{ type: string; id: string }> = ({
       dimension.value,
       "AuxiliaryStaffFte",
       phase,
-      customDataId
+      customDataId,
+      [signal]
     );
-  }, [id, dimension, type, phase, customDataId]);
+  }, [type, id, dimension.value, phase, customDataId, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -61,6 +64,8 @@ export const AuxiliaryStaff: React.FC<{ type: string; id: string }> = ({
     }, [dimension, data]);
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       CensusCategories.find((x) => x.value === value) ?? PupilsPerStaffRole;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-census/partials/headcount.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/headcount.tsx
@@ -16,6 +16,7 @@ import { HeadcountData } from "src/views/compare-your-census/partials";
 import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { Census, CensusApi } from "src/services";
 import { DimensionedChart } from "src/composed/dimensioned-chart";
+import { useAbort } from "src/hooks/useAbort";
 
 export const Headcount: React.FC<{ type: string; id: string }> = ({
   type,
@@ -25,6 +26,7 @@ export const Headcount: React.FC<{ type: string; id: string }> = ({
   const customDataId = useContext(CustomDataContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
   const [data, setData] = useState<Census[] | null>();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await CensusApi.query(
@@ -33,9 +35,10 @@ export const Headcount: React.FC<{ type: string; id: string }> = ({
       dimension.value,
       "WorkforceHeadcount",
       phase,
-      customDataId
+      customDataId,
+      [signal]
     );
-  }, [id, dimension, type, phase, customDataId]);
+  }, [id, dimension, type, phase, customDataId, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -66,6 +69,8 @@ export const Headcount: React.FC<{ type: string; id: string }> = ({
     }, [dimension, data]);
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       CensusCategories.find((x) => x.value === value) ?? PupilsPerStaffRole;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-census/partials/non-classroom-support.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/non-classroom-support.tsx
@@ -11,6 +11,7 @@ import { NonClassroomSupportData } from "src/views/compare-your-census/partials"
 import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { Census, CensusApi } from "src/services";
 import { DimensionedChart } from "src/composed/dimensioned-chart";
+import { useAbort } from "src/hooks/useAbort";
 
 export const NonClassroomSupport: React.FC<{ type: string; id: string }> = ({
   type,
@@ -20,6 +21,7 @@ export const NonClassroomSupport: React.FC<{ type: string; id: string }> = ({
   const customDataId = useContext(CustomDataContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
   const [data, setData] = useState<Census[] | null>();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await CensusApi.query(
@@ -28,9 +30,10 @@ export const NonClassroomSupport: React.FC<{ type: string; id: string }> = ({
       dimension.value,
       "NonClassroomSupportStaffFte",
       phase,
-      customDataId
+      customDataId,
+      [signal]
     );
-  }, [id, dimension, type, phase, customDataId]);
+  }, [id, dimension, type, phase, customDataId, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -61,6 +64,8 @@ export const NonClassroomSupport: React.FC<{ type: string; id: string }> = ({
     }, [dimension, data]);
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       CensusCategories.find((x) => x.value === value) ?? PupilsPerStaffRole;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-census/partials/school-workforce.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/school-workforce.tsx
@@ -15,6 +15,7 @@ import { SchoolCensusData } from "src/views/compare-your-census/partials";
 import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { Census, CensusApi } from "src/services";
 import { DimensionedChart } from "src/composed/dimensioned-chart";
+import { useAbort } from "src/hooks/useAbort";
 
 export const SchoolWorkforce: React.FC<{ type: string; id: string }> = ({
   type,
@@ -24,6 +25,7 @@ export const SchoolWorkforce: React.FC<{ type: string; id: string }> = ({
   const customDataId = useContext(CustomDataContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
   const [data, setData] = useState<Census[] | null>();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await CensusApi.query(
@@ -32,9 +34,10 @@ export const SchoolWorkforce: React.FC<{ type: string; id: string }> = ({
       dimension.value,
       "WorkforceFte",
       phase,
-      customDataId
+      customDataId,
+      [signal]
     );
-  }, [id, dimension, type, phase, customDataId]);
+  }, [id, dimension, type, phase, customDataId, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -65,6 +68,8 @@ export const SchoolWorkforce: React.FC<{ type: string; id: string }> = ({
     }, [dimension, data]);
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       CensusCategories.find((x) => x.value === value) ?? PupilsPerStaffRole;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-census/partials/senior-leadership.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/senior-leadership.tsx
@@ -11,6 +11,7 @@ import { SeniorLeadershipData } from "src/views/compare-your-census/partials";
 import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { Census, CensusApi } from "src/services";
 import { DimensionedChart } from "src/composed/dimensioned-chart";
+import { useAbort } from "src/hooks/useAbort";
 
 export const SeniorLeadership: React.FC<{ type: string; id: string }> = ({
   type,
@@ -20,6 +21,7 @@ export const SeniorLeadership: React.FC<{ type: string; id: string }> = ({
   const customDataId = useContext(CustomDataContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
   const [data, setData] = useState<Census[] | null>();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await CensusApi.query(
@@ -28,9 +30,10 @@ export const SeniorLeadership: React.FC<{ type: string; id: string }> = ({
       dimension.value,
       "SeniorLeadershipFte",
       phase,
-      customDataId
+      customDataId,
+      [signal]
     );
-  }, [id, dimension, type, phase, customDataId]);
+  }, [id, dimension, type, phase, customDataId, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -61,6 +64,8 @@ export const SeniorLeadership: React.FC<{ type: string; id: string }> = ({
     }, [dimension, data]);
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       CensusCategories.find((x) => x.value === value) ?? PupilsPerStaffRole;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-census/partials/teaching-assistants.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/teaching-assistants.tsx
@@ -11,6 +11,7 @@ import { TeachingAssistantsData } from "src/views/compare-your-census/partials";
 import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { Census, CensusApi } from "src/services";
 import { DimensionedChart } from "src/composed/dimensioned-chart";
+import { useAbort } from "src/hooks/useAbort";
 
 export const TeachingAssistants: React.FC<{ type: string; id: string }> = ({
   type,
@@ -20,6 +21,7 @@ export const TeachingAssistants: React.FC<{ type: string; id: string }> = ({
   const customDataId = useContext(CustomDataContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
   const [data, setData] = useState<Census[] | null>();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await CensusApi.query(
@@ -28,9 +30,10 @@ export const TeachingAssistants: React.FC<{ type: string; id: string }> = ({
       dimension.value,
       "TeachingAssistantsFte",
       phase,
-      customDataId
+      customDataId,
+      [signal]
     );
-  }, [id, dimension, type, phase, customDataId]);
+  }, [id, dimension, type, phase, customDataId, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -61,6 +64,8 @@ export const TeachingAssistants: React.FC<{ type: string; id: string }> = ({
     }, [dimension, data]);
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       CensusCategories.find((x) => x.value === value) ?? PupilsPerStaffRole;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-census/partials/total-teachers.tsx
+++ b/front-end-components/src/views/compare-your-census/partials/total-teachers.tsx
@@ -11,6 +11,7 @@ import { TotalTeachersData } from "src/views/compare-your-census/partials";
 import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { Census, CensusApi } from "src/services";
 import { DimensionedChart } from "src/composed/dimensioned-chart";
+import { useAbort } from "src/hooks/useAbort";
 
 export const TotalTeachers: React.FC<{ type: string; id: string }> = ({
   type,
@@ -20,6 +21,7 @@ export const TotalTeachers: React.FC<{ type: string; id: string }> = ({
   const customDataId = useContext(CustomDataContext);
   const [dimension, setDimension] = useState(PupilsPerStaffRole);
   const [data, setData] = useState<Census[] | null>();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await CensusApi.query(
@@ -28,9 +30,10 @@ export const TotalTeachers: React.FC<{ type: string; id: string }> = ({
       dimension.value,
       "TeachersFte",
       phase,
-      customDataId
+      customDataId,
+      [signal]
     );
-  }, [id, dimension, type, phase, customDataId]);
+  }, [id, dimension, type, phase, customDataId, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -61,6 +64,8 @@ export const TotalTeachers: React.FC<{ type: string; id: string }> = ({
     }, [dimension, data]);
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       CensusCategories.find((x) => x.value === value) ?? PupilsPerStaffRole;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/administrative-supplies.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/administrative-supplies.tsx
@@ -17,6 +17,7 @@ import {
   AdministrativeSuppliesExpenditure,
 } from "src/services";
 import { AccordionSection } from "src/composed/accordion-section";
+import { useAbort } from "src/hooks/useAbort";
 
 export const AdministrativeSupplies: React.FC<CompareYourCostsProps> = ({
   type,
@@ -28,6 +29,7 @@ export const AdministrativeSupplies: React.FC<CompareYourCostsProps> = ({
   const [data, setData] = useState<
     AdministrativeSuppliesExpenditure[] | null
   >();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await ExpenditureApi.query<AdministrativeSuppliesExpenditure>(
@@ -36,9 +38,10 @@ export const AdministrativeSupplies: React.FC<CompareYourCostsProps> = ({
       dimension.value,
       "AdministrationSupplies",
       phase,
-      customDataId
+      customDataId,
+      [signal]
     );
-  }, [id, dimension, type, phase, customDataId]);
+  }, [type, id, dimension.value, phase, customDataId, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -47,6 +50,8 @@ export const AdministrativeSupplies: React.FC<CompareYourCostsProps> = ({
   }, [getData]);
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/catering-staff-services.tsx
@@ -23,6 +23,7 @@ import {
 } from "src/services";
 import { TotalCateringCostsType } from "src/components/total-catering-costs-type";
 import { AccordionSection } from "src/composed/accordion-section";
+import { useAbort } from "src/hooks/useAbort";
 
 export const CateringStaffServices: React.FC<CompareYourCostsProps> = ({
   type,
@@ -34,6 +35,7 @@ export const CateringStaffServices: React.FC<CompareYourCostsProps> = ({
   const [data, setData] = useState<CateringStaffServicesExpenditure[] | null>();
   const [totalCateringCostsField, setTotalCateringCostsField] =
     useState<TotalCateringCostsField>("totalGrossCateringCosts");
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await ExpenditureApi.query<CateringStaffServicesExpenditure>(
@@ -42,9 +44,10 @@ export const CateringStaffServices: React.FC<CompareYourCostsProps> = ({
       dimension.value,
       "CateringStaffServices",
       phase,
-      customDataId
+      customDataId,
+      [signal]
     );
-  }, [id, dimension, type, phase, customDataId]);
+  }, [type, id, dimension.value, phase, customDataId, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -66,6 +69,8 @@ export const CateringStaffServices: React.FC<CompareYourCostsProps> = ({
   const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
     event
   ) => {
+    abort();
+
     const dimension =
       CostCategories.find((x) => x.value === event.target.value) ??
       PoundsPerPupil;

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-ict.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-ict.tsx
@@ -14,6 +14,7 @@ import { PhaseContext, CustomDataContext } from "src/contexts";
 import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, EducationalIctExpenditure } from "src/services";
 import { AccordionSection } from "src/composed/accordion-section";
+import { useAbort } from "src/hooks/useAbort";
 
 export const EducationalIct: React.FC<CompareYourCostsProps> = ({
   type,
@@ -23,6 +24,7 @@ export const EducationalIct: React.FC<CompareYourCostsProps> = ({
   const phase = useContext(PhaseContext);
   const customDataId = useContext(CustomDataContext);
   const [data, setData] = useState<EducationalIctExpenditure[] | null>();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await ExpenditureApi.query<EducationalIctExpenditure>(
@@ -31,9 +33,10 @@ export const EducationalIct: React.FC<CompareYourCostsProps> = ({
       dimension.value,
       "EducationalIct",
       phase,
-      customDataId
+      customDataId,
+      [signal]
     );
-  }, [id, dimension, type, phase, customDataId]);
+  }, [type, id, dimension.value, phase, customDataId, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -42,6 +45,8 @@ export const EducationalIct: React.FC<CompareYourCostsProps> = ({
   }, [getData]);
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-supplies.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/educational-supplies.tsx
@@ -14,6 +14,7 @@ import { CustomDataContext, PhaseContext } from "src/contexts";
 import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, EducationalSuppliesExpenditure } from "src/services";
 import { AccordionSection } from "src/composed/accordion-section";
+import { useAbort } from "src/hooks/useAbort";
 
 export const EducationalSupplies: React.FC<CompareYourCostsProps> = ({
   type,
@@ -23,6 +24,7 @@ export const EducationalSupplies: React.FC<CompareYourCostsProps> = ({
   const phase = useContext(PhaseContext);
   const customDataId = useContext(CustomDataContext);
   const [data, setData] = useState<EducationalSuppliesExpenditure[] | null>();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await ExpenditureApi.query<EducationalSuppliesExpenditure>(
@@ -31,9 +33,10 @@ export const EducationalSupplies: React.FC<CompareYourCostsProps> = ({
       dimension.value,
       "EducationalSupplies",
       phase,
-      customDataId
+      customDataId,
+      [signal]
     );
-  }, [id, dimension, type, phase, customDataId]);
+  }, [type, id, dimension.value, phase, customDataId, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -53,6 +56,8 @@ export const EducationalSupplies: React.FC<CompareYourCostsProps> = ({
   );
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/non-educational-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/non-educational-support-staff.tsx
@@ -17,6 +17,7 @@ import {
   NonEducationalSupportStaffExpenditure,
 } from "src/services";
 import { AccordionSection } from "src/composed/accordion-section";
+import { useAbort } from "src/hooks/useAbort";
 
 export const NonEducationalSupportStaff: React.FC<CompareYourCostsProps> = ({
   type,
@@ -28,6 +29,7 @@ export const NonEducationalSupportStaff: React.FC<CompareYourCostsProps> = ({
   const [data, setData] = useState<
     NonEducationalSupportStaffExpenditure[] | null
   >();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await ExpenditureApi.query<NonEducationalSupportStaffExpenditure>(
@@ -36,9 +38,10 @@ export const NonEducationalSupportStaff: React.FC<CompareYourCostsProps> = ({
       dimension.value,
       "NonEducationalSupportStaff",
       phase,
-      customDataId
+      customDataId,
+      [signal]
     );
-  }, [id, dimension, type, phase, customDataId]);
+  }, [type, id, dimension.value, phase, customDataId, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -58,6 +61,8 @@ export const NonEducationalSupportStaff: React.FC<CompareYourCostsProps> = ({
   );
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/other-costs.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/other-costs.tsx
@@ -14,12 +14,14 @@ import { PhaseContext, CustomDataContext } from "src/contexts";
 import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, OtherCostsDataExpenditure } from "src/services";
 import { AccordionSection } from "src/composed/accordion-section";
+import { useAbort } from "src/hooks/useAbort";
 
 export const OtherCosts: React.FC<CompareYourCostsProps> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const phase = useContext(PhaseContext);
   const customDataId = useContext(CustomDataContext);
   const [data, setData] = useState<OtherCostsDataExpenditure[] | null>();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await ExpenditureApi.query<OtherCostsDataExpenditure>(
@@ -28,9 +30,10 @@ export const OtherCosts: React.FC<CompareYourCostsProps> = ({ type, id }) => {
       dimension.value,
       "Other",
       phase,
-      customDataId
+      customDataId,
+      [signal]
     );
-  }, [id, dimension, type, phase, customDataId]);
+  }, [type, id, dimension.value, phase, customDataId, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -50,6 +53,8 @@ export const OtherCosts: React.FC<CompareYourCostsProps> = ({ type, id }) => {
   );
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/premises-staff-services.tsx
@@ -14,6 +14,7 @@ import { PhaseContext, CustomDataContext } from "src/contexts";
 import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, PremisesStaffServicesExpenditure } from "src/services";
 import { AccordionSection } from "src/composed/accordion-section";
+import { useAbort } from "src/hooks/useAbort";
 
 export const PremisesStaffServices: React.FC<CompareYourCostsProps> = ({
   type,
@@ -23,6 +24,7 @@ export const PremisesStaffServices: React.FC<CompareYourCostsProps> = ({
   const phase = useContext(PhaseContext);
   const customDataId = useContext(CustomDataContext);
   const [data, setData] = useState<PremisesStaffServicesExpenditure[] | null>();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await ExpenditureApi.query<PremisesStaffServicesExpenditure>(
@@ -31,9 +33,10 @@ export const PremisesStaffServices: React.FC<CompareYourCostsProps> = ({
       dimension.value,
       "PremisesStaffServices",
       phase,
-      customDataId
+      customDataId,
+      [signal]
     );
-  }, [id, dimension, type, phase, customDataId]);
+  }, [type, id, dimension.value, phase, customDataId, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -53,6 +56,8 @@ export const PremisesStaffServices: React.FC<CompareYourCostsProps> = ({
   );
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       PremisesCategories.find((x) => x.value === value) ?? PoundsPerMetreSq;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/teaching-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/teaching-support-staff.tsx
@@ -14,6 +14,7 @@ import { PhaseContext, CustomDataContext } from "src/contexts";
 import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, TeachingSupportStaffExpenditure } from "src/services";
 import { AccordionSection } from "src/composed/accordion-section";
+import { useAbort } from "src/hooks/useAbort";
 
 export const TeachingSupportStaff: React.FC<CompareYourCostsProps> = ({
   type,
@@ -23,6 +24,7 @@ export const TeachingSupportStaff: React.FC<CompareYourCostsProps> = ({
   const phase = useContext(PhaseContext);
   const customDataId = useContext(CustomDataContext);
   const [data, setData] = useState<TeachingSupportStaffExpenditure[] | null>();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await ExpenditureApi.query<TeachingSupportStaffExpenditure>(
@@ -31,9 +33,10 @@ export const TeachingSupportStaff: React.FC<CompareYourCostsProps> = ({
       dimension.value,
       "TeachingTeachingSupportStaff",
       phase,
-      customDataId
+      customDataId,
+      [signal]
     );
-  }, [id, dimension, type, phase, customDataId]);
+  }, [type, id, dimension.value, phase, customDataId, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -53,6 +56,8 @@ export const TeachingSupportStaff: React.FC<CompareYourCostsProps> = ({
   );
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-costs/partials/accordion-sections/utilities.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/accordion-sections/utilities.tsx
@@ -14,12 +14,14 @@ import { PhaseContext, CustomDataContext } from "src/contexts";
 import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart-wrapper";
 import { ExpenditureApi, UtilitiesExpenditure } from "src/services";
 import { AccordionSection } from "src/composed/accordion-section";
+import { useAbort } from "src/hooks/useAbort";
 
 export const Utilities: React.FC<CompareYourCostsProps> = ({ type, id }) => {
   const [dimension, setDimension] = useState(PoundsPerMetreSq);
   const phase = useContext(PhaseContext);
   const customDataId = useContext(CustomDataContext);
   const [data, setData] = useState<UtilitiesExpenditure[] | null>();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await ExpenditureApi.query<UtilitiesExpenditure>(
@@ -28,9 +30,10 @@ export const Utilities: React.FC<CompareYourCostsProps> = ({ type, id }) => {
       dimension.value,
       "Utilities",
       phase,
-      customDataId
+      customDataId,
+      [signal]
     );
-  }, [id, dimension, type, phase, customDataId]);
+  }, [type, id, dimension.value, phase, customDataId, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -50,6 +53,8 @@ export const Utilities: React.FC<CompareYourCostsProps> = ({ type, id }) => {
   );
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       PremisesCategories.find((x) => x.value === value) ?? PoundsPerMetreSq;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-costs/partials/total-expenditure.tsx
+++ b/front-end-components/src/views/compare-your-costs/partials/total-expenditure.tsx
@@ -16,6 +16,7 @@ import { HorizontalBarChartWrapperData } from "src/composed/horizontal-bar-chart
 import { ExpenditureApi, TotalExpenditureExpenditure } from "src/services";
 import { CompareYourCostsProps } from "./accordion-sections/types";
 import { DimensionedChart } from "src/composed/dimensioned-chart";
+import { useAbort } from "src/hooks/useAbort";
 
 export const TotalExpenditure: React.FC<CompareYourCostsProps> = ({
   id,
@@ -26,6 +27,7 @@ export const TotalExpenditure: React.FC<CompareYourCostsProps> = ({
   const phase = useContext(PhaseContext);
   const customDataId = useContext(CustomDataContext);
   const [data, setData] = useState<TotalExpenditureExpenditure[] | null>();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await ExpenditureApi.query<TotalExpenditureExpenditure>(
@@ -34,9 +36,10 @@ export const TotalExpenditure: React.FC<CompareYourCostsProps> = ({
       dimension.value,
       "TotalExpenditure",
       phase,
-      customDataId
+      customDataId,
+      [signal]
     );
-  }, [id, dimension, type, phase, customDataId]);
+  }, [type, id, dimension.value, phase, customDataId, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -73,6 +76,8 @@ export const TotalExpenditure: React.FC<CompareYourCostsProps> = ({
     }, [dimension, data]);
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/administrative-supplies.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/administrative-supplies.tsx
@@ -12,6 +12,7 @@ import {
   BreakdownInclude,
 } from "src/components/central-services-breakdown";
 import { AccordionSection } from "src/composed/accordion-section";
+import { useAbort } from "src/hooks/useAbort";
 
 export const AdministrativeSupplies: React.FC<{
   id: string;
@@ -21,15 +22,17 @@ export const AdministrativeSupplies: React.FC<{
   const [data, setData] = useState<
     AdministrativeSuppliesTrustExpenditure[] | null
   >();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await ExpenditureApi.trust<AdministrativeSuppliesTrustExpenditure>(
       id,
       dimension.value,
       "AdministrationSupplies",
-      breakdown === BreakdownExclude
+      breakdown === BreakdownExclude,
+      [signal]
     );
-  }, [id, dimension, breakdown]);
+  }, [id, dimension.value, breakdown, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -38,6 +41,8 @@ export const AdministrativeSupplies: React.FC<{
   }, [getData]);
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/catering-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/catering-staff-services.tsx
@@ -18,6 +18,7 @@ import {
 } from "src/components/central-services-breakdown";
 import { TotalCateringCostsType } from "src/components/total-catering-costs-type";
 import { AccordionSection } from "src/composed/accordion-section";
+import { useAbort } from "src/hooks/useAbort";
 
 export const CateringStaffServices: React.FC<{
   id: string;
@@ -29,15 +30,17 @@ export const CateringStaffServices: React.FC<{
   >();
   const [totalCateringCostsField, setTotalCateringCostsField] =
     useState<TotalCateringCostsField>("totalGrossCateringCosts");
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await ExpenditureApi.trust<CateringStaffServicesTrustExpenditure>(
       id,
       dimension.value,
       "CateringStaffServices",
-      breakdown === BreakdownExclude
+      breakdown === BreakdownExclude,
+      [signal]
     );
-  }, [id, dimension, breakdown]);
+  }, [id, dimension.value, breakdown, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -59,6 +62,8 @@ export const CateringStaffServices: React.FC<{
   const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
     event
   ) => {
+    abort();
+
     const dimension =
       CostCategories.find((x) => x.value === event.target.value) ??
       PoundsPerPupil;

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-ict.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-ict.tsx
@@ -9,6 +9,7 @@ import {
   BreakdownInclude,
 } from "src/components/central-services-breakdown";
 import { AccordionSection } from "src/composed/accordion-section";
+import { useAbort } from "src/hooks/useAbort";
 
 export const EducationalIct: React.FC<{
   id: string;
@@ -16,15 +17,17 @@ export const EducationalIct: React.FC<{
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const { breakdown } = useCentralServicesBreakdownContext(true);
   const [data, setData] = useState<EducationalIctTrustExpenditure[] | null>();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await ExpenditureApi.trust<EducationalIctTrustExpenditure>(
       id,
       dimension.value,
       "EducationalIct",
-      breakdown === BreakdownExclude
+      breakdown === BreakdownExclude,
+      [signal]
     );
-  }, [id, dimension, breakdown]);
+  }, [id, dimension.value, breakdown, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -33,6 +36,8 @@ export const EducationalIct: React.FC<{
   }, [getData]);
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-supplies.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/educational-supplies.tsx
@@ -12,6 +12,7 @@ import {
   BreakdownInclude,
 } from "src/components/central-services-breakdown";
 import { AccordionSection } from "src/composed/accordion-section";
+import { useAbort } from "src/hooks/useAbort";
 
 export const EducationalSupplies: React.FC<{
   id: string;
@@ -21,15 +22,17 @@ export const EducationalSupplies: React.FC<{
   const [data, setData] = useState<
     EducationalSuppliesTrustExpenditure[] | null
   >();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await ExpenditureApi.trust<EducationalSuppliesTrustExpenditure>(
       id,
       dimension.value,
       "EducationalSupplies",
-      breakdown === BreakdownExclude
+      breakdown === BreakdownExclude,
+      [signal]
     );
-  }, [id, dimension, breakdown]);
+  }, [id, dimension.value, breakdown, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -49,6 +52,8 @@ export const EducationalSupplies: React.FC<{
   }, [dimension, breakdown]);
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/non-educational-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/non-educational-support-staff.tsx
@@ -12,6 +12,7 @@ import {
   BreakdownInclude,
 } from "src/components/central-services-breakdown";
 import { AccordionSection } from "src/composed/accordion-section";
+import { useAbort } from "src/hooks/useAbort";
 
 export const NonEducationalSupportStaff: React.FC<{
   id: string;
@@ -21,15 +22,17 @@ export const NonEducationalSupportStaff: React.FC<{
   const [data, setData] = useState<
     NonEducationalSupportStaffTrustExpenditure[] | null
   >();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await ExpenditureApi.trust<NonEducationalSupportStaffTrustExpenditure>(
       id,
       dimension.value,
       "NonEducationalSupportStaff",
-      breakdown === BreakdownExclude
+      breakdown === BreakdownExclude,
+      [signal]
     );
-  }, [id, dimension, breakdown]);
+  }, [id, dimension.value, breakdown, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -49,6 +52,8 @@ export const NonEducationalSupportStaff: React.FC<{
   }, [dimension, breakdown]);
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/other-costs.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/other-costs.tsx
@@ -9,6 +9,7 @@ import {
   BreakdownInclude,
 } from "src/components/central-services-breakdown";
 import { AccordionSection } from "src/composed/accordion-section";
+import { useAbort } from "src/hooks/useAbort";
 
 export const OtherCosts: React.FC<{
   id: string;
@@ -16,15 +17,17 @@ export const OtherCosts: React.FC<{
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const { breakdown } = useCentralServicesBreakdownContext(true);
   const [data, setData] = useState<OtherCostsDataTrustExpenditure[] | null>();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await ExpenditureApi.trust<OtherCostsDataTrustExpenditure>(
       id,
       dimension.value,
       "Other",
-      breakdown === BreakdownExclude
+      breakdown === BreakdownExclude,
+      [signal]
     );
-  }, [id, dimension, breakdown]);
+  }, [id, dimension.value, breakdown, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -44,6 +47,8 @@ export const OtherCosts: React.FC<{
   }, [dimension, breakdown]);
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/premises-staff-services.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/premises-staff-services.tsx
@@ -12,6 +12,7 @@ import {
   BreakdownInclude,
 } from "src/components/central-services-breakdown";
 import { AccordionSection } from "src/composed/accordion-section";
+import { useAbort } from "src/hooks/useAbort";
 
 export const PremisesStaffServices: React.FC<{
   id: string;
@@ -21,15 +22,17 @@ export const PremisesStaffServices: React.FC<{
   const [data, setData] = useState<
     PremisesStaffServicesTrustExpenditure[] | null
   >();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await ExpenditureApi.trust<PremisesStaffServicesTrustExpenditure>(
       id,
       dimension.value,
       "PremisesStaffServices",
-      breakdown === BreakdownExclude
+      breakdown === BreakdownExclude,
+      [signal]
     );
-  }, [id, dimension, breakdown]);
+  }, [id, dimension.value, breakdown, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -49,6 +52,8 @@ export const PremisesStaffServices: React.FC<{
   }, [dimension, breakdown]);
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       PremisesCategories.find((x) => x.value === value) ?? PoundsPerMetreSq;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/teaching-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/teaching-support-staff.tsx
@@ -12,6 +12,7 @@ import {
   BreakdownInclude,
 } from "src/components/central-services-breakdown";
 import { AccordionSection } from "src/composed/accordion-section";
+import { useAbort } from "src/hooks/useAbort";
 
 export const TeachingSupportStaff: React.FC<{ id: string }> = ({ id }) => {
   const [dimension, setDimension] = useState(PoundsPerPupil);
@@ -19,15 +20,17 @@ export const TeachingSupportStaff: React.FC<{ id: string }> = ({ id }) => {
   const [data, setData] = useState<
     TeachingSupportStaffTrustExpenditure[] | null
   >();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await ExpenditureApi.trust<TeachingSupportStaffTrustExpenditure>(
       id,
       dimension.value,
       "TeachingTeachingSupportStaff",
-      breakdown === BreakdownExclude
+      breakdown === BreakdownExclude,
+      [signal]
     );
-  }, [id, dimension, breakdown]);
+  }, [id, dimension.value, breakdown, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -47,6 +50,8 @@ export const TeachingSupportStaff: React.FC<{ id: string }> = ({ id }) => {
   }, [dimension, breakdown]);
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/utilities.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/utilities.tsx
@@ -9,6 +9,7 @@ import {
   BreakdownInclude,
 } from "src/components/central-services-breakdown";
 import { AccordionSection } from "src/composed/accordion-section";
+import { useAbort } from "src/hooks/useAbort";
 
 export const Utilities: React.FC<{
   id: string;
@@ -16,15 +17,17 @@ export const Utilities: React.FC<{
   const [dimension, setDimension] = useState(PoundsPerMetreSq);
   const { breakdown } = useCentralServicesBreakdownContext(true);
   const [data, setData] = useState<UtilitiesTrustExpenditure[] | null>();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await ExpenditureApi.trust<UtilitiesTrustExpenditure>(
       id,
       dimension.value,
       "Utilities",
-      breakdown === BreakdownExclude
+      breakdown === BreakdownExclude,
+      [signal]
     );
-  }, [id, dimension, breakdown]);
+  }, [id, dimension.value, breakdown, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -44,6 +47,8 @@ export const Utilities: React.FC<{
   }, [dimension, breakdown]);
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       PremisesCategories.find((x) => x.value === value) ?? PoundsPerMetreSq;
     setDimension(dimension);

--- a/front-end-components/src/views/compare-your-trust/partials/total-expenditure.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/total-expenditure.tsx
@@ -13,6 +13,7 @@ import {
   BreakdownInclude,
 } from "src/components/central-services-breakdown";
 import { DimensionedChart } from "src/composed/dimensioned-chart";
+import { useAbort } from "src/hooks/useAbort";
 
 export const TotalExpenditure: React.FC<{
   id: string;
@@ -20,15 +21,17 @@ export const TotalExpenditure: React.FC<{
   const [dimension, setDimension] = useState(PoundsPerPupil);
   const { breakdown } = useCentralServicesBreakdownContext(true);
   const [data, setData] = useState<TotalExpenditureTrustExpenditure[] | null>();
+  const { abort, signal } = useAbort();
   const getData = useCallback(async () => {
     setData(null);
     return await ExpenditureApi.trust<TotalExpenditureTrustExpenditure>(
       id,
       dimension.value,
       "TotalExpenditure",
-      breakdown === BreakdownExclude
+      breakdown === BreakdownExclude,
+      [signal]
     );
-  }, [id, dimension, breakdown]);
+  }, [id, dimension.value, breakdown, signal]);
 
   useEffect(() => {
     getData().then((result) => {
@@ -63,6 +66,8 @@ export const TotalExpenditure: React.FC<{
     }, [dimension, data, breakdown]);
 
   const handleDimensionChange = (value: string) => {
+    abort();
+
     const dimension =
       CostCategories.find((x) => x.value === value) ?? PoundsPerPupil;
     setDimension(dimension);

--- a/front-end-components/src/views/historic-data-2/partials/census-section.tsx
+++ b/front-end-components/src/views/historic-data-2/partials/census-section.tsx
@@ -16,6 +16,7 @@ import { Loading } from "src/components/loading";
 import { HistoricData2Props } from "../types";
 import { censusCharts } from ".";
 import { DataWarning } from "src/components/charts/data-warning";
+import { useAbort } from "src/hooks/useAbort";
 
 export const CensusSection: React.FC<HistoricData2Props> = ({
   financeType,
@@ -32,9 +33,7 @@ export const CensusSection: React.FC<HistoricData2Props> = ({
     {}
   );
   const [loadError, setLoadError] = useState<string>();
-  const [cancelSignal, setCancelSignal] = useState<AbortController>(
-    new AbortController()
-  );
+  const { abort, signal } = useAbort();
 
   const getData = useCallback(async () => {
     if (!load) {
@@ -48,9 +47,7 @@ export const CensusSection: React.FC<HistoricData2Props> = ({
       dimension.value,
       overallPhase,
       financeType,
-      fetchTimeout
-        ? [cancelSignal.signal, AbortSignal.timeout(fetchTimeout)]
-        : [cancelSignal.signal]
+      fetchTimeout ? [signal, AbortSignal.timeout(fetchTimeout)] : [signal]
     );
   }, [
     dimension.value,
@@ -59,7 +56,7 @@ export const CensusSection: React.FC<HistoricData2Props> = ({
     load,
     overallPhase,
     fetchTimeout,
-    cancelSignal,
+    signal,
   ]);
 
   useEffect(() => {
@@ -79,14 +76,12 @@ export const CensusSection: React.FC<HistoricData2Props> = ({
   const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
     event
   ) => {
-    cancelSignal?.abort();
+    abort();
 
     const dimension =
       CensusCategories.find((x) => x.value === event.target.value) ??
       defaultDimension;
     setDimension(dimension);
-
-    setCancelSignal(new AbortController());
   };
 
   return (

--- a/front-end-components/src/views/historic-data-2/partials/spending-section.tsx
+++ b/front-end-components/src/views/historic-data-2/partials/spending-section.tsx
@@ -19,6 +19,7 @@ import { CateringCostsHistoryChart } from "./catering-costs-history-chart";
 import { spendingSections } from ".";
 import classNames from "classnames";
 import { DataWarning } from "src/components/charts/data-warning";
+import { useAbort } from "src/hooks/useAbort";
 
 export const SpendingSection: React.FC<HistoricData2Props> = ({
   financeType,
@@ -35,9 +36,7 @@ export const SpendingSection: React.FC<HistoricData2Props> = ({
     SchoolHistoryComparison<ExpenditureHistoryItem>
   >({});
   const [loadError, setLoadError] = useState<string>();
-  const [cancelSignal, setCancelSignal] = useState<AbortController>(
-    new AbortController()
-  );
+  const { abort, signal } = useAbort();
 
   const getData = useCallback(async () => {
     if (!load) {
@@ -52,9 +51,7 @@ export const SpendingSection: React.FC<HistoricData2Props> = ({
       dimension.value,
       overallPhase,
       financeType,
-      fetchTimeout
-        ? [cancelSignal.signal, AbortSignal.timeout(fetchTimeout)]
-        : [cancelSignal.signal]
+      fetchTimeout ? [signal, AbortSignal.timeout(fetchTimeout)] : [signal]
     );
   }, [
     dimension.value,
@@ -64,7 +61,7 @@ export const SpendingSection: React.FC<HistoricData2Props> = ({
     overallPhase,
     type,
     fetchTimeout,
-    cancelSignal,
+    signal,
   ]);
 
   useEffect(() => {
@@ -84,14 +81,12 @@ export const SpendingSection: React.FC<HistoricData2Props> = ({
   const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
     event
   ) => {
-    cancelSignal?.abort();
+    abort();
 
     const dimension =
       CostCategories.find((x) => x.value === event.target.value) ??
       defaultDimension;
     setDimension(dimension);
-
-    setCancelSignal(new AbortController());
   };
 
   return (

--- a/web/src/Web.App/Controllers/Api/CensusProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/CensusProxyController.cs
@@ -93,7 +93,7 @@ public class CensusProxyController(
         [FromQuery] string dimension,
         [FromQuery] string? phase,
         [FromQuery] string? financeType,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken = default)
     {
         using (logger.BeginScope(new
         {

--- a/web/src/Web.App/Controllers/Api/HighNeedsProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/HighNeedsProxyController.cs
@@ -53,7 +53,7 @@ public class HighNeedsProxyController(
     [ProducesResponseType<LocalAuthorityHighNeedsHistoryResponse[]>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Route("history")]
-    public async Task<IActionResult> History([FromQuery] string code, CancellationToken cancellationToken)
+    public async Task<IActionResult> History([FromQuery] string code, CancellationToken cancellationToken = default)
     {
         try
         {

--- a/web/tests/Web.E2ETests/Extensions/LocatorExtensions.cs
+++ b/web/tests/Web.E2ETests/Extensions/LocatorExtensions.cs
@@ -65,7 +65,7 @@ public static class LocatorExtensions
     public static async Task<ILocator> ShouldBeChecked(this ILocator locator, bool isChecked)
     {
         var actualCheckedStatus = await locator.IsCheckedAsync();
-        Assert.Equal(actualCheckedStatus, isChecked);
+        Assert.Equal(isChecked, actualCheckedStatus);
         return locator;
     }
 
@@ -120,7 +120,7 @@ public static class LocatorExtensions
 
             for (var j = 0; j < expectedTableCell.Count; j++)
             {
-                Assert.Equal(actualTableCell[j], expectedTableCell[j]);
+                Assert.Equal(expectedTableCell[j], actualTableCell[j]);
             }
         }
 
@@ -138,7 +138,7 @@ public static class LocatorExtensions
 
         for (var i = 0; i < actual.Count; i++)
         {
-            Assert.Equal(actual[i], expected[i]);
+            Assert.Equal(expected[i], actual[i]);
         }
 
         return locator;
@@ -147,7 +147,7 @@ public static class LocatorExtensions
     public static async Task<ILocator> TextEqual(this ILocator locator, string expected)
     {
         var actual = await locator.InnerTextAsync();
-        Assert.Equal(actual, expected);
+        Assert.Equal(expected, actual);
         return locator;
     }
 

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/BenchmarkCensusPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/BenchmarkCensusPage.cs
@@ -100,13 +100,9 @@ public class BenchmarkCensusPage(IPage page)
         await ViewAsChartRadio.Click();
     }
 
-    public async Task AreTableHeadersForChartDisplayed(CensusChartNames chartName, string[] expected,
-        bool waitForRequest)
+    public async Task AreTableHeadersForChartDisplayed(CensusChartNames chartName, string[] expected)
     {
-        if (waitForRequest)
-        {
-            await page.WaitForRequestFinishedAsync();
-        }
+        await page.WaitForRequestFinishedAsync();
 
         var table = chartName switch
         {

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/CompareYourCostsPage.cs
@@ -279,6 +279,7 @@ public class CompareYourCostsPage(IPage page)
 
     public async Task IsGraphTickTextEqual(int nth, string text)
     {
+        await page.WaitForRequestFinishedAsync();
         var actual = await ChartTicks.Nth(nth).Locator("text").TextContentAsync();
         Assert.Equal(text, actual);
     }

--- a/web/tests/Web.E2ETests/Pages/School/BenchmarkCensusPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/BenchmarkCensusPage.cs
@@ -140,13 +140,9 @@ public class BenchmarkCensusPage(IPage page)
         await ViewAsChartRadio.Click();
     }
 
-    public async Task AreTableHeadersForChartDisplayed(CensusChartNames chartName, string[] expected,
-        bool waitForRequest)
+    public async Task AreTableHeadersForChartDisplayed(CensusChartNames chartName, string[] expected)
     {
-        if (waitForRequest)
-        {
-            await page.WaitForRequestFinishedAsync();
-        }
+        await page.WaitForRequestFinishedAsync();
 
         var table = chartName switch
         {

--- a/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
@@ -184,6 +184,7 @@ public class CompareYourCostsPage(IPage page)
     public async Task SelectDimensionForChart(ComparisonChartNames chartName, string value)
     {
         await ChartDimensionDropdown(chartName).SelectOption(value);
+        await page.WaitForRequestFinishedAsync();
     }
 
     public async Task IsDimensionSelectedForChart(ComparisonChartNames chartName, string value)
@@ -369,6 +370,7 @@ public class CompareYourCostsPage(IPage page)
 
     public async Task IsGraphTickTextEqual(int nth, string text)
     {
+        await page.WaitForRequestFinishedAsync();
         var actual = await ChartTicks.Nth(nth).Locator("text").TextContentAsync();
         Assert.Equal(text, actual);
     }

--- a/web/tests/Web.E2ETests/Pages/Trust/BenchmarkCensusPage.cs
+++ b/web/tests/Web.E2ETests/Pages/Trust/BenchmarkCensusPage.cs
@@ -100,13 +100,9 @@ public class BenchmarkCensusPage(IPage page)
         await ViewAsChartRadio.Click();
     }
 
-    public async Task AreTableHeadersForChartDisplayed(CensusChartNames chartName, string[] expected,
-        bool waitForRequest)
+    public async Task AreTableHeadersForChartDisplayed(CensusChartNames chartName, string[] expected)
     {
-        if (waitForRequest)
-        {
-            await page.WaitForRequestFinishedAsync();
-        }
+        await page.WaitForRequestFinishedAsync();
 
         var table = chartName switch
         {

--- a/web/tests/Web.E2ETests/Pages/Trust/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/Trust/CompareYourCostsPage.cs
@@ -120,6 +120,7 @@ public class CompareYourCostsPage(IPage page)
     public async Task SelectDimensionForChart(ComparisonChartNames chartName, string value)
     {
         await ChartDimensionDropdown(chartName).SelectOption(value);
+        await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
     }
 
     public async Task IsDimensionSelectedForChart(ComparisonChartNames chartName, string value)
@@ -240,6 +241,7 @@ public class CompareYourCostsPage(IPage page)
 
     public async Task HoverOnGraphBar(int nth = 0)
     {
+        await page.WaitForRequestFinishedAsync();
         await ChartBars.Nth(nth).HoverAsync();
     }
 

--- a/web/tests/Web.E2ETests/Steps/LocalAuthority/BenchmarkCensusSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/LocalAuthority/BenchmarkCensusSteps.cs
@@ -68,8 +68,7 @@ public class BenchmarkCensusSteps(PageDriver driver)
     public async Task ThenTheFollowingHeadersAreDisplayedFor(string chartName, Table table)
     {
         Assert.NotNull(_censusPage);
-        await _censusPage.AreTableHeadersForChartDisplayed(ChartNameFromFriendlyName(chartName),
-            table.Header.ToArray(), !table.Header.Contains("Pupils per staff role"));
+        await _censusPage.AreTableHeadersForChartDisplayed(ChartNameFromFriendlyName(chartName), table.Header.ToArray());
     }
 
     [Then("the table view is showing")]

--- a/web/tests/Web.E2ETests/Steps/School/BenchmarkCensusSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/BenchmarkCensusSteps.cs
@@ -74,8 +74,7 @@ public class BenchmarkCensusSteps(PageDriver driver)
     public async Task ThenTheFollowingHeadersAreDisplayedFor(string chartName, Table table)
     {
         Assert.NotNull(_censusPage);
-        await _censusPage.AreTableHeadersForChartDisplayed(ChartNameFromFriendlyName(chartName),
-            table.Header.ToArray(), !table.Header.Contains("Pupils per staff role"));
+        await _censusPage.AreTableHeadersForChartDisplayed(ChartNameFromFriendlyName(chartName), table.Header.ToArray());
     }
 
     [Then("the table view is showing")]

--- a/web/tests/Web.E2ETests/Steps/Trust/BenchmarkCensusSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/Trust/BenchmarkCensusSteps.cs
@@ -68,8 +68,7 @@ public class BenchmarkCensusSteps(PageDriver driver)
     public async Task ThenTheFollowingHeadersAreDisplayedFor(string chartName, Table table)
     {
         Assert.NotNull(_censusPage);
-        await _censusPage.AreTableHeadersForChartDisplayed(ChartNameFromFriendlyName(chartName),
-            table.Header.ToArray(), !table.Header.Contains("Pupils per staff role"));
+        await _censusPage.AreTableHeadersForChartDisplayed(ChartNameFromFriendlyName(chartName), table.Header.ToArray());
     }
 
     [Then("the table view is showing")]

--- a/web/tests/Web.E2ETests/Steps/Trust/CompareYourCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/Trust/CompareYourCostsSteps.cs
@@ -150,7 +150,7 @@ public class CompareYourCostsSteps(PageDriver driver)
         await _comparisonPage.IsSectionVisible(ChartNameFromFriendlyName(chartName), false, "Show", "chart");
     }
 
-    [Then(@"additional information is displayed")]
+    [Then("additional information is displayed")]
     public async Task ThenAdditionalInformationIsDisplayed()
     {
         Assert.NotNull(_comparisonPage);


### PR DESCRIPTION
### Context
[AB#258443](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/258443) [AB#259847](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/259847)

### Change proposed in this pull request
- Added abort signal support to all APIs 
- Called `AbortController.abort()` on dimension changes
- Wrapper `AbortController` in hook for re-usability
- Validated E2E tests

### Guidance to review 
Functionally the user should not notice any impact after this change. Once related PRs are merged, however, incomplete dimension drop down change `fetch` requests should abort all the way down to the underlying database call. E2E tests may be run to validate. These may need to be monitored as part of the merged pipeline run as some of the async requests from the client were flaky when running locally.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

