### PR TITLE
docs: stop > character clashing with mermaid parsing

### DIFF
--- a/documentation/data/3_Processing.md
+++ b/documentation/data/3_Processing.md
@@ -296,7 +296,7 @@ flowchart TD
             select_top_60 --> select_region
             select_region -- < 30 --> select_N --> comparator_Set
             select_region -- = 30 --> comparator_Set
-            select_region -- > 30 --> select_closest_30 --> comparator_Set
+            select_region -- &gt; 30 --> select_closest_30 --> comparator_Set
         end 
 
         dist -- Non PFI/Boarding school --> select_top_60
@@ -370,7 +370,7 @@ flowchart TD
             select_top_60 --> select_region
             select_region -- < 30 --> select_N --> comparator_Set
             select_region -- = 30 --> comparator_Set
-            select_region -- > 30 --> select_closest_30 --> comparator_Set
+            select_region -- &gt; 30 --> select_closest_30 --> comparator_Set
         end
 
         dist --> select_top_60


### PR DESCRIPTION
### Context
Currently the clashing `>` character stops mermaid rendering it

<img width="587" alt="image" src="https://github.com/user-attachments/assets/465cdca1-96af-4111-9e94-72246a38a20a" />


### Change proposed in this pull request
-

### Guidance to review 
-

### Checklist (add/remove as appropriate)
- [ ] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] Your code builds clean without any errors or warnings
- [ ] You have run all unit/integration tests and they pass
- [ ] Your branch has been rebased onto main
- [ ] You have tested by running locally
- [ ] You have reviewed with UX/Design

