### PR TITLE
Added static High needs glossary page

### DIFF
--- a/web/src/Web.App/Constants/PageTitles.cs
+++ b/web/src/Web.App/Constants/PageTitles.cs
@@ -83,4 +83,5 @@ public static class PageTitles
     public const string ForecastAndRisks = "Forecast and risks";
     public const string CostCategories = "Cost category breakdown";
     public const string SchoolFinancialBenchmarkingInsightsSummary = "Financial Benchmarking and Insights Summary";
+    public const string HighNeedsGlossary = "High needs benchmarking glossary";
 }

--- a/web/src/Web.App/Controllers/StaticContentController.cs
+++ b/web/src/Web.App/Controllers/StaticContentController.cs
@@ -1,4 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
+using Web.App.ViewModels;
+
 namespace Web.App.Controllers;
 
 [Controller]
@@ -56,5 +58,15 @@ public class StaticContentController : Controller
 
     [HttpGet]
     [Route("guidance/cost-categories")]
-    public IActionResult CostCategories() => View();
+    public IActionResult CostCategories()
+    {
+        return View();
+    }
+
+    [HttpGet]
+    [Route("guidance/high-needs-glossary")]
+    public IActionResult HighNeedsGlossary()
+    {
+        return View(new HighNeedsGlossaryViewModel());
+    }
 }

--- a/web/src/Web.App/ViewModels/HighNeedsGlossaryViewModel.cs
+++ b/web/src/Web.App/ViewModels/HighNeedsGlossaryViewModel.cs
@@ -1,0 +1,19 @@
+namespace Web.App.ViewModels;
+
+public class HighNeedsGlossaryViewModel
+{
+    public HighNeedsGlossaryItem[] Glossary =>
+    [
+        new()
+        {
+            Term = "AAR",
+            Meaning = "Academy Accounts Return"
+        }
+    ];
+}
+
+public class HighNeedsGlossaryItem
+{
+    public string? Term { get; init; }
+    public string? Meaning { get; init; }
+}

--- a/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsHelp/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsHelp/Default.cshtml
@@ -1,7 +1,7 @@
 ﻿<div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-        <h2 class="govuk-heading-m">Help & support</h2>
-        <ul class="app-links app-links-two-columns">
+        <h2 class="govuk-heading-m">Help &amp; support</h2>
+        <ul class="app-links app-links-three-columns">
             <li>
                 <h3 class="govuk-heading-s">Frameworks</h3>
                 <ul class="govuk-list">
@@ -16,9 +16,9 @@
                         <a
                             href="https://www.gov.uk/government/publications/high-needs-budgets-effective-management-in-local-authorities"
                             class="govuk-link govuk-link--no-visited-state">
-                            High needs budgets: effective management in LA's
+                            High needs budgets: effective management in LAs
                         </a>
-                    </li>                    
+                    </li>
                 </ul>
             </li>
             <li>
@@ -44,7 +44,7 @@
                             class="govuk-link govuk-link--no-visited-state">
                             Section 251 (budget)
                         </a>
-                    </li>                    
+                    </li>
                     <li>
                         <a
                             href="https://www.gov.uk/government/publications/local-authority-interactive-tool-lait"
@@ -58,6 +58,16 @@
                             class="govuk-link govuk-link--no-visited-state">
                             Population
                         </a>
+                    </li>
+                </ul>
+            </li>
+            <li>
+                <h3 class="govuk-heading-s">Guidance</h3>
+                <ul class="govuk-list">
+                    <li>
+                        <a href="@Url.ActionLink("HighNeedsGlossary", "StaticContent")" class="govuk-link"
+                           rel="noreferrer noopener" target="_blank" id="high-needs-glossary">Glossary of terms
+                            (opens in new tab)</a>
                     </li>
                 </ul>
             </li>

