### PR TITLE
Added conditional SEND content to 'how we chose schools' commentary

### DIFF
--- a/web/src/Web.App/Domain/OverallPhaseTypes.cs
+++ b/web/src/Web.App/Domain/OverallPhaseTypes.cs
@@ -1,7 +1,5 @@
-using System.Diagnostics.CodeAnalysis;
 namespace Web.App.Domain;
 
-[ExcludeFromCodeCoverage]
 public static class OverallPhaseTypes
 {
     public const string Primary = "Primary";
@@ -36,5 +34,12 @@ public static class OverallPhaseTypes
         PostSixteen,
         AlternativeProvision,
         UniversityTechnicalCollege
+    ];
+
+    public static string[] SendCharacteristicsPhases =>
+    [
+        Special,
+        PupilReferralUnit,
+        AlternativeProvision
     ];
 }

--- a/web/src/Web.App/ViewModels/ComparatorCharacteristicsCommentaryViewModel.cs
+++ b/web/src/Web.App/ViewModels/ComparatorCharacteristicsCommentaryViewModel.cs
@@ -1,0 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
+using Web.App.Domain;
+
+namespace Web.App.ViewModels;
+
+[ExcludeFromCodeCoverage]
+public class ComparatorCharacteristicsCommentaryViewModel(string? overallPhase, bool? showTitle = false)
+{
+    public bool HasSendCharacteristics => OverallPhaseTypes.SendCharacteristicsPhases.Contains(overallPhase);
+    public bool ShowTitle => showTitle ?? false;
+}

--- a/web/src/Web.App/ViewModels/SchoolComparatorsViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolComparatorsViewModel.cs
@@ -1,7 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
 using Web.App.Domain;
 
 namespace Web.App.ViewModels;
 
