### PR TITLE
Prevent error logging to App Insights when underlying task canceled upon client request

### DIFF
--- a/documentation/developers/11_Task_Cancellation.md
+++ b/documentation/developers/11_Task_Cancellation.md
@@ -1,0 +1,257 @@
+# Task Cancellation within FBIT
+
+.NET supports the cancellation of asynchronous tasks via [`CancellationToken`](https://learn.microsoft.com/en-us/dotnet/api/system.threading.cancellationtoken)s. This has been implemented across FBIT for client side requests from the [`fetch` API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) (with [`signal`](https://developer.mozilla.org/en-US/docs/Web/API/Request/signal)), through Web and down to the underlying dependent services accessed via the API, such as [`DbDataReader.ReadAsync()`](https://learn.microsoft.com/en-us/dotnet/api/system.data.common.dbdatareader.readasync) (via [Dapper](https://github.com/DapperLib/Dapper)).
+
+## Implementation
+
+### Client
+
+To support the cancellation logic, the client component making the `fetch` must supply an abort signal with the command options. This is usually achieved using a/multiple `AbortController`s, e.g.:
+
+```ts
+// single signal
+const abortController = new AbortController();
+
+const params = new URLSearchParams({
+    someParameter: "something",
+});
+await fetch("/api/path" + params, {
+    // ...other options...
+    signal: abortController.signal,
+});
+
+// ...
+abortController.abort();
+```
+
+```ts
+// multiple signals
+const abortController1 = new AbortController();
+const abortController2 = new AbortController();
+const signals = [abortController1.signal, abortController2.signal];
+
+const params = new URLSearchParams({
+    someParameter: "something",
+});
+await fetch("/api/path" + params, {
+    // ...other options...
+    signal: signals?.length ? AbortSignal.any(signals) : undefined,
+});
+
+// ...
+abortController2.abort();
+```
+
+> **💡 Note:** `AbortController`s may only be `abort()`ed once. To re-use the variable, create a new instance as required. The `useAbort()` hook in `front-end-components` helps to manage this.
+
+Examples of the above in use are in the search suggester autocomplete (once [`debounce`](https://lodash.com/docs#debounce) gate has been fulfilled) or the dimension drop downs on organisation benchmarking pages. When replicating the `abort()` functionality in a web browser, network monitoring will likely show the request as `(canceled)` and the server response is discarded.
+
+### Web proxy
+
+All Web proxy actions should have a `CancellationToken` as their final method parameter. This token should be passed down to services that call the underlying APIs. e.g.:
+
+```cs
+[ApiController]
+[Route("api/path")]
+public class SomeProxyController(ISomeService someService) : Controller
+{
+    [HttpGet]
+    public async Task<IActionResult> SomeAction(string someParameter, CancellationToken cancellationToken = default)
+    {
+        try 
+        {
+            var response = await someService.GetSomethingAsync(someParameter, cancellationToken);
+            if (response == null)
+            {
+                return new NotFoundResult();
+            }
+
+            return new JsonResult(response);
+        } 
+        catch (TaskCanceledException)
+        {
+            return StatusCode(499);
+        }
+        catch (Exception)
+        {
+            // additional context usually logged here
+            return StatusCode(500);
+        }
+    }
+}
+```
+
+`GetResultOrThrow()` will raise a `TaskCanceledException` if the API response has the status code `499`.
+
+`GetAsync()` also calls `ToApiResult()` with the cancellation token to handle the case when the underlying API has returned, but then the cancellation request is handled by the originating endpoint.
+
+```cs
+public interface ISomeService
+{
+    Task<Something?> GetSomethingAsync(string someParameter, CancellationToken cancellationToken = default);
+}
+
+public class SomeService(ISomeApi api) : ISomeService
+{
+    public async Task<Something?> GetSomethingAsync(string someParameter, CancellationToken cancellationToken = default)
+    {
+        var query = new ApiQuery()
+            .AddIfNotNull("someParameter", someParameter);
+            
+        var result = await api
+            .GetAsync(query, cancellationToken)
+            .GetResultOrThrow<Something>();
+        return result;
+    }
+}
+```
+
+```cs
+public interface ISomeApi
+{
+    Task<ApiResult> GetAsync(ApiQuery? query = null, CancellationToken cancellationToken = default);
+}
+
+public class SomeApi(HttpClient httpClient, string? key = null) : ApiBase(httpClient, key), ISomeApi
+{
+    public async Task<ApiResult> GetAsync(ApiQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        return await GetAsync($"/some/api{query?.ToQueryString()}", cancellationToken);
+    }
+}
+```
+
+### API
+
+Similarly to the Web proxy actions, the API functions should also include the `CancellationToken` as the final method parameter. This token should be passed down to dependent services that ultimately perform some asynchronous work. e.g.:
+
+```cs
+public class GetSomethingFunction(ISomeDataService service)
+{
+    [Function(nameof(GetSomethingFunction))]
+    public async Task<HttpResponseData> RunAsync(
+        [HttpTrigger(AuthorizationLevel.Admin, "get", Route = "some/api")] HttpRequestData req,
+        CancellationToken cancellationToken = default)
+    {
+        var queryParams = req.GetParameters<SomeParameters>();
+        var data = await service.GetAsync(queryParams.SomeParameter);
+        return await req.CreateJsonResponseAsync(data, cancellationToken: cancellationToken);
+    }
+}
+```
+
+```cs
+public interface ISomeDataService
+{
+    Task<Models.Something?> GetAsync(string someParameter, CancellationToken cancellationToken = default);
+}
+
+[ExcludeFromCodeCoverage]
+public class SomeDataService(IDatabaseFactory dbFactory) : ISomeDataService
+{
+    public async Task<Models.Something?> GetAsync(string someParameter, CancellationToken cancellationToken = default)
+    {
+        var query = new SomeQuery()            
+            .WhereSomethingEqual(someParameter);
+
+        using var conn = await dbFactory.GetConnection();
+        return await conn.QueryFirstOrDefaultAsync<Models.Something>(query, cancellationToken);
+    }
+}
+```
+
+`ExceptionHandingMiddleware` in each function app intercepts exceptions of the following types and returns a `499` response in the case of a task being cancelled:
+
+* `System.OperationCanceledException`
+* `System.Threading.Tasks.TaskCanceledException`
+* `Microsoft.Data.SqlClient.SqlException` (when `Message` contains `Operation cancelled by user`)
+
+The above known set of types may need to be extended if/when additional dependent services are implemented.
+
+## Control flow
+
+The examples below assume that the Web Proxy is attempting to resolve the underlying request using `ApiResult.GetResultOrThrow<T>()`. Any potential `TaskCanceledException`s will not be rethrown when using `ApiResult.GetResultOrDefault<T>()`.
+
+### Successfully completed request
+
+```mermaid
+sequenceDiagram
+    accDescr: Successfully completed request
+    
+    participant Browser (fetch)
+    participant Web Proxy
+    participant API
+    participant Dependent service
+
+    Note over Browser (fetch): User makes request
+    Browser (fetch)->>Web Proxy: Front end request
+    Web Proxy->>API: API request
+    API->>Dependent service: Service request
+    activate Dependent service
+    Note over Dependent service: ⌛
+    Dependent service->>API: Service response
+    deactivate Dependent service
+    API->>Web Proxy: 200 API response
+    Web Proxy->>Browser (fetch): 200 front end response
+    Note over Browser (fetch): Response consumed
+```
+
+### Cancelled in progress request
+
+```mermaid
+sequenceDiagram
+    accDescr: Cancelled in progress request
+    
+    participant Browser (fetch)
+    participant Web Proxy
+    participant API
+    participant Dependent service
+
+    Note over Browser (fetch): User makes request
+    Browser (fetch)->>Web Proxy: Front end request
+    Web Proxy->>API: API request
+    API->>Dependent service: Service request
+    activate Dependent service
+    Note over Dependent service: ⌛
+    Browser (fetch)-->>Web Proxy: Request aborted
+    Web Proxy-->>API: Cancellation request
+    API-->>Dependent service: Cancellation request
+    Note over Dependent service: Task cancelled
+    Dependent service->>API: Exception
+    deactivate Dependent service
+    Note over API: OperationCanceledException<br/>or TaskCanceledException<br/>or SqlException
+    API->>Web Proxy: 499 API response
+    Web Proxy->>Web Proxy: TaskCancelledException
+    Web Proxy->>Browser (fetch): 499 front end response
+    Note over Browser (fetch): Response discarded
+```
+
+### Cancelled completed request
+
+```mermaid
+sequenceDiagram
+    accDescr: Cancelled completed request
+    
+    participant Browser (fetch)
+    participant Web Proxy
+    participant API
+    participant Dependent service
+
+    Note over Browser (fetch): User makes request
+    Browser (fetch)->>Web Proxy: Front end request
+    Web Proxy->>API: API request
+    API->>Dependent service: Service request
+    activate Dependent service
+    Note over Dependent service: ⌛
+    Dependent service->>API: Service response
+    deactivate Dependent service
+    Browser (fetch)-->>Web Proxy: Request aborted
+    Web Proxy-->>API: Cancellation request
+    Note over API: Cancellation acknowledged<br/>but underlying service<br/>request already complete
+    API->>Web Proxy: 200 API response
+    Web Proxy->>Browser (fetch): 200 front end response
+    Note over Browser (fetch): Response discarded
+```
+
+<!-- Leave the rest of this page blank -->
+\newpage

--- a/web/src/Web.App/Controllers/Api/ExpenditureProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/ExpenditureProxyController.cs
@@ -66,6 +66,10 @@ public class ExpenditureProxyController(
                         throw new ArgumentOutOfRangeException(nameof(type));
                 }
             }
+            catch (TaskCanceledException)
+            {
+                return StatusCode(499);
+            }
             catch (Exception e)
             {
                 logger.LogError(e, "An error getting expenditure data: {DisplayUrl}", Request.GetDisplayUrl());

--- a/web/src/Web.App/Controllers/Api/SuggestProxyController.cs
+++ b/web/src/Web.App/Controllers/Api/SuggestProxyController.cs
@@ -2,6 +2,7 @@
 using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
 using Web.App.Services;
+
 namespace Web.App.Controllers.Api;
 
 [ApiController]
@@ -45,6 +46,10 @@ public class SuggestProxyController(
                     default:
                         throw new ArgumentOutOfRangeException(nameof(type));
                 }
+            }
+            catch (TaskCanceledException)
+            {
+                return StatusCode(499);
             }
             catch (Exception e)
             {

--- a/web/src/Web.App/Infrastructure/Extensions/ApiResultExtensions.cs
+++ b/web/src/Web.App/Infrastructure/Extensions/ApiResultExtensions.cs
@@ -34,7 +34,10 @@ public static class ApiResultExtensions
     public static async Task<TRet?> GetResult<TRet>(this Task<ApiResult> result, Func<ApiResult, TRet> onError)
     {
         var rs = await result;
-        if (rs is not SuccessApiResult s) return onError(rs);
+        if (rs is not SuccessApiResult s)
+        {
+            return onError(rs);
+        }
 
         return s.Body switch
         {
@@ -47,7 +50,10 @@ public static class ApiResultExtensions
     public static async Task<string> GetString(this Task<ApiResult> result, Func<ApiResult, string> onError)
     {
         var rs = await result;
-        if (rs is not SuccessApiResult s) return onError(rs);
+        if (rs is not SuccessApiResult s)
+        {
+            return onError(rs);
+        }
 
         return s.Body switch
         {
@@ -71,7 +77,11 @@ public static class ApiResultExtensions
 
     public static T? GetResultOrDefault<T>(this ApiResult result, T? defaultValue = default)
     {
-        if (result is not SuccessApiResult s) return defaultValue;
+        if (result is not SuccessApiResult s)
+        {
+            return defaultValue;
+        }
+
         return s.Body switch
         {
             JsonResponseBody j => j.ReadAs<T>(),
@@ -96,7 +106,7 @@ public static class ApiResultExtensions
 
         if (result is CancelledApiResult)
         {
-            return default!;
+            throw new TaskCanceledException("The request was cancelled");
         }
 
         throw new ArgumentNullException();

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -243,6 +243,15 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         return this;
     }
 
+    public BenchmarkingWebAppClient SetupEstablishmentWithTaskCanceledException()
+    {
+        EstablishmentApi.Reset();
+        EstablishmentApi
+            .Setup(api => api.SuggestSchools(It.IsAny<string>(), It.IsAny<string[]?>(), It.IsAny<bool?>(), It.IsAny<CancellationToken>()))
+            .Throws(new TaskCanceledException());
+        return this;
+    }
+
     public BenchmarkingWebAppClient SetupEstablishment(SearchResponse<SchoolSummary> schools)
     {
         EstablishmentApi.Reset();
@@ -535,6 +544,13 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     {
         ComparatorSetApi.Reset();
         ComparatorSetApi.Setup(api => api.GetDefaultSchoolAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Throws(new Exception());
+        return this;
+    }
+
+    public BenchmarkingWebAppClient SetupComparatorSetApiWithTaskCanceledException()
+    {
+        ComparatorSetApi.Reset();
+        ComparatorSetApi.Setup(api => api.GetDefaultSchoolAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Throws(new TaskCanceledException());
         return this;
     }
 

--- a/web/tests/Web.Integration.Tests/Proxy/WhenRequestingExpenditure.cs
+++ b/web/tests/Web.Integration.Tests/Proxy/WhenRequestingExpenditure.cs
@@ -15,4 +15,15 @@ public class WhenRequestingExpenditure(SchoolBenchmarkingWebAppClient client) : 
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
     }
+
+    [Fact]
+    public async Task CanReturnClientClosedRequest()
+    {
+        const string urn = "123456";
+        var response = await client
+            .SetupComparatorSetApiWithTaskCanceledException()
+            .Get(Paths.ApiExpenditure("school", urn, "dummy", "dummy"));
+
+        Assert.Equal((HttpStatusCode)499, response.StatusCode);
+    }
 }

--- a/web/tests/Web.Integration.Tests/Proxy/WhenRequestingSuggest.cs
+++ b/web/tests/Web.Integration.Tests/Proxy/WhenRequestingSuggest.cs
@@ -1,13 +1,204 @@
-using Newtonsoft.Json.Linq;
 using System.Net;
+using Newtonsoft.Json.Linq;
+using Web.App;
+using Web.App.Domain;
 using Web.App.Infrastructure.Apis;
 using Xunit;
-using Web.App.Domain;
 
 namespace Web.Integration.Tests.Proxy;
 
 public class WhenRequestingSuggest(SchoolBenchmarkingWebAppClient client) : IClassFixture<SchoolBenchmarkingWebAppClient>
 {
+    public static IEnumerable<object[]> TrustTestData =>
+        new List<object[]>
+        {
+            new object[]
+            {
+                "Test",
+                new SuggestOutput<Trust>
+                {
+                    Results =
+                    [
+                        new SuggestValue<Trust>
+                        {
+                            Text = "*Test* Trust",
+                            Document = new Trust
+                            {
+                                CompanyNumber = "12345678",
+                                TrustName = "Test Trust"
+                            }
+                        }
+                    ]
+                },
+                new SuggestOutput<Trust>
+                {
+                    Results =
+                    [
+                        new SuggestValue<Trust>
+                        {
+                            Text = "*Test* Trust (12345678)",
+                            Document = new Trust
+                            {
+                                CompanyNumber = "12345678",
+                                TrustName = "Test Trust"
+                            }
+                        }
+                    ]
+                }
+            },
+            new object[]
+            {
+                "123",
+                new SuggestOutput<Trust>
+                {
+                    Results =
+                    [
+                        new SuggestValue<Trust>
+                        {
+                            Text = "*123*45678",
+                            Document = new Trust
+                            {
+                                CompanyNumber = "12345678",
+                                TrustName = "Test Trust"
+                            }
+                        }
+                    ]
+                },
+                new SuggestOutput<Trust>
+                {
+                    Results =
+                    [
+                        new SuggestValue<Trust>
+                        {
+                            Text = "Test Trust (*123*45678)",
+                            Document = new Trust
+                            {
+                                CompanyNumber = "12345678",
+                                TrustName = "Test Trust"
+                            }
+                        }
+                    ]
+                }
+            },
+            new object[]
+            {
+                "Test",
+                new SuggestOutput<Trust>
+                {
+                    Results =
+                    [
+                        new SuggestValue<Trust>
+                        {
+                            Text = "*Test* Trust",
+                            Document = new Trust
+                            {
+                                CompanyNumber = "12345678",
+                                TrustName = "Test Trust"
+                            }
+                        },
+                        new SuggestValue<Trust>
+                        {
+                            Text = "Another *Test* Trust",
+                            Document = new Trust
+                            {
+                                CompanyNumber = "87654321",
+                                TrustName = "Another Test Trust"
+                            }
+                        }
+
+                    ]
+                },
+                new SuggestOutput<Trust>
+                {
+                    Results =
+                    [
+                        new SuggestValue<Trust>
+                        {
+                            Text = "*Test* Trust (12345678)",
+                            Document = new Trust
+                            {
+                                CompanyNumber = "12345678",
+                                TrustName = "Test Trust"
+                            }
+                        },
+                        new SuggestValue<Trust>
+                        {
+                            Text = "Another *Test* Trust (87654321)",
+                            Document = new Trust
+                            {
+                                CompanyNumber = "87654321",
+                                TrustName = "Another Test Trust"
+                            }
+                        }
+                    ]
+                }
+            },
+            new object[]
+            {
+                "123",
+                new SuggestOutput<Trust>
+                {
+                    Results =
+                    [
+                        new SuggestValue<Trust>
+                        {
+                            Text = "*123*45678",
+                            Document = new Trust
+                            {
+                                CompanyNumber = "12345678",
+                                TrustName = "Test Trust"
+                            }
+                        },
+                        new SuggestValue<Trust>
+                        {
+                            Text = "*123*45679",
+                            Document = new Trust
+                            {
+                                CompanyNumber = "12345679",
+                                TrustName = "Another Test Trust"
+                            }
+                        }
+                    ]
+                },
+                new SuggestOutput<Trust>
+                {
+                    Results =
+                    [
+                        new SuggestValue<Trust>
+                        {
+                            Text = "Test Trust (*123*45678)",
+                            Document = new Trust
+                            {
+                                CompanyNumber = "12345678",
+                                TrustName = "Test Trust"
+                            }
+                        },
+                        new SuggestValue<Trust>
+                        {
+                            Text = "Another Test Trust (*123*45679)",
+                            Document = new Trust
+                            {
+                                CompanyNumber = "12345679",
+                                TrustName = "Another Test Trust"
+                            }
+                        }
+                    ]
+                }
+            },
+            new object[]
+            {
+                "Test",
+                new SuggestOutput<Trust>
+                {
+                    Results = []
+                },
+                new SuggestOutput<Trust>
+                {
+                    Results = []
+                }
+            }
+        };
+
     [Theory]
     [InlineData("school")]
     [InlineData("trust")]
@@ -62,193 +253,13 @@ public class WhenRequestingSuggest(SchoolBenchmarkingWebAppClient client) : ICla
         }
     }
 
-    public static IEnumerable<object[]> TrustTestData =>
-        new List<object[]>
-        {
-            new object[]
-            {
-                "Test",
-                new SuggestOutput<Trust>
-                {
-                    Results =
-                    [
-                        new SuggestValue<Trust>
-                        {
-                            Text = "*Test* Trust",
-                            Document = new Trust
-                            {
-                                CompanyNumber = "12345678",
-                                TrustName = "Test Trust"
-                            }
-                        }
-                    ]
-                },
-                new SuggestOutput<Trust>
-                {
-                    Results =
-                    [
-                        new SuggestValue<Trust>
-                         {
-                             Text = "*Test* Trust (12345678)",
-                             Document = new Trust
-                             {
-                                 CompanyNumber = "12345678",
-                                 TrustName = "Test Trust"
-                             }
-                         }
-                    ]
-                }
-            },
-            new object[]
-            {
-                "123",
-                new SuggestOutput<Trust>
-                {
-                    Results =
-                    [
-                        new SuggestValue<Trust>
-                        {
-                            Text = "*123*45678",
-                            Document = new Trust
-                            {
-                                CompanyNumber = "12345678",
-                                TrustName = "Test Trust"
-                            }
-                        }
-                    ]
-                },
-                new SuggestOutput<Trust>
-                {
-                    Results =
-                    [
-                    new SuggestValue<Trust>
-                     {
-                         Text = "Test Trust (*123*45678)",
-                         Document = new Trust
-                         {
-                             CompanyNumber = "12345678",
-                             TrustName = "Test Trust"
-                         }
-                     }
-                    ]
-                }
-            },
-            new object[]
-            {
-                "Test",
-                new SuggestOutput<Trust>
-                {
-                    Results =
-                    [
-                        new SuggestValue<Trust>
-                        {
-                            Text = "*Test* Trust",
-                            Document = new Trust
-                            {
-                                CompanyNumber = "12345678",
-                                TrustName = "Test Trust"
-                            }
-                        },
-                        new SuggestValue<Trust>
-                        {
-                            Text = "Another *Test* Trust",
-                            Document = new Trust
-                            {
-                                CompanyNumber = "87654321",
-                                TrustName = "Another Test Trust"
-                            }
-                        },
+    [Fact]
+    public async Task CanReturnClientClosedRequest()
+    {
+        const string urn = "123456";
+        var response = await client.SetupEstablishmentWithTaskCanceledException()
+            .Get(Paths.ApiSuggest(urn, OrganisationTypes.School));
 
-                    ]
-                },
-                new SuggestOutput<Trust>
-                {
-                    Results =
-                    [
-                         new SuggestValue<Trust>
-                         {
-                             Text = "*Test* Trust (12345678)",
-                             Document = new Trust
-                             {
-                                 CompanyNumber = "12345678",
-                                 TrustName = "Test Trust"
-                             }
-                         },
-                         new SuggestValue<Trust>
-                         {
-                             Text = "Another *Test* Trust (87654321)",
-                             Document = new Trust
-                             {
-                                 CompanyNumber = "87654321",
-                                 TrustName = "Another Test Trust"
-                             }
-                         }
-                     ]
-                }
-            },
-            new object[]
-            {
-                "123",
-                new SuggestOutput<Trust>
-                {
-                    Results =
-                    [
-                        new SuggestValue<Trust>
-                        {
-                            Text = "*123*45678",
-                            Document = new Trust
-                            {
-                                CompanyNumber = "12345678",
-                                TrustName = "Test Trust"
-                            }
-                        },
-                        new SuggestValue<Trust>
-                        {
-                            Text = "*123*45679",
-                            Document = new Trust
-                            {
-                                CompanyNumber = "12345679",
-                                TrustName = "Another Test Trust"
-                            }
-                        },
-                    ]
-                },
-                new SuggestOutput<Trust>
-                {
-                    Results =
-                    [
-                         new SuggestValue<Trust>
-                         {
-                             Text = "Test Trust (*123*45678)",
-                             Document = new Trust
-                             {
-                                 CompanyNumber = "12345678",
-                                 TrustName = "Test Trust"
-                             }
-                         },
-                         new SuggestValue<Trust>
-                         {
-                             Text = "Another Test Trust (*123*45679)",
-                             Document = new Trust
-                             {
-                                 CompanyNumber = "12345679",
-                                 TrustName = "Another Test Trust"
-                             }
-                         }
-                    ]
-                }
-            },
-            new object[]
-            {
-                "Test",
-                new SuggestOutput<Trust>
-                {
-                    Results = []
-                },
-                new SuggestOutput<Trust>
-                {
-                    Results = []
-                },
-            },
-        };
+        Assert.Equal((HttpStatusCode)499, response.StatusCode);
+    }
 }

--- a/web/tests/Web.Tests/Infrastructure/GivenAHttpResponseMessage.cs
+++ b/web/tests/Web.Tests/Infrastructure/GivenAHttpResponseMessage.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json.Linq;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Extensions;
 using Xunit;
+
 namespace Web.Tests.Infrastructure;
 
 public class GivenAHttpResponseMessage
@@ -12,13 +13,17 @@ public class GivenAHttpResponseMessage
     private readonly Fixture _fixture = new();
 
     private static Task<HttpResponseMessage> CreateMessage(HttpStatusCode statusCode, HttpContent? content = null)
-        => Task.FromResult(new HttpResponseMessage(statusCode)
+    {
+        return Task.FromResult(new HttpResponseMessage(statusCode)
         {
             Content = content
         });
+    }
 
     private static Task<HttpResponseMessage> CreateMessage(CancellationToken cancellationToken)
-        => Task.FromCanceled<HttpResponseMessage>(cancellationToken);
+    {
+        return Task.FromCanceled<HttpResponseMessage>(cancellationToken);
+    }
 
     [Theory]
     [InlineData(HttpStatusCode.OK)]
@@ -93,7 +98,7 @@ public class GivenAHttpResponseMessage
     }
 
     [Fact]
-    public async Task ShouldReturnEmpty499WhenRequestCancelled()
+    public async Task ShouldReturn499AndThrowExceptionWhenRequestCancelled()
     {
         var cancellationToken = new CancellationTokenSource(TimeSpan.Zero).Token;
         var result = await CreateMessage(cancellationToken).ToApiResult(cancellationToken);
@@ -102,6 +107,6 @@ public class GivenAHttpResponseMessage
 
         Assert.Null(exception);
         Assert.Equal(499, (int)result.Status);
-        Assert.Null(result.GetResultOrThrow<string>());
+        Assert.Throws<TaskCanceledException>(() => result.GetResultOrThrow<string>());
     }
 }


### PR DESCRIPTION
### Context
[AB#261909](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/261909) [AB#261910](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/261910) [AB#262158](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/262158) #2349

### Change proposed in this pull request
This has been added to known problematic proxy endpoints, but may be expanded to more as required and/or rolled out everywhere with a [global `IActionFilter`](https://learn.microsoft.com/en-us/aspnet/core/web-api/handle-errors?view=aspnetcore-9.0#use-exceptions-to-modify-the-response) instead of manually `try`/`catch`ing in each `ApiController`. This would be managed as new tech debt. As per #2349, this error never reaches the client in the case of a canceled request but it is polluting the logs unnecessarily.

Also included documentation as to the cancellation logic and flow within the application.

### Guidance to review 
May be replicated on the School/Trust/LA Suggester and/or School Benchmark Spending pages. For the latter, quickly change dimensions back and forth a number of times (e.g. up/down keys once focused) to cancel the underlying request. In some of these cases the in-progress task will be cancelled which returns a `499` from the API but should not be logged as an error in Web.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