--- a/web/src/Web.App/Views/StaticContent/HighNeedsGlossary.cshtml
+++ b/web/src/Web.App/Views/StaticContent/HighNeedsGlossary.cshtml
@@ -1,0 +1,36 @@
+﻿@using Web.App.Extensions
+@model Web.App.ViewModels.HighNeedsGlossaryViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.HighNeedsGlossary;
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <h1 class="govuk-heading-l">@PageTitles.HighNeedsGlossary</h1>
+
+        <p class="govuk-body">
+            The table details some of the terms used in the high needs benchmarking service.
+        </p>
+
+        <table class="govuk-table">
+            <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden">High needs benchmarking
+                glossary
+            </caption>
+            <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Term</th>
+                <th scope="col" class="govuk-table__header">Meaning</th>
+            </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+            @foreach (var item in Model.Glossary)
+            {
+                <tr class="govuk-table__row" id="high-needs-glossary-@item.Term?.ToSlug()">
+                    <td class="govuk-table__cell">@item.Term</td>
+                    <td class="govuk-table__cell">@item.Meaning</td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/web/tests/Web.A11yTests/Pages/WhenViewingCostCategoriesGuidance.cs
+++ b/web/tests/Web.A11yTests/Pages/WhenViewingCostCategoriesGuidance.cs
@@ -1,0 +1,20 @@
+using Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Web.A11yTests.Pages;
+
+public class WhenViewingCostCategoriesGuidance(
+    ITestOutputHelper testOutputHelper,
+    WebDriver webDriver)
+    : PageBase(testOutputHelper, webDriver)
+{
+    protected override string PageUrl => "/guidance/cost-categories";
+
+    [Fact]
+    public async Task ThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await EvaluatePage();
+    }
+}

--- a/web/tests/Web.A11yTests/Pages/WhenViewingHighNeedsGlossary.cs
+++ b/web/tests/Web.A11yTests/Pages/WhenViewingHighNeedsGlossary.cs
@@ -1,0 +1,20 @@
+using Web.A11yTests.Drivers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Web.A11yTests.Pages;
+
+public class WhenViewingHighNeedsGlossary(
+    ITestOutputHelper testOutputHelper,
+    WebDriver webDriver)
+    : PageBase(testOutputHelper, webDriver)
+{
+    protected override string PageUrl => "/guidance/high-needs-glossary";
+
+    [Fact]
+    public async Task ThenThereAreNoAccessibilityIssues()
+    {
+        await GoToPage();
+        await EvaluatePage();
+    }
+}

--- a/web/tests/Web.E2ETests/Features/HighNeedsGlossary.feature
+++ b/web/tests/Web.E2ETests/Features/HighNeedsGlossary.feature
@@ -1,0 +1,5 @@
+﻿Feature: High needs glossary
+
+    Scenario: Terms displayed in the glossary table
+        Given I am on high needs glossary page
+        Then there are 1 items in the glossary

--- a/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsDashboard.feature
+++ b/web/tests/Web.E2ETests/Features/LocalAuthority/HighNeedsDashboard.feature
@@ -17,3 +17,9 @@
         Given I am on local authority high needs dashboard for local authority with code '204'
         When I click on view historic data
         Then the historic data page is displayed
+
+    @HighNeedsFlagEnabled
+    Scenario: Go to glossary of terms
+        Given I am on local authority high needs dashboard for local authority with code '204'
+        When I click on Glossary of terms link
+        Then the high needs glossary page is displayed

--- a/web/tests/Web.E2ETests/Pages/HighNeedsGlossaryPage.cs
+++ b/web/tests/Web.E2ETests/Pages/HighNeedsGlossaryPage.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Playwright;
+using Xunit;
+
+namespace Web.E2ETests.Pages;
+
+public class HighNeedsGlossaryPage(IPage page) : BasePage(page)
+{
+    private readonly IPage _page = page;
+
+    public override async Task IsDisplayed()
+    {
+        await PageH1Heading.ShouldBeVisible();
+    }
+
+    public async Task AssertGlossary(int count)
+    {
+        var glossaryRows = _page.Locator("[id^=high-needs-glossary-]");
+        var actualCount = await glossaryRows.CountAsync();
+        Assert.Equal(count, actualCount);
+    }
+}

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsDashboardPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsDashboardPage.cs
@@ -75,4 +75,11 @@ public class HighNeedsDashboardPage(IPage page)
         await ViewHistoricDataButton.Click();
         return new HighNeedsHistoricDataPage(page);
     }
+
+    public async Task<HighNeedsGlossaryPage> ClickOnHighNeedsGlossaryLink()
+    {
+        await page.Locator("#high-needs-glossary").ClickAsync();
+        await page.BringToFrontAsync();
+        return new HighNeedsGlossaryPage(page);
+    }
 }

