### PR TITLE
Disassociate Front Door rule set with route and remove custom domain

### DIFF
--- a/web/terraform/README.md
+++ b/web/terraform/README.md
@@ -23,16 +23,13 @@ No modules.
 |------|------|
 | [azurerm_application_insights_web_test.web_app_test](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights_web_test) | resource |
 | [azurerm_cdn_frontdoor_custom_domain.web-app-custom-domain](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_custom_domain) | resource |
-| [azurerm_cdn_frontdoor_custom_domain.web-app-custom-domain-sfb](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_custom_domain) | resource |
 | [azurerm_cdn_frontdoor_custom_domain_association.web-app-custom-domain](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_custom_domain_association) | resource |
-| [azurerm_cdn_frontdoor_custom_domain_association.web-app-custom-domain-sfb](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_custom_domain_association) | resource |
 | [azurerm_cdn_frontdoor_endpoint.web-app-front-door-endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint) | resource |
 | [azurerm_cdn_frontdoor_firewall_policy.web-app-front-door-waf-policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_firewall_policy) | resource |
 | [azurerm_cdn_frontdoor_origin.web-app-front-door-origin-app-service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_origin) | resource |
 | [azurerm_cdn_frontdoor_origin_group.web-app-front-door-origin-group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_origin_group) | resource |
 | [azurerm_cdn_frontdoor_profile.web-app-front-door-profile](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_profile) | resource |
 | [azurerm_cdn_frontdoor_route.web-app-front-door-route](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_route) | resource |
-| [azurerm_cdn_frontdoor_rule.web-app-redirect-rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |
 | [azurerm_cdn_frontdoor_rule_set.web-app-rules](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
 | [azurerm_cdn_frontdoor_security_policy.web-app-front-door-security-policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_security_policy) | resource |
 | [azurerm_cosmosdb_account.session-cache-account](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_account) | resource |

--- a/web/terraform/front-door.tf
+++ b/web/terraform/front-door.tf
@@ -2,7 +2,6 @@ locals {
   host_name = (lower(var.environment) == "production" ? azurerm_cdn_frontdoor_custom_domain.web-app-custom-domain[0].host_name : azurerm_cdn_frontdoor_endpoint.web-app-front-door-endpoint.host_name)
   custom-domain-ids = (lower(var.environment) == "production" ? [
     azurerm_cdn_frontdoor_custom_domain.web-app-custom-domain[0].id,
-    azurerm_cdn_frontdoor_custom_domain.web-app-custom-domain-sfb[0].id,
   ] : [])
 }
 
@@ -59,7 +58,6 @@ resource "azurerm_cdn_frontdoor_route" "web-app-front-door-route" {
   cdn_frontdoor_endpoint_id     = azurerm_cdn_frontdoor_endpoint.web-app-front-door-endpoint.id
   cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.web-app-front-door-origin-group.id
   cdn_frontdoor_origin_ids      = [azurerm_cdn_frontdoor_origin.web-app-front-door-origin-app-service.id]
-  cdn_frontdoor_rule_set_ids    = [azurerm_cdn_frontdoor_rule_set.web-app-rules.id]
   enabled                       = true
 
   forwarding_protocol    = "MatchRequest"
@@ -191,24 +189,6 @@ resource "azurerm_cdn_frontdoor_custom_domain_association" "web-app-custom-domai
   cdn_frontdoor_route_ids        = [azurerm_cdn_frontdoor_route.web-app-front-door-route.id]
 }
 
-resource "azurerm_cdn_frontdoor_custom_domain" "web-app-custom-domain-sfb" {
-  count                    = lower(var.environment) == "production" ? 1 : 0
-  name                     = "${var.environment-prefix}-custom-domain-sfb"
-  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.web-app-front-door-profile.id
-  host_name                = "schools-financial-benchmarking.service.gov.uk"
-
-  tls {
-    certificate_type    = "ManagedCertificate"
-    minimum_tls_version = "TLS12"
-  }
-}
-
-resource "azurerm_cdn_frontdoor_custom_domain_association" "web-app-custom-domain-sfb" {
-  count                          = lower(var.environment) == "production" ? 1 : 0
-  cdn_frontdoor_custom_domain_id = azurerm_cdn_frontdoor_custom_domain.web-app-custom-domain-sfb[0].id
-  cdn_frontdoor_route_ids        = [azurerm_cdn_frontdoor_route.web-app-front-door-route.id]
-}
-
 resource "random_uuid" "idgen" {
 }
 
@@ -266,35 +246,4 @@ resource "azurerm_monitor_diagnostic_setting" "front-door-analytics" {
 resource "azurerm_cdn_frontdoor_rule_set" "web-app-rules" {
   name                     = "${var.environment-prefix}ruleset"
   cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.web-app-front-door-profile.id
-}
-
-resource "azurerm_cdn_frontdoor_rule" "web-app-redirect-rule" {
-  depends_on = [
-    azurerm_cdn_frontdoor_origin_group.web-app-front-door-origin-group,
-    azurerm_cdn_frontdoor_origin.web-app-front-door-origin-app-service
-  ]
-
-  name                      = "${var.environment-prefix}redirectrule"
-  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.web-app-rules.id
-  order                     = 1
-  behavior_on_match         = "Stop"
-
-  conditions {
-    host_name_condition {
-      operator         = "Equal"
-      negate_condition = true
-      match_values     = [local.host_name]
-      transforms       = ["Lowercase", "Trim"]
-    }
-  }
-
-  actions {
-    url_redirect_action {
-      redirect_type        = "TemporaryRedirect"
-      redirect_protocol    = "MatchRequest"
-      destination_hostname = local.host_name
-      destination_path     = "/"
-      query_string         = "redirect=true" // leaving blank will preserve original query string
-    }
-  }
 }


### PR DESCRIPTION
### Context
[AB#263444](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/263444) [AB#264856](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/264856)

### Change proposed in this pull request
Post-SFB decommission tidy up:
- Drop SFB custom domain from Front Door
- Drop rule from Front Door ruleset
- Disassociate ruleset from Front Door route
  - This does not actually perform the disassociation in Azure, even though Terraform suggests that this will happen
  - Instead this should be done manually, as documented in the [release test plan](#2468) so that the subsequent `terraform plan` is happy
  - Possibly a bug in the Azure RM Terraform provider, related to:
    - https://github.com/hashicorp/terraform-provider-azurerm/issues/27312 

### Guidance to review 
Deployed to `d18` feature environment for validation. A future PR will remove the ruleset completely. This cannot be done at the same time as disassociating it due to possibly a different bug in the Azure RM Terraform provider, related to:
  - https://github.com/hashicorp/terraform-provider-azurerm/issues/20744 
  - https://github.com/hashicorp/terraform-provider-azurerm/issues/22924 
  - https://github.com/hashicorp/terraform-provider-azurerm/issues/27652 

More details on the user story.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [ ] ~~Your code builds clean without any errors or warnings~~
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

