### PR TITLE
Added Save/Copy buttons as progressive enhancements to SSR charts

### DIFF
--- a/web/src/Web.App/AssetSrc/ts/components/chart-actions/ChartActions.ts
+++ b/web/src/Web.App/AssetSrc/ts/components/chart-actions/ChartActions.ts
@@ -1,0 +1,81 @@
+import classNames from "classnames";
+import { DownloadService } from "../../services/index.ts";
+
+// todo: migrate to Vue.js component (#261747)
+export function ChartActions({
+  copyEventId,
+  costCodes,
+  elementId,
+  placeholderElement,
+  saveEventId,
+  showCopy,
+  showSave,
+  showTitle,
+  title,
+}: ChartActionsProps): void {
+  const classes = "govuk-button govuk-button--secondary share-button";
+
+  if (placeholderElement) {
+    const buttonsElement = document.createElement("div");
+    placeholderElement.parentNode?.insertBefore(
+      buttonsElement,
+      placeholderElement
+    );
+    buttonsElement.className = "share-buttons";
+    const elementSelector = () => document.getElementById(elementId);
+
+    if (showSave) {
+      const saveButton = document.createElement("button");
+      buttonsElement.appendChild(saveButton);
+
+      saveButton.className = classNames(classes, "share-button--save");
+      saveButton.setAttribute("data-module", "govuk-button");
+      saveButton.setAttribute("data-prevent-double-click", "true");
+      saveButton.setAttribute(
+        "data-custom-event-chart-name",
+        (saveEventId && title) ?? ""
+      );
+      saveButton.setAttribute("data-custom-event-id", saveEventId ?? "");
+      saveButton.addEventListener("click", (ev: MouseEvent) => {
+        DownloadService.saveImageToBrowser({
+          costCodes,
+          elementSelector,
+          showTitle,
+          title,
+          triggerElement: ev.target as HTMLButtonElement,
+        });
+      });
+      saveButton.innerHTML = title
+        ? `Save <span class="govuk-visually-hidden">${title}</span> as image`
+        : "Save as image";
+    }
+
+    if (showCopy) {
+      const copyButton = document.createElement("button");
+      buttonsElement.appendChild(copyButton);
+
+      copyButton.className = classNames(classes, "share-button--copy");
+      copyButton.setAttribute("data-module", "govuk-button");
+      copyButton.setAttribute("data-prevent-double-click", "true");
+      copyButton.setAttribute(
+        "data-custom-event-chart-name",
+        (copyEventId && title) ?? ""
+      );
+      copyButton.setAttribute("data-custom-event-id", copyEventId ?? "");
+      copyButton.addEventListener("click", (ev: MouseEvent) => {
+        DownloadService.copyImageToClipboard({
+          costCodes,
+          elementSelector,
+          showTitle,
+          title,
+          triggerElement: ev.target as HTMLButtonElement,
+        });
+      });
+      copyButton.innerHTML = title
+        ? `Copy <span class="govuk-visually-hidden">${title}</span> image`
+        : "Copy image";
+    }
+
+    placeholderElement.remove();
+  }
+}

--- a/web/src/Web.App/AssetSrc/ts/components/chart-actions/index.d.ts
+++ b/web/src/Web.App/AssetSrc/ts/components/chart-actions/index.d.ts
@@ -1,0 +1,12 @@
+interface ChartActionsProps {
+  copyEventId?: string;
+  costCodes?: string[];
+  disabled?: boolean;
+  elementId: string;
+  placeholderElement: HTMLElement;
+  saveEventId?: string;
+  showCopy?: boolean;
+  showSave?: boolean;
+  showTitle?: boolean;
+  title?: string;
+}

--- a/web/src/Web.App/AssetSrc/ts/components/suggester/Suggester.ts
+++ b/web/src/Web.App/AssetSrc/ts/components/suggester/Suggester.ts
@@ -1,13 +1,13 @@
 import accessibleAutocomplete from "accessible-autocomplete";
 import debounce from "lodash.debounce";
 
