### PR TITLE
feat: create new insights endpoint `commercial-resources`

### DIFF
--- a/platform/src/abstractions/Platform.Sql/QueryBuilders/CommericalResourcesQueries.cs
+++ b/platform/src/abstractions/Platform.Sql/QueryBuilders/CommericalResourcesQueries.cs
@@ -1,0 +1,6 @@
+namespace Platform.Sql.QueryBuilders;
+
+public class CommercialResourcesQuery() : PlatformQuery(Sql)
+{
+    private const string Sql = "SELECT * FROM VW_CommercialResources /**where**/";
+}

--- a/platform/src/abstractions/Platform.Sql/QueryBuilders/PlatformQuery.cs
+++ b/platform/src/abstractions/Platform.Sql/QueryBuilders/PlatformQuery.cs
@@ -257,4 +257,19 @@ public abstract class PlatformQuery : SqlBuilder
         Where(sql);
         return this;
     }
+
+    public PlatformQuery WhereCategoryIn(params string[] categories)
+    {
+        if (categories.Length > 0)
+        {
+            const string sql = "Category IN @Categories";
+            var parameters = new
+            {
+                Categories = categories
+            };
+
+            Where(sql, parameters);
+        }
+        return this;
+    }
 }

--- a/platform/src/apis/Platform.Api.Insight/Configuration/Services.cs
+++ b/platform/src/apis/Platform.Api.Insight/Configuration/Services.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Platform.Api.Insight.Features.Balance;
 using Platform.Api.Insight.Features.BudgetForecast;
 using Platform.Api.Insight.Features.Census;
+using Platform.Api.Insight.Features.CommercialResources;
 using Platform.Api.Insight.Features.Expenditure;
 using Platform.Api.Insight.Features.Files;
 using Platform.Api.Insight.Features.Income;
@@ -80,5 +81,6 @@ internal static class Services
         .AddIncomeFeature()
         .AddMetricRagRatingsFeature()
         .AddSchoolsFeature()
-        .AddTrustsFeature();
+        .AddTrustsFeature()
+        .AddCommercialResourcesFeature();
 }

--- a/platform/src/apis/Platform.Api.Insight/Constants.cs
+++ b/platform/src/apis/Platform.Api.Insight/Constants.cs
@@ -12,6 +12,7 @@ public static class Constants
         public const string Balance = "Balance";
         public const string BudgetForecast = "Budget Forecast";
         public const string Census = "Census";
+        public const string CommercialResources = "Commercial Resources";
         public const string Income = "Income";
         public const string Expenditure = "Expenditure";
         public const string Years = "Years";

--- a/platform/src/apis/Platform.Api.Insight/Features/CommercialResources/CommercialResourcesFeature.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/CommercialResources/CommercialResourcesFeature.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics.CodeAnalysis;
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+using Platform.Api.Insight.Features.CommercialResources.Parameters;
+using Platform.Api.Insight.Features.CommercialResources.Services;
+using Platform.Api.Insight.Features.CommercialResources.Validators;
+
+namespace Platform.Api.Insight.Features.CommercialResources;
+
+[ExcludeFromCodeCoverage]
+public static class CommercialResourcesFeature
+{
+    public static IServiceCollection AddCommercialResourcesFeature(this IServiceCollection serviceCollection)
+    {
+        serviceCollection
+            .AddSingleton<ICommercialResourcesService, CommercialResourcesService>()
+            .AddTransient<IValidator<CommercialResourcesParameters>, CommercialResourcesParametersValidator>();
+
+        return serviceCollection;
+    }
+}

--- a/platform/src/apis/Platform.Api.Insight/Features/CommercialResources/GetCommercialResourcesFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/CommercialResources/GetCommercialResourcesFunction.cs
@@ -36,7 +36,7 @@ public class GetCommercialResourcesFunction(ICommercialResourcesService service,
             return await req.CreateValidationErrorsResponseAsync(validationResult.Errors, cancellationToken: cancellationToken);
         }
 
