### PR TITLE
 Always display all 'chosen based on' items, regardless of school overall phase

### DIFF
--- a/web/src/Web.App/Views/Shared/_ComparatorCharacteristicsCommentary.cshtml
+++ b/web/src/Web.App/Views/Shared/_ComparatorCharacteristicsCommentary.cshtml
@@ -9,13 +9,8 @@
     <li>school phase or type</li>
     <li>region</li>
     <li>number of pupils</li>
-    @if (Model.HasSendCharacteristics)
-    {
-        <li>pupils eligible for free school meals (FSM)</li>
-        <li>
-            pupils with special educational needs (SEN), or proportion of various SEN provisions for special schools
-        </li>
-    }
+    <li>pupils eligible for free school meals (FSM)</li>
+    <li>pupils with special educational needs (SEN), or proportion of various SEN provisions for special schools</li>
 </ul>
 
 @if (Model.HasSendCharacteristics)

--- a/web/tests/Web.Integration.Tests/Pages/Schools/Comparators/WhenViewingComparators.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/Comparators/WhenViewingComparators.cs
@@ -101,7 +101,7 @@ public partial class WhenViewingComparators(SchoolBenchmarkingWebAppClient clien
         var howList = tab.QuerySelectorAll(".govuk-list").ElementAtOrDefault(0);
         Assert.NotNull(howList);
         var howListItems = howList.QuerySelectorAll("li");
-        Assert.Equal(OverallPhaseTypes.SendCharacteristicsPhases.Contains(school.OverallPhase) ? 5 : 3, howListItems.Length);
+        Assert.Equal(5, howListItems.Length);
 
         var senList = tab.QuerySelectorAll(".govuk-list").ElementAtOrDefault(1);
         if (OverallPhaseTypes.SendCharacteristicsPhases.Contains(school.OverallPhase))


### PR DESCRIPTION
### Context
[AB#260803](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/260803) [AB#263969](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/263969) #2450

### Change proposed in this pull request
Fix for incorrect implementation in #2450

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