-export function suggester<T>(
-  type: "school" | "trust" | "local-authority",
-  inputElementId: string,
-  targetElementId: string,
-  documentKey: keyof T,
-  exclude?: string[]
-): void {
+export function Suggester<T>({
+  type,
+  inputElementId,
+  targetElementId,
+  documentKey,
+  exclude,
+}: SuggesterProps<T>): void {
   let abortController = new AbortController();
 
   const handleSuggest = async (query: string): Promise<SuggestResult<T>[]> => {

--- a/web/src/Web.App/AssetSrc/ts/components/suggester/index.d.ts
+++ b/web/src/Web.App/AssetSrc/ts/components/suggester/index.d.ts
@@ -1,0 +1,12 @@
+interface SuggesterProps<T> {
+  documentKey: keyof T;
+  exclude?: string[];
+  inputElementId: string;
+  targetElementId: string;
+  type: "school" | "trust" | "local-authority";
+}
+
+interface SuggestResult<T> {
+  text: string;
+  document: T;
+}

--- a/web/src/Web.App/AssetSrc/ts/index.d.ts
+++ b/web/src/Web.App/AssetSrc/ts/index.d.ts
@@ -1,0 +1,5 @@
+interface ApiError {
+  error?: Error;
+}
+
+type ApiResponse<T> = T[] | ApiError;

--- a/web/src/Web.App/AssetSrc/ts/index.ts
+++ b/web/src/Web.App/AssetSrc/ts/index.ts
@@ -1,3 +1,0 @@
-import { suggester } from "./suggester.ts";
-
-export { suggester };

--- a/web/src/Web.App/AssetSrc/ts/main.ts
+++ b/web/src/Web.App/AssetSrc/ts/main.ts
@@ -1,0 +1,3 @@
+import { suggester } from "./suggester/component.ts";
+
+export { suggester };

--- a/web/src/Web.App/AssetSrc/ts/main.ts
+++ b/web/src/Web.App/AssetSrc/ts/main.ts
@@ -1,3 +1,4 @@
-import { suggester } from "./suggester/component.ts";
+import { ChartActions } from "./components/chart-actions/ChartActions.ts";
+import { Suggester } from "./components/suggester/Suggester.ts";
 
-export { suggester };
+export { ChartActions, Suggester };

--- a/web/src/Web.App/AssetSrc/ts/services/DownloadService.ts
+++ b/web/src/Web.App/AssetSrc/ts/services/DownloadService.ts
@@ -1,0 +1,248 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+import saveAs from "file-saver";
+import {
+  CopyImageToClipboardProps,
+  DownloadPngImageOptions,
+  ImageOptions,
+  SaveImageToBrowserProps,
+} from "./types.js";
+import { ImageService } from "./ImageService.ts";
+
+const imageTitleHeight = 50;
+const type = "image/png";
+const backgroundColor = "#fff";
+const costCodesListHeight = 50;
+
+export class DownloadService {
+  static saveImageToBrowser({
+    triggerElement,
+    ...rest
+  }: SaveImageToBrowserProps) {
+    triggerElement.disabled = true;
+
+    DownloadService.downloadPngImage({ mode: "save", ...rest })
+      .then(
+        () => {
+          console.debug("Image saved successfully");
+        },
+        (err: Error) => {
+          console.warn("Unable to save image", err);
+        }
+      )
+      .finally(() => {
+        triggerElement.disabled = false;
+      });
+  }
+
+  static copyImageToClipboard({
+    triggerElement,
+    ...rest
+  }: CopyImageToClipboardProps) {
+    triggerElement.disabled = true;
+    const originalHtml = triggerElement.innerHTML;
+
+    DownloadService.downloadPngImage({ mode: "copy", ...rest })
+      .then(
+        () => {
+          console.debug("Image copied successfully");
+          triggerElement.innerHTML = "Copied";
+          setTimeout(() => {
+            triggerElement.innerHTML = originalHtml;
+          }, 2000);
+        },
+        (err: Error) => {
+          console.warn("Unable to copy image", err);
+        }
+      )
+      .finally(() => {
+        triggerElement.disabled = false;
+      });
+  }
+
+  static async downloadPngImage({
+    costCodes,
+    elementSelector,
+    fileName: fileNameProp,
+    filter,
+    mode,
+    onCopied,
+    onLoading,
+    onSaved,
+    showTitle,
+    title,
+  }: DownloadPngImageOptions) {
+    const fileName = getFileName(title, fileNameProp);
+    const element = elementSelector();
+    if (!element) {
+      return;
+    }
+
+    const getBlob = async () => {
+      return await ImageService.toBlob(
+        element,
+        getImageOptions(element, type, title, showTitle, costCodes, filter)
+      );
+    };
+
+    const download = async () => {
+      const blob = await getBlob();
+      if (blob) {
+        if (window.saveAs) {
+          window.saveAs(blob, fileName);
+        } else {
+          saveAs.saveAs(blob, fileName);
+        }
+
+        if (onSaved) {
+          onSaved(fileName);
+        }
+      }
+    };
+
+    const copy = async () => {
+      const blob = await getBlob();
+      if (blob) {
+        const data = [new ClipboardItem({ [type]: blob })];
+        await navigator.clipboard.write(data);
+        if (onCopied) {
+          onCopied(fileName);
+        }
+      }
+    };
+
+    if (onLoading) {
+      onLoading(true);
+
+      // If loader event is subscribed, allow it to be triggered before the actual generate and download PNG process
+      // due to the latter performing a synchronous XMLHttpRequest on the main thread which is documented as being
+      // detrimental effects to the end user's experience (see `Issues` in browser DevTools for more information).
+      setTimeout(() => {
+        if (mode === "copy") {
+          copy()
+            .then(
+              () => {
+                console.debug("Copied successfully");
+              },
+              (err: Error) => {
+                console.error(`Unable to copy image ${fileName}`, err);
+              }
+            )
+            .finally(() => {
+              onLoading(false);
+            });
+        } else {
+          download()
+            .then(
+              () => {
+                console.debug("Downloaded successfully");
+              },
+              (err: Error) => {
+                console.error(`Unable to download image ${fileName}`, err);
+              }
+            )
+            .finally(() => {
+              onLoading(false);
+            });
+        }
+      }, 100);
+    } else {
+      if (mode === "copy") {
+        await copy();
+      } else {
+        await download();
+      }
+    }
+  }
+}
+
+function getFileName(title?: string, fileName?: string) {
+  return title
+    ? `${title
+        .toLowerCase()
+        .replace(/\W/g, " ")
+        .replace(/\s{2,}/g, " ")
+        .trim()
+        .replace(/\s/g, "-")}.png`
+    : (fileName ?? "download.png");
+}
+
+function getImageOptions(
+  element: HTMLElement,
+  type: string,
+  title?: string,
+  showTitle?: boolean,
+  costCodes?: string[],
+  filter?: (domNode: HTMLElement) => boolean
+): ImageOptions {
+  let height = element.clientHeight;
+
+  // use customised onCloned() callback to add additional elements to the DOM once already
+  // cloned for the purpose of generating the image (so as to not affect the original DOM,
+  // but still be able to apply styles and fonts as resolved from class names).
+
+  if (title && showTitle) {
+    height += imageTitleHeight;
+  }
+  if (costCodes) {
+    height += costCodesListHeight;
+  }
+
+  const onCloned = (node: HTMLElement): void => {
+    if (costCodes) {
+      node.insertBefore(createCostCodeList(costCodes), node.firstChild);
+    }
+    if (title && showTitle) {
+      node.insertBefore(createTitleElement(title), node.firstChild);
+    }
+  };
+
+  return {
+    cacheBust: true,
+    backgroundColor,
+    type,
+    filter,
+    width: element.clientWidth,
+    height,
+    onCloned,
+  };
+}
+
+function createCostCodeList(costCodes: string[]): HTMLElement {
+  const costCodeList = document.createElement("ul") as HTMLElement;
+  costCodeList.style.display = "flex";
+  costCodeList.style.flexWrap = "wrap";
+  costCodeList.style.gap = "10px";
+  costCodeList.style.listStyle = "none";
+  costCodeList.style.padding = "0px";
+
+  costCodes.forEach((costCode) => {
+    const li = document.createElement("li");
+    li.innerText = costCode;
+    li.style.fontFamily = '"GDS Transport", arial, sans-serif';
+    li.style.fontSize = "1rem";
+    li.style.display = "inline-block";
+    li.style.color = "rgb(12, 45, 74)";
+    li.style.backgroundColor = "rgb(187, 212, 234)";
+    li.style.overflowWrap = "break-word";
+    li.style.padding = "2px 8px 3px 8px";
+
+    costCodeList.appendChild(li);
+  });
+
+  return costCodeList;
+}
+
+function createTitleElement(title: string): HTMLElement {
+  const child = document.createElement("h2");
+  child.innerText = title;
+  child.style.fontFamily = '"GDS Transport", arial, sans-serif';
+  child.style.fontSize = "1.25rem";
+  child.style.fontWeight = "700";
+  child.style.height = `${imageTitleHeight}px`;
+  child.style.height = `${imageTitleHeight}px`;
+  child.style.margin = `${imageTitleHeight / 4}px 0 -${imageTitleHeight / 4}px 0`;
+  child.style.padding = "0";
+
+  return child;
+}

--- a/web/src/Web.App/AssetSrc/ts/services/ImageService.ts
+++ b/web/src/Web.App/AssetSrc/ts/services/ImageService.ts
@@ -1,0 +1,76 @@
+import { applyStyle } from "html-to-image/lib/apply-style.js";
+import { cloneNode } from "html-to-image/lib/clone-node.js";
+import { embedImages } from "html-to-image/lib/embed-images.js";
+import { embedWebFonts } from "html-to-image/lib/embed-webfonts.js";
+import {
+  getImageSize,
+  getPixelRatio,
+  createImage,
+  canvasToBlob,
+  nodeToDataURL,
+  checkCanvasDimensions,
+} from "html-to-image/lib/util.js";
+import { ImageOptions } from "./types.js";
+
+// below merged in from https://github.com/bubkoo/html-to-image/blob/master/src/index.ts
+// with the addition of the onCloned() callback as added to the extended `Options` object
+export class ImageService {
+  static async toSvg<T extends HTMLElement>(
+    node: T,
+    options: ImageOptions = {}
+  ): Promise<string> {
+    const { width, height } = getImageSize(node, options);
+    const clonedNode = (await cloneNode(node, options, true)) as HTMLElement;
+    if (options.onCloned) {
+      options.onCloned(clonedNode);
+    }
+
+    await embedWebFonts(clonedNode, options);
+    await embedImages(clonedNode, options);
+    applyStyle(clonedNode, options);
+    const datauri = await nodeToDataURL(clonedNode, width, height);
+    return datauri;
+  }
+
+  static async toCanvas<T extends HTMLElement>(
+    node: T,
+    options: ImageOptions = {}
+  ): Promise<HTMLCanvasElement> {
+    const { width, height } = getImageSize(node, options);
+    const svg = await ImageService.toSvg(node, options);
+    const img = await createImage(svg);
+
+    const canvas = document.createElement("canvas");
+    const context = canvas.getContext("2d")!;
+    const ratio = options.pixelRatio ?? getPixelRatio();
+    const canvasWidth = options.canvasWidth ?? width;
+    const canvasHeight = options.canvasHeight ?? height;
+
+    canvas.width = canvasWidth * ratio;
+    canvas.height = canvasHeight * ratio;
+
+    if (!options.skipAutoScale) {
+      checkCanvasDimensions(canvas);
+    }
+    canvas.style.width = `${canvasWidth}`;
+    canvas.style.height = `${canvasHeight}`;
+
+    if (options.backgroundColor) {
+      context.fillStyle = options.backgroundColor;
+      context.fillRect(0, 0, canvas.width, canvas.height);
+    }
+
+    context.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+    return canvas;
+  }
+
+  static async toBlob<T extends HTMLElement>(
+    node: T,
+    options: ImageOptions = {}
+  ): Promise<Blob | null> {
+    const canvas = await ImageService.toCanvas(node, options);
+    const blob = await canvasToBlob(canvas);
+    return blob;
+  }
+}

--- a/web/src/Web.App/AssetSrc/ts/services/index.ts
+++ b/web/src/Web.App/AssetSrc/ts/services/index.ts
@@ -1,0 +1,4 @@
+import { DownloadService } from "./DownloadService.ts";
+import { ImageService } from "./ImageService.ts";
+
+export { DownloadService, ImageService };

--- a/web/src/Web.App/AssetSrc/ts/services/types.d.ts
+++ b/web/src/Web.App/AssetSrc/ts/services/types.d.ts
@@ -1,0 +1,44 @@
+import { Options } from "html-to-image/lib/types.js";
+
+type DownloadMode = "save" | "copy";
+
+interface ImageOptions extends Options {
+  onCloned?: (node: HTMLElement) => void;
+}
+
+interface DownloadOptions extends Pick<ImageOptions, "filter"> {
+  costCodes?: string[];
+  fileName?: string;
+}
+
+interface DownloadPngImageOptions extends DownloadOptions {
+  elementSelector: () => HTMLElement | undefined | null;
+  mode: DownloadMode;
+  onCopied?: (fileName: string) => void;
+  onLoading?: (loading: boolean) => void;
+  onSaved?: (fileName: string) => void;
+  showTitle?: boolean;
+  title?: string;
+}
+
+interface ElementAndAttributes {
+  costCodes?: string[] | undefined;
+  element: HTMLElement;
+  title?: string;
+}
+
+interface DownloadPngImagesOptions extends DownloadOptions {
+  elementsSelector: () => ElementAndAttributes[];
+  onImagesLoading?: (loading: boolean) => void;
+  onProgress?: (percentage: number) => void;
+  showTitles?: boolean;
+  signal?: AbortSignal;
+}
+
+type SaveImageToBrowserProps = {
+  triggerElement: HTMLButtonElement;
+} & Omit<DownloadPngImageOptions, "mode" | "onCopied" | "onSaved">;
+
+type CopyImageToClipboardProps = {
+  triggerElement: HTMLButtonElement;
+} & Omit<DownloadPngImageOptions, "mode" | "onCopied" | "onSaved">;

--- a/web/src/Web.App/AssetSrc/ts/suggester/component.ts
+++ b/web/src/Web.App/AssetSrc/ts/suggester/component.ts
@@ -1,17 +1,6 @@
 import accessibleAutocomplete from "accessible-autocomplete";
 import debounce from "lodash.debounce";
 
-interface SuggestResult<T> {
-  text: string;
-  document: T;
-}
-
-interface ApiError {
-  error?: Error;
-}
-
-type ApiResponse<T> = T[] | ApiError;
-
 export function suggester<T>(
   type: "school" | "trust" | "local-authority",
   inputElementId: string,

--- a/web/src/Web.App/AssetSrc/ts/suggester/index.d.ts
+++ b/web/src/Web.App/AssetSrc/ts/suggester/index.d.ts
@@ -1,4 +1,0 @@
-interface SuggestResult<T> {
-  text: string;
-  document: T;
-}

--- a/web/src/Web.App/AssetSrc/ts/suggester/index.d.ts
+++ b/web/src/Web.App/AssetSrc/ts/suggester/index.d.ts
@@ -1,0 +1,4 @@
+interface SuggestResult<T> {
+  text: string;
+  document: T;
+}

--- a/web/src/Web.App/Controllers/SchoolSpendingController.cs
+++ b/web/src/Web.App/Controllers/SchoolSpendingController.cs
@@ -75,6 +75,7 @@ public class SchoolSpendingController(
                 var viewModel = new SchoolSpendingViewModel(school, ratings, pupilExpenditure, areaExpenditure,
                     userData.ComparatorSet, userData.CustomData, renderSsrCharts);
 
+                // todo: return non-/ssr view here rather than conditional in view/component itself (#261663)
                 return View(viewModel);
             }
             catch (Exception e)
@@ -135,6 +136,7 @@ public class SchoolSpendingController(
                 var renderSsrCharts = await featureManager.IsEnabledAsync(FeatureFlags.SchoolSpendingPrioritiesSsrCharts);
                 var viewModel = new SchoolSpendingViewModel(school, rating, pupilExpenditure, areaExpenditure, renderSsrCharts: renderSsrCharts);
 
+                // todo: return non-/ssr view here rather than conditional in view/component itself (#261663)
                 return View(viewModel);
             }
             catch (Exception e)

--- a/web/src/Web.App/ViewComponents/ChartActionsViewComponent.cs
+++ b/web/src/Web.App/ViewComponents/ChartActionsViewComponent.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Web.App.ViewModels.Components;
+
+namespace Web.App.ViewComponents;
+
+public class ChartActionsViewComponent : ViewComponent
+{
+    public IViewComponentResult Invoke(
+        string? elementId,
+        string? title,
+        bool? showTitle,
+        string? copyEventId,
+        string? saveEventId,
+        List<string>? costCodes,
+        bool? progressivelyEnhance)
+    {
+        return View(new ChartActionsViewModel(
+            elementId,
+            title,
+            showTitle,
+            copyEventId,
+            saveEventId,
+            costCodes,
+            progressivelyEnhance));
+    }
+}

--- a/web/src/Web.App/ViewComponents/PageActionsViewComponent.cs
+++ b/web/src/Web.App/ViewComponents/PageActionsViewComponent.cs
@@ -13,8 +13,10 @@ public class PageActionsViewComponent : ViewComponent
         string? saveTitleAttr,
         string? costCodesAttr,
         string? waitForEventType,
-        string? downloadLink)
-        => View(new PageActionsViewModel(
+        string? downloadLink,
+        bool? progressivelyEnhance)
+    {
+        return View(new PageActionsViewModel(
             saveButtonVisible,
             downloadButtonVisible,
             saveClassName,
@@ -22,5 +24,7 @@ public class PageActionsViewComponent : ViewComponent
             saveTitleAttr,
             costCodesAttr,
             waitForEventType,
-            downloadLink));
+            downloadLink,
+            progressivelyEnhance));
+    }
 }

--- a/web/src/Web.App/ViewComponents/SchoolSpendingCostsViewComponent.cs
+++ b/web/src/Web.App/ViewComponents/SchoolSpendingCostsViewComponent.cs
@@ -4,6 +4,8 @@ using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.ChartRendering;
 using Web.App.Infrastructure.Extensions;
 using Web.App.ViewModels.Components;
+
+// ReSharper disable ClassNeverInstantiated.Global
 // ReSharper disable PropertyCanBeMadeInitOnly.Global
 // ReSharper disable UnusedAutoPropertyAccessor.Global
 

--- a/web/src/Web.App/ViewModels/Components/ChartActionsViewModel.cs
+++ b/web/src/Web.App/ViewModels/Components/ChartActionsViewModel.cs
@@ -1,0 +1,19 @@
+namespace Web.App.ViewModels.Components;
+
+public class ChartActionsViewModel(
+    string? elementId,
+    string? title,
+    bool? showTitle,
+    string? copyEventId,
+    string? saveEventId,
+    List<string>? costCodes,
+    bool? progressivelyEnhance)
+{
+    public string ElementId { get; init; } = elementId ?? string.Empty;
+    public string Title { get; init; } = title ?? string.Empty;
+    public bool ShowTitle { get; init; } = showTitle ?? true;
+    public string CopyEventId { get; init; } = copyEventId ?? "copy-chart-as-image";
+    public string SaveEventId { get; init; } = saveEventId ?? "save-chart-as-image";
+    public List<string>? CostCodes { get; init; } = costCodes ?? [];
+    public bool ProgressivelyEnhance { get; init; } = progressivelyEnhance == true;
+}

--- a/web/src/Web.App/ViewModels/Components/PageActionsViewModel.cs
+++ b/web/src/Web.App/ViewModels/Components/PageActionsViewModel.cs
@@ -11,7 +11,8 @@ public class PageActionsViewModel(
     string? saveTitleAttr,
     string? costCodesAttr,
     string? waitForEventType,
-    string? downloadLink)
+    string? downloadLink,
+    bool? progressivelyEnhance)
 {
     public bool SaveButtonVisible { get; init; } = saveButtonVisible == true;
     public bool DownloadButtonVisible { get; init; } = downloadButtonVisible == true;
@@ -26,4 +27,6 @@ public class PageActionsViewModel(
     private Uri? DownloadLink { get; } = string.IsNullOrWhiteSpace(downloadLink) ? null : new Uri(downloadLink);
     public string DownloadAction => DownloadLink?.GetLeftPart(UriPartial.Path) ?? "#";
     public Dictionary<string, StringValues> DownloadParameters => QueryHelpers.ParseQuery(DownloadLink?.Query);
+
+    public bool ProgressivelyEnhance { get; init; } = progressivelyEnhance == true;
 }

--- a/web/src/Web.App/ViewModels/Enhancements/ChartActionsViewModel.cs
+++ b/web/src/Web.App/ViewModels/Enhancements/ChartActionsViewModel.cs
@@ -1,0 +1,11 @@
+namespace Web.App.ViewModels.Enhancements;
+
+public class ChartActionsViewModel
+{
+    public string CopyEventId { get; init; } = "copy-chart-as-image";
+    public string? DataSetAttribute { get; init; }
+    public string SaveEventId { get; init; } = "save-chart-as-image";
+    public bool? ShowCopy { get; init; }
+    public bool? ShowSave { get; init; }
+    public bool? ShowTitle { get; init; }
+}

--- a/web/src/Web.App/ViewModels/Enhancements/SuggesterViewModel.cs
+++ b/web/src/Web.App/ViewModels/Enhancements/SuggesterViewModel.cs
@@ -1,9 +1,9 @@
 namespace Web.App.ViewModels.Enhancements;
 
-public class SuggestScriptsViewModel
+public class SuggesterViewModel
 {
     public string? InputElementId { get; init; }
     public string? SelectedEstablishmentField { get; init; }
-    public string? Type { get; set; }
-    public string? IdField { get; set; }
+    public string? Type { get; init; }
+    public string? IdField { get; init; }
 }

--- a/web/src/Web.App/Views/LocalAuthoritySearch/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthoritySearch/Index.cshtml
@@ -15,7 +15,7 @@
 
 @section scripts
 {
-    @await Html.PartialAsync("Enhancements/_SuggestScripts", new SuggestScriptsViewModel
+    @await Html.PartialAsync("Enhancements/_Suggester", new SuggesterViewModel
     {
         InputElementId = nameof(ISearchTermViewModel.Term),
         SelectedEstablishmentField = nameof(ISearchTermViewModel.EstablishmentId),

--- a/web/src/Web.App/Views/LocalAuthoritySearch/Search.cshtml
+++ b/web/src/Web.App/Views/LocalAuthoritySearch/Search.cshtml
@@ -71,7 +71,7 @@
 
 @section scripts
 {
-    @await Html.PartialAsync("Enhancements/_SuggestScripts", new SuggestScriptsViewModel
+    @await Html.PartialAsync("Enhancements/_Suggester", new SuggesterViewModel
     {
         InputElementId = nameof(ISearchTermViewModel.Term),
         SelectedEstablishmentField = nameof(ISearchTermViewModel.EstablishmentId),

--- a/web/src/Web.App/Views/SchoolSearch/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolSearch/Index.cshtml
@@ -15,7 +15,7 @@
 
 @section scripts
 {
-    @await Html.PartialAsync("Enhancements/_SuggestScripts", new SuggestScriptsViewModel
+    @await Html.PartialAsync("Enhancements/_Suggester", new SuggesterViewModel
     {
         InputElementId = nameof(ISearchTermViewModel.Term),
         SelectedEstablishmentField = nameof(ISearchTermViewModel.EstablishmentId),

--- a/web/src/Web.App/Views/SchoolSearch/Search.cshtml
+++ b/web/src/Web.App/Views/SchoolSearch/Search.cshtml
@@ -73,7 +73,7 @@
 
 @section scripts
 {
-    @await Html.PartialAsync("Enhancements/_SuggestScripts", new SuggestScriptsViewModel
+    @await Html.PartialAsync("Enhancements/_Suggester", new SuggesterViewModel
     {
         InputElementId = nameof(ISearchTermViewModel.Term),
         SelectedEstablishmentField = nameof(ISearchTermViewModel.EstablishmentId),

--- a/web/src/Web.App/Views/SchoolSpending/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/Index.cshtml
@@ -11,7 +11,8 @@
         saveClassName = "costs-chart-wrapper",
         saveFileName = $"spending-priorities-{Model.Urn}.zip",
         saveTitleAttr = "data-title",
-        costCodesAttr = "data-cost-codes"
+        costCodesAttr = "data-cost-codes",
+        progressivelyEnhance = Model.RenderSsrCharts
     })
 }
 

--- a/web/src/Web.App/Views/SchoolSpending/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/Index.cshtml
@@ -1,4 +1,5 @@
-﻿@model Web.App.ViewModels.SchoolSpendingViewModel
+﻿@using Web.App.ViewModels.Enhancements
+@model Web.App.ViewModels.SchoolSpendingViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.Spending;
 }
@@ -87,5 +88,16 @@
         urn = Model.Urn,
         isPartOfTrust = Model.IsPartOfTrust,
         renderSsrCharts = Model.RenderSsrCharts
+    })
+}
+
+@section scripts
+{
+    @await Html.PartialAsync("Enhancements/_ChartActions", new ChartActionsViewModel
+    {
+        DataSetAttribute = "chart-actions",
+        ShowCopy = true,
+        ShowSave = true,
+        ShowTitle = true
     })
 }

--- a/web/src/Web.App/Views/Shared/Components/ChartActions/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/ChartActions/Default.cshtml
@@ -1,0 +1,24 @@
+@using Newtonsoft.Json
+@using Web.App.Extensions
+@model Web.App.ViewModels.Components.ChartActionsViewModel
+
+<div class="chart-actions-wrapper">
+    <div class="chart-actions">
+        @if (Model.ProgressivelyEnhance)
+        {
+            // todo
+        }
+        else
+        {
+            <div
+                data-share-content-by-element-id
+                data-element-id="@Model.ElementId"
+                data-title="@Model.Title"
+                data-show-title="@Model.ShowTitle.ToString().ToLower()"
+                data-copy-event-id="@Model.CopyEventId"
+                data-save-event-id="@Model.SaveEventId"
+                data-cost-codes="@Model.CostCodes.ToJson(Formatting.None)">
+            </div>
+        }
+    </div>
+</div>

--- a/web/src/Web.App/Views/Shared/Components/ChartActions/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/ChartActions/Default.cshtml
@@ -6,7 +6,12 @@
     <div class="chart-actions">
         @if (Model.ProgressivelyEnhance)
         {
-            // todo
+            <div
+                data-chart-actions
+                data-element-id="@Model.ElementId"
+                data-title="@Model.Title"
+                data-cost-codes="@Model.CostCodes.ToJson(Formatting.None)">
+            </div>
         }
         else
         {

--- a/web/src/Web.App/Views/Shared/Components/PageActions/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/PageActions/Default.cshtml
@@ -4,28 +4,35 @@
     <div class="page-actions">
         @if (Model.SaveButtonVisible)
         {
-            <div
-                data-launch-modal
-                data-modal-name="modal-save-images"
-                data-element-class-name="@Model.SaveClassName"
-                data-button-label="Save chart images"
-                data-modal-title="Save chart images"
-                data-element-title-attr="@Model.SaveTitleAttr"
-                data-cost-codes-attr="@Model.CostCodesAttr"
-                data-show-titles="true"
-                data-show-progress="true"
-                data-file-name="@Model.SaveFileName"
-                data-save-event-id="save-chart-as-image"
-                data-main-content-id="main-content"
-                data-wait-for-event-type="@Model.WaitForEventType"
-                class="page-action">
-                <button
-                    class="govuk-button govuk-button--secondary"
-                    data-module="govuk-button"
-                    aria-disabled="true"
-                    disabled="disabled">Save chart images
-                </button>
-            </div>
+            if (Model.ProgressivelyEnhance)
+            {
+                // todo
+            }
+            else
+            {
+                <div
+                    data-launch-modal
+                    data-modal-name="modal-save-images"
+                    data-element-class-name="@Model.SaveClassName"
+                    data-button-label="Save chart images"
+                    data-modal-title="Save chart images"
+                    data-element-title-attr="@Model.SaveTitleAttr"
+                    data-cost-codes-attr="@Model.CostCodesAttr"
+                    data-show-titles="true"
+                    data-show-progress="true"
+                    data-file-name="@Model.SaveFileName"
+                    data-save-event-id="save-chart-as-image"
+                    data-main-content-id="main-content"
+                    data-wait-for-event-type="@Model.WaitForEventType"
+                    class="page-action">
+                    <button
+                        class="govuk-button govuk-button--secondary"
+                        data-module="govuk-button"
+                        aria-disabled="true"
+                        disabled="disabled">Save chart images
+                    </button>
+                </div>
+            }
         }
         @if (Model.DownloadButtonVisible)
         {

--- a/web/src/Web.App/Views/Shared/Components/SchoolSpendingCosts/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/SchoolSpendingCosts/Default.cshtml
@@ -31,6 +31,7 @@
             .ToList() ?? [];
 
         var uuid = Guid.NewGuid();
+        var renderSsChart = !string.IsNullOrWhiteSpace(cost?.ChartSvg);
 
         <section id="spending-priorities-@category?.Rating.CostCategoryAnchorId">
             <div class="govuk-grid-row govuk-!-margin-bottom-2"
@@ -41,15 +42,13 @@
                 @if (!Model.IsCustomData)
                 {
                     <div class="govuk-grid-column-one-third">
-                        <div
-                            data-share-content-by-element-id
-                            data-element-id="@uuid"
-                            data-title="@categoryHeading"
-                            data-show-title="true"
-                            data-copy-event-id="copy-chart-as-image"
-                            data-save-event-id="save-chart-as-image"
-                            data-cost-codes="@costCodes.ToJson(Formatting.None)">
-                        </div>
+                        @await Component.InvokeAsync("ChartActions", new
+                        {
+                            elementId = uuid.ToString(),
+                            title = categoryHeading,
+                            costCodes,
+                            progressivelyEnhance = renderSsChart
+                        })
                     </div>
                 }
 
@@ -95,7 +94,7 @@
                             </div>
                         }
 
-                        @if (!string.IsNullOrWhiteSpace(cost?.ChartSvg))
+                        @if (renderSsChart)
                         {
                             <div class="govuk-!-margin-bottom-2 ssr-chart">
                                 @Html.Raw(cost.ChartSvg)

--- a/web/src/Web.App/Views/Shared/Enhancements/_ChartActions.cshtml
+++ b/web/src/Web.App/Views/Shared/Enhancements/_ChartActions.cshtml
@@ -1,0 +1,30 @@
+@using Web.App.Extensions
+@model Web.App.ViewModels.Enhancements.ChartActionsViewModel
+
+<script type="module" add-nonce="true">
+    import {ChartActions} from "@Html.FileVersionedPath("/js/main.min.js")";
+
+    const copyEventId = "@(Model.CopyEventId)";
+    const saveEventId = "@(Model.SaveEventId)";
+    const showCopy = @(Model.ShowCopy == true ? "true" : "false");
+    const showSave = @(Model.ShowSave == true ? "true" : "false");
+    const showTitle =  @(Model.ShowTitle == true ? "true" : "false");
+    const elements = document.querySelectorAll("[data-@Model.DataSetAttribute]");
+
+    elements.forEach(element => {
+        const costCodes = JSON.parse(element.getAttribute("data-cost-codes") ?? []);
+        const elementId = element.getAttribute("data-element-id");
+        const title = showTitle && element.getAttribute("data-title");
+        ChartActions({
+            placeholderElement: element,
+            elementId,
+            copyEventId,
+            costCodes,
+            saveEventId,
+            showCopy,
+            showSave,
+            showTitle,
+            title
+        });
+    });
+</script>

--- a/web/src/Web.App/Views/Shared/Enhancements/_SuggestScripts.cshtml
+++ b/web/src/Web.App/Views/Shared/Enhancements/_SuggestScripts.cshtml
@@ -1,8 +1,0 @@
-@using Web.App.Extensions
-@model Web.App.ViewModels.Enhancements.SuggestScriptsViewModel
-
-<script type="module" add-nonce="true">
-    import {suggester} from "@Html.FileVersionedPath("/js/main.min.js")";
-
-    suggester("@Model.Type", "@Model.InputElementId", "@Model.SelectedEstablishmentField", "@Model.IdField");
-</script>

--- a/web/src/Web.App/Views/Shared/Enhancements/_Suggester.cshtml
+++ b/web/src/Web.App/Views/Shared/Enhancements/_Suggester.cshtml
@@ -1,0 +1,12 @@
+@using Web.App.Extensions
+@model Web.App.ViewModels.Enhancements.SuggesterViewModel
+
+<script type="module" add-nonce="true">
+    import {Suggester} from "@Html.FileVersionedPath("/js/main.min.js")";
+
+    Suggester({
+        type: "@Model.Type",
+        inputElementId: "@Model.InputElementId",
+        targetElementId: "@Model.SelectedEstablishmentField",
+        documentKey: "@Model.IdField"});
+</script>

--- a/web/src/Web.App/Views/TrustSearch/Index.cshtml
+++ b/web/src/Web.App/Views/TrustSearch/Index.cshtml
@@ -15,7 +15,7 @@
 
 @section scripts
 {
-    @await Html.PartialAsync("Enhancements/_SuggestScripts", new SuggestScriptsViewModel
+    @await Html.PartialAsync("Enhancements/_Suggester", new SuggesterViewModel
     {
         InputElementId = nameof(ISearchTermViewModel.Term),
         SelectedEstablishmentField = nameof(ISearchTermViewModel.EstablishmentId),

--- a/web/src/Web.App/Views/TrustSearch/Search.cshtml
+++ b/web/src/Web.App/Views/TrustSearch/Search.cshtml
@@ -71,7 +71,7 @@
 
 @section scripts
 {
-    @await Html.PartialAsync("Enhancements/_SuggestScripts", new SuggestScriptsViewModel
+    @await Html.PartialAsync("Enhancements/_Suggester", new SuggesterViewModel
     {
         InputElementId = nameof(ISearchTermViewModel.Term),
         SelectedEstablishmentField = nameof(ISearchTermViewModel.EstablishmentId),

--- a/web/src/Web.App/package-lock.json
+++ b/web/src/Web.App/package-lock.json
@@ -11,13 +11,18 @@
       "dependencies": {
         "accessible-autocomplete": "^3.0.0",
         "async": "^3.2.5",
+        "classnames": "^2.5.1",
+        "file-saver": "^2.0.5",
         "front-end": "^1.0.0",
         "govuk-frontend": "^5.7.0",
+        "html-to-image": "1.11.11",
+        "jszip": "^3.10.1",
         "lodash.debounce": "^4.0.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.1",
         "@swc/core": "^1.11.21",
+        "@types/file-saver": "^2.0.7",
         "@types/lodash.debounce": "^4.0.9",
         "@typescript-eslint/parser": "^8.31.1",
         "eslint": "^8.57.1",
@@ -137,13 +142,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.26.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@eslint/js/-/js-9.26.0.tgz",
-      "integrity": "sha1-HhMSa2ej2xURHS3MYfaaKs/3C9U=",
+      "version": "9.27.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@eslint/js/-/js-9.27.0.tgz",
+      "integrity": "sha1-GBojRgh3xIT23QOJD04/ov3rj/A=",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@gulp-sourcemaps/identity-map": {
@@ -1062,6 +1070,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/file-saver": {
+      "version": "2.0.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@types/file-saver/-/file-saver-2.0.7.tgz",
+      "integrity": "sha1-jbsvJL3HSGxUqoVOtBSUC70Fb30=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1087,9 +1102,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.15.18",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@types/node/-/node-22.15.18.tgz",
-      "integrity": "sha1-L4JA9+ky9XHC1F9VW6C2w/enWWM=",
+      "version": "22.15.19",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@types/node/-/node-22.15.19.tgz",
+      "integrity": "sha1-up8yFnUkOvBFbWB/qCpIZZMeDO8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2516,9 +2531,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.154",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.154.tgz",
-      "integrity": "sha1-gkMNZoSO/vcDo7ZD+ypoK9CK4ms=",
+      "version": "1.5.155",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.155.tgz",
+      "integrity": "sha1-gJ3Qrprh24fDWODAwXwJov/EMtE=",
       "dev": true,
       "license": "ISC"
     },
@@ -3519,9 +3534,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.10.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/govuk-frontend/-/govuk-frontend-5.10.0.tgz",
-      "integrity": "sha1-gSpaFORGYTBgO2C52j1DprBrcGk=",
+      "version": "5.10.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/govuk-frontend/-/govuk-frontend-5.10.1.tgz",
+      "integrity": "sha1-VTQ1cmeRnibnLNwCi7rRkGtMm6E=",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
@@ -5707,9 +5722,9 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.88.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/sass/-/sass-1.88.0.tgz",
-      "integrity": "sha1-zRSVdJvr2eSsqG6T7mCzkEoQd4k=",
+      "version": "1.89.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/sass/-/sass-1.89.0.tgz",
+      "integrity": "sha1-bfcjYMXD7CqYM8Sa2v5XsoIGdS0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6115,14 +6130,13 @@
       }
     },
     "node_modules/synckit": {
-      "version": "0.11.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/synckit/-/synckit-0.11.5.tgz",
-      "integrity": "sha1-JYsxhXNlEvfvEaQtZ8TzrUnaF0Q=",
+      "version": "0.11.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/synckit/-/synckit-0.11.6.tgz",
+      "integrity": "sha1-50Kgwnu8H7yW8gEHcFIQFcyn7Vw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pkgr/core": "^0.2.4",
-        "tslib": "^2.8.1"
+        "@pkgr/core": "^0.2.4"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -6132,9 +6146,9 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.2.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/tapable/-/tapable-2.2.1.tgz",
-      "integrity": "sha1-GWenPvQGCoLxKrlq+G1S/bdu7KA=",
+      "version": "2.2.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/tapable/-/tapable-2.2.2.tgz",
+      "integrity": "sha1-q0mENA0wy5mJpJADLwhtu4tW2HI=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6152,14 +6166,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.39.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/terser/-/terser-5.39.1.tgz",
-      "integrity": "sha1-HIDmveKzYsb58+eeKVwiijiC2YM=",
+      "version": "5.39.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/terser/-/terser-5.39.2.tgz",
+      "integrity": "sha1-WhYmAwckpnLi5bXJzZBwMIwg6Pk=",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
+        "acorn": "^8.14.0",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -6706,9 +6720,9 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.4.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/watchpack/-/watchpack-2.4.2.tgz",
-      "integrity": "sha1-L+6u1nQS58MxhOWnnKc4+9OFZNo=",
+      "version": "2.4.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/watchpack/-/watchpack-2.4.3.tgz",
+      "integrity": "sha1-EQs6YAxSX2o5q2bPNUzwiyBcKdw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/web/src/Web.App/package.json
+++ b/web/src/Web.App/package.json
@@ -6,13 +6,18 @@
   "dependencies": {
     "accessible-autocomplete": "^3.0.0",
     "async": "^3.2.5",
+    "classnames": "^2.5.1",
+    "file-saver": "^2.0.5",
     "front-end": "^1.0.0",
     "govuk-frontend": "^5.7.0",
+    "html-to-image": "1.11.11",
+    "jszip": "^3.10.1",
     "lodash.debounce": "^4.0.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.1",
     "@swc/core": "^1.11.21",
+    "@types/file-saver": "^2.0.7",
     "@types/lodash.debounce": "^4.0.9",
     "@typescript-eslint/parser": "^8.31.1",
     "eslint": "^8.57.1",

--- a/web/src/Web.App/tsconfig.json
+++ b/web/src/Web.App/tsconfig.json
@@ -123,7 +123,7 @@
     /* Skip type checking all .d.ts files. */
   },
   "include": [
-    "AssetSrc/ts/*.ts",
+    "AssetSrc/ts/**/*.ts",
     "types/*.d.ts"
   ]
 }

--- a/web/src/Web.App/webpack.config.cjs
+++ b/web/src/Web.App/webpack.config.cjs
@@ -2,7 +2,7 @@ const path = require("path");
 
 module.exports = {
   mode: "production",
-  entry: "./AssetSrc/ts/index.ts",
+  entry: "./AssetSrc/ts/main.ts",
   module: {
     rules: [
       {


### PR DESCRIPTION
### Context
[AB#258039](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/258039) [AB#260350](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/260350)

### Change proposed in this pull request
- Removed `front-end` React-bound elements when charts SSR rendered on School Spending Priorities
- Moved `suggester.ts` into `./suggester`
- Added Save/Copy buttons as progressive enhancements to SSR charts (to be migrated into Vue.js component in future PR)
- SSR feature-based conditional to be moved to Action from View in future PR

### Guidance to review 
Run `npm i` and `npm run build` to update `wwwroot/js`. Restart `Web` and browse to a School spending priorities page, ensuring that `chart-rendering-fa` is running alongside other Platform APIs. Charts should be server-rendered and Save/Copy buttons loaded if JavaScript enabled. 'Save all' modal implementation split off into separate work item due to dependency on Vue.js components support. This has been deployed to the `d11` feature environment.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

