### PR TITLE
Clear any previously selected comparator Trusts during E2E run

### DIFF
--- a/web/tests/Web.E2ETests/Features/Trust/Comparators.feature
+++ b/web/tests/Web.E2ETests/Features/Trust/Comparators.feature
@@ -3,6 +3,7 @@ Feature: View Trust comparator set
     Background:
         Given I am on the service home
         And I have signed in with organisation '010: FBIT TEST - Multi-Academy Trust (Open)'
+        And I have no previous comparators selected for company number '10074054'
         And I am on compare by page for trust with company number '10074054'
         When I select the option By Name and click continue
         And I select the trust with company number '00000001' from suggester

--- a/web/tests/Web.E2ETests/Features/Trust/CreateComparators.feature
+++ b/web/tests/Web.E2ETests/Features/Trust/CreateComparators.feature
@@ -3,6 +3,7 @@ Feature: Trust create comparator set
     Background:
         Given I am on the service home
         And I have signed in with organisation '010: FBIT TEST - Multi-Academy Trust (Open)'
+        And I have no previous comparators selected for company number '10074054'
         And I am on compare by page for trust with company number '00000001'
 
     Scenario: Can view create comparator set page

--- a/web/tests/Web.E2ETests/Pages/Trust/Comparators/RevertComparatorsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/Trust/Comparators/RevertComparatorsPage.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Playwright;
+
+namespace Web.E2ETests.Pages.Trust.Comparators;
+
+public class RevertComparatorsPage(IPage page)
+{
+    private ILocator PageH1Heading => page.Locator(Selectors.H1,
+        new PageLocatorOptions
+        {
+            HasText = "Remove all your trusts?"
+        });
+    private ILocator ContinueButton => page.Locator(Selectors.GovButton,
+        new PageLocatorOptions
+        {
+            HasText = "Remove all trusts"
+        });
+
+    public async Task IsDisplayed()
+    {
+        await PageH1Heading.ShouldBeVisible();
+        await ContinueButton.ShouldBeVisible();
+    }
+
+    public async Task<HomePage> ClickContinue()
+    {
+        await ContinueButton.ClickAsync();
+        return new HomePage(page);
+    }
+}

--- a/web/tests/Web.E2ETests/Steps/Trust/ComparatorsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/Trust/ComparatorsSteps.cs
@@ -14,6 +14,18 @@ public class ComparatorsSteps(PageDriver driver)
     private CreateComparatorsByPage? _createComparatorsByPage;
     private TrustBenchmarkSpendingPage? _trustBenchmarkSpendingPage;
 
+    [Given("I have no previous comparators selected for company number '(.*)'")]
+    public async Task GivenIHaveNoPreviousComparatorsSelectedForCompanyNumber(string companyNumber)
+    {
+        var url = RevertComparatorsUrl(companyNumber);
+        var page = await driver.Current;
+        await page.GotoAndWaitForLoadAsync(url);
+
+        var revertComparatorsPage = new RevertComparatorsPage(page);
+        await revertComparatorsPage.IsDisplayed();
+        await revertComparatorsPage.ClickContinue();
+    }
+
     [Given("I am on compare by page for trust with company number '(.*)'")]
     public async Task GivenIAmOnCompareByPageForTrustWithCompanyNumber(string companyNumber)
     {
@@ -89,5 +101,12 @@ public class ComparatorsSteps(PageDriver driver)
         }
     }
 
-    private static string CreateComparatorsByUrl(string urn) => $"{TestConfiguration.ServiceUrl}/trust/{urn}/comparators/create/by";
+    private static string RevertComparatorsUrl(string urn)
+    {
+        return $"{TestConfiguration.ServiceUrl}/trust/{urn}/comparators/revert";
+    }
+    private static string CreateComparatorsByUrl(string urn)
+    {
+        return $"{TestConfiguration.ServiceUrl}/trust/{urn}/comparators/create/by";
+    }
 }

--- a/web/tests/Web.E2ETests/Steps/Trust/CreateComparatorsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/Trust/CreateComparatorsSteps.cs
@@ -14,6 +14,18 @@ public class CreateComparatorsSteps(PageDriver driver)
     private CreateComparatorsByPage? _createComparatorsByPage;
     private TrustBenchmarkSpendingPage? _trustBenchmarkSpendingPage;
 
+    [Given("I have no previous comparators selected for company number '(.*)'")]
+    public async Task GivenIHaveNoPreviousComparatorsSelectedForCompanyNumber(string companyNumber)
+    {
+        var url = RevertComparatorsUrl(companyNumber);
+        var page = await driver.Current;
+        await page.GotoAndWaitForLoadAsync(url);
+
+        var revertComparatorsPage = new RevertComparatorsPage(page);
+        await revertComparatorsPage.IsDisplayed();
+        await revertComparatorsPage.ClickContinue();
+    }
+
     [Given("I am on compare by page for trust with company number '(.*)'")]
     public async Task GivenIAmOnCompareByPageForTrustWithCompanyNumber(string companyNumber)
     {
@@ -104,5 +116,12 @@ public class CreateComparatorsSteps(PageDriver driver)
         }
     }
 
-    private static string CreateComparatorsByUrl(string urn) => $"{TestConfiguration.ServiceUrl}/trust/{urn}/comparators/create/by";
+    private static string RevertComparatorsUrl(string urn)
+    {
+        return $"{TestConfiguration.ServiceUrl}/trust/{urn}/comparators/revert";
+    }
+    private static string CreateComparatorsByUrl(string urn)
+    {
+        return $"{TestConfiguration.ServiceUrl}/trust/{urn}/comparators/create/by";
+    }
 }


### PR DESCRIPTION
### Context
[AB#254608](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/254608) [AB#260042](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/260042)

### Change proposed in this pull request
Fix failing tests since #2337 merged and `d02` re-seeded.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