-        var result = await service.GetCommercialResourcesByCategory(cancellationToken, queryParams.Categories);
+        var result = await service.GetCommercialResourcesByCategory(queryParams.Categories, cancellationToken);
         return await req.CreateJsonResponseAsync(result, cancellationToken: cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/CommercialResources/GetCommercialResourcesFunction.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/CommercialResources/GetCommercialResourcesFunction.cs
@@ -1,0 +1,42 @@
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentValidation;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.OpenApi.Models;
+using Platform.Api.Insight.Features.CommercialResources.Parameters;
+using Platform.Api.Insight.Features.CommercialResources.Responses;
+using Platform.Api.Insight.Features.CommercialResources.Services;
+using Platform.Functions;
+using Platform.Functions.Extensions;
+using Platform.Functions.OpenApi;
+
+namespace Platform.Api.Insight.Features.CommercialResources;
+
+public class GetCommercialResourcesFunction(ICommercialResourcesService service,
+    IValidator<CommercialResourcesParameters> commercialResourcesParametersValidator)
+{
+    [Function(nameof(GetCommercialResourcesFunction))]
+    [OpenApiSecurityHeader]
+    [OpenApiOperation(nameof(GetCommercialResourcesFunction), Constants.Features.CommercialResources)]
+    [OpenApiParameter("categories", In = ParameterLocation.Query, Description = "List of cost categories", Type = typeof(string[]), Required = false)]
+    [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(CommercialResourcesResponse[]))]
+    [OpenApiResponseWithoutBody(HttpStatusCode.BadRequest)]
+    public async Task<HttpResponseData> RunAsync(
+        [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.CommercialResources)] HttpRequestData req,
+        CancellationToken cancellationToken = default)
+    {
+        var queryParams = req.GetParameters<CommercialResourcesParameters>();
+
+        var validationResult = await commercialResourcesParametersValidator.ValidateAsync(queryParams, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            return await req.CreateValidationErrorsResponseAsync(validationResult.Errors, cancellationToken: cancellationToken);
+        }
+
+        var result = await service.GetCommercialResourcesByCategory(cancellationToken, queryParams.Categories);
+        return await req.CreateJsonResponseAsync(result, cancellationToken: cancellationToken);
+    }
+}

--- a/platform/src/apis/Platform.Api.Insight/Features/CommercialResources/Parameters/CommercialResourcesParameters.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/CommercialResources/Parameters/CommercialResourcesParameters.cs
@@ -1,5 +1,6 @@
 using System.Collections.Specialized;
 using Platform.Functions;
+using Platform.Functions.Extensions;
 
 namespace Platform.Api.Insight.Features.CommercialResources.Parameters;
 
@@ -9,6 +10,6 @@ public record CommercialResourcesParameters : QueryParameters
 
     public override void SetValues(NameValueCollection query)
     {
-        Categories = query["categories"]?.Split(',') ?? [];
+        Categories = query.ToStringArray("categories");
     }
 }

--- a/platform/src/apis/Platform.Api.Insight/Features/CommercialResources/Parameters/CommercialResourcesParameters.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/CommercialResources/Parameters/CommercialResourcesParameters.cs
@@ -1,0 +1,14 @@
+using System.Collections.Specialized;
+using Platform.Functions;
+
+namespace Platform.Api.Insight.Features.CommercialResources.Parameters;
+
+public record CommercialResourcesParameters : QueryParameters
+{
+    public string[] Categories { get; private set; } = [];
+
+    public override void SetValues(NameValueCollection query)
+    {
+        Categories = query["categories"]?.Split(',') ?? [];
+    }
+}

--- a/platform/src/apis/Platform.Api.Insight/Features/CommercialResources/Responses/CommercialResourcesResponse.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/CommercialResources/Responses/CommercialResourcesResponse.cs
@@ -1,0 +1,12 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Platform.Api.Insight.Features.CommercialResources.Responses;
+
+[ExcludeFromCodeCoverage]
+public record CommercialResourcesResponse
+{
+    public string? Category { get; set; }
+    public string? SubCategory { get; set; }
+    public string? Title { get; set; }
+    public string? Url { get; set; }
+}