+[ExcludeFromCodeCoverage]
 public class SchoolComparatorsViewModel(
     School school,
     string? by = null,
@@ -16,6 +18,7 @@ public class SchoolComparatorsViewModel(
     public string? By => by;
     public string? UserDefinedSetId => userDefinedSetId;
     public bool HasCustomData => hasCustomData;
+    public string? OverallPhase => school.OverallPhase;
     public IEnumerable<SchoolCharacteristicPupil> PupilSchools => pupil ?? [];
     public IEnumerable<SchoolCharacteristicBuilding> BuildingSchools => building ?? [];
     public IEnumerable<SchoolCharacteristicUserDefined> UserDefinedSchools => userDefined ?? [];

--- a/web/src/Web.App/Views/SchoolComparators/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolComparators/Index.cshtml
@@ -1,6 +1,5 @@
-﻿@using Microsoft.FeatureManagement.Mvc.TagHelpers
-@using Web.App.Extensions
-@using Web.App.TagHelpers
+﻿@using Web.App.Extensions
+@using Web.App.ViewModels
 @model Web.App.ViewModels.SchoolComparatorsViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.SchoolComparators;
@@ -51,10 +50,10 @@
             </ul>
             <div class="govuk-tabs__panel" id="running">
                 <h2 class="govuk-heading-l">Running cost categories</h2>
-                <p class="govuk-body">We've chosen @Model.PupilSchools.Count() similar schools to benchmark this school against running cost categories, which includes all staffing (excluding premises staff), ICT, consultancy and catering.</p>
-                <h3 class="govuk-heading-m">How we chose these schools</h3>
-                <p class="govuk-body">We chose these schools based on:</p>
-                @await Html.PartialAsync("_RunningCostCategoriesList")
+                <p class="govuk-body">We've chosen @Model.PupilSchools.Count() similar schools to benchmark this school
+                    against running cost categories, which includes all staffing (excluding premises staff), ICT,
+                    consultancy and catering.</p>
+                @await Html.PartialAsync("_ComparatorCharacteristicsCommentary", new ComparatorCharacteristicsCommentaryViewModel(Model.OverallPhase, true))
                 <table class="govuk-table">
                     <caption class="govuk-table__caption govuk-table__caption--m">Schools we've chosen</caption>
                     <thead class="govuk-table__head">

--- a/web/src/Web.App/Views/SchoolComparators/Workforce.cshtml
+++ b/web/src/Web.App/Views/SchoolComparators/Workforce.cshtml
@@ -1,6 +1,5 @@
-﻿@using Microsoft.FeatureManagement.Mvc.TagHelpers
-@using Web.App.Extensions
-@using Web.App.TagHelpers
+﻿@using Web.App.Extensions
+@using Web.App.ViewModels
 @model Web.App.ViewModels.SchoolComparatorsViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.SchoolComparators;
@@ -35,10 +34,10 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-        <p class="govuk-body">We've chosen @Model.PupilSchools.Count() similar schools to benchmark this school against running cost categories, which includes all staffing (excluding premises staff), ICT, consultancy and catering.</p>
-        <h2 class="govuk-heading-m">How we chose these schools</h2>
-        <p class="govuk-body">We chose these schools based on:</p>
-        @await Html.PartialAsync("_RunningCostCategoriesList")
+        <p class="govuk-body">We've chosen @Model.PupilSchools.Count() similar schools to benchmark this school against
+            running cost categories, which includes all staffing (excluding premises staff), ICT, consultancy and
+            catering.</p>
+        @await Html.PartialAsync("_ComparatorCharacteristicsCommentary", new ComparatorCharacteristicsCommentaryViewModel(Model.OverallPhase, true))
         <table class="govuk-table">
             <caption class="govuk-table__caption govuk-table__caption--m">Schools we've chosen</caption>
             <thead class="govuk-table__head">

--- a/web/src/Web.App/Views/SchoolFinancialBenchmarkingInsightsSummary/_WhoYouAreComparedWith.cshtml
+++ b/web/src/Web.App/Views/SchoolFinancialBenchmarkingInsightsSummary/_WhoYouAreComparedWith.cshtml
@@ -1,3 +1,4 @@
+@using Web.App.ViewModels
 @model Web.App.ViewModels.SchoolFinancialBenchmarkingInsightsSummaryViewModel
 
 <section id="compared-with-section" aria-labelledby="compared-with">
@@ -14,16 +15,15 @@
     <div class="two-halves-with-divider">
         <div>
             <p class="govuk-body">
-                <strong>Running cost categories</strong> i.e. those that relate to the educational operations of the school
-                include staffing (excluding premises staff), ICT, consultancy and catering.
+                <strong>Running cost categories</strong> i.e. those that relate to the educational operations of the
+                school include staffing (excluding premises staff), ICT, consultancy and catering.
             </p>
-            <p class="govuk-body">We choose these schools based on:</p>
-            @await Html.PartialAsync("_RunningCostCategoriesList")
+            @await Html.PartialAsync("_ComparatorCharacteristicsCommentary", new ComparatorCharacteristicsCommentaryViewModel(Model.OverallPhase))
         </div>
         <div>
             <p class="govuk-body">
-                <strong>Building cost categories</strong> i.e. those that relate to the upkeep of the school premises, such
-                as utilities, cleaning and maintenance costs.
+                <strong>Building cost categories</strong> i.e. those that relate to the upkeep of the school premises,
+                such as utilities, cleaning and maintenance costs.
             </p>
             <p class="govuk-body">We choose these schools based on:</p>
             @await Html.PartialAsync("_BuildingCostCategoriesList")

--- a/web/src/Web.App/Views/Shared/_ComparatorCharacteristicsCommentary.cshtml
+++ b/web/src/Web.App/Views/Shared/_ComparatorCharacteristicsCommentary.cshtml
@@ -1,0 +1,30 @@
+@model Web.App.ViewModels.ComparatorCharacteristicsCommentaryViewModel
+@if (Model.ShowTitle)
+{
+    <h2 class="govuk-heading-m">How we chose these schools</h2>
+}
+
+<p class="govuk-body">We chose these schools based on:</p>
+<ul class="govuk-list govuk-list--bullet">
+    <li>school phase or type</li>
+    <li>region</li>
+    <li>number of pupils</li>
+    @if (Model.HasSendCharacteristics)
+    {
+        <li>pupils eligible for free school meals (FSM)</li>
+        <li>
+            pupils with special educational needs (SEN), or proportion of various SEN provisions for special schools
+        </li>
+    }
+</ul>
+
+@if (Model.HasSendCharacteristics)
+{
+    <p class="govuk-body">SEN characteristics will be taken into account when comparators are chosen, these include:</p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>communication and interaction</li>
+        <li>cognition and learning</li>
+        <li>social, emotional, and mental health (SEMH)</li>
+        <li>sensory and/or physical needs</li>
+    </ul>
+}

--- a/web/src/Web.App/Views/Shared/_RunningCostCategoriesList.cshtml
+++ b/web/src/Web.App/Views/Shared/_RunningCostCategoriesList.cshtml
@@ -1,7 +1,0 @@
-<ul class="govuk-list govuk-list--bullet">
-    <li>school phase or type</li>
-    <li>region</li>
-    <li>number of pupils</li>
-    <li>pupils eligible for free school meals (FSM)</li>
-    <li>pupils with special educational needs (SEN), or proportion of various SEN provisions for special schools</li>
-</ul>

--- a/web/tests/Web.Integration.Tests/Pages/Schools/Comparators/WhenViewingComparators.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/Comparators/WhenViewingComparators.cs
@@ -1,0 +1,166 @@
+﻿using System.Text.RegularExpressions;
+using AngleSharp.Html.Dom;
+using AutoFixture;
+using Web.App.Domain;
+using Web.App.Extensions;
+using Xunit;
+
+namespace Web.Integration.Tests.Pages.Schools.Comparators;
+
+public partial class WhenViewingComparators(SchoolBenchmarkingWebAppClient client)
+    : PageBase<SchoolBenchmarkingWebAppClient>(client)
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanDisplay(bool hasUserData)
+    {
+        var (page, school, _, _) = await SetupNavigateInitPage(hasUserData: hasUserData);
+        AssertPageLayout(page, school, hasUserData);
+    }
+
+    [Theory]
+    [InlineData(OverallPhaseTypes.Primary)]
+    [InlineData(OverallPhaseTypes.Special)]
+    public async Task CanDisplayRunningCostCategoriesTab(string overallPhase)
+    {
+        var (page, school, comparatorSet, characteristics) = await SetupNavigateInitPage(overallPhase);
+        AssertRunningCostCategoriesTab(page, school, comparatorSet, characteristics);
+    }
+
+    [Fact]
+    public async Task CanDisplayBuildingCostCategoriesTab()
+    {
+        var (page, school, comparatorSet, characteristics) = await SetupNavigateInitPage();
+        AssertBuildingCostCategories(page, school, comparatorSet, characteristics);
+    }
+
+    private async Task<(IHtmlDocument page, School school, SchoolComparatorSet comparatorSet, SchoolCharacteristic[] characteristics)> SetupNavigateInitPage(string overallPhase = OverallPhaseTypes.Primary, bool hasUserData = false)
+    {
+        var school = Fixture.Build<School>()
+            .With(x => x.URN, "123456")
+            .With(x => x.OverallPhase, overallPhase)
+            .Create();
+
+        const int comparators = 3;
+        var comparatorSet = Fixture.Build<SchoolComparatorSet>()
+            .With(c => c.Pupil, Fixture.CreateMany<string>(comparators).ToArray())
+            .With(c => c.Building, Fixture.CreateMany<string>(comparators).ToArray())
+            .Create();
+        var characteristics = Fixture.Build<SchoolCharacteristic>()
+            .CreateMany(comparators)
+            .ToArray();
+        characteristics.First().URN = school.URN;
+
+        UserData[]? userData = null;
+        if (hasUserData)
+        {
+            var customData = Fixture.Build<UserData>()
+                .With(u => u.Type, "custom-data")
+                .Create();
+            userData = [customData];
+        }
+
+        var page = await Client
+            .SetupEstablishment(school)
+            .SetupSchoolInsight(characteristics)
+            .SetupUserData(userData)
+            .SetupComparatorSet(school, comparatorSet)
+            .Navigate(Paths.SchoolComparators(school.URN));
+
+        return (page, school, comparatorSet, characteristics);
+    }
+
+    private static void AssertPageLayout(IHtmlDocument page, School school, bool hasUserData)
+    {
+        DocumentAssert.TitleAndH1(page,
+            "Schools we chose for benchmarking - Financial Benchmarking and Insights Tool - GOV.UK",
+            "Schools we chose for benchmarking");
+
+        var action = page.QuerySelector("a.govuk-link:contains('Choose your own set of schools')");
+
+        if (hasUserData)
+        {
+            Assert.Null(action);
+        }
+        else
+        {
+            DocumentAssert.Link(action, "Choose your own set of schools", Paths.SchoolComparatorsCreate(school.URN).ToAbsolute());
+        }
+    }
+
+    private static void AssertRunningCostCategoriesTab(IHtmlDocument page, School school, SchoolComparatorSet comparatorSet, SchoolCharacteristic[] characteristics)
+    {
+        var tab = page.QuerySelector("#running");
+        Assert.NotNull(tab);
+
+        var intro = tab.QuerySelectorAll(".govuk-body").FirstOrDefault();
+        Assert.NotNull(intro);
+        Assert.Contains($"We've chosen {comparatorSet.Pupil.Length} similar schools", intro.TextContent);
+
+        var howList = tab.QuerySelectorAll(".govuk-list").ElementAtOrDefault(0);
+        Assert.NotNull(howList);
+        var howListItems = howList.QuerySelectorAll("li");
+        Assert.Equal(OverallPhaseTypes.SendCharacteristicsPhases.Contains(school.OverallPhase) ? 5 : 3, howListItems.Length);
+
+        var senList = tab.QuerySelectorAll(".govuk-list").ElementAtOrDefault(1);
+        if (OverallPhaseTypes.SendCharacteristicsPhases.Contains(school.OverallPhase))
+        {
+            Assert.NotNull(senList);
+            var senListItems = senList.QuerySelectorAll("li");
+            Assert.Equal(4, senListItems.Length);
+        }
+        else
+        {
+            Assert.Null(senList);
+        }
+
+        var table = tab.QuerySelector(".govuk-table");
+        Assert.NotNull(table);
+        var tableRows = table.QuerySelectorAll("tbody > tr");
+        Assert.Equal(characteristics.Length, tableRows.Length);
+
+        for (var i = 0; i < characteristics.Length; i++)
+        {
+            var comparator = characteristics.ElementAt(i);
+            var actualRow = tableRows.ElementAt(i);
+
+            Assert.Equal(
+                $"{comparator.SchoolName} {(comparator.URN == school.URN ? "(Your chosen school)" : comparator.Address)} {comparator.OverallPhase} {comparator.TotalPupils} {comparator.PercentSpecialEducationNeeds}% {comparator.PercentFreeSchoolMeals}%",
+                MultipleWhitespaceRegex().Replace(actualRow.TextContent.Trim(), " "));
+        }
+    }
+
+    private static void AssertBuildingCostCategories(IHtmlDocument page, School school, SchoolComparatorSet comparatorSet, SchoolCharacteristic[] characteristics)
+    {
+        var tab = page.QuerySelector("#building");
+        Assert.NotNull(tab);
+
+        var intro = tab.QuerySelectorAll(".govuk-body").FirstOrDefault();
+        Assert.NotNull(intro);
+        Assert.Contains($"We've chosen {comparatorSet.Building.Length} similar schools", intro.TextContent);
+
+        var howList = tab.QuerySelectorAll(".govuk-list").ElementAtOrDefault(0);
+        Assert.NotNull(howList);
+        var howListItems = howList.QuerySelectorAll("li");
+        Assert.Equal(5, howListItems.Length);
+
+        var table = tab.QuerySelector(".govuk-table");
+        Assert.NotNull(table);
+        var tableRows = table.QuerySelectorAll("tbody > tr");
+        Assert.Equal(characteristics.Length, tableRows.Length);
+
+        for (var i = 0; i < characteristics.Length; i++)
+        {
+            var comparator = characteristics.ElementAt(i);
+            var actualRow = tableRows.ElementAt(i);
+
+            Assert.Equal(
+                $"{comparator.SchoolName} {(comparator.URN == school.URN ? "(Your chosen school)" : comparator.Address)} {comparator.OverallPhase} {comparator.TotalPupils} {comparator.TotalInternalFloorArea:F1} {comparator.BuildingAverageAge.ToAge()}",
+                MultipleWhitespaceRegex().Replace(actualRow.TextContent.Trim(), " "));
+        }
+    }
+
+    [GeneratedRegex("\\s{2,}")]
+    private static partial Regex MultipleWhitespaceRegex();
+}

--- a/web/tests/Web.Tests/Domain/GivenAnOverallPhaseTypes.cs
+++ b/web/tests/Web.Tests/Domain/GivenAnOverallPhaseTypes.cs
@@ -1,0 +1,62 @@
+using Web.App.Domain;
+using Xunit;
+
+namespace Web.Tests.Domain;
+
+public class GivenAnOverallPhaseTypes
+{
+    [Fact]
+    public void ShouldReturnExpectedAllPhaseTypes()
+    {
+        string[] expected =
+        [
+            OverallPhaseTypes.Primary,
+            OverallPhaseTypes.Secondary,
+            OverallPhaseTypes.Special,
+            OverallPhaseTypes.PupilReferralUnit,
+            OverallPhaseTypes.AllThrough,
+            OverallPhaseTypes.Nursery,
+            OverallPhaseTypes.PostSixteen,
+            OverallPhaseTypes.AlternativeProvision,
+            OverallPhaseTypes.UniversityTechnicalCollege
+        ];
+
+        var actual = OverallPhaseTypes.All;
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ShouldReturnExpectedAcademyPhaseTypes()
+    {
+        string[] expected =
+        [
+            OverallPhaseTypes.Primary,
+            OverallPhaseTypes.Secondary,
+            OverallPhaseTypes.Special,
+            OverallPhaseTypes.AllThrough,
+            OverallPhaseTypes.PostSixteen,
+            OverallPhaseTypes.AlternativeProvision,
+            OverallPhaseTypes.UniversityTechnicalCollege
+        ];
+
+        var actual = OverallPhaseTypes.AcademyPhases;
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ShouldReturnExpectedAcademySendCharacteristicsPhaseTypes()
+    {
+        string[] expected =
+        [
+            OverallPhaseTypes.Special,
+            OverallPhaseTypes.PupilReferralUnit,
+            OverallPhaseTypes.AlternativeProvision
+        ];
+
+        var actual = OverallPhaseTypes.SendCharacteristicsPhases;
+
+        Assert.Equal(expected, actual);
+    }
+}


### PR DESCRIPTION
### Context
AB#260808 [AB#263969](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/263969)

### Change proposed in this pull request
- Conditional content change on affected partial view
- Integration test coverage

### Guidance to review 
Browse to `/school/<URN>/comparators` with URNs for schools with different overall phases to verify the existence or not of the SEND commentary.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

