### PR TITLE
chore: bump `front-end` to `1.1.101`

### DIFF
--- a/web/src/Web.App/package-lock.json
+++ b/web/src/Web.App/package-lock.json
@@ -5394,9 +5394,9 @@
       }
     },
     "node_modules/front-end": {
-      "version": "1.1.100",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-1.1.100.tgz",
-      "integrity": "sha1-GYCht48UmgD441UMi4nF8fMv4hw=",
+      "version": "1.1.101",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/front-end/-/front-end-1.1.101.tgz",
+      "integrity": "sha1-vZ+68vgIJQBZhPw/+CK16ZDtUeU=",
       "dependencies": {
         "accessible-autocomplete": "^3.0.0",
         "classnames": "^2.5.1",


### PR DESCRIPTION
### Context
[AB#261891](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/261891) #2481 

### Change proposed in this pull request
bump `front-end` to `1.1.101` following changes on #2481 

### Guidance to review 
This should fix the currently failing tests for web

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

