### PR TITLE
Included academy recoupment in outturn value for historical High Needs spending

### DIFF
--- a/web/src/Web.App/Controllers/Api/Mappers/LocalAuthorityHighNeedsResponseMapper.cs
+++ b/web/src/Web.App/Controllers/Api/Mappers/LocalAuthorityHighNeedsResponseMapper.cs
@@ -63,14 +63,15 @@ public static class LocalAuthorityHighNeedsResponseMapper
                 }
             }
 
+            outturn += academyRecoupment ?? 0;
             results.Add(new LocalAuthorityHighNeedsHistoryDashboardResponse
             {
                 Year = year,
                 Outturn = outturn,
                 Budget = budget,
                 Funding = dsgFunding,
-                BudgetDifference = budget - (outturn + academyRecoupment ?? 0),
-                FundingDifference = dsgFunding == null ? null : dsgFunding - (outturn + academyRecoupment ?? 0)
+                BudgetDifference = budget - outturn,
+                FundingDifference = dsgFunding - outturn
             });
         }
 

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsDashboard.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsDashboard.cs
@@ -285,9 +285,9 @@ public class WhenViewingHighNeeds(SchoolBenchmarkingWebAppClient client) : PageB
             {
                 var outturn = history.Outturn.Single(o => o.Year == fundingYear);
                 var dsg = history.Dsg?.SingleOrDefault(o => o.Year == fundingYear);
-                var outturnValue = outturn.Total;
+                var outturnValue = outturn.Total + dsg?.AcademyRecoupment;
                 var dsgFunding = dsg?.DsgFunding;
-                var differenceValue = dsgFunding - (outturnValue + dsg?.AcademyRecoupment);
+                var differenceValue = dsgFunding - outturnValue;
                 DocumentAssert.AssertNodeText(fundingBodyRows.ElementAt(i), $"{fundingYear - 1}\n                to\n                {fundingYear}  {dsgFunding?.ToString("C0")}  {outturnValue?.ToString("C0")}  {differenceValue?.ToString("C0")}");
                 fundingYear--;
             }
@@ -305,9 +305,9 @@ public class WhenViewingHighNeeds(SchoolBenchmarkingWebAppClient client) : PageB
                 var outturn = history.Outturn.Single(o => o.Year == expenditureYear);
                 var budget = history.Budget.Single(o => o.Year == expenditureYear);
                 var dsg = history.Dsg?.SingleOrDefault(o => o.Year == expenditureYear);
-                var outturnValue = outturn.Total;
+                var outturnValue = outturn.Total + dsg?.AcademyRecoupment;
                 var budgetValue = budget.Total;
-                var differenceValue = budgetValue - (outturnValue + dsg?.AcademyRecoupment ?? 0);
+                var differenceValue = budgetValue - outturnValue;
                 DocumentAssert.AssertNodeText(expenditureBodyRows.ElementAt(i), $"{expenditureYear - 1}\n                to\n                {expenditureYear}  {budgetValue?.ToString("C0")}  {outturnValue?.ToString("C0")}  {differenceValue?.ToString("C0")}");
                 expenditureYear--;
             }

--- a/web/tests/Web.Tests/Controllers/Api/Mappers/WhenLocalAuthorityHighNeedsHistoryResponseMapperMapsToDashboardWithCode.cs
+++ b/web/tests/Web.Tests/Controllers/Api/Mappers/WhenLocalAuthorityHighNeedsHistoryResponseMapperMapsToDashboardWithCode.cs
@@ -1,4 +1,5 @@
 using Web.App.Controllers.Api.Mappers;
+using Web.App.Controllers.Api.Responses;
 using Web.App.Domain.LocalAuthorities;
 using Xunit;
 
