### PR TITLE
Replaced 'page actions' visibility booleans with array of enums

### DIFF
--- a/web/src/Web.App/Constants/PageActions.cs
+++ b/web/src/Web.App/Constants/PageActions.cs
@@ -1,0 +1,7 @@
+namespace Web.App;
+
+public enum PageActions
+{
+    DownloadData,
+    SaveChartImages
+}

--- a/web/src/Web.App/ViewComponents/PageActionsSsrViewComponent.cs
+++ b/web/src/Web.App/ViewComponents/PageActionsSsrViewComponent.cs
@@ -6,8 +6,7 @@ namespace Web.App.ViewComponents;
 public class PageActionsSsrViewComponent : ViewComponent
 {
     public IViewComponentResult Invoke(
-        bool? saveButtonVisible,
-        bool? downloadButtonVisible,
+        PageActions[]? actions,
         string? saveClassName,
         string? saveFileName,
         string? saveTitleAttr,
@@ -16,8 +15,7 @@ public class PageActionsSsrViewComponent : ViewComponent
         string? downloadLink)
     {
         return View(new PageActionsViewModel(
-            saveButtonVisible,
-            downloadButtonVisible,
+            actions,
             saveClassName,
             saveFileName,
             saveTitleAttr,

--- a/web/src/Web.App/ViewComponents/PageActionsViewComponent.cs
+++ b/web/src/Web.App/ViewComponents/PageActionsViewComponent.cs
@@ -6,8 +6,7 @@ namespace Web.App.ViewComponents;
 public class PageActionsViewComponent : ViewComponent
 {
     public IViewComponentResult Invoke(
-        bool? saveButtonVisible,
-        bool? downloadButtonVisible,
+        PageActions[]? actions,
         string? saveClassName,
         string? saveFileName,
         string? saveTitleAttr,
@@ -16,8 +15,7 @@ public class PageActionsViewComponent : ViewComponent
         string? downloadLink)
     {
         return View(new PageActionsViewModel(
-            saveButtonVisible,
-            downloadButtonVisible,
+            actions,
             saveClassName,
             saveFileName,
             saveTitleAttr,

--- a/web/src/Web.App/ViewModels/Components/PageActionsViewModel.cs
+++ b/web/src/Web.App/ViewModels/Components/PageActionsViewModel.cs
@@ -4,8 +4,7 @@ using Microsoft.Extensions.Primitives;
 namespace Web.App.ViewModels.Components;
 
 public class PageActionsViewModel(
-    bool? saveButtonVisible,
-    bool? downloadButtonVisible,
+    PageActions[]? actions,
     string? saveClassName,
     string? saveFileName,
     string? saveTitleAttr,
@@ -13,8 +12,7 @@ public class PageActionsViewModel(
     string? waitForEventType,
     string? downloadLink)
 {
-    public bool SaveButtonVisible { get; init; } = saveButtonVisible == true;
-    public bool DownloadButtonVisible { get; init; } = downloadButtonVisible == true;
+    public PageActions[] Actions => actions ?? [];
 
     public string SaveClassName { get; init; } = saveClassName ?? "chart-wrapper";
     public string SaveFileName { get; init; } = saveFileName ?? "charts.zip";

--- a/web/src/Web.App/Views/SchoolCensus/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolCensus/Index.cshtml
@@ -11,7 +11,7 @@
 {
     @await Component.InvokeAsync("PageActions", new
     {
-        downloadButtonVisible = true,
+        actions = new[] { PageActions.DownloadData },
         downloadLink = Url.ActionLink("Download", "SchoolCensus", new
         {
             urn = Model.Urn,

--- a/web/src/Web.App/Views/SchoolComparison/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/Index.cshtml
@@ -1,6 +1,5 @@
 ﻿@using Newtonsoft.Json
 @using Web.App.Extensions
-
 @model Web.App.ViewModels.SchoolComparisonViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.Comparison;
@@ -19,8 +18,7 @@
 {
     @await Component.InvokeAsync("PageActions", new
     {
-        saveButtonVisible = true,
-        downloadButtonVisible = true,
+        actions = new[] { PageActions.SaveChartImages, PageActions.DownloadData },
         saveClassName = "costs-chart-wrapper",
         saveTitleAttr = "data-title",
         saveFileName = $"benchmark-spending-{Model.Urn}.zip",

--- a/web/src/Web.App/Views/SchoolSpending/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/Index.cshtml
@@ -7,7 +7,7 @@
 {
     @await Component.InvokeAsync("PageActions", new
     {
-        saveButtonVisible = true,
+        actions = new[] { PageActions.SaveChartImages },
         saveClassName = "costs-chart-wrapper",
         saveFileName = $"spending-priorities-{Model.Urn}.zip",
         saveTitleAttr = "data-title",

--- a/web/src/Web.App/Views/SchoolSpending/IndexSsr.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/IndexSsr.cshtml
@@ -8,7 +8,7 @@
 {
     @await Component.InvokeAsync("PageActionsSsr", new
     {
-        saveButtonVisible = true,
+        actions = new[] { PageActions.SaveChartImages },
         saveClassName = "costs-chart-wrapper",
         saveFileName = $"spending-priorities-{Model.Urn}.zip",
         saveTitleAttr = "data-title",

--- a/web/src/Web.App/Views/Shared/Components/PageActions/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/PageActions/Default.cshtml
@@ -2,46 +2,51 @@
 
 <div class="page-actions-wrapper">
     <div class="page-actions">
-        @if (Model.SaveButtonVisible)
+        @* ReSharper disable once SwitchStatementHandlesSomeKnownEnumValuesWithDefault *@
+        @foreach (var action in Model.Actions)
         {
-            <div
-                data-launch-modal
-                data-modal-name="modal-save-images"
-                data-element-class-name="@Model.SaveClassName"
-                data-button-label="Save chart images"
-                data-modal-title="Save chart images"
-                data-element-title-attr="@Model.SaveTitleAttr"
-                data-cost-codes-attr="@Model.CostCodesAttr"
-                data-show-titles="true"
-                data-show-progress="true"
-                data-file-name="@Model.SaveFileName"
-                data-save-event-id="save-chart-as-image"
-                data-main-content-id="main-content"
-                data-wait-for-event-type="@Model.WaitForEventType"
-                class="page-action">
-                <button
-                    class="govuk-button govuk-button--secondary"
-                    data-module="govuk-button"
-                    aria-disabled="true"
-                    disabled="disabled">Save chart images
-                </button>
-            </div>
-        }
-        @if (Model.DownloadButtonVisible)
-        {
-            <form class="page-action" method="get" action="@Model.DownloadAction">
-                @foreach (var item in Model.DownloadParameters)
-                {
-                    <input type="hidden" name="@item.Key" value="@item.Value"/>
-                }
-                <button
-                    class="govuk-button govuk-button--secondary"
-                    data-module="govuk-button"
-                    type="submit"
-                    data-custom-event-id="download-page-data">
-                    Download page data
-                </button>
-            </form>
+            switch (action)
+            {
+                case PageActions.SaveChartImages:
+                    <div
+                        data-launch-modal
+                        data-modal-name="modal-save-images"
+                        data-element-class-name="@Model.SaveClassName"
+                        data-button-label="Save chart images"
+                        data-modal-title="Save chart images"
+                        data-element-title-attr="@Model.SaveTitleAttr"
+                        data-cost-codes-attr="@Model.CostCodesAttr"
+                        data-show-titles="true"
+                        data-show-progress="true"
+                        data-file-name="@Model.SaveFileName"
+                        data-save-event-id="save-chart-as-image"
+                        data-main-content-id="main-content"
+                        data-wait-for-event-type="@Model.WaitForEventType"
+                        class="page-action">
+                        <button
+                            class="govuk-button govuk-button--secondary"
+                            data-module="govuk-button"
+                            aria-disabled="true"
+                            disabled="disabled">Save chart images
+                        </button>
+                    </div>
+                    break;
+                case PageActions.DownloadData:
+                    <form class="page-action" method="get" action="@Model.DownloadAction">
+                        @foreach (var item in Model.DownloadParameters)
+                        {
+                            <input type="hidden" name="@item.Key" value="@item.Value"/>
+                        }
+                        <button
+                            class="govuk-button govuk-button--secondary"
+                            data-module="govuk-button"
+                            type="submit"
+                            data-custom-event-id="download-page-data">
+                            Download page data
+                        </button>
+                    </form>
+                    break;
+            }
         }
     </div>
 </div>

--- a/web/src/Web.App/Views/Shared/Components/PageActionsSsr/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/PageActionsSsr/Default.cshtml
@@ -2,9 +2,15 @@
 
 <div class="page-actions-wrapper">
     <div class="page-actions">
-        @if (Model.SaveButtonVisible)
+        @* ReSharper disable once SwitchStatementHandlesSomeKnownEnumValuesWithDefault *@
+        @foreach (var action in Model.Actions)
         {
-            <div id="page-actions-button"></div>
+            switch (action)
+            {
+                case PageActions.SaveChartImages:
+                    <div id="page-actions-button"></div>
+                    break;
+            }
         }
     </div>
 </div>

--- a/web/src/Web.App/Views/TrustComparison/Index.cshtml
+++ b/web/src/Web.App/Views/TrustComparison/Index.cshtml
@@ -8,7 +8,7 @@
 
 @await Component.InvokeAsync("PageActions", new
 {
-    saveButtonVisible = true,
+    actions = new[] { PageActions.SaveChartImages },
     saveFileName = $"benchmark-spending-{Model.CompanyNumber}.zip",
     saveClassName = "costs-chart-wrapper",
     saveTitleAttr = "data-title",
@@ -44,7 +44,7 @@
 
 @await Component.InvokeAsync("TrustFinanceTools", new
 {
-    identifier = Model.CompanyNumber, 
+    identifier = Model.CompanyNumber,
     tools = new[]
     {
         FinanceTools.BenchmarkCensus,


### PR DESCRIPTION
### Context
AB#258039 AB#262307

### Change proposed in this pull request
- Replaced boolean `saveButtonVisible` and `downloadButtonVisible` parameters in page actions view models with optional array of `PageActions` enum values
- Updated consuming views to loop through and render content in the presence of each `PageActions` enum instead of reading from the original booleans

### Guidance to review 
Functionally, this change should not have any adverse effect on the user experience.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

