### PR TITLE
Added new property to `TrustExpenditure` model for returning from proxy endpoints

### DIFF
--- a/web/src/Web.App/Domain/Insight/Expenditure.cs
+++ b/web/src/Web.App/Domain/Insight/Expenditure.cs
@@ -150,6 +150,8 @@ public record TrustExpenditure : ExpenditureBase
     public decimal? SchoolStaffDevelopmentTrainingCosts { get; set; }
     public decimal? SchoolStaffRelatedInsuranceCosts { get; set; }
     public decimal? SchoolSupplyTeacherInsurableCosts { get; set; }
+
+    public int? HighestSalaryEmolumentBandValue { get; set; }
 }
 
 public record ExpenditureHistory : ExpenditureBase


### PR DESCRIPTION
### Context
[AB#261891](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/261891) [AB#265053](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/265053)

### Change proposed in this pull request
Addition of `HighestSalaryEmolumentBandValue` property to `TrustExpenditure`, as already supplied by Insight API endpoints.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