@@ -20,32 +21,16 @@ public class WhenLocalAuthorityHighNeedsHistoryResponseMapperMapsToDashboardWith
             switch (actual.Year)
             {
                 case 2021:
-                    AssertFieldsMapped(Outturn2021, actual.Outturn);
-                    AssertFieldsMapped(Budget2021, actual.Budget);
-                    Assert.Equal(Budget2021.Total - (Outturn2021.Total + Dsg2021.AcademyRecoupment), actual.BudgetDifference);
-                    Assert.Equal(Dsg2021.DsgFunding, actual.Funding);
-                    Assert.Equal(Dsg2021.DsgFunding - (Outturn2021.Total + Dsg2021.AcademyRecoupment), actual.FundingDifference);
+                    AssertValues(Outturn2021, Budget2021, Dsg2021, actual);
                     break;
                 case 2022:
-                    AssertFieldsMapped(Outturn2022, actual.Outturn);
-                    AssertFieldsMapped(Budget2022, actual.Budget);
-                    Assert.Equal(Budget2022.Total - (Outturn2022.Total + Dsg2022.AcademyRecoupment), actual.BudgetDifference);
-                    Assert.Equal(Dsg2022.DsgFunding, actual.Funding);
-                    Assert.Equal(Dsg2022.DsgFunding - (Outturn2022.Total + Dsg2022.AcademyRecoupment), actual.FundingDifference);
+                    AssertValues(Outturn2022, Budget2022, Dsg2022, actual);
                     break;
                 case 2023:
-                    AssertFieldsMapped(Outturn2023, actual.Outturn);
-                    AssertFieldsMapped(Budget2023, actual.Budget);
-                    Assert.Equal(Budget2023.Total - (Outturn2023.Total + Dsg2023.AcademyRecoupment), actual.BudgetDifference);
-                    Assert.Equal(Dsg2023.DsgFunding, actual.Funding);
-                    Assert.Equal(Dsg2023.DsgFunding - (Outturn2023.Total + Dsg2023.AcademyRecoupment), actual.FundingDifference);
+                    AssertValues(Outturn2023, Budget2023, Dsg2023, actual);
                     break;
                 case 2024:
-                    AssertFieldsMapped(Outturn2024, actual.Outturn);
-                    AssertFieldsMapped(Budget2024, actual.Budget);
-                    Assert.Equal(Budget2024.Total - (Outturn2024.Total + Dsg2024.AcademyRecoupment), actual.BudgetDifference);
-                    Assert.Equal(Dsg2024.DsgFunding, actual.Funding);
-                    Assert.Equal(Dsg2024.DsgFunding - (Outturn2024.Total + Dsg2024.AcademyRecoupment), actual.FundingDifference);
+                    AssertValues(Outturn2024, Budget2024, Dsg2024, actual);
                     break;
                 default:
                     throw new IndexOutOfRangeException();
@@ -67,25 +52,13 @@ public class WhenLocalAuthorityHighNeedsHistoryResponseMapperMapsToDashboardWith
             switch (actual.Year)
             {
                 case 2021:
-                    AssertFieldsMapped(Outturn2021, actual.Outturn);
-                    AssertFieldsMapped(Budget2021, actual.Budget);
-                    Assert.Equal(Budget2021.Total - (Outturn2021.Total + Dsg2021.AcademyRecoupment), actual.BudgetDifference);
-                    Assert.Equal(Dsg2021.DsgFunding, actual.Funding);
-                    Assert.Equal(Dsg2021.DsgFunding - (Outturn2021.Total + Dsg2021.AcademyRecoupment), actual.FundingDifference);
+                    AssertValues(Outturn2021, Budget2021, Dsg2021, actual);
                     break;
                 case 2022:
-                    AssertFieldsMapped(null, actual.Outturn);
-                    AssertFieldsMapped(null, actual.Budget);
-                    Assert.Null(actual.BudgetDifference);
-                    Assert.Null(actual.Funding);
-                    Assert.Null(actual.FundingDifference);
+                    AssertNullValues(actual);
                     break;
                 case 2023:
-                    AssertFieldsMapped(Outturn2023, actual.Outturn);
-                    AssertFieldsMapped(Budget2023, actual.Budget);
-                    Assert.Equal(Budget2023.Total - (Outturn2023.Total + Dsg2023.AcademyRecoupment), actual.BudgetDifference);
-                    Assert.Equal(Dsg2023.DsgFunding, actual.Funding);
-                    Assert.Equal(Dsg2023.DsgFunding - (Outturn2023.Total + Dsg2023.AcademyRecoupment), actual.FundingDifference);
+                    AssertValues(Outturn2023, Budget2023, Dsg2023, actual);
                     break;
                 default:
                     throw new IndexOutOfRangeException();
@@ -107,18 +80,10 @@ public class WhenLocalAuthorityHighNeedsHistoryResponseMapperMapsToDashboardWith
             switch (actual.Year)
             {
                 case 2022:
-                    AssertFieldsMapped(Outturn2022, actual.Outturn);
-                    AssertFieldsMapped(Budget2022, actual.Budget);
-                    Assert.Equal(Budget2022.Total - (Outturn2022.Total + Dsg2022.AcademyRecoupment), actual.BudgetDifference);
-                    Assert.Equal(Dsg2022.DsgFunding, actual.Funding);
-                    Assert.Equal(Dsg2022.DsgFunding - (Outturn2022.Total + Dsg2022.AcademyRecoupment), actual.FundingDifference);
+                    AssertValues(Outturn2022, Budget2022, Dsg2022, actual);
                     break;
                 case 2023:
-                    AssertFieldsMapped(Outturn2023, actual.Outturn);
-                    AssertFieldsMapped(Budget2023, actual.Budget);
-                    Assert.Equal(Budget2023.Total - (Outturn2023.Total + Dsg2023.AcademyRecoupment), actual.BudgetDifference);
-                    Assert.Equal(Dsg2023.DsgFunding, actual.Funding);
-                    Assert.Equal(Dsg2023.DsgFunding - (Outturn2023.Total + Dsg2023.AcademyRecoupment), actual.FundingDifference);
+                    AssertValues(Outturn2023, Budget2023, Dsg2023, actual);
                     break;
                 default:
                     throw new IndexOutOfRangeException();
@@ -126,8 +91,21 @@ public class WhenLocalAuthorityHighNeedsHistoryResponseMapperMapsToDashboardWith
         }
     }
 
-    private static void AssertFieldsMapped(HighNeedsYear? expected, decimal? actual)
+    private static void AssertValues(HighNeedsYear outturn, HighNeedsYear budget, HighNeedsDsgYear dsg, LocalAuthorityHighNeedsHistoryDashboardResponse actual)
     {
-        Assert.Equal(expected?.Total, actual);
+        Assert.Equal(outturn.Total + dsg.AcademyRecoupment, actual.Outturn);
+        Assert.Equal(budget.Total, actual.Budget);
+        Assert.Equal(budget.Total - (outturn.Total + dsg.AcademyRecoupment), actual.BudgetDifference);
+        Assert.Equal(dsg.DsgFunding, actual.Funding);
+        Assert.Equal(dsg.DsgFunding - (outturn.Total + dsg.AcademyRecoupment), actual.FundingDifference);
+    }
+
+    private static void AssertNullValues(LocalAuthorityHighNeedsHistoryDashboardResponse actual)
+    {
+        Assert.Null(actual.Outturn);
+        Assert.Null(actual.Budget);
+        Assert.Null(actual.BudgetDifference);
+        Assert.Null(actual.Funding);
+        Assert.Null(actual.FundingDifference);
     }
 }


### PR DESCRIPTION
### Context
AB#265019 AB#265789

### Change proposed in this pull request
Fixed calculation to include academy recoupment in base outturn value, which is also used in difference calculations.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto ~~main~~ `feature/high-needs`
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