--- a/platform/src/apis/Platform.Api.Insight/Features/CommercialResources/Routes.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/CommercialResources/Routes.cs
@@ -1,0 +1,6 @@
+namespace Platform.Api.Insight.Features.CommercialResources;
+
+public static class Routes
+{
+    public const string CommercialResources = "commercial-resources";
+}

--- a/platform/src/apis/Platform.Api.Insight/Features/CommercialResources/Services/CommercialResourcesService.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/CommercialResources/Services/CommercialResourcesService.cs
@@ -10,13 +10,13 @@ namespace Platform.Api.Insight.Features.CommercialResources.Services;
 
 public interface ICommercialResourcesService
 {
-    Task<IEnumerable<CommercialResourcesResponse>> GetCommercialResourcesByCategory(CancellationToken cancellationToken = default, params string[] categories);
+    Task<IEnumerable<CommercialResourcesResponse>> GetCommercialResourcesByCategory(string[] categories, CancellationToken cancellationToken = default);
 }
 
 [ExcludeFromCodeCoverage]
 public class CommercialResourcesService(IDatabaseFactory dbFactory) : ICommercialResourcesService
 {
-    public async Task<IEnumerable<CommercialResourcesResponse>> GetCommercialResourcesByCategory(CancellationToken cancellationToken = default, params string[] categories)
+    public async Task<IEnumerable<CommercialResourcesResponse>> GetCommercialResourcesByCategory(string[] categories, CancellationToken cancellationToken = default)
     {
         using var conn = await dbFactory.GetConnection();
 

--- a/platform/src/apis/Platform.Api.Insight/Features/CommercialResources/Services/CommercialResourcesService.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/CommercialResources/Services/CommercialResourcesService.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Platform.Api.Insight.Features.CommercialResources.Responses;
+using Platform.Sql;
+using Platform.Sql.QueryBuilders;
+
+namespace Platform.Api.Insight.Features.CommercialResources.Services;
+
+public interface ICommercialResourcesService
+{
+    Task<IEnumerable<CommercialResourcesResponse>> GetCommercialResourcesByCategory(CancellationToken cancellationToken = default, params string[] categories);
+}
+
+[ExcludeFromCodeCoverage]
+public class CommercialResourcesService(IDatabaseFactory dbFactory) : ICommercialResourcesService
+{
+    public async Task<IEnumerable<CommercialResourcesResponse>> GetCommercialResourcesByCategory(CancellationToken cancellationToken = default, params string[] categories)
+    {
+        using var conn = await dbFactory.GetConnection();
+
+        var builder = new CommercialResourcesQuery().WhereCategoryIn(categories);
+
+        return await conn.QueryAsync<CommercialResourcesResponse>(builder, cancellationToken);
+    }
+}

--- a/platform/src/apis/Platform.Api.Insight/Features/CommercialResources/Validators/CommericalResourcesParametersValidators.cs
+++ b/platform/src/apis/Platform.Api.Insight/Features/CommercialResources/Validators/CommericalResourcesParametersValidators.cs
@@ -1,0 +1,18 @@
+﻿using System.Linq;
+using FluentValidation;
+using Platform.Api.Insight.Features.CommercialResources.Parameters;
+using Platform.Domain;
+
+namespace Platform.Api.Insight.Features.CommercialResources.Validators;
+
+public class CommercialResourcesParametersValidator : AbstractValidator<CommercialResourcesParameters>
+{
+    public CommercialResourcesParametersValidator()
+    {
+        RuleFor(x => x.Categories)
+            .Must(categories => categories == null || ContainValidCategories(categories))
+            .WithMessage($"{{PropertyName}} must be null or only contain the supported values: {string.Join(", ", CostCategories.All)}");
+    }
+
+    private static bool ContainValidCategories(string[] categories) => categories.All(CostCategories.IsValid);
+}

--- a/platform/tests/Platform.Insight.Tests/CommercialResources/GetCommercialResourcesFunctionTest.cs
+++ b/platform/tests/Platform.Insight.Tests/CommercialResources/GetCommercialResourcesFunctionTest.cs
@@ -45,8 +45,8 @@ public class GetCommercialResourcesFunctionTests : FunctionsTestBase
 
         _service
             .Setup(x => x.GetCommercialResourcesByCategory(
-                It.IsAny<CancellationToken>(),
-                It.IsAny<string[]>()))
+                It.IsAny<string[]>(),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(models);
 
         var query = new Dictionary<string, StringValues>
@@ -85,6 +85,6 @@ public class GetCommercialResourcesFunctionTests : FunctionsTestBase
         Assert.Contains(values, p => p.PropertyName == nameof(CommercialResourcesParameters.Categories));
 
         _service
-            .Verify(d => d.GetCommercialResourcesByCategory(It.IsAny<CancellationToken>(), It.IsAny<string[]>()), Times.Never);
+            .Verify(d => d.GetCommercialResourcesByCategory(It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/platform/tests/Platform.Insight.Tests/CommercialResources/GetCommercialResourcesFunctionTest.cs
+++ b/platform/tests/Platform.Insight.Tests/CommercialResources/GetCommercialResourcesFunctionTest.cs
@@ -1,0 +1,90 @@
+﻿using System.Net;
+using AutoFixture;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using Platform.Api.Insight.Features.CommercialResources;
+using Platform.Api.Insight.Features.CommercialResources.Parameters;
+using Platform.Api.Insight.Features.CommercialResources.Responses;
+using Platform.Api.Insight.Features.CommercialResources.Services;
+using Platform.Domain;
+using Platform.Functions;
+using Platform.Test;
+using Platform.Test.Extensions;
+using Xunit;
+
+namespace Platform.Insight.Tests.CommercialResources;
+
+public class GetCommercialResourcesFunctionTests : FunctionsTestBase
+{
+    private readonly Fixture _fixture;
+    private readonly GetCommercialResourcesFunction _function;
+    private readonly Mock<ICommercialResourcesService> _service;
+    private readonly Mock<IValidator<CommercialResourcesParameters>> _validator;
+
+    public GetCommercialResourcesFunctionTests()
+    {
+        _service = new Mock<ICommercialResourcesService>();
+        _validator = new Mock<IValidator<CommercialResourcesParameters>>();
+        _function = new GetCommercialResourcesFunction(_service.Object, _validator.Object);
+        _fixture = new Fixture();
+    }
+
+    [Fact]
+    public async Task ShouldReturn200OnValidRequest()
+    {
+        var models = _fixture
+            .Build<CommercialResourcesResponse>()
+            .CreateMany()
+            .ToArray();
+
+        _validator
+            .Setup(v => v.ValidateAsync(It.IsAny<CommercialResourcesParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
+        _service
+            .Setup(x => x.GetCommercialResourcesByCategory(
+                It.IsAny<CancellationToken>(),
+                It.IsAny<string[]>()))
+            .ReturnsAsync(models);
+
+        var query = new Dictionary<string, StringValues>
+        {
+            { "categories", CostCategories.All },
+        };
+
+        var result = await _function.RunAsync(CreateHttpRequestData(query), CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal(ContentType.ApplicationJson, result.ContentType());
+
+        var body = await result.ReadAsJsonAsync<CommercialResourcesResponse[]>();
+        Assert.NotNull(body);
+        Assert.Equivalent(models, body);
+    }
+
+    [Fact]
+    public async Task ShouldReturn400OnValidationError()
+    {
+        _validator
+            .Setup(v => v.ValidateAsync(It.IsAny<CommercialResourcesParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult([
+                new ValidationFailure(nameof(CommercialResourcesParameters.Categories), "error")
+            ]));
+
+        var result = await _function.RunAsync(CreateHttpRequestData(), CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
+        Assert.Equal(ContentType.ApplicationJson, result.ContentType());
+
+        var values = await result.ReadAsJsonAsync<IEnumerable<ValidationError>>();
+        Assert.NotNull(values);
+        Assert.Contains(values, p => p.PropertyName == nameof(CommercialResourcesParameters.Categories));
+
+        _service
+            .Verify(d => d.GetCommercialResourcesByCategory(It.IsAny<CancellationToken>(), It.IsAny<string[]>()), Times.Never);
+    }
+}

--- a/platform/tests/Platform.Insight.Tests/CommercialResources/Parameters/CommercialResourcesParametersTests.cs
+++ b/platform/tests/Platform.Insight.Tests/CommercialResources/Parameters/CommercialResourcesParametersTests.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Specialized;
+using Platform.Api.Insight.Features.CommercialResources.Parameters;
+using Platform.Domain;
+using Xunit;
+
+namespace Platform.Insight.Tests.CommercialResources.Parameters;
+
+public class CommercialResourcesParametersTests
+{
+    [Fact]
+    public void ShouldSetValuesFromQuery()
+    {
+        var values = new NameValueCollection
+        {
+            { "categories", $"{CostCategories.TeachingStaff},{CostCategories.EducationalSupplies}" },
+        };
+
+        var parameters = new CommercialResourcesParameters();
+        parameters.SetValues(values);
+
+        Assert.Equal([CostCategories.TeachingStaff, CostCategories.EducationalSupplies,], parameters.Categories);
+    }
+}

--- a/platform/tests/Platform.Insight.Tests/CommercialResources/Services/WhenCommercialResourcesServiceQueriesAsync.cs
+++ b/platform/tests/Platform.Insight.Tests/CommercialResources/Services/WhenCommercialResourcesServiceQueriesAsync.cs
@@ -40,7 +40,7 @@ public class WhenCommercialResourcesServiceQueriesAsync
             })
             .ReturnsAsync(results);
 
-        var actual = await _service.GetCommercialResourcesByCategory(CancellationToken.None, categories);
+        var actual = await _service.GetCommercialResourcesByCategory(categories, CancellationToken.None);
 
         Assert.Equal(results, actual);
         Assert.Equal("SELECT * FROM VW_CommercialResources", actualSql);
@@ -61,7 +61,7 @@ public class WhenCommercialResourcesServiceQueriesAsync
             })
             .ReturnsAsync(results);
 
-        var actual = await _service.GetCommercialResourcesByCategory(CancellationToken.None, categories);
+        var actual = await _service.GetCommercialResourcesByCategory(categories, CancellationToken.None);
 
         Assert.Equal(results, actual);
         Assert.Equal("SELECT * FROM VW_CommercialResources WHERE Category IN @Categories", actualSql);

--- a/platform/tests/Platform.Insight.Tests/CommercialResources/Services/WhenCommercialResourcesServiceQueriesAsync.cs
+++ b/platform/tests/Platform.Insight.Tests/CommercialResources/Services/WhenCommercialResourcesServiceQueriesAsync.cs
@@ -1,0 +1,69 @@
+﻿using AutoFixture;
+using Moq;
+using Platform.Api.Insight.Features.CommercialResources.Responses;
+using Platform.Api.Insight.Features.CommercialResources.Services;
+using Platform.Domain;
+using Platform.Sql;
+using Platform.Sql.QueryBuilders;
+using Xunit;
+
+namespace Platform.Insight.Tests.CommercialResources.Services;
+
+public class WhenCommercialResourcesServiceQueriesAsync
+{
+    private readonly Mock<IDatabaseConnection> _connection;
+    private readonly Fixture _fixture = new();
+    private readonly CommercialResourcesService _service;
+
+    public WhenCommercialResourcesServiceQueriesAsync()
+    {
+        _connection = new Mock<IDatabaseConnection>();
+
+        var dbFactory = new Mock<IDatabaseFactory>();
+        dbFactory.Setup(d => d.GetConnection()).ReturnsAsync(_connection.Object);
+
+        _service = new CommercialResourcesService(dbFactory.Object);
+    }
+
+    [Fact]
+    public async Task ShouldQueryAsyncWhenGetAll()
+    {
+        string[] categories = [];
+        var results = _fixture.Build<CommercialResourcesResponse>().CreateMany().ToArray();
+        string? actualSql = null;
+
+        _connection
+            .Setup(c => c.QueryAsync<CommercialResourcesResponse>(It.IsAny<PlatformQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<PlatformQuery, CancellationToken>((query, _) =>
+            {
+                actualSql = query.QueryTemplate.RawSql.Trim();
+            })
+            .ReturnsAsync(results);
+
+        var actual = await _service.GetCommercialResourcesByCategory(CancellationToken.None, categories);
+
+        Assert.Equal(results, actual);
+        Assert.Equal("SELECT * FROM VW_CommercialResources", actualSql);
+    }
+
+    [Fact]
+    public async Task ShouldQueryAsyncWhenGetCategories()
+    {
+        string[] categories = [CostCategories.TeachingStaff, CostCategories.EducationalSupplies];
+        var results = _fixture.Build<CommercialResourcesResponse>().CreateMany().ToArray();
+        string? actualSql = null;
+
+        _connection
+            .Setup(c => c.QueryAsync<CommercialResourcesResponse>(It.IsAny<PlatformQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<PlatformQuery, CancellationToken>((query, _) =>
+            {
+                actualSql = query.QueryTemplate.RawSql.Trim();
+            })
+            .ReturnsAsync(results);
+
+        var actual = await _service.GetCommercialResourcesByCategory(CancellationToken.None, categories);
+
+        Assert.Equal(results, actual);
+        Assert.Equal("SELECT * FROM VW_CommercialResources WHERE Category IN @Categories", actualSql);
+    }
+}

--- a/platform/tests/Platform.Insight.Tests/CommercialResources/Validators/WhenCommercialResourcesParametersValidatorValidates.cs
+++ b/platform/tests/Platform.Insight.Tests/CommercialResources/Validators/WhenCommercialResourcesParametersValidatorValidates.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Specialized;
+using Platform.Api.Insight.Features.CommercialResources.Parameters;
+using Platform.Api.Insight.Features.CommercialResources.Validators;
+using Platform.Domain;
+using Xunit;
+
+namespace Platform.Insight.Tests.CommercialResources.Validators;
+
+public class WhenCommercialResourcesParametersValidatorValidates
+{
+    private readonly CommercialResourcesParametersValidator _validator = new();
+
+    [Theory]
+    [InlineData($"{CostCategories.TeachingStaff}")]
+    [InlineData($"{CostCategories.TeachingStaff},{CostCategories.EducationalSupplies},{CostCategories.Other}")]
+    [InlineData(null)]
+    public async Task ShouldBeValidWithGoodParameters(string? categories)
+    {
+        var parameters = new CommercialResourcesParameters();
+        parameters.SetValues(new NameValueCollection
+        {
+            { "categories", categories }
+        });
+
+        var actual = await _validator.ValidateAsync(parameters);
+        Assert.True(actual.IsValid);
+        Assert.Empty(actual.Errors);
+    }
+
+    [Theory]
+    [InlineData("this,should,fail")]
+    public async Task ShouldBeInvalidWithBadParameters(string categories)
+    {
+        var parameters = new CommercialResourcesParameters();
+        parameters.SetValues(new NameValueCollection
+        {
+            { "categories", categories }
+        });
+
+        var actual = await _validator.ValidateAsync(parameters);
+        Assert.False(actual.IsValid);
+        Assert.NotEmpty(actual.Errors);
+    }
+}


### PR DESCRIPTION
### Context
[AB#259512](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/259512) [AB#260669](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/260669)

### Change proposed in this pull request
Adds new insights endpoint `commercial-resources`
Optional parameter of `categories` a list of cost categories, if passed only records of those categories will be returned. If omitted the default behaviour is to return all commercial resources records from the view.

### Guidance to review 
Temporarily seeded d01 with data for this table for use in development. This will be replaced once the commercial resources links are finalised 
Platform api tests to follow on a future PR

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

