### PR TITLE
Applied new `[ValidateLaCode]` attribute to actions and controllers that consume `code`

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -33,7 +33,7 @@ In a console window:
 > run `dotnet user-secrets set "PLACEHOLDER" "PLACEHOLDER".` This will create a `secrets.json` file in the folder
 > location
 >
-described [here](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-8.0&tabs=linux#how-the-secret-manager-tool-works).
+described [in Microsoft docs](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-8.0&tabs=linux#how-the-secret-manager-tool-works).
 > At this point `secrets.json` can be updated manually with the settings described below.
 
 #### Platform APIs

--- a/web/src/Web.App/Attributes/ValidateArgumentAttribute.cs
+++ b/web/src/Web.App/Attributes/ValidateArgumentAttribute.cs
@@ -37,7 +37,11 @@ public static partial class ValidateArgumentAttributeRegex
 
     [GeneratedRegex(@"^\d{8}$")]
     public static partial Regex CompanyNumberRegex();
+
+    [GeneratedRegex(@"^\d{3}$")]
+    public static partial Regex LaCodeRegex();
 }
 
 public class ValidateUrnAttribute() : ValidateArgumentAttribute("urn", ValidateArgumentAttributeRegex.UrnRegex());
 public class ValidateCompanyNumberAttribute() : ValidateArgumentAttribute("companyNumber", ValidateArgumentAttributeRegex.CompanyNumberRegex());
+public class ValidateLaCodeAttribute() : ValidateArgumentAttribute("code", ValidateArgumentAttributeRegex.LaCodeRegex());

--- a/web/src/Web.App/Controllers/Api/EducationHealthCarePlansProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/EducationHealthCarePlansProxyController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
+using Web.App.Attributes;
 using Web.App.Controllers.Api.Mappers;
 using Web.App.Controllers.Api.Responses;
 using Web.App.Domain.NonFinancial;
@@ -23,6 +24,7 @@ public class EducationHealthCarePlansProxyController(
     [ProducesResponseType<EducationHealthCarePlansComparisonResponse[]>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Route("comparison")]
+    [ValidateLaCode]
     public async Task<IActionResult> Comparison([FromQuery] string code, [FromQuery] string[]? set = null, CancellationToken cancellationToken = default)
     {
         try
@@ -53,6 +55,7 @@ public class EducationHealthCarePlansProxyController(
     [ProducesResponseType<EducationHealthCarePlansHistoryResponse[]>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Route("history")]
+    [ValidateLaCode]
     public async Task<IActionResult> History([FromQuery] string code, CancellationToken cancellationToken = default)
     {
         try

--- a/web/src/Web.App/Controllers/Api/HighNeedsProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/HighNeedsProxyController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
+using Web.App.Attributes;
 using Web.App.Controllers.Api.Mappers;
 using Web.App.Controllers.Api.Responses;
 using Web.App.Domain.LocalAuthorities;
@@ -23,6 +24,7 @@ public class HighNeedsProxyController(
     [ProducesResponseType<LocalAuthorityHighNeedsComparisonResponse[]>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Route("comparison")]
+    [ValidateLaCode]
     public async Task<IActionResult> Comparison([FromQuery] string code, [FromQuery] string[]? set = null, CancellationToken cancellationToken = default)
     {
         try
@@ -53,6 +55,7 @@ public class HighNeedsProxyController(
     [ProducesResponseType<LocalAuthorityHighNeedsHistoryResponse[]>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Route("history")]
+    [ValidateLaCode]
     public async Task<IActionResult> History([FromQuery] string code, CancellationToken cancellationToken = default)
     {
         try

--- a/web/src/Web.App/Controllers/LocalAuthorityCensusController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityCensusController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.FeatureManagement.Mvc;
+using Web.App.Attributes;
 using Web.App.Attributes.RequestTelemetry;
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
@@ -12,6 +13,7 @@ namespace Web.App.Controllers;
 [Controller]
 [FeatureGate(FeatureFlags.LocalAuthorities)]
 [Route("local-authority/{code}/census")]
+[ValidateLaCode]
 [LocalAuthorityRequestTelemetry(TrackedRequestFeature.BenchmarkWorkforce)]
 public class LocalAuthorityCensusController(
     IEstablishmentApi establishmentApi,

--- a/web/src/Web.App/Controllers/LocalAuthorityComparisonController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityComparisonController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.FeatureManagement.Mvc;
+using Web.App.Attributes;
 using Web.App.Attributes.RequestTelemetry;
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
@@ -12,6 +13,7 @@ namespace Web.App.Controllers;
 [Controller]
 [FeatureGate(FeatureFlags.LocalAuthorities)]
 [Route("local-authority/{code}/comparison")]
+[ValidateLaCode]
 [LocalAuthorityRequestTelemetry(TrackedRequestFeature.BenchmarkCosts)]
 public class LocalAuthorityComparisonController(
     IEstablishmentApi establishmentApi,

--- a/web/src/Web.App/Controllers/LocalAuthorityController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.FeatureManagement.Mvc;
+using Web.App.Attributes;
 using Web.App.Attributes.RequestTelemetry;
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
@@ -13,6 +14,7 @@ namespace Web.App.Controllers;
 [Controller]
 [FeatureGate(FeatureFlags.LocalAuthorities)]
 [Route("local-authority/{code}")]
+[ValidateLaCode]
 public class LocalAuthorityController(
     ILogger<LocalAuthorityController> logger,
     IEstablishmentApi establishmentApi)

--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsBenchmarkingController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsBenchmarkingController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.FeatureManagement.Mvc;
+using Web.App.Attributes;
 using Web.App.Attributes.RequestTelemetry;
 using Web.App.Domain;
 using Web.App.Extensions;
@@ -15,6 +16,7 @@ namespace Web.App.Controllers;
 [Controller]
 [FeatureGate(FeatureFlags.LocalAuthorities, FeatureFlags.HighNeeds)]
 [Route("local-authority/{code}/high-needs/benchmarking")]
+[ValidateLaCode]
 public class LocalAuthorityHighNeedsBenchmarkingController(
     ILogger<LocalAuthorityHighNeedsBenchmarkingController> logger,
     IEstablishmentApi establishmentApi,

--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.FeatureManagement.Mvc;
+using Web.App.Attributes;
 using Web.App.Attributes.RequestTelemetry;
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
@@ -14,6 +15,7 @@ namespace Web.App.Controllers;
 [Controller]
 [FeatureGate(FeatureFlags.LocalAuthorities, FeatureFlags.HighNeeds)]
 [Route("local-authority/{code}/high-needs")]
+[ValidateLaCode]
 public class LocalAuthorityHighNeedsController(
     ILogger<LocalAuthorityHighNeedsController> logger,
     IEstablishmentApi establishmentApi,

--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsHistoricDataController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsHistoricDataController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.FeatureManagement.Mvc;
+using Web.App.Attributes;
 using Web.App.Attributes.RequestTelemetry;
 using Web.App.Domain;
 using Web.App.Domain.LocalAuthorities;
@@ -15,6 +16,7 @@ namespace Web.App.Controllers;
 [Controller]
 [FeatureGate(FeatureFlags.LocalAuthorities, FeatureFlags.HighNeeds)]
 [Route("local-authority/{code}/high-needs/history")]
+[ValidateLaCode]
 public class LocalAuthorityHighNeedsHistoricDataController(
     ILogger<LocalAuthorityHighNeedsHistoricDataController> logger,
     IEstablishmentApi establishmentApi,

--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsNationalRankingsController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsNationalRankingsController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.FeatureManagement.Mvc;
+using Web.App.Attributes;
 using Web.App.Attributes.RequestTelemetry;
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
@@ -14,6 +15,7 @@ namespace Web.App.Controllers;
 [Controller]
 [FeatureGate(FeatureFlags.LocalAuthorities, FeatureFlags.HighNeeds)]
 [Route("local-authority/{code}/high-needs/national-rank")]
+[ValidateLaCode]
 public class LocalAuthorityHighNeedsNationalRankingsController(
     ILogger<LocalAuthorityHighNeedsNationalRankingsController> logger,
     IEstablishmentApi establishmentApi,

--- a/web/src/Web.App/Extensions/ServiceCollectionExtensions.cs
+++ b/web/src/Web.App/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using FluentValidation;
 using IdentityModel.Client;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -17,6 +18,7 @@ using Web.App.Infrastructure.Apis.LocalAuthorities;
 using Web.App.Infrastructure.Apis.NonFinancial;
 using Web.App.Infrastructure.Storage;
 using Web.App.Services;
+using Web.App.Validators;
 
 namespace Web.App.Extensions;
 
@@ -291,8 +293,18 @@ public static class ServiceCollectionExtensions
             });
     }
 
-    public static IServiceCollection AddActionResults(this IServiceCollection services) => services
-        .AddSingleton<IActionResultExecutor<CsvResult>, CsvResultActionResultExecutor>()
-        .AddSingleton<IActionResultExecutor<CsvResults>, CsvResultsActionResultExecutor>()
-        .AddSingleton<ICsvService, CsvService>();
+    public static IServiceCollection AddActionResults(this IServiceCollection services)
+    {
+        return services
+            .AddSingleton<IActionResultExecutor<CsvResult>, CsvResultActionResultExecutor>()
+            .AddSingleton<IActionResultExecutor<CsvResults>, CsvResultsActionResultExecutor>()
+            .AddSingleton<ICsvService, CsvService>();
+    }
+
+    public static IServiceCollection AddValidation(this IServiceCollection services)
+    {
+        return services
+            .AddScoped<IFinancialPlanStageValidator, FinancialPlanStageValidator>()
+            .AddScoped<IValidator<OrganisationIdentifier>, OrganisationIdentifierValidator>();
+    }
 }

--- a/web/src/Web.App/Program.cs
+++ b/web/src/Web.App/Program.cs
@@ -16,7 +16,6 @@ using Web.App.HealthChecks;
 using Web.App.Middleware;
 using Web.App.Services;
 using Web.App.Telemetry;
-using Web.App.Validators;
 
 [assembly: InternalsVisibleTo("Web.Tests")]
 
@@ -40,12 +39,12 @@ builder.Services
     .AddScoped<ISchoolComparatorSetService, SchoolComparatorSetService>()
     .AddScoped<ITrustComparatorSetService, TrustComparatorSetService>()
     .AddScoped<ISuggestService, SuggestService>()
-    .AddScoped<IFinancialPlanStageValidator, FinancialPlanStageValidator>()
     .AddScoped<ICustomDataService, CustomDataService>()
     .AddScoped<IUserDataService, UserDataService>()
     .AddScoped<IClaimsIdentifierService, ClaimsIdentifierService>()
     .AddScoped<ILocalAuthorityComparatorSetService, LocalAuthorityComparatorSetService>()
     .AddScoped<ISearchService, SearchService>()
+    .AddValidation()
     .AddActionResults();
 
 builder.Services.AddHealthChecks()

--- a/web/src/Web.App/Validators/OrganisationIdentifierValidator.cs
+++ b/web/src/Web.App/Validators/OrganisationIdentifierValidator.cs
@@ -23,21 +23,24 @@ public class OrganisationIdentifierValidator : AbstractValidator<OrganisationIde
 
         RuleFor(p => p.Value)
             .Length(6)
+            .Must(p => p.All(char.IsDigit))
             .When(p => p.Type == OrganisationTypes.School)
             .When(p => p.ValueAsInt != null)
-            .WithMessage("School URN must be 6 characters");
+            .Configure(rule => rule.MessageBuilder = _ => "School URN must be 6 digits");
 
         RuleFor(p => p.Value)
             .Length(8)
+            .Must(p => p.All(char.IsDigit))
             .When(p => p.Type == OrganisationTypes.Trust)
             .When(p => p.ValueAsInt != null)
-            .WithMessage("Trust company number must be 8 characters");
+            .Configure(rule => rule.MessageBuilder = _ => "Trust company number must be 8 digits");
 
         RuleFor(p => p.Value)
             .Length(3)
+            .Must(p => p.All(char.IsDigit))
             .When(p => p.Type == OrganisationTypes.LocalAuthority)
             .When(p => p.ValueAsInt != null)
-            .WithMessage("Local authority code must be 3 characters");
+            .Configure(rule => rule.MessageBuilder = _ => "Local authority code must be 3 digits");
 
         RuleFor(p => p.ValueAsInt)
             .NotEmpty()

--- a/web/src/Web.App/Validators/OrganisationIdentifierValidator.cs
+++ b/web/src/Web.App/Validators/OrganisationIdentifierValidator.cs
@@ -1,0 +1,65 @@
+using FluentValidation;
+
+namespace Web.App.Validators;
+
+public class OrganisationIdentifierValidator : AbstractValidator<OrganisationIdentifier>
+{
+    private readonly string[] _organisationTypes = [OrganisationTypes.School, OrganisationTypes.Trust, OrganisationTypes.LocalAuthority];
+
+    public OrganisationIdentifierValidator()
+    {
+        RuleFor(p => p.Value)
+            .NotEmpty()
+            .WithMessage("Organisation identifier must be provided");
+
+        RuleFor(p => p.Type)
+            .NotEmpty()
+            .WithMessage("Organisation type must be provided");
+
+        RuleFor(p => p.Type)
+            .Must(type => _organisationTypes.Contains(type))
+            .When(p => p.Type != null)
+            .WithMessage("Organisation type must be valid");
+
+        RuleFor(p => p.Value)
+            .Length(6)
+            .When(p => p.Type == OrganisationTypes.School)
+            .When(p => p.ValueAsInt != null)
+            .WithMessage("School URN must be 6 characters");
+
+        RuleFor(p => p.Value)
+            .Length(8)
+            .When(p => p.Type == OrganisationTypes.Trust)
+            .When(p => p.ValueAsInt != null)
+            .WithMessage("Trust company number must be 8 characters");
+
+        RuleFor(p => p.Value)
+            .Length(3)
+            .When(p => p.Type == OrganisationTypes.LocalAuthority)
+            .When(p => p.ValueAsInt != null)
+            .WithMessage("Local authority code must be 3 characters");
+
+        RuleFor(p => p.ValueAsInt)
+            .NotEmpty()
+            .When(p => p.Value != null)
+            .WithMessage("Organisation identifier must be a number");
+    }
+}
+
+public class OrganisationIdentifier
+{
+    public string? Value { get; init; }
+    public string? Type { get; init; }
+    internal int? ValueAsInt
+    {
+        get
+        {
+            if (int.TryParse(Value!, out var value))
+            {
+                return value;
+            }
+
+            return null;
+        }
+    }
+}

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/Search/WhenViewingLocalAuthoritySearch.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/Search/WhenViewingLocalAuthoritySearch.cs
@@ -18,12 +18,12 @@ public class WhenViewingLocalAuthoritySearch(SchoolBenchmarkingWebAppClient clie
         [
             new LocalAuthoritySummary
             {
-                Code = "123456",
+                Code = "123",
                 Name = "LA Name 1"
             },
             new LocalAuthoritySummary
             {
-                Code = "654321",
+                Code = "654",
                 Name = "LA Name 2"
             }
         ]

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/Search/WhenViewingLocalAuthoritySearchResults.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/Search/WhenViewingLocalAuthoritySearchResults.cs
@@ -18,12 +18,12 @@ public class WhenViewingLocalAuthoritySearchResults(SchoolBenchmarkingWebAppClie
         [
             new LocalAuthoritySummary
             {
-                Code = "123456",
+                Code = "123",
                 Name = "LA Name 1"
             },
             new LocalAuthoritySummary
             {
-                Code = "654321",
+                Code = "654",
                 Name = "LA Name 2"
             }
         ]
@@ -131,7 +131,7 @@ public class WhenViewingLocalAuthoritySearchResults(SchoolBenchmarkingWebAppClie
     [Fact]
     public async Task CanSelectSearchResult()
     {
-        const string code = "123456";
+        const string code = "123";
         var page = await Client
             .SetupEstablishment(SearchResults)
             .Navigate(Paths.LocalAuthoritySearchResults());

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsBenchmarking.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsBenchmarking.cs
@@ -49,7 +49,9 @@ public class WhenViewingHighNeedsBenchmarking(SchoolBenchmarkingWebAppClient cli
 
     private async Task<(IHtmlDocument page, LocalAuthority authority, string[] set)> SetupNavigateInitPage(string[]? comparatorSet = null)
     {
-        var authority = Fixture.Build<LocalAuthority>().Create();
+        var authority = Fixture.Build<LocalAuthority>()
+            .With(a => a.Code, "123")
+            .Create();
         var set = comparatorSet ?? Fixture.Build<string>().CreateMany().ToArray();
 
         var page = await Client.SetupEstablishment(authority)

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsDashboard.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsDashboard.cs
@@ -108,6 +108,7 @@ public class WhenViewingHighNeeds(SchoolBenchmarkingWebAppClient client) : PageB
         bool notInRanking = false)
     {
         var authority = Fixture.Build<LocalAuthority>()
+            .With(a => a.Code, "123")
             .Create();
 
         var rankings = Fixture.Build<LocalAuthorityRank>()

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsHistoricData.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsHistoricData.cs
@@ -47,6 +47,7 @@ public class WhenViewingHighNeedsHistoricData(SchoolBenchmarkingWebAppClient cli
         LocalAuthority<HighNeeds>[]? highNeeds)> SetupNavigateInitPage(bool hasHighNeeds = true)
     {
         var authority = Fixture.Build<LocalAuthority>()
+            .With(a => a.Code, "123")
             .Create();
 
         var highNeeds = hasHighNeeds ? Fixture.Build<LocalAuthority<HighNeeds>>().CreateMany().ToArray() : [];

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsStartBenchmarking.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsStartBenchmarking.cs
@@ -177,15 +177,17 @@ public class WhenViewingHighNeedsStartBenchmarking(SchoolBenchmarkingWebAppClien
     private async Task<(IHtmlDocument page, LocalAuthorityStatisticalNeighbours authority, LocalAuthority[] authorities)> SetupNavigateInitPage(string[]? comparators = null, string? referrer = null)
     {
         var authority = Fixture.Build<LocalAuthorityStatisticalNeighbours>()
+            .With(a => a.Code, "123")
             .Create();
 
         var statisticalNeighbours = Fixture.Build<LocalAuthorityStatisticalNeighbour>()
             .CreateMany()
             .ToArray();
 
+        var random = new Random();
         authority.StatisticalNeighbours = statisticalNeighbours;
         var authorities = Fixture.Build<LocalAuthority>()
-            .With(l => l.Code, () => Fixture.Create<string>().Replace("-", string.Empty))
+            .With(l => l.Code, () => random.Next(100, 999).ToString())
             .CreateMany()
             .ToArray();
 

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHome.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHome.cs
@@ -117,14 +117,14 @@ public class WhenViewingHome(SchoolBenchmarkingWebAppClient client) : PageBase<S
     }
 
     [Fact]
-    public async Task CanDisplayBadRequest()
+    public async Task CanDisplayNotFoundForBadIdentifier()
     {
         const string code = "1234";
         var page = await Client
             .Navigate(Paths.LocalAuthorityHome(code));
 
         PageAssert.IsNotFoundPage(page);
-        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHome(code).ToAbsolute(), HttpStatusCode.BadRequest);
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHome(code).ToAbsolute(), HttpStatusCode.NotFound);
     }
 
     [Fact]

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHome.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHome.cs
@@ -117,6 +117,17 @@ public class WhenViewingHome(SchoolBenchmarkingWebAppClient client) : PageBase<S
     }
 
     [Fact]
+    public async Task CanDisplayBadRequest()
+    {
+        const string code = "1234";
+        var page = await Client
+            .Navigate(Paths.LocalAuthorityHome(code));
+
+        PageAssert.IsNotFoundPage(page);
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHome(code).ToAbsolute(), HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
     public async Task CanDisplayProblemWithService()
     {
         const string code = "123";
@@ -130,6 +141,7 @@ public class WhenViewingHome(SchoolBenchmarkingWebAppClient client) : PageBase<S
     private async Task<(IHtmlDocument page, LocalAuthority authority, LocalAuthoritySchool[] schools)> SetupNavigateInitPage(bool filteredSearchFeatureEnabled = false, params string[] phaseTypes)
     {
         var authority = Fixture.Build<LocalAuthority>()
+            .With(a => a.Code, "123")
             .Create();
 
         string[] disabledFlags = [];

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingResources.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingResources.cs
@@ -54,6 +54,7 @@ public class WhenViewingResources(SchoolBenchmarkingWebAppClient client) : PageB
     private async Task<(IHtmlDocument page, LocalAuthority authority)> SetupNavigateInitPage()
     {
         var authority = Fixture.Build<LocalAuthority>()
+            .With(a => a.Code, "123")
             .Create();
 
         var page = await Client.SetupEstablishment(authority)

--- a/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingDetails.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingDetails.cs
@@ -42,14 +42,14 @@ public class WhenViewingDetails(SchoolBenchmarkingWebAppClient client) : PageBas
     }
 
     [Fact]
-    public async Task CanDisplayBadRequest()
+    public async Task CanDisplayNotFoundForBadIdentifier()
     {
         const string urn = nameof(urn);
         var page = await Client
             .Navigate(Paths.SchoolDetails(urn));
 
         PageAssert.IsNotFoundPage(page);
-        DocumentAssert.AssertPageUrl(page, Paths.SchoolDetails(urn).ToAbsolute(), HttpStatusCode.BadRequest);
+        DocumentAssert.AssertPageUrl(page, Paths.SchoolDetails(urn).ToAbsolute(), HttpStatusCode.NotFound);
     }
 
     [Fact]

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingDetails.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/WhenViewingDetails.cs
@@ -40,14 +40,14 @@ public class WhenViewingDetails(SchoolBenchmarkingWebAppClient client) : PageBas
     }
 
     [Fact]
-    public async Task CanDisplayBadRequest()
+    public async Task CanDisplayNotFoundForBadIdentifier()
     {
         const string companyName = nameof(companyName);
         var page = await Client
             .Navigate(Paths.TrustDetails(companyName));
 
         PageAssert.IsNotFoundPage(page);
-        DocumentAssert.AssertPageUrl(page, Paths.TrustDetails(companyName).ToAbsolute(), HttpStatusCode.BadRequest);
+        DocumentAssert.AssertPageUrl(page, Paths.TrustDetails(companyName).ToAbsolute(), HttpStatusCode.NotFound);
     }
 
     [Fact]

--- a/web/tests/Web.Integration.Tests/Proxy/WhenRequestingEducationHealthCarePlansComparison.cs
+++ b/web/tests/Web.Integration.Tests/Proxy/WhenRequestingEducationHealthCarePlansComparison.cs
@@ -13,8 +13,8 @@ public class WhenEducationHealthCarePlansComparison(SchoolBenchmarkingWebAppClie
     [Fact]
     public async Task CanReturnCorrectResponseWhenComparatorSetExists()
     {
-        const string code = nameof(code);
-        var set = new[] { "code2", "code3" };
+        const string code = "123";
+        var set = new[] { "456", "789" };
 
         var plans = new[] { code }
             .Concat(set)
@@ -58,7 +58,7 @@ public class WhenEducationHealthCarePlansComparison(SchoolBenchmarkingWebAppClie
     [Fact]
     public async Task CanReturnNotFoundWhenComparatorSetDoesNotExist()
     {
-        const string code = nameof(code);
+        const string code = "123";
         string[] set = [];
 
         var response = await client
@@ -70,8 +70,8 @@ public class WhenEducationHealthCarePlansComparison(SchoolBenchmarkingWebAppClie
     [Fact]
     public async Task CanReturnInternalServerError()
     {
-        const string code = nameof(code);
-        var set = new[] { "code2", "code3" };
+        const string code = "123";
+        var set = new[] { "456", "789" };
 
         var response = await client
             .SetupEducationHealthCarePlansWithException()

--- a/web/tests/Web.Integration.Tests/Proxy/WhenRequestingEducationHealthCarePlansHistory.cs
+++ b/web/tests/Web.Integration.Tests/Proxy/WhenRequestingEducationHealthCarePlansHistory.cs
@@ -14,7 +14,7 @@ public class WhenEducationHealthCarePlansHistory(SchoolBenchmarkingWebAppClient 
     [Fact]
     public async Task CanReturnCorrectResponse()
     {
-        const string code = nameof(code);
+        const string code = "123";
         const int startYear = 2021;
         const int endYear = 2022;
 
@@ -72,7 +72,7 @@ public class WhenEducationHealthCarePlansHistory(SchoolBenchmarkingWebAppClient 
     [Fact]
     public async Task CanReturnInternalServerError()
     {
-        const string code = nameof(code);
+        const string code = "123";
         var response = await client
             .SetupEducationHealthCarePlansWithException()
             .Get(Paths.ApiEducationHealthCarePlansHistory(code));

--- a/web/tests/Web.Integration.Tests/Proxy/WhenRequestingHighNeedsComparison.cs
+++ b/web/tests/Web.Integration.Tests/Proxy/WhenRequestingHighNeedsComparison.cs
@@ -14,7 +14,7 @@ public class WhenRequestingHighNeedsComparison(SchoolBenchmarkingWebAppClient cl
     [Fact]
     public async Task CanReturnCorrectResponse()
     {
-        const string code = nameof(code);
+        const string code = "123";
         var set = new[] { "code2", "code3" };
 
         var localAuthorities = new[] { code }
@@ -51,7 +51,7 @@ public class WhenRequestingHighNeedsComparison(SchoolBenchmarkingWebAppClient cl
     [Fact]
     public async Task CanReturnNotFoundWhenComparatorSetDoesNotExist()
     {
-        const string code = nameof(code);
+        const string code = "123";
         string[] set = [];
 
         var response = await client
@@ -63,8 +63,8 @@ public class WhenRequestingHighNeedsComparison(SchoolBenchmarkingWebAppClient cl
     [Fact]
     public async Task CanReturnInternalServerError()
     {
-        const string code = nameof(code);
-        var set = new[] { "code2", "code3" };
+        const string code = "123";
+        var set = new[] { "456", "789" };
 
         var response = await client
             .SetupLocalAuthoritiesWithException()

--- a/web/tests/Web.Integration.Tests/Proxy/WhenRequestingHighNeedsHistory.cs
+++ b/web/tests/Web.Integration.Tests/Proxy/WhenRequestingHighNeedsHistory.cs
@@ -19,10 +19,10 @@ public class WhenRequestingHighNeedsHistory(SchoolBenchmarkingWebAppClient clien
             .With(h => h.StartYear, 2021)
             .With(h => h.EndYear, 2022)
             .Create();
-        const string sort = nameof(sort);
+        const string code = "123";
         var response = await client
             .SetupHighNeeds(null, history)
-            .Get(Paths.ApiHighNeedsHistory(sort));
+            .Get(Paths.ApiHighNeedsHistory(code));
 
         Assert.IsType<HttpResponseMessage>(response);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -42,10 +42,10 @@ public class WhenRequestingHighNeedsHistory(SchoolBenchmarkingWebAppClient clien
     [Fact]
     public async Task CanReturnInternalServerError()
     {
-        const string sort = nameof(sort);
+        const string code = "123";
         var response = await client
             .SetupLocalAuthoritiesWithException()
-            .Get(Paths.ApiHighNeedsHistory(sort));
+            .Get(Paths.ApiHighNeedsHistory(code));
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
     }

--- a/web/tests/Web.Tests/Attributes/GivenAValidateLaCodeAttribute.cs
+++ b/web/tests/Web.Tests/Attributes/GivenAValidateLaCodeAttribute.cs
@@ -1,0 +1,75 @@
+﻿using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Moq;
+using Web.App.Attributes;
+using Xunit;
+
+namespace Web.Tests.Attributes;
+
+public class GivenAValidateLaCodeAttribute
+{
+    [Theory]
+    [InlineData("code", "123")]
+    [InlineData("code", "")]
+    [InlineData("code", null)]
+    [InlineData("other", "abc")]
+    public void ReturnsOkWhenValidLaCodeProvidedOrMissing(string argument, object? code)
+    {
+        // arrange
+        var attribute = new ValidateLaCodeAttribute();
+        var context = BuildContext(new Dictionary<string, object?>
+        {
+            { argument, code }
+        });
+
+        // act
+        attribute.OnActionExecuting(context);
+
+        // assert
+        Assert.NotNull(context.Result);
+        Assert.IsType<OkResult>(context.Result);
+    }
+
+    [Theory]
+    [InlineData("code", "1234")]
+    [InlineData("code", "abc")]
+    public void ReturnsBadRequestWhenInvalidLaCodeProvided(string argument, object? code)
+    {
+        // arrange
+        var attribute = new ValidateLaCodeAttribute();
+        var context = BuildContext(new Dictionary<string, object?>
+        {
+            { argument, code }
+        });
+
+        // act
+        attribute.OnActionExecuting(context);
+
+        // assert
+        Assert.NotNull(context.Result);
+        var result = Assert.IsType<ViewResult>(context.Result);
+        Assert.Equal((int)HttpStatusCode.BadRequest, result.StatusCode);
+    }
+
+    private static ActionExecutingContext BuildContext(Dictionary<string, object?> actionArguments)
+    {
+        return new ActionExecutingContext(
+            new ActionContext(
+                Mock.Of<HttpContext>(),
+                Mock.Of<RouteData>(),
+                Mock.Of<ActionDescriptor>(),
+                Mock.Of<ModelStateDictionary>()
+            ),
+            new List<IFilterMetadata>(),
+            actionArguments,
+            Mock.Of<Controller>())
+        {
+            Result = new OkResult()
+        };
+    }
+}

--- a/web/tests/Web.Tests/Attributes/GivenAValidateLaCodeAttribute.cs
+++ b/web/tests/Web.Tests/Attributes/GivenAValidateLaCodeAttribute.cs
@@ -1,34 +1,40 @@
-﻿using System.Net;
+﻿using FluentValidation;
+using FluentValidation.Results;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Web.App;
 using Web.App.Attributes;
+using Web.App.Validators;
 using Xunit;
 
 namespace Web.Tests.Attributes;
 
 public class GivenAValidateLaCodeAttribute
 {
+    private readonly Mock<IValidator<OrganisationIdentifier>> _validator = new();
+
     [Theory]
     [InlineData("code", "123")]
     [InlineData("code", "")]
     [InlineData("code", null)]
     [InlineData("other", "abc")]
-    public void ReturnsOkWhenValidLaCodeProvidedOrMissing(string argument, object? code)
+    public void ReturnsOkWhenValidLaCodeProvidedOrMissing(string argument, string? code)
     {
         // arrange
-        var attribute = new ValidateLaCodeAttribute();
-        var context = BuildContext(new Dictionary<string, object?>
-        {
-            { argument, code }
-        });
+        var validationResult = new ValidationResult();
+        _validator.Setup(v => v.Validate(It.Is<OrganisationIdentifier>(i => i.Value == code && i.Type == OrganisationTypes.LocalAuthority)))
+            .Returns(validationResult);
+
+        var (filter, context) = BuildFilterAndContext(argument, code);
 
         // act
-        attribute.OnActionExecuting(context);
+        filter.OnActionExecuting(context);
 
         // assert
         Assert.NotNull(context.Result);
@@ -36,29 +42,32 @@ public class GivenAValidateLaCodeAttribute
     }
 
     [Theory]
-    [InlineData("code", "1234")]
-    [InlineData("code", "abc")]
-    public void ReturnsBadRequestWhenInvalidLaCodeProvided(string argument, object? code)
+    [InlineData("code", "invalid")]
+    public void ReturnsNotFoundWhenLaCodeValidationFails(string argument, string? code)
     {
         // arrange
-        var attribute = new ValidateLaCodeAttribute();
-        var context = BuildContext(new Dictionary<string, object?>
-        {
-            { argument, code }
-        });
+        var validationResult = new ValidationResult([new ValidationFailure("code", "LA code is invalid")]);
+        _validator.Setup(v => v.Validate(It.Is<OrganisationIdentifier>(i => i.Value == code && i.Type == OrganisationTypes.LocalAuthority)))
+            .Returns(validationResult);
+
+        var (filter, context) = BuildFilterAndContext(argument, code);
 
         // act
-        attribute.OnActionExecuting(context);
+        filter.OnActionExecuting(context);
 
         // assert
         Assert.NotNull(context.Result);
-        var result = Assert.IsType<ViewResult>(context.Result);
-        Assert.Equal((int)HttpStatusCode.BadRequest, result.StatusCode);
+        Assert.IsType<NotFoundResult>(context.Result);
     }
 
-    private static ActionExecutingContext BuildContext(Dictionary<string, object?> actionArguments)
+    private (ValidateArgumentFilter filter, ActionExecutingContext context) BuildFilterAndContext(string argument, object? companyNumber)
     {
-        return new ActionExecutingContext(
+        var actionArguments = new Dictionary<string, object?>
+        {
+            { argument, companyNumber }
+        };
+
+        var context = new ActionExecutingContext(
             new ActionContext(
                 Mock.Of<HttpContext>(),
                 Mock.Of<RouteData>(),
@@ -71,5 +80,15 @@ public class GivenAValidateLaCodeAttribute
         {
             Result = new OkResult()
         };
+
+        var attribute = new ValidateLaCodeAttribute();
+        var filter = new ValidateArgumentFilter(
+            new NullLogger<ValidateArgumentFilter>(),
+            _validator.Object,
+            attribute.ArgumentName,
+            attribute.Type,
+            attribute.TypeName);
+
+        return (filter, context);
     }
 }

--- a/web/tests/Web.Tests/Attributes/GivenAValidateUrnAttribute.cs
+++ b/web/tests/Web.Tests/Attributes/GivenAValidateUrnAttribute.cs
@@ -1,34 +1,40 @@
-﻿using System.Net;
+﻿using FluentValidation;
+using FluentValidation.Results;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Web.App;
 using Web.App.Attributes;
+using Web.App.Validators;
 using Xunit;
 
 namespace Web.Tests.Attributes;
 
 public class GivenAValidateUrnAttribute
 {
+    private readonly Mock<IValidator<OrganisationIdentifier>> _validator = new();
+
     [Theory]
     [InlineData("urn", "123456")]
     [InlineData("urn", "")]
     [InlineData("urn", null)]
     [InlineData("other", "abc")]
-    public void ReturnsOkWhenValidUrnProvidedOrMissing(string argument, object? urn)
+    public void ReturnsOkWhenValidUrnProvidedOrMissing(string argument, string? urn)
     {
         // arrange
-        var attribute = new ValidateUrnAttribute();
-        var context = BuildContext(new Dictionary<string, object?>
-        {
-            { argument, urn }
-        });
+        var validationResult = new ValidationResult();
+        _validator.Setup(v => v.Validate(It.Is<OrganisationIdentifier>(i => i.Value == urn && i.Type == OrganisationTypes.School)))
+            .Returns(validationResult);
+
+        var (filter, context) = BuildFilterAndContext(argument, urn);
 
         // act
-        attribute.OnActionExecuting(context);
+        filter.OnActionExecuting(context);
 
         // assert
         Assert.NotNull(context.Result);
@@ -36,29 +42,32 @@ public class GivenAValidateUrnAttribute
     }
 
     [Theory]
-    [InlineData("urn", "1234567")]
-    [InlineData("urn", "abcdef")]
-    public void ReturnsBadRequestWhenInvalidUrnProvided(string argument, object? urn)
+    [InlineData("urn", "invalid")]
+    public void ReturnsNotFoundWhenUrnValidationFails(string argument, string? urn)
     {
         // arrange
-        var attribute = new ValidateUrnAttribute();
-        var context = BuildContext(new Dictionary<string, object?>
-        {
-            { argument, urn }
-        });
+        var validationResult = new ValidationResult([new ValidationFailure("code", "LA code is invalid")]);
+        _validator.Setup(v => v.Validate(It.Is<OrganisationIdentifier>(i => i.Value == urn && i.Type == OrganisationTypes.School)))
+            .Returns(validationResult);
+
+        var (filter, context) = BuildFilterAndContext(argument, urn);
 
         // act
-        attribute.OnActionExecuting(context);
+        filter.OnActionExecuting(context);
 
         // assert
         Assert.NotNull(context.Result);
-        var result = Assert.IsType<ViewResult>(context.Result);
-        Assert.Equal((int)HttpStatusCode.BadRequest, result.StatusCode);
+        Assert.IsType<NotFoundResult>(context.Result);
     }
 
-    private static ActionExecutingContext BuildContext(Dictionary<string, object?> actionArguments)
+    private (ValidateArgumentFilter filter, ActionExecutingContext context) BuildFilterAndContext(string argument, object? companyNumber)
     {
-        return new ActionExecutingContext(
+        var actionArguments = new Dictionary<string, object?>
+        {
+            { argument, companyNumber }
+        };
+
+        var context = new ActionExecutingContext(
             new ActionContext(
                 Mock.Of<HttpContext>(),
                 Mock.Of<RouteData>(),
@@ -71,5 +80,15 @@ public class GivenAValidateUrnAttribute
         {
             Result = new OkResult()
         };
+
+        var attribute = new ValidateUrnAttribute();
+        var filter = new ValidateArgumentFilter(
+            new NullLogger<ValidateArgumentFilter>(),
+            _validator.Object,
+            attribute.ArgumentName,
+            attribute.Type,
+            attribute.TypeName);
+
+        return (filter, context);
     }
 }

--- a/web/tests/Web.Tests/Validators/GivenAnOrganisationIdentifierValidator.cs
+++ b/web/tests/Web.Tests/Validators/GivenAnOrganisationIdentifierValidator.cs
@@ -1,0 +1,155 @@
+using Web.App;
+using Web.App.Validators;
+using Xunit;
+
+namespace Web.Tests.Validators;
+
+public class GivenAnOrganisationIdentifierValidator
+{
+    private readonly OrganisationIdentifierValidator _validator = new();
+
+    [Fact]
+    public void ShouldFailValidationIfIdentifierOrTypeMissing()
+    {
+        var identifier = new OrganisationIdentifier();
+        string[] expected =
+        [
+            "Organisation identifier must be provided",
+            "Organisation type must be provided"
+        ];
+
+        var results = _validator.Validate(identifier);
+
+        Assert.False(results.IsValid);
+        Assert.NotEmpty(results.Errors);
+        Assert.Equal(expected, results.Errors.Select(e => e.ErrorMessage));
+    }
+
+    [Fact]
+    public void ShouldFailValidationIfTypeInvalid()
+    {
+        var identifier = new OrganisationIdentifier
+        {
+            Value = "123456",
+            Type = "invalid"
+        };
+
+        string[] expected =
+        [
+            "Organisation type must be valid"
+        ];
+
+        var results = _validator.Validate(identifier);
+
+        Assert.False(results.IsValid);
+        Assert.NotEmpty(results.Errors);
+        Assert.Equal(expected, results.Errors.Select(e => e.ErrorMessage));
+    }
+
+    [Theory]
+    [InlineData(OrganisationTypes.School)]
+    [InlineData(OrganisationTypes.Trust)]
+    [InlineData(OrganisationTypes.LocalAuthority)]
+    public void ShouldFailValidationIfIdentifierInvalid(string type)
+    {
+        var identifier = new OrganisationIdentifier
+        {
+            Value = "invalid",
+            Type = type
+        };
+
+        string[] expected =
+        [
+            "Organisation identifier must be a number"
+        ];
+
+        var results = _validator.Validate(identifier);
+
+        Assert.False(results.IsValid);
+        Assert.NotEmpty(results.Errors);
+        Assert.Equal(expected, results.Errors.Select(e => e.ErrorMessage));
+    }
+
+    [Theory]
+    [InlineData("1234")]
+    public void ShouldFailValidationIfUrnInvalid(string urn)
+    {
+        var identifier = new OrganisationIdentifier
+        {
+            Value = urn,
+            Type = OrganisationTypes.School
+        };
+
+        string[] expected =
+        [
+            "School URN must be 6 characters"
+        ];
+
+        var results = _validator.Validate(identifier);
+
+        Assert.False(results.IsValid);
+        Assert.NotEmpty(results.Errors);
+        Assert.Equal(expected, results.Errors.Select(e => e.ErrorMessage));
+    }
+
+    [Theory]
+    [InlineData("1234")]
+    public void ShouldFailValidationIfCompanyNumberInvalid(string companyNumber)
+    {
+        var identifier = new OrganisationIdentifier
+        {
+            Value = companyNumber,
+            Type = OrganisationTypes.Trust
+        };
+
+        string[] expected =
+        [
+            "Trust company number must be 8 characters"
+        ];
+
+        var results = _validator.Validate(identifier);
+
+        Assert.False(results.IsValid);
+        Assert.NotEmpty(results.Errors);
+        Assert.Equal(expected, results.Errors.Select(e => e.ErrorMessage));
+    }
+
+    [Theory]
+    [InlineData("1234")]
+    public void ShouldFailValidationIfLaCodeInvalid(string code)
+    {
+        var identifier = new OrganisationIdentifier
+        {
+            Value = code,
+            Type = OrganisationTypes.LocalAuthority
+        };
+
+        string[] expected =
+        [
+            "Local authority code must be 3 characters"
+        ];
+
+        var results = _validator.Validate(identifier);
+
+        Assert.False(results.IsValid);
+        Assert.NotEmpty(results.Errors);
+        Assert.Equal(expected, results.Errors.Select(e => e.ErrorMessage));
+    }
+
+    [Theory]
+    [InlineData(OrganisationTypes.School, "123456")]
+    [InlineData(OrganisationTypes.Trust, "12345678")]
+    [InlineData(OrganisationTypes.LocalAuthority, "123")]
+    public void ShouldPassValidationIfIdentifierValid(string type, string value)
+    {
+        var identifier = new OrganisationIdentifier
+        {
+            Value = value,
+            Type = type
+        };
+
+        var results = _validator.Validate(identifier);
+
+        Assert.True(results.IsValid);
+    }
+}

--- a/web/tests/Web.Tests/Validators/GivenAnOrganisationIdentifierValidator.cs
+++ b/web/tests/Web.Tests/Validators/GivenAnOrganisationIdentifierValidator.cs
@@ -72,6 +72,7 @@ public class GivenAnOrganisationIdentifierValidator
 
     [Theory]
     [InlineData("1234")]
+    [InlineData("-12345")]
     public void ShouldFailValidationIfUrnInvalid(string urn)
     {
         var identifier = new OrganisationIdentifier
@@ -82,7 +83,7 @@ public class GivenAnOrganisationIdentifierValidator
 
         string[] expected =
         [
-            "School URN must be 6 characters"
+            "School URN must be 6 digits"
         ];
 
         var results = _validator.Validate(identifier);
@@ -94,6 +95,7 @@ public class GivenAnOrganisationIdentifierValidator
 
     [Theory]
     [InlineData("1234")]
+    [InlineData("-1234567")]
     public void ShouldFailValidationIfCompanyNumberInvalid(string companyNumber)
     {
         var identifier = new OrganisationIdentifier
@@ -104,7 +106,7 @@ public class GivenAnOrganisationIdentifierValidator
 
         string[] expected =
         [
-            "Trust company number must be 8 characters"
+            "Trust company number must be 8 digits"
         ];
 
         var results = _validator.Validate(identifier);
@@ -116,6 +118,7 @@ public class GivenAnOrganisationIdentifierValidator
 
     [Theory]
     [InlineData("1234")]
+    [InlineData("-12")]
     public void ShouldFailValidationIfLaCodeInvalid(string code)
     {
         var identifier = new OrganisationIdentifier
@@ -126,7 +129,7 @@ public class GivenAnOrganisationIdentifierValidator
 
         string[] expected =
         [
-            "Local authority code must be 3 characters"
+            "Local authority code must be 3 digits"
         ];
 
         var results = _validator.Validate(identifier);


### PR DESCRIPTION
### Context
[AB#254608](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/254608) [AB#260043](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/260043) #2337 

### Change proposed in this pull request
- Implemented action filter above for LA codeand applied to controllers/actions
- Updated integration tests to ensure all dummy LA codes are of correct format
- Refactored earlier implementation to instead make use of `IValidator`

### Guidance to review 
Dependency on #2337.
Any URL including a bad LA code should fail with `404` and the 'page not found' view. E2E/A11y should be unaffected.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

