### PR TITLE
fix: Revert 'Remove custom SFB domain and rulesets assigned to Front Door'

### DIFF
--- a/web/terraform/README.md
+++ b/web/terraform/README.md
@@ -23,13 +23,17 @@ No modules.
 |------|------|
 | [azurerm_application_insights_web_test.web_app_test](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights_web_test) | resource |
 | [azurerm_cdn_frontdoor_custom_domain.web-app-custom-domain](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_custom_domain) | resource |
+| [azurerm_cdn_frontdoor_custom_domain.web-app-custom-domain-sfb](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_custom_domain) | resource |
 | [azurerm_cdn_frontdoor_custom_domain_association.web-app-custom-domain](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_custom_domain_association) | resource |
+| [azurerm_cdn_frontdoor_custom_domain_association.web-app-custom-domain-sfb](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_custom_domain_association) | resource |
 | [azurerm_cdn_frontdoor_endpoint.web-app-front-door-endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint) | resource |
 | [azurerm_cdn_frontdoor_firewall_policy.web-app-front-door-waf-policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_firewall_policy) | resource |
 | [azurerm_cdn_frontdoor_origin.web-app-front-door-origin-app-service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_origin) | resource |
 | [azurerm_cdn_frontdoor_origin_group.web-app-front-door-origin-group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_origin_group) | resource |
 | [azurerm_cdn_frontdoor_profile.web-app-front-door-profile](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_profile) | resource |
 | [azurerm_cdn_frontdoor_route.web-app-front-door-route](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_route) | resource |
+| [azurerm_cdn_frontdoor_rule.web-app-redirect-rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |
+| [azurerm_cdn_frontdoor_rule_set.web-app-rules](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
 | [azurerm_cdn_frontdoor_security_policy.web-app-front-door-security-policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_security_policy) | resource |
 | [azurerm_cosmosdb_account.session-cache-account](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_account) | resource |
 | [azurerm_cosmosdb_sql_container.session-cache-container](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_sql_container) | resource |

--- a/web/terraform/front-door.tf
+++ b/web/terraform/front-door.tf
@@ -2,6 +2,7 @@ locals {
   host_name = (lower(var.environment) == "production" ? azurerm_cdn_frontdoor_custom_domain.web-app-custom-domain[0].host_name : azurerm_cdn_frontdoor_endpoint.web-app-front-door-endpoint.host_name)
   custom-domain-ids = (lower(var.environment) == "production" ? [
     azurerm_cdn_frontdoor_custom_domain.web-app-custom-domain[0].id,
+    azurerm_cdn_frontdoor_custom_domain.web-app-custom-domain-sfb[0].id,
   ] : [])
 }
 
@@ -58,7 +59,7 @@ resource "azurerm_cdn_frontdoor_route" "web-app-front-door-route" {
   cdn_frontdoor_endpoint_id     = azurerm_cdn_frontdoor_endpoint.web-app-front-door-endpoint.id
   cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.web-app-front-door-origin-group.id
   cdn_frontdoor_origin_ids      = [azurerm_cdn_frontdoor_origin.web-app-front-door-origin-app-service.id]
-  cdn_frontdoor_rule_set_ids    = []
+  cdn_frontdoor_rule_set_ids    = [azurerm_cdn_frontdoor_rule_set.web-app-rules.id]
   enabled                       = true
 
   forwarding_protocol    = "MatchRequest"
@@ -190,6 +191,24 @@ resource "azurerm_cdn_frontdoor_custom_domain_association" "web-app-custom-domai
   cdn_frontdoor_route_ids        = [azurerm_cdn_frontdoor_route.web-app-front-door-route.id]
 }
 
+resource "azurerm_cdn_frontdoor_custom_domain" "web-app-custom-domain-sfb" {
+  count                    = lower(var.environment) == "production" ? 1 : 0
+  name                     = "${var.environment-prefix}-custom-domain-sfb"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.web-app-front-door-profile.id
+  host_name                = "schools-financial-benchmarking.service.gov.uk"
+
+  tls {
+    certificate_type    = "ManagedCertificate"
+    minimum_tls_version = "TLS12"
+  }
+}
+
+resource "azurerm_cdn_frontdoor_custom_domain_association" "web-app-custom-domain-sfb" {
+  count                          = lower(var.environment) == "production" ? 1 : 0
+  cdn_frontdoor_custom_domain_id = azurerm_cdn_frontdoor_custom_domain.web-app-custom-domain-sfb[0].id
+  cdn_frontdoor_route_ids        = [azurerm_cdn_frontdoor_route.web-app-front-door-route.id]
+}
+
 resource "random_uuid" "idgen" {
 }
 
@@ -241,5 +260,41 @@ resource "azurerm_monitor_diagnostic_setting" "front-door-analytics" {
 
   metric {
     category = "AllMetrics"
+  }
+}
+
+resource "azurerm_cdn_frontdoor_rule_set" "web-app-rules" {
+  name                     = "${var.environment-prefix}ruleset"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.web-app-front-door-profile.id
+}
+
+resource "azurerm_cdn_frontdoor_rule" "web-app-redirect-rule" {
+  depends_on = [
+    azurerm_cdn_frontdoor_origin_group.web-app-front-door-origin-group,
+    azurerm_cdn_frontdoor_origin.web-app-front-door-origin-app-service
+  ]
+
+  name                      = "${var.environment-prefix}redirectrule"
+  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.web-app-rules.id
+  order                     = 1
+  behavior_on_match         = "Stop"
+
+  conditions {
+    host_name_condition {
+      operator         = "Equal"
+      negate_condition = true
+      match_values     = [local.host_name]
+      transforms       = ["Lowercase", "Trim"]
+    }
+  }
+
+  actions {
+    url_redirect_action {
+      redirect_type        = "TemporaryRedirect"
+      redirect_protocol    = "MatchRequest"
+      destination_hostname = local.host_name
+      destination_path     = "/"
+      query_string         = "redirect=true" // leaving blank will preserve original query string
+    }
   }
 }


### PR DESCRIPTION
### Context
AB#263444 AB#264744 #2466

### Change proposed in this pull request
Reverts commit 0ffd11fdbde686141b5d0017ee146e39119d2dea from #2466 

### Guidance to review 
Original Terraform change has broken the pipeline due to dependency issues between the route and the rule set. This will be resolved separately.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)

