### PR TITLE
Versioned recently moved Content API endpoints

### DIFF
--- a/platform/src/abstractions/Platform.Test/FunctionsTestBase.cs
+++ b/platform/src/abstractions/Platform.Test/FunctionsTestBase.cs
@@ -17,4 +17,15 @@ public class FunctionsTestBase
         var reqMock = MockHttpRequestData.Create(query, headers);
         return reqMock;
     }
+
+    protected static HttpHeadersCollection CreateVersionedHeader(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            return [];
+        }
+
+        var kvp = new KeyValuePair<string, string>("x-api-version", version);
+        return new HttpHeadersCollection([kvp]);
+    }
 }

--- a/platform/src/apis/Platform.Api.Content/Features/CommercialResources/CommercialResourcesFeature.cs
+++ b/platform/src/apis/Platform.Api.Content/Features/CommercialResources/CommercialResourcesFeature.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
+using Platform.Api.Content.Features.CommercialResources.Handlers;
 using Platform.Api.Content.Features.CommercialResources.Services;
+using Platform.Functions;
 
 namespace Platform.Api.Content.Features.CommercialResources;
 
@@ -10,6 +12,8 @@ public static class CommercialResourcesFeature
     public static IServiceCollection AddCommercialResourcesFeature(this IServiceCollection serviceCollection)
     {
         serviceCollection
+            .AddSingleton<IGetCommercialResourcesHandler, GetCommercialResourcesV1Handler>()
+            .AddSingleton<IVersionedHandlerDispatcher<IGetCommercialResourcesHandler>, VersionedHandlerDispatcher<IGetCommercialResourcesHandler>>()
             .AddSingleton<ICommercialResourcesService, CommercialResourcesService>();
 
         return serviceCollection;

--- a/platform/src/apis/Platform.Api.Content/Features/CommercialResources/GetCommercialResourcesFunction.cs
+++ b/platform/src/apis/Platform.Api.Content/Features/CommercialResources/GetCommercialResourcesFunction.cs
@@ -1,28 +1,33 @@
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.OpenApi.Models;
+using Platform.Api.Content.Features.CommercialResources.Handlers;
 using Platform.Api.Content.Features.CommercialResources.Models;
-using Platform.Api.Content.Features.CommercialResources.Services;
 using Platform.Functions;
-using Platform.Functions.Extensions;
 using Platform.Functions.OpenApi;
 
 namespace Platform.Api.Content.Features.CommercialResources;
 
-public class GetCommercialResourcesFunction(ICommercialResourcesService service)
+public class GetCommercialResourcesFunction(IVersionedHandlerDispatcher<IGetCommercialResourcesHandler> dispatcher) : VersionedFunctionBase<IGetCommercialResourcesHandler>(dispatcher)
 {
     [Function(nameof(GetCommercialResourcesFunction))]
     [OpenApiSecurityHeader]
     [OpenApiOperation(nameof(GetCommercialResourcesFunction), Constants.Features.CommercialResources)]
+    [OpenApiParameter(Functions.Constants.ApiVersion, Type = typeof(string), In = ParameterLocation.Header)]
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(CommercialResource[]))]
+    [OpenApiResponseWithBody(HttpStatusCode.BadRequest, ContentType.ApplicationJsonProblem, typeof(ProblemDetails))]
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.CommercialResources)] HttpRequestData req,
         CancellationToken cancellationToken = default)
     {
-        var result = await service.GetCommercialResources(cancellationToken);
-        return await req.CreateJsonResponseAsync(result, cancellationToken);
+        return await WithHandlerAsync(
+            req,
+            handler => handler.HandleAsync(req, cancellationToken),
+            cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Content/Features/CommercialResources/Handlers/GetCommercialResourcesV1Handler.cs
+++ b/platform/src/apis/Platform.Api.Content/Features/CommercialResources/Handlers/GetCommercialResourcesV1Handler.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Http;
+using Platform.Api.Content.Features.CommercialResources.Services;
+using Platform.Functions;
+using Platform.Functions.Extensions;
+
+namespace Platform.Api.Content.Features.CommercialResources.Handlers;
+
+public interface IGetCommercialResourcesHandler : IVersionedHandler
+{
+    Task<HttpResponseData> HandleAsync(HttpRequestData request, CancellationToken cancellationToken);
+}
+
+public class GetCommercialResourcesV1Handler(ICommercialResourcesService service) : IGetCommercialResourcesHandler
+{
+    public string Version => "1.0";
+
+    public async Task<HttpResponseData> HandleAsync(HttpRequestData request, CancellationToken cancellationToken)
+    {
+        var result = await service.GetCommercialResources(cancellationToken);
+        return await request.CreateJsonResponseAsync(result, cancellationToken);
+    }
+}

--- a/platform/src/apis/Platform.Api.Content/Features/Files/FilesFeature.cs
+++ b/platform/src/apis/Platform.Api.Content/Features/Files/FilesFeature.cs
@@ -1,6 +1,8 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
+using Platform.Api.Content.Features.Files.Handlers;
 using Platform.Api.Content.Features.Files.Services;
+using Platform.Functions;
 
 namespace Platform.Api.Content.Features.Files;
 
@@ -10,6 +12,8 @@ public static class FilesFeature
     public static IServiceCollection AddFilesFeature(this IServiceCollection serviceCollection)
     {
         serviceCollection
+            .AddSingleton<IGetTransparencyFilesHandler, GetTransparencyFilesV1Handler>()
+            .AddSingleton<IVersionedHandlerDispatcher<IGetTransparencyFilesHandler>, VersionedHandlerDispatcher<IGetTransparencyFilesHandler>>()
             .AddSingleton<IFilesService, FilesService>();
 
         return serviceCollection;

--- a/platform/src/apis/Platform.Api.Content/Features/Files/GetTransparencyFilesFunction.cs
+++ b/platform/src/apis/Platform.Api.Content/Features/Files/GetTransparencyFilesFunction.cs
@@ -1,28 +1,33 @@
 ﻿using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.OpenApi.Models;
+using Platform.Api.Content.Features.Files.Handlers;
 using Platform.Api.Content.Features.Files.Responses;
-using Platform.Api.Content.Features.Files.Services;
 using Platform.Functions;
-using Platform.Functions.Extensions;
 using Platform.Functions.OpenApi;
 
 namespace Platform.Api.Content.Features.Files;
 
-public class GetTransparencyFilesFunction(IFilesService service)
+public class GetTransparencyFilesFunction(IVersionedHandlerDispatcher<IGetTransparencyFilesHandler> dispatcher) : VersionedFunctionBase<IGetTransparencyFilesHandler>(dispatcher)
 {
     [Function(nameof(GetTransparencyFilesFunction))]
     [OpenApiSecurityHeader]
     [OpenApiOperation(nameof(GetTransparencyFilesFunction), Constants.Features.Files)]
+    [OpenApiParameter(Functions.Constants.ApiVersion, Type = typeof(string), In = ParameterLocation.Header)]
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(FileResponse[]))]
+    [OpenApiResponseWithBody(HttpStatusCode.BadRequest, ContentType.ApplicationJsonProblem, typeof(ProblemDetails))]
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.Transparency)] HttpRequestData req,
         CancellationToken cancellationToken = default)
     {
-        var result = await service.GetActiveFilesByType(cancellationToken, "transparency-aar", "transparency-cfr");
-        return await req.CreateJsonResponseAsync(result.MapToApiResponse(), cancellationToken);
+        return await WithHandlerAsync(
+            req,
+            handler => handler.HandleAsync(req, cancellationToken),
+            cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Content/Features/Files/Handlers/GetTransparencyFilesV1Handler.cs
+++ b/platform/src/apis/Platform.Api.Content/Features/Files/Handlers/GetTransparencyFilesV1Handler.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Http;
+using Platform.Api.Content.Features.Files.Services;
+using Platform.Functions;
+using Platform.Functions.Extensions;
+
+namespace Platform.Api.Content.Features.Files.Handlers;
+
+public interface IGetTransparencyFilesHandler : IVersionedHandler
+{
+    Task<HttpResponseData> HandleAsync(HttpRequestData request, CancellationToken cancellationToken);
+}
+
+public class GetTransparencyFilesV1Handler(IFilesService service) : IGetTransparencyFilesHandler
+{
+    public string Version => "1.0";
+
+    public async Task<HttpResponseData> HandleAsync(HttpRequestData request, CancellationToken cancellationToken)
+    {
+        var result = await service.GetActiveFilesByType(cancellationToken, "transparency-aar", "transparency-cfr");
+        return await request.CreateJsonResponseAsync(result.MapToApiResponse(), cancellationToken);
+    }
+}

--- a/platform/src/apis/Platform.Api.Content/Features/Files/Services/FilesService.cs
+++ b/platform/src/apis/Platform.Api.Content/Features/Files/Services/FilesService.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Platform.Api.Content.Features.Files.Models;
@@ -13,7 +12,6 @@ public interface IFilesService
     Task<IEnumerable<FileModel>> GetActiveFilesByType(CancellationToken cancellationToken = default, params string[] types);
 }
 
-[ExcludeFromCodeCoverage]
 public class FilesService(IDatabaseFactory dbFactory) : IFilesService
 {
     public async Task<IEnumerable<FileModel>> GetActiveFilesByType(CancellationToken cancellationToken = default, params string[] types)

--- a/platform/src/apis/Platform.Api.Content/Features/Years/GetCurrentReturnYearsFunction.cs
+++ b/platform/src/apis/Platform.Api.Content/Features/Years/GetCurrentReturnYearsFunction.cs
@@ -1,28 +1,33 @@
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.OpenApi.Models;
+using Platform.Api.Content.Features.Years.Handlers;
 using Platform.Api.Content.Features.Years.Models;
-using Platform.Api.Content.Features.Years.Services;
 using Platform.Functions;
-using Platform.Functions.Extensions;
 using Platform.Functions.OpenApi;
 
 namespace Platform.Api.Content.Features.Years;
 
-public class GetCurrentReturnYearsFunction(IYearsService service)
+public class GetCurrentReturnYearsFunction(IVersionedHandlerDispatcher<IGetCurrentReturnYearsHandler> dispatcher) : VersionedFunctionBase<IGetCurrentReturnYearsHandler>(dispatcher)
 {
     [Function(nameof(GetCurrentReturnYearsFunction))]
     [OpenApiSecurityHeader]
     [OpenApiOperation(nameof(GetCurrentReturnYearsFunction), Constants.Features.Years)]
+    [OpenApiParameter(Functions.Constants.ApiVersion, Type = typeof(string), In = ParameterLocation.Header)]
     [OpenApiResponseWithBody(HttpStatusCode.OK, ContentType.ApplicationJson, typeof(FinanceYears))]
+    [OpenApiResponseWithBody(HttpStatusCode.BadRequest, ContentType.ApplicationJsonProblem, typeof(ProblemDetails))]
     public async Task<HttpResponseData> RunAsync(
         [HttpTrigger(AuthorizationLevel.Admin, MethodType.Get, Route = Routes.CurrentReturn)] HttpRequestData req,
         CancellationToken cancellationToken = default)
     {
-        var result = await service.GetCurrentReturnYears(cancellationToken);
-        return await req.CreateJsonResponseAsync(result, cancellationToken);
+        return await WithHandlerAsync(
+            req,
+            handler => handler.HandleAsync(req, cancellationToken),
+            cancellationToken);
     }
 }

--- a/platform/src/apis/Platform.Api.Content/Features/Years/Handlers/GetCurrentReturnYearsHandler.cs
+++ b/platform/src/apis/Platform.Api.Content/Features/Years/Handlers/GetCurrentReturnYearsHandler.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Http;
+using Platform.Api.Content.Features.Years.Services;
+using Platform.Functions;
+using Platform.Functions.Extensions;
+
+namespace Platform.Api.Content.Features.Years.Handlers;
+
+public interface IGetCurrentReturnYearsHandler : IVersionedHandler
+{
+    Task<HttpResponseData> HandleAsync(HttpRequestData request, CancellationToken cancellationToken);
+}
+
+public class GetCurrentReturnYearsV1Handler(IYearsService service) : IGetCurrentReturnYearsHandler
+{
+    public string Version => "1.0";
+
+    public async Task<HttpResponseData> HandleAsync(HttpRequestData request, CancellationToken cancellationToken)
+    {
+        var result = await service.GetCurrentReturnYears(cancellationToken);
+        return await request.CreateJsonResponseAsync(result, cancellationToken);
+    }
+}

--- a/platform/src/apis/Platform.Api.Content/Features/Years/YearsFeature.cs
+++ b/platform/src/apis/Platform.Api.Content/Features/Years/YearsFeature.cs
@@ -1,6 +1,8 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
+using Platform.Api.Content.Features.Years.Handlers;
 using Platform.Api.Content.Features.Years.Services;
+using Platform.Functions;
 
 namespace Platform.Api.Content.Features.Years;
 
@@ -10,6 +12,8 @@ public static class YearsFeature
     public static IServiceCollection AddYearsFeature(this IServiceCollection serviceCollection)
     {
         serviceCollection
+            .AddSingleton<IGetCurrentReturnYearsHandler, GetCurrentReturnYearsV1Handler>()
+            .AddSingleton<IVersionedHandlerDispatcher<IGetCurrentReturnYearsHandler>, VersionedHandlerDispatcher<IGetCurrentReturnYearsHandler>>()
             .AddSingleton<IYearsService, YearsService>();
 
         return serviceCollection;

--- a/platform/tests/Platform.ApiTests/Features/ContentCommercialResource.feature
+++ b/platform/tests/Platform.ApiTests/Features/ContentCommercialResource.feature
@@ -4,3 +4,13 @@
         Given a valid request
         When I submit the request
         Then the result should be ok and match the expected output
+        
+    Scenario: Submit a valid request for API version 1.0
+        Given a valid request with API version '1.0'
+        When I submit the request
+        Then the result should be ok and match the expected output
+        
+    Scenario: Submit a valid request for unsupported API version
+        Given a valid request with API version 'invalid'
+        When I submit the request
+        Then the result should be bad request

--- a/platform/tests/Platform.ApiTests/Features/ContentFiles.feature
+++ b/platform/tests/Platform.ApiTests/Features/ContentFiles.feature
@@ -23,3 +23,8 @@
           | CFR 2020/21 | CFR_2020-21_Full_Data_Workbook.xlsx |
           | CFR 2021/22 | CFR_2021-22_Full_Data_Workbook.xlsx |
           | CFR 2022/23 | CFR_2022-23_Full_Data_Workbook.xlsx |
+          
+    Scenario: Sending a valid transparency files request for unsupported API version
+        Given a transparency files request with API version 'invalid'
+        When I submit the files request
+        Then the result should be bad request

--- a/platform/tests/Platform.ApiTests/Features/ContentYears.feature
+++ b/platform/tests/Platform.ApiTests/Features/ContentYears.feature
@@ -3,4 +3,22 @@
     Scenario: Sending a valid finance year request
         Given a current return years request
         When I submit the request
-        Then the current return years result should be ok
+        Then the current return years result should be:
+          | Field | Value |
+          | Aar   | 2022  |
+          | Cfr   | 2022  |
+          | S251  | 2024  |
+
+    Scenario: Sending a valid request for API version 1.0
+        Given a current return years request with API version '1.0'
+        When I submit the request
+        Then the current return years result should be:
+          | Field | Value |
+          | Aar   | 2022  |
+          | Cfr   | 2022  |
+          | S251  | 2024  |
+          
+    Scenario: Sending a valid request for unsupported API version
+        Given a current return years request with API version 'version'
+        When I submit the request
+        Then the current return years result should be bad request

--- a/platform/tests/Platform.ApiTests/Steps/ContentCommercialResourceSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/ContentCommercialResourceSteps.cs
@@ -22,6 +22,13 @@ public class ContentCommercialResourceSteps(ContentApiDriver api)
         });
     }
 
