### PR TITLE
fix: preserve existing context for suppression of negative and zero values

### DIFF
--- a/front-end-components/src/composed/dimensioned-chart/composed.tsx
+++ b/front-end-components/src/composed/dimensioned-chart/composed.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { useContext } from "react";
 import { CostCategories, ChartDimensions } from "src/components";
 import {
   ChartDimensionContext,
@@ -24,6 +24,10 @@ export function DimensionedChart<
   topLevel,
   ...props
 }: DimensionedChartProps<TData>) {
+  const { suppressNegativeOrZero, message } = useContext(
+    SuppressNegativeOrZeroContext
+  );
+
   const handleSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (
     event
   ) => {
@@ -52,8 +56,8 @@ export function DimensionedChart<
             value={{
               suppressNegativeOrZero:
                 override?.suppressNegativeOrZero?.suppressNegativeOrZero ??
-                false,
-              message: override?.suppressNegativeOrZero?.message ?? "",
+                suppressNegativeOrZero,
+              message: override?.suppressNegativeOrZero?.message ?? message,
             }}
           >
             <HorizontalBarChartWrapper


### PR DESCRIPTION
### Context
[AB#261891](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/261891) #2475 

### Change proposed in this pull request

This PR fixes a regression introduced in #2475

When using the override to set up the context, it now falls back to the existing `SuppressNegativeOrZeroContext` values if the override prop is not provided.

### Guidance to review 
`SchoolCompareYourCostFeature` `schools having 0 for a cost category in comparators set shouldn't display in the chart` tests should now pass after copying front-end assets to web.

Will need another bump to `front-end` following merging this PR to fix the tests.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

