### PR TITLE
E2E test coverage over cost codes for School/Trust comparison

### DIFF
--- a/front-end-components/src/components/context-codes-list/component.tsx
+++ b/front-end-components/src/components/context-codes-list/component.tsx
@@ -1,17 +1,25 @@
 import { ContextCodesListProps } from "src/components/context-codes-list";
 
-export const ContextCodesList: React.FC<ContextCodesListProps> = (props) => {
-  const { codes } = props;
-
-  return (
-    codes && (
-      <ul className="app-cost-code-list">
-        {codes.map((code) => (
-          <li key={code}>
-            <strong className="govuk-tag">{code}</strong>
-          </li>
-        ))}
-      </ul>
-    )
+export const ContextCodesList: React.FC<ContextCodesListProps> = ({
+  category,
+  codes,
+}) =>
+  codes && (
+    <ul
+      className="app-cost-code-list"
+      id={
+        category
+          ? `${category.toLowerCase().replace(/\W/g, "-")}-tags`.replace(
+              /-{2,}/g,
+              "-"
+            )
+          : undefined
+      }
+    >
+      {codes.map((code) => (
+        <li key={code}>
+          <strong className="govuk-tag">{code}</strong>
+        </li>
+      ))}
+    </ul>
   );
-};

--- a/front-end-components/src/components/context-codes-list/types.tsx
+++ b/front-end-components/src/components/context-codes-list/types.tsx
@@ -1,3 +1,4 @@
 export type ContextCodesListProps = {
+  category?: string;
   codes: string[];
 };

--- a/front-end-components/src/components/cost-codes-list/component.tsx
+++ b/front-end-components/src/components/cost-codes-list/component.tsx
@@ -8,6 +8,7 @@ export const CostCodesList: React.FC<CostCodesListProps> = ({ category }) => {
   return (
     categoryCostCodes && (
       <ContextCodesList
+        category={category}
         codes={categoryCostCodes.concat(
           categoryCostCodes.length > 0 && tags ? tags : []
         )}

--- a/web/src/Web.App/package-lock.json
+++ b/web/src/Web.App/package-lock.json
@@ -5394,9 +5394,9 @@
       }
     },
     "node_modules/front-end": {
-      "version": "1.1.97",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-1.1.97.tgz",
-      "integrity": "sha1-K1fBM+kxjCtx49AldGdRRb56nmI=",
+      "version": "1.1.98",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-1.1.98.tgz",
+      "integrity": "sha1-15rxyzsoW1rQycYk0mG2vF6yFig=",
       "dependencies": {
         "accessible-autocomplete": "^3.0.0",
         "classnames": "^2.5.1",

--- a/web/tests/Web.E2ETests/Features/School/CompareYourCosts.feature
+++ b/web/tests/Web.E2ETests/Features/School/CompareYourCosts.feature
@@ -325,8 +325,91 @@ Feature: School compare your costs
         Given I am on compare your costs page for school with URN '777042'
         When I click on download data
         Then the file 'comparison-777042.zip' is downloaded
-        
-    Scenario: Cost codes are displayed
+
+    Scenario: Cost codes are displayed for maintained school
         Given I am on compare your costs page for school with URN '777042'
-        When I click on show all sections
-        Then the cost codes are present
+        Then all sections on the page have the correct cost codes:
+          | Chart name                                               | Cost codes                                                       |
+          | Total teaching and teaching support staff costs          | E01, E02, E26, E03, E27                                          |
+          | Teaching staff costs                                     | E01                                                              |
+          | Supply teaching staff costs                              | E02                                                              |
+          | Educational consultancy costs                            | E27                                                              |
+          | Educational support staff costs                          | E03                                                              |
+          | Agency supply teaching staff costs                       | E26                                                              |
+          | Total non-educational support staff costs                | E05, E07, E28a                                                   |
+          | Administrative and clerical staff costs                  | E05                                                              |
+          | Other staff costs                                        | E07                                                              |
+          | Professional services (non-curriculum) costs             | E28a                                                             |
+          | Total educational supplies costs                         | E21, E19                                                         |
+          | Examination fees costs                                   | E21                                                              |
+          | Learning resources (not ICT equipment) costs             | E19                                                              |
+          | Educational learning resources costs                     | E20                                                              |
+          | Total premises staff and service costs                   | E14, E12, E18, E04                                               |
+          | Cleaning and caretaking costs                            | E14                                                              |
+          | Maintenance of premises costs                            | E12                                                              |
+          | Other occupation costs                                   | E18                                                              |
+          | Premises staff costs                                     | E04                                                              |
+          | Total utilities costs                                    | E16, E15                                                         |
+          | Energy costs                                             | E16                                                              |
+          | Water and sewerage costs                                 | E15                                                              |
+          | Administrative supplies (Non-educational)                | E22                                                              |
+          | Total catering costs (gross)                             | E06, E25                                                         |
+          | Catering staff costs                                     | E06                                                              |
+          | Catering supplies costs                                  | E25                                                              |
+          | Total other costs                                        | E30, E13, E08, E29, E23, E28b, E17, E24, E09, E11, E10, E31, E32 |
+          | Other insurance premiums costs                           | E23                                                              |
+          | Direct revenue financing costs                           | E30                                                              |
+          | Ground maintenance costs                                 | E13                                                              |
+          | Indirect employee expenses                               | E08                                                              |
+          | Interest charges for loan and bank                       | E29                                                              |
+          | PFI charges                                              | E28b                                                             |
+          | Rent and rates costs                                     | E17                                                              |
+          | Special facilities costs                                 | E24                                                              |
+          | Staff development and training costs                     | E09                                                              |
+          | Staff-related insurance costs                            | E11                                                              |
+          | Supply teacher insurance costs                           | E10                                                              |
+          | Community focused school staff (maintained schools only) | E31                                                              |
+          | Community focused school costs (maintained schools only) | E32                                                              |
+
+    Scenario: Cost codes are displayed for academy
+        Given I am on compare your costs page for school with URN '990250'
+        Then all sections on the page have the correct cost codes:
+          | Chart name                                      | Cost codes                                                                                                    |
+          | Total teaching and teaching support staff costs | BAE010, BAE020, BAE240, BAE030, BAE230, % of central services                                                 |
+          | Teaching staff costs                            | BAE010, % of central services                                                                                 |
+          | Supply teaching staff costs                     | BAE020, % of central services                                                                                 |
+          | Educational consultancy costs                   | BAE230, % of central services                                                                                 |
+          | Educational support staff costs                 | BAE030, % of central services                                                                                 |
+          | Agency supply teaching staff costs              | BAE240, % of central services                                                                                 |
+          | Total non-educational support staff costs       | BAE040, BAE260, BAE070, BAE300, % of central services                                                         |
+          | Administrative and clerical staff costs         | BAE040, % of central services                                                                                 |
+          | Auditors costs                                  | BAE260, % of central services                                                                                 |
+          | Other staff costs                               | BAE070, % of central services                                                                                 |
+          | Professional services (non-curriculum) costs    | BAE300, % of central services                                                                                 |
+          | Total educational supplies costs                | BAE220, BAE200, % of central services                                                                         |
+          | Examination fees costs                          | BAE220, % of central services                                                                                 |
+          | Learning resources (not ICT equipment) costs    | BAE200, % of central services                                                                                 |
+          | Educational learning resources costs            | BAE210, % of central services                                                                                 |
+          | Total premises staff and service costs          | BAE130, BAE120, BAE180, BAE050, % of central services                                                         |
+          | Cleaning and caretaking costs                   | BAE130, % of central services                                                                                 |
+          | Maintenance of premises costs                   | BAE120, % of central services                                                                                 |
+          | Other occupation costs                          | BAE180, % of central services                                                                                 |
+          | Premises staff costs                            | BAE050, % of central services                                                                                 |
+          | Total utilities costs                           | BAE150, BAE140, % of central services                                                                         |
+          | Energy costs                                    | BAE150, % of central services                                                                                 |
+          | Water and sewerage costs                        | BAE140, % of central services                                                                                 |
+          | Administrative supplies (Non-educational)       | BAE280, % of central services                                                                                 |
+          | Total catering costs (gross)                    | BAE060, BAE250, % of central services                                                                         |
+          | Catering staff costs                            | BAE060, % of central services                                                                                 |
+          | Catering supplies costs                         | BAE250, % of central services                                                                                 |
+          | Total other costs                               | BAE290, BAE320, BAE080, BAE320, BAE270, BAE310, BAE160, BAE190, BAE090, BAE110, BAE100, % of central services |
+          | Direct revenue financing costs                  | BAE290, % of central services                                                                                 |
+          | Ground maintenance costs                        | BAE320, % of central services                                                                                 |
+          | Indirect employee expenses                      | BAE080, % of central services                                                                                 |
+          | Interest charges for loan and bank              | BAE320, % of central services                                                                                 |
+          | PFI charges                                     | BAE310, % of central services                                                                                 |
+          | Rent and rates costs                            | BAE160, % of central services                                                                                 |
+          | Special facilities costs                        | BAE190, % of central services                                                                                 |
+          | Staff development and training costs            | BAE090, % of central services                                                                                 |
+          | Staff-related insurance costs                   | BAE110, % of central services                                                                                 |
+          | Supply teacher insurance costs                  | BAE100, % of central services                                                                                 |

--- a/web/tests/Web.E2ETests/Features/Trust/CompareYourCosts.feature
+++ b/web/tests/Web.E2ETests/Features/Trust/CompareYourCosts.feature
@@ -150,3 +150,46 @@ Feature: Trust compare your costs
         Then the save chart images button is visible
         When I click the save chart images button
         Then the save chart images modal is visible
+
+    Scenario: Cost codes are displayed
+        Given I am on compare your costs page for trust with company number '10074054'
+        Then all sections on the page have the correct cost codes:
+          | Chart name                                      | Cost codes                                                                                                    |
+          | Total teaching and teaching support staff costs | BAE010, BAE020, BAE240, BAE030, BAE230, % of central services                                                 |
+          | Teaching staff costs                            | BAE010, % of central services                                                                                 |
+          | Supply teaching staff costs                     | BAE020, % of central services                                                                                 |
+          | Educational consultancy costs                   | BAE230, % of central services                                                                                 |
+          | Educational support staff costs                 | BAE030, % of central services                                                                                 |
+          | Agency supply teaching staff costs              | BAE240, % of central services                                                                                 |
+          | Total non-educational support staff costs       | BAE040, BAE260, BAE070, BAE300, % of central services                                                         |
+          | Administrative and clerical staff costs         | BAE040, % of central services                                                                                 |
+          | Auditors costs                                  | BAE260, % of central services                                                                                 |
+          | Other staff costs                               | BAE070, % of central services                                                                                 |
+          | Professional services (non-curriculum) costs    | BAE300, % of central services                                                                                 |
+          | Total educational supplies costs                | BAE220, BAE200, % of central services                                                                         |
+          | Examination fees costs                          | BAE220, % of central services                                                                                 |
+          | Learning resources (not ICT equipment) costs    | BAE200, % of central services                                                                                 |
+          | Educational learning resources costs            | BAE210, % of central services                                                                                 |
+          | Total premises staff and service costs          | BAE130, BAE120, BAE180, BAE050, % of central services                                                         |
+          | Cleaning and caretaking costs                   | BAE130, % of central services                                                                                 |
+          | Maintenance of premises costs                   | BAE120, % of central services                                                                                 |
+          | Other occupation costs                          | BAE180, % of central services                                                                                 |
+          | Premises staff costs                            | BAE050, % of central services                                                                                 |
+          | Total utilities costs                           | BAE150, BAE140, % of central services                                                                         |
+          | Energy costs                                    | BAE150, % of central services                                                                                 |
+          | Water and sewerage costs                        | BAE140, % of central services                                                                                 |
+          | Administrative supplies (Non-educational)       | BAE280, % of central services                                                                                 |
+          | Total catering costs (gross)                    | BAE060, BAE250, % of central services                                                                         |
+          | Catering staff costs                            | BAE060, % of central services                                                                                 |
+          | Catering supplies costs                         | BAE250, % of central services                                                                                 |
+          | Total other costs                               | BAE290, BAE320, BAE080, BAE320, BAE270, BAE310, BAE160, BAE190, BAE090, BAE110, BAE100, % of central services |
+          | Direct revenue financing costs                  | BAE290, % of central services                                                                                 |
+          | Ground maintenance costs                        | BAE320, % of central services                                                                                 |
+          | Indirect employee expenses                      | BAE080, % of central services                                                                                 |
+          | Interest charges for loan and bank              | BAE320, % of central services                                                                                 |
+          | PFI charges                                     | BAE310, % of central services                                                                                 |
+          | Rent and rates costs                            | BAE160, % of central services                                                                                 |
+          | Special facilities costs                        | BAE190, % of central services                                                                                 |
+          | Staff development and training costs            | BAE090, % of central services                                                                                 |
+          | Staff-related insurance costs                   | BAE110, % of central services                                                                                 |
+          | Supply teacher insurance costs                  | BAE100, % of central services                                                                                 |

--- a/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
@@ -473,20 +473,10 @@ public class CompareYourCostsPage(IPage page)
         Assert.True(expected.SequenceEqual(actual), $"Test fails on {chartName}. Expected: {string.Join(", ", expected)}, Actual: {string.Join(", ", actual)}");
     }
 
-    public async Task CostCodesArePresent()
+    public async Task HasCostCodesForChart(string chartName, string[] expected)
     {
-        var costCodes = await page.Locator(Selectors.CostCodesList).AllAsync();
-        Assert.Equal(42, costCodes.Count);
-
-        var costCodesWithLiChildren = await page.Locator(Selectors.CostCodesList)
-            .Filter(new() { Has = page.Locator("li") })
-            .AllAsync();
-        Assert.Equal(40, costCodesWithLiChildren.Count);
-
-        foreach (var costCodeList in costCodesWithLiChildren)
-        {
-            await costCodeList.IsVisibleAsync();
-        }
+        var costCodes = await page.Locator($"#{chartName.ToSlug()}-tags .govuk-tag").AllTextContentsAsync();
+        Assert.True(expected.SequenceEqual(costCodes), $"Test fails on {chartName}. Expected: {string.Join(", ", expected)}, Actual: {string.Join(", ", costCodes)}");
     }
 
     private ILocator ChartTable(ComparisonChartNames chartName)

--- a/web/tests/Web.E2ETests/Pages/Trust/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/Trust/CompareYourCostsPage.cs
@@ -318,6 +318,12 @@ public class CompareYourCostsPage(IPage page)
         await SaveImagesModal.ShouldBeVisible();
     }
 
+    public async Task HasCostCodesForChart(string chartName, string[] expected)
+    {
+        var costCodes = await page.Locator($"#{chartName.ToSlug()}-tags .govuk-tag").AllTextContentsAsync();
+        Assert.True(expected.SequenceEqual(costCodes), $"Test fails on {chartName}. Expected: {string.Join(", ", expected)}, Actual: {string.Join(", ", costCodes)}");
+    }
+
     private async Task IsSectionContentVisible(ComparisonChartNames chartName, bool visibility, string chartMode)
     {
         var contentLocator = chartName switch

--- a/web/tests/Web.E2ETests/Steps/School/CompareYourCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/CompareYourCostsSteps.cs
@@ -333,7 +333,7 @@ public class CompareYourCostsSteps(PageDriver driver)
     }
 
     [Then("the message stating reason for less schools is visible in '(.*)' section")]
-    public async Task ThenTheMessageStatingReasonForLessSchoolsIsVisible(string subCategorySection)
+    public async Task ThenTheMessageStatingReasonForLessSchoolsIsVisibleInSection(string subCategorySection)
     {
         Assert.NotNull(_comparisonPage);
         await _comparisonPage.IsWarningTextVisible(subCategorySection);
@@ -394,14 +394,16 @@ public class CompareYourCostsSteps(PageDriver driver)
         Assert.Equal(fileName, downloadedFilePath);
     }
 
-    [Then("the cost codes are present")]
-    public async Task ThenTheCostCodesArePresent()
+    [Then("all sections on the page have the correct cost codes:")]
+    public async Task ThenAllSectionsOnThePageHaveTheCorrectCostCodes(DataTable table)
     {
         Assert.NotNull(_comparisonPage);
 
-        await _comparisonPage.CostCodesArePresent();
+        foreach (var row in table.Rows)
+        {
+            await _comparisonPage.HasCostCodesForChart(row["Chart name"], row["Cost codes"].Split(",", StringSplitOptions.TrimEntries));
+        }
     }
-
 
     private void ChartDownloaded(string chartName)
     {

--- a/web/tests/Web.E2ETests/Steps/Trust/CompareYourCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/Trust/CompareYourCostsSteps.cs
@@ -283,6 +283,17 @@ public class CompareYourCostsSteps(PageDriver driver)
         await _comparisonPage.IsSaveImagesModalDisplayed();
     }
 
+    [Then("all sections on the page have the correct cost codes:")]
+    public async Task ThenAllSectionsOnThePageHaveTheCorrectCostCodes(DataTable table)
+    {
+        Assert.NotNull(_comparisonPage);
+
+        foreach (var row in table.Rows)
+        {
+            await _comparisonPage.HasCostCodesForChart(row["Chart name"], row["Cost codes"].Split(",", StringSplitOptions.TrimEntries));
+        }
+    }
+
     private void ChartDownloaded(string chartName)
     {
         Assert.NotNull(_download);


### PR DESCRIPTION
### Context
[AB#258231](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/258231) [AB#264306](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/264306)

### Change proposed in this pull request
E2E updates to validate cost codes on School/Academy/Trust

### Guidance to review 
`front-end` changes will need to be bumped in `Web` in order for E2E to pass.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

