### PR TITLE
Applied new `[ValidateId]` attribute to proxy controller actions that consume `id` and `type`

### DIFF
--- a/web/src/Web.App/Attributes/ValidateArgumentAttribute.cs
+++ b/web/src/Web.App/Attributes/ValidateArgumentAttribute.cs
@@ -87,8 +87,10 @@ internal class ValidateArgumentFilter(
     }
 }
 
-public class ValidateUrnAttribute() : ValidateArgumentAttribute("urn", OrganisationTypes.School);
+public class ValidateUrnAttribute(string argumentName = "urn") : ValidateArgumentAttribute(argumentName, OrganisationTypes.School);
 
-public class ValidateCompanyNumberAttribute() : ValidateArgumentAttribute("companyNumber", OrganisationTypes.Trust);
+public class ValidateCompanyNumberAttribute(string argumentName = "companyNumber") : ValidateArgumentAttribute(argumentName, OrganisationTypes.Trust);
 
-public class ValidateLaCodeAttribute() : ValidateArgumentAttribute("code", OrganisationTypes.LocalAuthority);
+public class ValidateLaCodeAttribute(string argumentName = "code") : ValidateArgumentAttribute(argumentName, OrganisationTypes.LocalAuthority);
+
+public class ValidateIdAttribute(string argumentName = "id", string typeArgumentName = "type") : ValidateArgumentAttribute(argumentName, string.Empty, typeArgumentName);

