### PR TITLE
Ensured E2E tests pass when chart SSR flag enabled or disabled

### DIFF
--- a/web/tests/Web.E2ETests/Pages/School/SpendingCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/SpendingCostsPage.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Playwright;
+﻿using System.Text.RegularExpressions;
+using Microsoft.Playwright;
 using Xunit;
 
 namespace Web.E2ETests.Pages.School;
@@ -39,8 +40,8 @@ public partial class SpendingCostsPage(IPage page)
             });
 
     private ILocator PageH3Headings => page.Locator(Selectors.H3);
-    private ILocator AllCharts => page.Locator(Selectors.ReactChartContainer);
-    private ILocator AllChartsStats => page.Locator(Selectors.ReactChartStats);
+    private ILocator AllCharts => page.Locator(Selectors.ChartContainer);
+    private ILocator AllChartsStats => page.Locator(Selectors.ChartStats);
 
     private ILocator TeachingAndTeachingSupplyStaffLink => page.Locator(Selectors.GovLink,
         new PageLocatorOptions
@@ -261,6 +262,12 @@ public partial class SpendingCostsPage(IPage page)
             var suffixElement = wrapper.Locator(".chart-stat-suffix");
             var label = (await labelElement.TextContentAsync())?.Trim();
             var value = (await valueElement.TextContentAsync())?.Trim();
+
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                value = MultipleWhitespaceRegex().Replace(value, string.Empty);
+            }
+
             var suffix = (await suffixElement.TextContentAsync())?.Trim();
             if (!string.IsNullOrEmpty(label) && value != null && suffix != null)
             {
@@ -313,4 +320,7 @@ public partial class SpendingCostsPage(IPage page)
             Assert.Contains(expectedHeading, allContent);
         }
     }
+
+    [GeneratedRegex("\\s{2,}")]
+    private static partial Regex MultipleWhitespaceRegex();
 }

--- a/web/tests/Web.E2ETests/Pages/Trust/Benchmarking/TrustBenchmarkSpendingPage.cs
+++ b/web/tests/Web.E2ETests/Pages/Trust/Benchmarking/TrustBenchmarkSpendingPage.cs
@@ -28,7 +28,7 @@ public class TrustBenchmarkSpendingPage(IPage page)
     private ILocator CateringServicesDimension => page.Locator(Selectors.CateringServicesDimension);
     private ILocator OtherDimension => page.Locator(Selectors.OtherDimension);
     private ILocator Sections => page.Locator(Selectors.GovAccordionSection);
-    private ILocator AllCharts => page.Locator(Selectors.ReactChartContainer);
+    private ILocator AllCharts => page.Locator(Selectors.ChartContainer);
     private ILocator ViewAsTableRadio => page.Locator(Selectors.SpendingModeTable);
     private ILocator ExcludeCentralSpendingRadio => page.Locator(Selectors.CentralSpendingModeExclude);
     private ILocator TrustComparisonTitles => page.Locator(Selectors.TrustComparisonTitles);

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -99,8 +99,8 @@ public static class Selectors
     public const string TrustSearchInput = "#trust-input";
     public const string SearchTermInput = "#__Term";
 
-    public const string ReactChartContainer = ".recharts-responsive-container";
-    public const string ReactChartStats = ".chart-stat-summary";
+    public const string ChartContainer = ".costs-chart-wrapper";
+    public const string ChartStats = ".chart-stat-summary";
     public const string AdditionalDetailsPopUps = ".recharts-wrapper .recharts-tooltip-wrapper";
     public const string SchoolNamesLinksInCharts = ".recharts-text .govuk-link";
     public const string ChartBars = ".recharts-surface path.recharts-rectangle.chart-cell";


### PR DESCRIPTION
### Context
[AB#258039](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/258039) [AB#260352](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/260352)

### Change proposed in this pull request
E2E test updates to ensure successful runs with/without the feature flag.

### Guidance to review 
Toggle state of feature flag locally and run the E2E test suite to validate. Most worked out-of-the box, bar some selector changes and whitespace trimming.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