+    [Given("a valid request with API version '(.*)'")]
+    public void GivenAValidRequestWithApiVersion(string version)
+    {
+        GivenAValidRequest();
+        api[Key].Request.Headers.Add("x-api-version", version);
+    }
+
     [When("I submit the request")]
     public async Task WhenISubmitTheRequest()
     {
@@ -40,6 +47,13 @@ public class ContentCommercialResourceSteps(ContentApiDriver api)
         var expected = GetArrayData("CommercialResources.json");
 
         Assert.True(JToken.DeepEquals(expected, actual));
+    }
+
+    [Then("the result should be bad request")]
+    public void ThenTheResultShouldBeBadRequest()
+    {
+        var response = api[Key].Response;
+        AssertHttpResponse.IsBadRequest(response);
     }
 
     private static JArray GetArrayData(string file)

--- a/platform/tests/Platform.ApiTests/Steps/ContentFilesSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/ContentFilesSteps.cs
@@ -21,6 +21,13 @@ public class ContentFilesSteps(ContentApiDriver api)
         });
     }
 
+    [Given("a transparency files request with API version '(.*)'")]
+    public void GivenATransparencyFilesRequestWithApiVersion(string version)
+    {
+        GivenATransparencyFilesRequest();
+        api[FilesKey].Request.Headers.Add("x-api-version", version);
+    }
+
     [When("I submit the files request")]
     public async Task WhenISubmitTheFilesRequest()
     {
@@ -36,5 +43,12 @@ public class ContentFilesSteps(ContentApiDriver api)
         var content = await response.Content.ReadAsByteArrayAsync();
         var result = content.FromJson<FileResponse[]>();
         table.CompareToSet(result);
+    }
+
+    [Then("the result should be bad request")]
+    public void ThenTheResultShouldBeBadRequest()
+    {
+        var response = api[FilesKey].Response;
+        AssertHttpResponse.IsBadRequest(response);
     }
 }