--- a/web/src/Web.App/Controllers/Api/BalanceProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/BalanceProxyController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
+using Web.App.Attributes;
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.Insight;
@@ -26,6 +27,7 @@ public class BalanceProxyController(
     [ProducesResponseType<BalanceHistoryRows>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Route("history")]
+    [ValidateId]
     public async Task<IActionResult> History(
         [FromQuery] string type,
         [FromQuery] string id,
@@ -71,6 +73,7 @@ public class BalanceProxyController(
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Route("user-defined")]
     [Authorize]
+    [ValidateId]
     public async Task<IActionResult> UserDefined(
         [FromQuery] string type,
         [FromQuery] string id,

--- a/web/src/Web.App/Controllers/Api/BalanceProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/BalanceProxyController.cs
@@ -26,6 +26,7 @@ public class BalanceProxyController(
     [Produces("application/json")]
     [ProducesResponseType<BalanceHistoryRows>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [Route("history")]
     [ValidateId]
     public async Task<IActionResult> History(
@@ -71,6 +72,7 @@ public class BalanceProxyController(
     [Produces("application/json")]
     [ProducesResponseType<TrustBalance[]>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [Route("user-defined")]
     [Authorize]
     [ValidateId]

--- a/web/src/Web.App/Controllers/Api/BudgetForecastProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/BudgetForecastProxyController.cs
@@ -17,10 +17,11 @@ public class BudgetForecastProxyController(ILogger<BudgetForecastProxyController
     /// <param name="companyNumber" example="07465701"></param>
     /// <param name="cancellationToken"></param>
     [HttpGet]
-    [ValidateCompanyNumber]
     [Produces("application/json")]
     [ProducesResponseType<BudgetForecastReturn[]>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ValidateCompanyNumber]
     public async Task<IActionResult> Index([FromQuery] string companyNumber, CancellationToken cancellationToken = default)
     {
         using (logger.BeginScope(new

--- a/web/src/Web.App/Controllers/Api/CensusProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/CensusProxyController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
+using Web.App.Attributes;
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.Establishment;
@@ -23,6 +24,7 @@ public class CensusProxyController(
     [Produces("application/json")]
     [ProducesResponseType<Census[]>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ValidateId]
     public async Task<IActionResult> Query(
         [FromQuery] string type,
         [FromQuery] string id,
@@ -88,6 +90,7 @@ public class CensusProxyController(
     [ProducesResponseType<HistoryComparison<CensusHistory>>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Route("history/comparison")]
+    [ValidateUrn("id")]
     public async Task<IActionResult> HistoryComparison(
         [FromQuery] string id,
         [FromQuery] string dimension,

--- a/web/src/Web.App/Controllers/Api/CensusProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/CensusProxyController.cs
@@ -24,6 +24,7 @@ public class CensusProxyController(
     [Produces("application/json")]
     [ProducesResponseType<Census[]>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ValidateId]
     public async Task<IActionResult> Query(
         [FromQuery] string type,
@@ -59,7 +60,9 @@ public class CensusProxyController(
     [Produces("application/json")]
     [ProducesResponseType<CensusHistoryRows>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [Route("history")]
+    [ValidateUrn("id")]
     public async Task<IActionResult> History([FromQuery] string id, [FromQuery] string dimension, CancellationToken cancellationToken = default)
     {
         using (logger.BeginScope(new
@@ -89,6 +92,7 @@ public class CensusProxyController(
     [Produces("application/json")]
     [ProducesResponseType<HistoryComparison<CensusHistory>>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [Route("history/comparison")]
     [ValidateUrn("id")]
     public async Task<IActionResult> HistoryComparison(

--- a/web/src/Web.App/Controllers/Api/EducationHealthCarePlansProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/EducationHealthCarePlansProxyController.cs
@@ -23,6 +23,7 @@ public class EducationHealthCarePlansProxyController(
     [Produces("application/json")]
     [ProducesResponseType<EducationHealthCarePlansComparisonResponse[]>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [Route("comparison")]
     [ValidateLaCode]
     public async Task<IActionResult> Comparison([FromQuery] string code, [FromQuery] string[]? set = null, CancellationToken cancellationToken = default)
@@ -54,6 +55,7 @@ public class EducationHealthCarePlansProxyController(
     [Produces("application/json")]
     [ProducesResponseType<EducationHealthCarePlansHistoryResponse[]>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [Route("history")]
     [ValidateLaCode]
     public async Task<IActionResult> History([FromQuery] string code, CancellationToken cancellationToken = default)

--- a/web/src/Web.App/Controllers/Api/ExpenditureProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/ExpenditureProxyController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
+using Web.App.Attributes;
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.Establishment;
@@ -28,6 +29,7 @@ public class ExpenditureProxyController(
     /// <param name="customDataId"></param>
     /// <param name="cancellationToken"></param>
     [HttpGet]
+    [ValidateId]
     [Produces("application/json")]
     [ProducesResponseType<SchoolExpenditure[]>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -80,6 +82,7 @@ public class ExpenditureProxyController(
     [ProducesResponseType<ExpenditureHistoryRows>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Route("history")]
+    [ValidateId]
     public async Task<IActionResult> History(
         [FromQuery] string type,
         [FromQuery] string id,
@@ -122,6 +125,7 @@ public class ExpenditureProxyController(
     [ProducesResponseType<HistoryComparison<ExpenditureHistory>>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Route("history/comparison")]
+    [ValidateId]
     public async Task<IActionResult> HistoryComparison(
         [FromQuery] string type,
         [FromQuery] string id,
@@ -172,6 +176,7 @@ public class ExpenditureProxyController(
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Authorize]
+    [ValidateId]
     public async Task<IActionResult> UserDefined(
         [FromQuery] string type,
         [FromQuery] string id,

--- a/web/src/Web.App/Controllers/Api/ExpenditureProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/ExpenditureProxyController.cs
@@ -29,11 +29,12 @@ public class ExpenditureProxyController(
     /// <param name="customDataId"></param>
     /// <param name="cancellationToken"></param>
     [HttpGet]
-    [ValidateId]
     [Produces("application/json")]
     [ProducesResponseType<SchoolExpenditure[]>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ValidateId]
     public async Task<IActionResult> Query(
         [FromQuery] string type,
         [FromQuery] string id,
@@ -81,6 +82,7 @@ public class ExpenditureProxyController(
     [Produces("application/json")]
     [ProducesResponseType<ExpenditureHistoryRows>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [Route("history")]
     [ValidateId]
     public async Task<IActionResult> History(
@@ -124,6 +126,7 @@ public class ExpenditureProxyController(
     [Produces("application/json")]
     [ProducesResponseType<HistoryComparison<ExpenditureHistory>>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [Route("history/comparison")]
     [ValidateId]
     public async Task<IActionResult> HistoryComparison(
@@ -175,6 +178,7 @@ public class ExpenditureProxyController(
     [ProducesResponseType<TrustExpenditure[]>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [Authorize]
     [ValidateId]
     public async Task<IActionResult> UserDefined(

--- a/web/src/Web.App/Controllers/Api/HighNeedsProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/HighNeedsProxyController.cs
@@ -23,6 +23,7 @@ public class HighNeedsProxyController(
     [Produces("application/json")]
     [ProducesResponseType<LocalAuthorityHighNeedsComparisonResponse[]>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [Route("comparison")]
     [ValidateLaCode]
     public async Task<IActionResult> Comparison([FromQuery] string code, [FromQuery] string[]? set = null, CancellationToken cancellationToken = default)
@@ -54,6 +55,7 @@ public class HighNeedsProxyController(
     [Produces("application/json")]
     [ProducesResponseType<LocalAuthorityHighNeedsHistoryResponse[]>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [Route("history")]
     [ValidateLaCode]
     public async Task<IActionResult> History([FromQuery] string code, CancellationToken cancellationToken = default)

--- a/web/src/Web.App/Controllers/Api/IncomeProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/IncomeProxyController.cs
@@ -20,6 +20,7 @@ public class IncomeProxyController(ILogger<IncomeProxyController> logger, IIncom
     [Produces("application/json")]
     [ProducesResponseType<IncomeHistoryRows>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [Route("history")]
     [ValidateId]
     public async Task<IActionResult> History(

--- a/web/src/Web.App/Controllers/Api/IncomeProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/IncomeProxyController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
+using Web.App.Attributes;
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.Insight;
@@ -20,6 +21,7 @@ public class IncomeProxyController(ILogger<IncomeProxyController> logger, IIncom
     [ProducesResponseType<IncomeHistoryRows>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Route("history")]
+    [ValidateId]
     public async Task<IActionResult> History(
         [FromQuery] string type,
         [FromQuery] string id,

--- a/web/src/Web.App/Controllers/Api/UserDataProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/UserDataProxyController.cs
@@ -14,12 +14,12 @@ public class UserDataProxyController(ILogger<UserDataProxyController> logger, IU
 {
     [HttpGet]
     [Route("school/{urn}")]
-    [ValidateUrn]
     [Produces("application/json")]
     [ProducesResponseType<UserData>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ValidateUrn]
     public async Task<IActionResult> SchoolUserData(string urn, CancellationToken cancellationToken = default)
     {
         using (logger.BeginScope(new
@@ -47,8 +47,12 @@ public class UserDataProxyController(ILogger<UserDataProxyController> logger, IU
 
     [HttpGet]
     [Route("trust/{companyNumber}")]
-    [ValidateCompanyNumber]
     [Produces("application/json")]
+    [ProducesResponseType<UserData>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ValidateCompanyNumber]
     public async Task<IActionResult> TrustUserData(string companyNumber, CancellationToken cancellationToken = default)
     {
         using (logger.BeginScope(new
@@ -76,12 +80,12 @@ public class UserDataProxyController(ILogger<UserDataProxyController> logger, IU
 
     [HttpGet]
     [Route("school/custom-data/{urn}")]
-    [ValidateUrn]
     [Produces("application/json")]
     [ProducesResponseType<UserData>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ValidateUrn]
     public async Task<IActionResult> SchoolCustomDataUserData(string urn, CancellationToken cancellationToken = default)
     {
         using (logger.BeginScope(new

--- a/web/tests/Web.Integration.Tests/Proxy/WhenRequestingCensusHistoryComparison.cs
+++ b/web/tests/Web.Integration.Tests/Proxy/WhenRequestingCensusHistoryComparison.cs
@@ -19,7 +19,7 @@ public class WhenRequestingCensusHistoryComparison(SchoolBenchmarkingWebAppClien
         {
             new object?[]
             {
-                "urn",
+                "123456",
                 "dimension",
                 null,
                 null,
@@ -34,7 +34,7 @@ public class WhenRequestingCensusHistoryComparison(SchoolBenchmarkingWebAppClien
             },
             new object?[]
             {
-                "urn",
+                "234567",
                 "dimension",
                 "phase",
                 "financeType",

--- a/web/tests/Web.Integration.Tests/Proxy/WhenRequestingExpenditureHistoryComparison.cs
+++ b/web/tests/Web.Integration.Tests/Proxy/WhenRequestingExpenditureHistoryComparison.cs
@@ -19,7 +19,7 @@ public class WhenRequestingExpenditureHistoryComparison(SchoolBenchmarkingWebApp
         {
             new object?[]
             {
-                "urn",
+                "123456",
                 "dimension",
                 null,
                 null,
@@ -34,7 +34,7 @@ public class WhenRequestingExpenditureHistoryComparison(SchoolBenchmarkingWebApp
             },
             new object?[]
             {
-                "urn",
+                "234567",
                 "dimension",
                 "phase",
                 "financeType",

--- a/web/tests/Web.Integration.Tests/Proxy/WhenRequestingExpenditureUserDefined.cs
+++ b/web/tests/Web.Integration.Tests/Proxy/WhenRequestingExpenditureUserDefined.cs
@@ -14,7 +14,7 @@ public class WhenRequestingExpenditureUserDefined(SchoolBenchmarkingWebAppClient
     public static IEnumerable<object?[]> UserDefinedTrustTestData =>
         new List<object?[]>
         {
-            new object?[] { "companyNumber", "dimension", "category", TrustExpenditure }
+            new object?[] { "12345678", "dimension", "category", TrustExpenditure }
         };
 
     [Theory]

--- a/web/tests/Web.Tests/Attributes/GivenAValidateIdAttribute.cs
+++ b/web/tests/Web.Tests/Attributes/GivenAValidateIdAttribute.cs
@@ -1,0 +1,101 @@
+﻿using System.Net;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Web.App;
+using Web.App.Attributes;
+using Web.App.Validators;
+using Xunit;
+
+namespace Web.Tests.Attributes;
+
+public class GivenAValidateIdAttribute
+{
+    private readonly Mock<IValidator<OrganisationIdentifier>> _validator = new();
+
+    [Theory]
+    [InlineData("id", "123456", "type", OrganisationTypes.School)]
+    [InlineData("id", "", "type", OrganisationTypes.School)]
+    [InlineData("id", null, "type", OrganisationTypes.School)]
+    [InlineData("id", "12345678", "type", OrganisationTypes.Trust)]
+    [InlineData("id", "", "type", OrganisationTypes.Trust)]
+    [InlineData("id", "123", "type", OrganisationTypes.LocalAuthority)]
+    [InlineData("id", "", "type", OrganisationTypes.LocalAuthority)]
+    [InlineData("id", null, "type", OrganisationTypes.LocalAuthority)]
+    [InlineData("other", "abc", "type", OrganisationTypes.School)]
+    public void ReturnsOkWhenValidIdAndTypeProvidedOrMissing(string idArgument, string? id, string typeArgument, string? type)
+    {
+        // arrange
+        var validationResult = new ValidationResult();
+        _validator.Setup(v => v.Validate(It.Is<OrganisationIdentifier>(i => i.Value == id && i.Type == type)))
+            .Returns(validationResult);
+
+        var (filter, context) = BuildFilterAndContext(idArgument, id, typeArgument, type);
+
+        // act
+        filter.OnActionExecuting(context);
+
+        // assert
+        Assert.NotNull(context.Result);
+        Assert.IsType<OkResult>(context.Result);
+    }
+
+    [Theory]
+    [InlineData("id", "123456", "type", "other")]
+    public void ReturnsNotFoundWhenValidationFails(string idArgument, string? id, string typeArgument, string? type)
+    {
+        // arrange
+        var validationResult = new ValidationResult([new ValidationFailure(idArgument, "Value is invalid")]);
+        _validator.Setup(v => v.Validate(It.Is<OrganisationIdentifier>(i => i.Value == id && i.Type == type)))
+            .Returns(validationResult);
+
+        var (filter, context) = BuildFilterAndContext(idArgument, id, typeArgument, type);
+
+        // act
+        filter.OnActionExecuting(context);
+
+        // assert
+        Assert.NotNull(context.Result);
+        Assert.IsType<NotFoundResult>(context.Result);
+    }
+
+    private (ValidateArgumentFilter filter, ActionExecutingContext context) BuildFilterAndContext(string idArgument, string? id, string typeArgument, string? type)
+    {
+        var actionArguments = new Dictionary<string, object?>
+        {
+            { idArgument, id },
+            { typeArgument, type }
+        };
+
+        var context = new ActionExecutingContext(
+            new ActionContext(
+                Mock.Of<HttpContext>(),
+                Mock.Of<RouteData>(),
+                Mock.Of<ActionDescriptor>(),
+                Mock.Of<ModelStateDictionary>()
+            ),
+            new List<IFilterMetadata>(),
+            actionArguments,
+            Mock.Of<Controller>())
+        {
+            Result = new OkResult()
+        };
+
+        var attribute = new ValidateIdAttribute();
+        var filter = new ValidateArgumentFilter(
+            new NullLogger<ValidateArgumentFilter>(),
+            _validator.Object,
+            attribute.ArgumentName,
+            attribute.Type,
+            attribute.TypeName);
+
+        return (filter, context);
+    }
+}


### PR DESCRIPTION
### Context
[AB#254608](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/254608) [AB#260043](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/260043) #2339 

### Change proposed in this pull request
- Implemented action filter above for School/Trust/LA identifiers and applied to proxy controllers actions
- Updated integration tests to ensure all dummy identifiers are of correct format

### Guidance to review 
Dependency on #2339.
Any URL including a bad URN/Company Number/LA code for their respective organisation type should fail with `404` and the 'page not found' view. E2E/A11y should be unaffected.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