--- a/web/tests/Web.E2ETests/Steps/HighNeedsGlossarySteps.cs
+++ b/web/tests/Web.E2ETests/Steps/HighNeedsGlossarySteps.cs
@@ -1,0 +1,35 @@
+﻿using Web.E2ETests.Drivers;
+using Web.E2ETests.Pages;
+using Xunit;
+
+namespace Web.E2ETests.Steps;
+
+[Binding]
+[Scope(Feature = "High needs glossary")]
+public class HighNeedsGlossarySteps(PageDriver driver)
+{
+    private HighNeedsGlossaryPage? _highNeedsGlossaryPage;
+
+    [Given("I am on high needs glossary page")]
+    public async Task GivenIAmOnHighNeedsGlossaryPage()
+    {
+        var url = HighNeedsGlossaryUrl();
+        var page = await driver.Current;
+        await page.GotoAndWaitForLoadAsync(url);
+
+        _highNeedsGlossaryPage = new HighNeedsGlossaryPage(page);
+        await _highNeedsGlossaryPage.IsDisplayed();
+    }
+
+    [Then("there are (.*) items in the glossary")]
+    public async Task ThenThereAreItemsInTheGlossary(int count)
+    {
+        Assert.NotNull(_highNeedsGlossaryPage);
+        await _highNeedsGlossaryPage.AssertGlossary(count);
+    }
+
+    private static string HighNeedsGlossaryUrl()
+    {
+        return $"{TestConfiguration.ServiceUrl}/guidance/high-needs-glossary";
+    }
+}

--- a/web/tests/Web.E2ETests/Steps/LocalAuthority/HighNeedsDashboardSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/LocalAuthority/HighNeedsDashboardSteps.cs
@@ -1,4 +1,5 @@
 using Web.E2ETests.Drivers;
+using Web.E2ETests.Pages;
 using Web.E2ETests.Pages.LocalAuthority;
 using Xunit;
 
@@ -9,6 +10,7 @@ namespace Web.E2ETests.Steps.LocalAuthority;
 public class HighNeedsBenchmarkingDashboardSteps(PageDriver driver)
 {
     private HighNeedsDashboardPage? _highNeedsBenchmarkingPage;
+    private HighNeedsGlossaryPage? _highNeedsGlossaryPage;
     private HighNeedsHistoricDataPage? _highNeedsHistoricDataPage;
     private HighNeedsNationalRankingsPage? _highNeedsNationalRankingsPage;
     private HighNeedsStartBenchmarkingPage? _highNeedsStartBenchmarkingPage;
@@ -45,6 +47,13 @@ public class HighNeedsBenchmarkingDashboardSteps(PageDriver driver)
         _highNeedsHistoricDataPage = await _highNeedsBenchmarkingPage.ClickViewHistoricData();
     }
 
+    [When("I click on Glossary of terms link")]
+    public async Task WhenIClickOnGlossaryOfTermsLink()
+    {
+        Assert.NotNull(_highNeedsBenchmarkingPage);
+        _highNeedsGlossaryPage = await _highNeedsBenchmarkingPage.ClickOnHighNeedsGlossaryLink();
+    }
+
     [Then("the start benchmarking page is displayed")]
     public async Task ThenTheStartBenchmarkingPageIsDisplayed()
     {
@@ -64,6 +73,13 @@ public class HighNeedsBenchmarkingDashboardSteps(PageDriver driver)
     {
         Assert.NotNull(_highNeedsHistoricDataPage);
         await _highNeedsHistoricDataPage.IsDisplayed();
+    }
+
+    [Then("the high needs glossary page is displayed")]
+    public async Task ThenTheHighNeedsGlossaryPageIsDisplayed()
+    {
+        Assert.NotNull(_highNeedsGlossaryPage);
+        await _highNeedsGlossaryPage.IsDisplayed();
     }
 
     private static string LocalAuthorityHighNeedsDashboardUrl(string laCode)


### PR DESCRIPTION
### Context
[AB#260743](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/260743) [AB#263948](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/263948)

### Change proposed in this pull request
- Added static High needs glossary page
- E2E and A11y coverage

### Guidance to review 
This first pass adds the page and link from the High needs dashboard. Subsequent PR to populate the actual glossary with supplied content.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

