### PR TITLE
Resolved y-axis domain issue when single value being rendered to line chart

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -100,8 +100,8 @@
       data-phases='["Secondary","Primary","Post-16"]'
     ></div>-->
     <!--<div id="compare-your-costs" data-type="school" data-id="150203" data-suppress-negative-or-zero="true"></div>-->
-    <!--<div id="historic-data" data-type="school" data-id="990095"></div>-->
-    <!--<div id="historic-data-2" data-type="school" data-id="123456" data-phase="Primary" data-finance-type="Maintained"></div>-->
+    <!--<div id="historic-data" data-type="school" data-id="150963"></div>-->
+    <div id="historic-data-2" data-type="school" data-id="150963" data-phase="Primary" data-finance-type="Maintained"></div>
     <!--<div
       id="compare-your-costs"
       data-type="local-authority"
@@ -150,7 +150,7 @@
     </svg> -->
     <!-- <div id="la-national-rank" data-code="942"></div> -->
     <!--<div id="historic-data-high-needs" data-code="201"></div>-->
-    <div id="benchmark-data-high-needs" data-code="201" data-set='["202", "203", "204"]' data-edit-link="/edit-link"></div>
+    <!--<div id="benchmark-data-high-needs" data-code="201" data-set='["202", "203", "204"]' data-edit-link="/edit-link"></div>-->
     <!-- <div id="historic-data" data-type="school" data-id="114504"></div> -->
     <script type="module" src="/src/main.tsx"></script>
     <script


### PR DESCRIPTION
### Context
[AB#233948](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/233948) [AB#262258](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/262258)

### Change proposed in this pull request
Fix to y-axis domain under certain scenarios described in the related work item.

### Guidance to review 
Run Web and Platform APIs locally (targeting `d01`) and spin up the Vite dev server to validate the fix for a new school in 2023-4 academic year. `Web` will need `front-end` bump in future PR to pull in the above fix.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

