### PR TITLE
Prevent exception being thrown from downstream API user-cancelled tasks

### DIFF
--- a/web/src/Web.App/Infrastructure/Apis/ApiResults/CancelledApiResult.cs
+++ b/web/src/Web.App/Infrastructure/Apis/ApiResults/CancelledApiResult.cs
@@ -1,0 +1,5 @@
+using System.Net;
+
+namespace Web.App.Infrastructure.Apis;
+
+public sealed class CancelledApiResult() : ApiResult((HttpStatusCode)499);

--- a/web/src/Web.App/Infrastructure/Extensions/ApiResultExtensions.cs
+++ b/web/src/Web.App/Infrastructure/Extensions/ApiResultExtensions.cs
@@ -94,6 +94,11 @@ public static class ApiResultExtensions
             };
         }
 
+        if (result is CancelledApiResult)
+        {
+            return default!;
+        }
+
         throw new ArgumentNullException();
     }
 
@@ -105,7 +110,7 @@ public static class ApiResultExtensions
         }
 
         result.EnsureSuccess();
-        return Array.Empty<byte>();
+        return [];
     }
 
     public static async Task<byte[]> GetBodyOrThrow(this Task<ApiResult> result)

--- a/web/tests/Web.Tests/Infrastructure/GivenAHttpResponseMessage.cs
+++ b/web/tests/Web.Tests/Infrastructure/GivenAHttpResponseMessage.cs
@@ -24,6 +24,7 @@ public class GivenAHttpResponseMessage
     [InlineData(HttpStatusCode.OK)]
     [InlineData(HttpStatusCode.Created)]
     [InlineData(HttpStatusCode.Accepted)]
+    [InlineData((HttpStatusCode)499)]
     public async Task ShouldNotThrow(HttpStatusCode code)
     {
         var result = await CreateMessage(code, new JsonContent(new
@@ -92,14 +93,15 @@ public class GivenAHttpResponseMessage
     }
 
     [Fact]
-    public async Task ShouldReturn499WhenRequestCancelled()
+    public async Task ShouldReturnEmpty499WhenRequestCancelled()
     {
         var cancellationToken = new CancellationTokenSource(TimeSpan.Zero).Token;
-
         var result = await CreateMessage(cancellationToken).ToApiResult(cancellationToken);
 
-        var exception = Assert.Throws<StatusCodeException>(() => result.EnsureSuccess());
-        Assert.Equal(499, (int)exception.Status);
-        Assert.Equal("The API returned `Client Closed Request` (underlying status code 499)", exception.Message);
+        var exception = Record.Exception(() => result.EnsureSuccess());
+
+        Assert.Null(exception);
+        Assert.Equal(499, (int)result.Status);
+        Assert.Null(result.GetResultOrThrow<string>());
     }
 }


### PR DESCRIPTION
### Context
[AB#260643](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/260643) [AB#260921](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/260921)

### Change proposed in this pull request
`499` errors from API should be treated as neutral and return an empty response rather than re-throw as an exception. The latter pollutes the logs and would never be observed by the client anyway due to that request having been cancelled (via `fetch` signals and `CancellationToken`s).

### Guidance to review 
Easiest way to replicate the original issue is to [browse to a page with a dimension drop down](https://localhost:7095/school/777042/comparison) and quickly switch between dimensions a few times. The API should throw a `System.Threading.Tasks.TaskCanceledException` which is returned to the Web proxy as a `499`. Before this change, this would then be re-thrown as a `500` but after should return an empty `499` response instead, with no exceptions logged to App Insights.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