--- a/platform/tests/Platform.ApiTests/Steps/ContentYearsSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/ContentYearsSteps.cs
@@ -1,7 +1,7 @@
-﻿using Platform.ApiTests.Assertion;
+﻿using Platform.Api.Content.Features.Years.Models;
+using Platform.ApiTests.Assertion;
 using Platform.ApiTests.Drivers;
 using Platform.Json;
-using Xunit;
 
 namespace Platform.ApiTests.Steps;
 
@@ -21,19 +21,35 @@ public class ContentYearsSteps(ContentApiDriver api)
         });
     }
 
+    [Given("a current return years request with API version '(.*)'")]
+    public void GivenACurrentReturnYearsRequestWithApiVersion(string version)
+    {
+        GivenACurrentReturnYearsRequest();
+        api[Key].Request.Headers.Add("x-api-version", version);
+    }
+
     [When("I submit the request")]
     public async Task WhenISubmitTheRequest()
     {
         await api.Send();
     }
 
-    [Then("the current return years result should be ok")]
-    public async Task ThenTheCurrentReturnYearsResultShouldBeOk()
+    [Then("the current return years result should be:")]
+    public async Task ThenTheCurrentReturnYearsResultShouldBe(DataTable table)
     {
         var response = api[Key].Response;
         AssertHttpResponse.IsOk(response);
 
         var content = await response.Content.ReadAsStringAsync();
-        Assert.Equal(new { aar = "2022", cfr = "2022", s251 = "2024" }.ToJson(), content);
+        var result = content.FromJson<FinanceYears>();
+
+        table.CompareToInstance(result);
+    }
+
+    [Then("the current return years result should be bad request")]
+    public void ThenTheCurrentReturnYearsResultShouldBeBadRequest()
+    {
+        var response = api[Key].Response;
+        AssertHttpResponse.IsBadRequest(response);
     }
 }

