### PR TITLE
feat: create `CommercialResources` table and view

### DIFF
--- a/core-infrastructure/src/db/Core.Database/Scripts/114-CreateCommercialResourcesTable.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/114-CreateCommercialResourcesTable.sql
@@ -4,12 +4,14 @@ IF NOT EXISTS(SELECT *
 BEGIN
 CREATE TABLE [dbo].[CommercialResources]
 (
-    ResourceID   INT IDENTITY(1,1) PRIMARY KEY,
+    Id          integer identity (1,1) NOT NULL,
     Category    nvarchar(50)   NOT NULL,
     SubCategory nvarchar(50)   NOT NULL,
     Title       nvarchar(255)  NOT NULL,
     Url         nvarchar(2000)  NOT NULL,
     ValidFrom   datetimeoffset NOT NULL DEFAULT GETUTCDATE(),
     ValidTo     datetimeoffset NULL
+
+    CONSTRAINT PK_CommercialResources PRIMARY KEY (Id),
     );
 END

--- a/core-infrastructure/src/db/Core.Database/Scripts/114-CreateCommercialResourcesTable.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/114-CreateCommercialResourcesTable.sql
@@ -1,0 +1,15 @@
+IF NOT EXISTS(SELECT *
+              FROM INFORMATION_SCHEMA.TABLES
+              WHERE table_name = 'CommercialResources')
+BEGIN
+CREATE TABLE [dbo].[CommercialResources]
+(
+    ResourceID   INT IDENTITY(1,1) PRIMARY KEY,
+    Category    nvarchar(50)   NOT NULL,
+    SubCategory nvarchar(50)   NOT NULL,
+    Title       nvarchar(255)  NOT NULL,
+    Url         nvarchar(2000)  NOT NULL,
+    ValidFrom   datetimeoffset NOT NULL DEFAULT GETUTCDATE(),
+    ValidTo     datetimeoffset NULL
+    );
+END

--- a/core-infrastructure/src/db/Core.Database/Views/024-CommercialResources.sql
+++ b/core-infrastructure/src/db/Core.Database/Views/024-CommercialResources.sql
@@ -1,0 +1,9 @@
+DROP VIEW IF EXISTS VW_CommercialResources
+    GO
+
+CREATE VIEW VW_CommercialResources AS
+    SELECT [Category], [SubCategory], [Title], [Url]
+    FROM [dbo].[CommercialResources]
+    WHERE [ValidFrom] < GETUTCDATE()
+    AND ([ValidTo] IS NULL OR [ValidTo] > GETUTCDATE())
+GO


### PR DESCRIPTION
### Context
[AB#259512](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/259512) [AB#260668](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/260668)

### Change proposed in this pull request
Creates a new table `CommercialResources` with the following columns
- ResourceID
- Category 
- SubCategory
- Title
- Url
- ValidTo
- ValidFrom

Creates a `VW_CommercialResources` view 

### Guidance to review 
Tested scripts locally 

Adds ResourceID as a unique identifier as Category, SubCategory and Title are not guaranteed to be unique if used as a composite primary key (there is at least one occurance where they are not in the current data).

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