--- a/platform/tests/Platform.Content.Tests/CommercialResources/Functions/GetCommercialResourcesFunctionTest.cs
+++ b/platform/tests/Platform.Content.Tests/CommercialResources/Functions/GetCommercialResourcesFunctionTest.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.Azure.Functions.Worker;
+using Moq;
+using Platform.Api.Content.Features.CommercialResources;
+using Platform.Api.Content.Features.CommercialResources.Handlers;
+using Platform.Functions;
+using Platform.Test;
+using Platform.Test.Mocks;
+using Xunit;
+
+namespace Platform.Content.Tests.CommercialResources.Functions;
+
+public class GetCommercialResourcesFunctionTests : FunctionsTestBase
+{
+    private readonly Mock<IVersionedHandlerDispatcher<IGetCommercialResourcesHandler>> _dispatcher;
+    private readonly GetCommercialResourcesFunction _function;
+    private readonly Mock<IGetCommercialResourcesHandler> _handler;
+
+    public GetCommercialResourcesFunctionTests()
+    {
+        _handler = new Mock<IGetCommercialResourcesHandler>();
+        _dispatcher = new Mock<IVersionedHandlerDispatcher<IGetCommercialResourcesHandler>>();
+        _function = new GetCommercialResourcesFunction(_dispatcher.Object);
+    }
+
+    [Theory]
+    [InlineData("version")]
+    [InlineData(null)]
+    public async Task ShouldReturnHandlerResponseOnValidOrMissingVersion(string? version = null)
+    {
+        var response = new MockHttpResponseData(Mock.Of<FunctionContext>());
+
+        var request = CreateHttpRequestData(null, CreateVersionedHeader(version));
+        _dispatcher
+            .Setup(d => d.GetHandler(version))
+            .Returns(_handler.Object);
+        _handler
+            .Setup(h => h.HandleAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        var result = await _function.RunAsync(request);
+
+        Assert.Equal(response, result);
+    }
+}

--- a/platform/tests/Platform.Content.Tests/CommercialResources/Handlers/GetCommercialResourcesV1HandlerTests.cs
+++ b/platform/tests/Platform.Content.Tests/CommercialResources/Handlers/GetCommercialResourcesV1HandlerTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Net;
 using AutoFixture;
 using Moq;
-using Platform.Api.Content.Features.CommercialResources;
+using Platform.Api.Content.Features.CommercialResources.Handlers;
 using Platform.Api.Content.Features.CommercialResources.Models;
 using Platform.Api.Content.Features.CommercialResources.Services;
 using Platform.Functions;
@@ -9,18 +9,18 @@ using Platform.Test;
 using Platform.Test.Extensions;
 using Xunit;
 
-namespace Platform.Content.Tests.CommercialResources;
+namespace Platform.Content.Tests.CommercialResources.Handlers;
 
-public class GetCommercialResourcesFunctionTests : FunctionsTestBase
+public class GetCommercialResourcesV1HandlerTests : FunctionsTestBase
 {
     private readonly Fixture _fixture;
-    private readonly GetCommercialResourcesFunction _function;
+    private readonly GetCommercialResourcesV1Handler _function;
     private readonly Mock<ICommercialResourcesService> _service;
 
-    public GetCommercialResourcesFunctionTests()
+    public GetCommercialResourcesV1HandlerTests()
     {
         _service = new Mock<ICommercialResourcesService>();
-        _function = new GetCommercialResourcesFunction(_service.Object);
+        _function = new GetCommercialResourcesV1Handler(_service.Object);
         _fixture = new Fixture();
     }
 
@@ -37,7 +37,7 @@ public class GetCommercialResourcesFunctionTests : FunctionsTestBase
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(models);
 
-        var result = await _function.RunAsync(CreateHttpRequestData(), CancellationToken.None);
+        var result = await _function.HandleAsync(CreateHttpRequestData(), CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);

--- a/platform/tests/Platform.Content.Tests/Files/Functions/GetTransparencyFilesFunctionTests.cs
+++ b/platform/tests/Platform.Content.Tests/Files/Functions/GetTransparencyFilesFunctionTests.cs
@@ -1,0 +1,44 @@
+using Microsoft.Azure.Functions.Worker;
+using Moq;
+using Platform.Api.Content.Features.Files;
+using Platform.Api.Content.Features.Files.Handlers;
+using Platform.Functions;
+using Platform.Test;
+using Platform.Test.Mocks;
+using Xunit;
+
+namespace Platform.Content.Tests.Files.Functions;
+
+public class GetTransparencyFilesFunctionTests : FunctionsTestBase
+{
+    private readonly Mock<IVersionedHandlerDispatcher<IGetTransparencyFilesHandler>> _dispatcher;
+    private readonly GetTransparencyFilesFunction _function;
+    private readonly Mock<IGetTransparencyFilesHandler> _handler;
+
+    public GetTransparencyFilesFunctionTests()
+    {
+        _handler = new Mock<IGetTransparencyFilesHandler>();
+        _dispatcher = new Mock<IVersionedHandlerDispatcher<IGetTransparencyFilesHandler>>();
+        _function = new GetTransparencyFilesFunction(_dispatcher.Object);
+    }
+
+    [Theory]
+    [InlineData("version")]
+    [InlineData(null)]
+    public async Task ShouldReturnHandlerResponseOnValidOrMissingVersion(string? version = null)
+    {
+        var response = new MockHttpResponseData(Mock.Of<FunctionContext>());
+
+        var request = CreateHttpRequestData(null, CreateVersionedHeader(version));
+        _dispatcher
+            .Setup(d => d.GetHandler(version))
+            .Returns(_handler.Object);
+        _handler
+            .Setup(h => h.HandleAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        var result = await _function.RunAsync(request);
+
+        Assert.Equal(response, result);
+    }
+}

--- a/platform/tests/Platform.Content.Tests/Files/Handlers/GetTransparencyFilesV1HandlerTests.cs
+++ b/platform/tests/Platform.Content.Tests/Files/Handlers/GetTransparencyFilesV1HandlerTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using AutoFixture;
 using Moq;
-using Platform.Api.Content.Features.Files;
+using Platform.Api.Content.Features.Files.Handlers;
 using Platform.Api.Content.Features.Files.Models;
 using Platform.Api.Content.Features.Files.Responses;
 using Platform.Api.Content.Features.Files.Services;
@@ -10,19 +10,19 @@ using Platform.Test;
 using Platform.Test.Extensions;
 using Xunit;
 
-namespace Platform.Content.Tests.Files;
+namespace Platform.Content.Tests.Files.Handlers;
 
-public class GetTransparencyFilesFunctionTests : FunctionsTestBase
+public class GetTransparencyFilesV1HandlerTests : FunctionsTestBase
 {
     private readonly Fixture _fixture;
-    private readonly GetTransparencyFilesFunction _function;
+    private readonly GetTransparencyFilesV1Handler _handler;
     private readonly Mock<IFilesService> _service;
 
-    public GetTransparencyFilesFunctionTests()
+    public GetTransparencyFilesV1HandlerTests()
     {
         _service = new Mock<IFilesService>();
         _fixture = new Fixture();
-        _function = new GetTransparencyFilesFunction(_service.Object);
+        _handler = new GetTransparencyFilesV1Handler(_service.Object);
     }
 
     [Fact]
@@ -34,7 +34,7 @@ public class GetTransparencyFilesFunctionTests : FunctionsTestBase
             .Setup(d => d.GetActiveFilesByType(It.IsAny<CancellationToken>(), "transparency-aar", "transparency-cfr"))
             .ReturnsAsync(models);
 
-        var result = await _function.RunAsync(CreateHttpRequestData());
+        var result = await _handler.HandleAsync(CreateHttpRequestData(), CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);

--- a/platform/tests/Platform.Content.Tests/Files/Services/WhenFilesServiceQueriesAsync.cs
+++ b/platform/tests/Platform.Content.Tests/Files/Services/WhenFilesServiceQueriesAsync.cs
@@ -1,0 +1,53 @@
+﻿using AutoFixture;
+using Moq;
+using Platform.Api.Content.Features.Files.Models;
+using Platform.Api.Content.Features.Files.Services;
+using Platform.Sql;
+using Platform.Sql.QueryBuilders;
+using Xunit;
+
+namespace Platform.Content.Tests.Files.Services;
+
+public class WhenFilesServiceQueriesAsync
+{
+    private readonly Mock<IDatabaseConnection> _connection;
+    private readonly Fixture _fixture = new();
+    private readonly FilesService _service;
+
+    public WhenFilesServiceQueriesAsync()
+    {
+        _connection = new Mock<IDatabaseConnection>();
+
+        var dbFactory = new Mock<IDatabaseFactory>();
+        dbFactory.Setup(d => d.GetConnection()).ReturnsAsync(_connection.Object);
+
+        _service = new FilesService(dbFactory.Object);
+    }
+
+    [Fact]
+    public async Task ShouldQueryAsync()
+    {
+        var types = _fixture.CreateMany<string>().ToArray();
+        var results = _fixture.Build<FileModel>().CreateMany().ToArray();
+        string? actualSql = null;
+        Dictionary<string, object>? actualParams = null;
+
+        _connection
+            .Setup(c => c.QueryAsync<FileModel>(It.IsAny<PlatformQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<PlatformQuery, CancellationToken>((query, _) =>
+            {
+                actualSql = query.QueryTemplate.RawSql.Trim();
+                actualParams = query.QueryTemplate.Parameters?.GetTemplateParameters("Types");
+            })
+            .ReturnsAsync(results);
+
+        var actual = await _service.GetActiveFilesByType(CancellationToken.None, types);
+
+        Assert.Equal(results, actual);
+        Assert.Equal("SELECT Type , Label , FileName\n FROM VW_ActiveFiles WHERE Type IN @Types", actualSql);
+        Assert.Equal(new Dictionary<string, object>
+        {
+            { "Types", types }
+        }, actualParams);
+    }
+}

--- a/platform/tests/Platform.Content.Tests/Years/Functions/GetCurrentReturnYearsFunctionTests.cs
+++ b/platform/tests/Platform.Content.Tests/Years/Functions/GetCurrentReturnYearsFunctionTests.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.Azure.Functions.Worker;
+using Moq;
+using Platform.Api.Content.Features.Years;
+using Platform.Api.Content.Features.Years.Handlers;
+using Platform.Functions;
+using Platform.Test;
+using Platform.Test.Mocks;
+using Xunit;
+
+namespace Platform.Content.Tests.Years.Functions;
+
+public class GetCurrentReturnYearsFunctionTests : FunctionsTestBase
+{
+    private readonly Mock<IVersionedHandlerDispatcher<IGetCurrentReturnYearsHandler>> _dispatcher;
+    private readonly GetCurrentReturnYearsFunction _function;
+    private readonly Mock<IGetCurrentReturnYearsHandler> _handler;
+
+    public GetCurrentReturnYearsFunctionTests()
+    {
+        _handler = new Mock<IGetCurrentReturnYearsHandler>();
+        _dispatcher = new Mock<IVersionedHandlerDispatcher<IGetCurrentReturnYearsHandler>>();
+        _function = new GetCurrentReturnYearsFunction(_dispatcher.Object);
+    }
+
+    [Theory]
+    [InlineData("version")]
+    [InlineData(null)]
+    public async Task ShouldReturnHandlerResponseOnValidOrMissingVersion(string? version = null)
+    {
+        var response = new MockHttpResponseData(Mock.Of<FunctionContext>());
+
+        var request = CreateHttpRequestData(null, CreateVersionedHeader(version));
+        _dispatcher
+            .Setup(d => d.GetHandler(version))
+            .Returns(_handler.Object);
+        _handler
+            .Setup(h => h.HandleAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        var result = await _function.RunAsync(request, CancellationToken.None);
+
+        Assert.Equal(response, result);
+    }
+}

--- a/platform/tests/Platform.Content.Tests/Years/Handlers/GetCurrentReturnYearsV1HandlerTests.cs
+++ b/platform/tests/Platform.Content.Tests/Years/Handlers/GetCurrentReturnYearsV1HandlerTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Net;
 using AutoFixture;
 using Moq;
-using Platform.Api.Content.Features.Years;
+using Platform.Api.Content.Features.Years.Handlers;
 using Platform.Api.Content.Features.Years.Models;
 using Platform.Api.Content.Features.Years.Services;
 using Platform.Functions;
@@ -9,18 +9,18 @@ using Platform.Test;
 using Platform.Test.Extensions;
 using Xunit;
 
-namespace Platform.Content.Tests.Years;
+namespace Platform.Content.Tests.Years.Handlers;
 
-public class GetCurrentReturnYearsFunctionTests : FunctionsTestBase
+public class GetCurrentReturnYearsV1HandlerTests : FunctionsTestBase
 {
     private readonly Fixture _fixture;
-    private readonly GetCurrentReturnYearsFunction _function;
+    private readonly GetCurrentReturnYearsV1Handler _handler;
     private readonly Mock<IYearsService> _service;
 
-    public GetCurrentReturnYearsFunctionTests()
+    public GetCurrentReturnYearsV1HandlerTests()
     {
         _service = new Mock<IYearsService>();
-        _function = new GetCurrentReturnYearsFunction(_service.Object);
+        _handler = new GetCurrentReturnYearsV1Handler(_service.Object);
         _fixture = new Fixture();
     }
 
@@ -34,7 +34,7 @@ public class GetCurrentReturnYearsFunctionTests : FunctionsTestBase
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(years);
 
-        var result = await _function.RunAsync(CreateHttpRequestData(), CancellationToken.None);
+        var result = await _handler.HandleAsync(CreateHttpRequestData(), CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);


### PR DESCRIPTION
### Context
[AB#264107](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/264107) [AB#264449](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/264449)

### Change proposed in this pull request
- Added handlers to support API version `1.0` on all of the Content API endpoints
- Unit and API test coverage

### Guidance to review 
[Versioning process](https://github.com/DFE-Digital/education-benchmarking-and-insights/blob/main/documentation/developers/12_API-Versioning.md) followed. Web consumer intentionally unaffected by addition of versioning (i.e. it should use the latest, and only, version).

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

