### PR TITLE
Content update pass

### DIFF
--- a/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsHelp/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsHelp/Default.cshtml
@@ -16,7 +16,7 @@
                         <a
                             href="https://www.gov.uk/government/publications/high-needs-budgets-effective-management-in-local-authorities"
                             class="govuk-link govuk-link--no-visited-state">
-                            High needs budgets: effective management in LAs
+                            High needs budgets
                         </a>
                     </li>
                 </ul>
@@ -42,7 +42,7 @@
                         <a
                             href="https://explore-education-statistics.service.gov.uk/data-catalogue/data-set/031ae956-10e9-4908-8236-937bdebefb71"
                             class="govuk-link govuk-link--no-visited-state">
-                            Section 251 (budget)
+                            Section 251 (planned expenditure)
                         </a>
                     </li>
                     <li>

--- a/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsHistory/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsHistory/Default.cshtml
@@ -5,12 +5,12 @@
     <ul class="govuk-tabs__list">
         <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
             <a class="govuk-tabs__tab" href="#funding-vs-outturn">
-                DSG high needs funding allocation vs. outturn
+                DSG high needs funding allocation vs outturn
             </a>
         </li>
         <li class="govuk-tabs__list-item">
             <a class="govuk-tabs__tab" href="#expenditure-vs-outturn">
-                Planned expenditure vs. outturn
+                Planned expenditure vs outturn
             </a>
         </li>
     </ul>
@@ -38,7 +38,7 @@
             href="@Url.Action("Index", "LocalAuthorityHighNeedsHistoricData", new { code = Model.Code })"
             role="button"
             class="govuk-button govuk-button--secondary"
-            data-module="govuk-button">View full historic data</a>
+            data-module="govuk-button">View full historical spending</a>
     </div>
 </div>
 

--- a/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsNationalRankings/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsNationalRankings/Default.cshtml
@@ -50,4 +50,4 @@
     href="@Url.Action("Index", "LocalAuthorityHighNeedsNationalRankings", new { code = Model.Code })"
     role="button"
     class="govuk-button govuk-button--secondary"
-    data-module="govuk-button">View full national view</a>
+    data-module="govuk-button">View full national data</a>

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsDashboardPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsDashboardPage.cs
@@ -11,15 +11,11 @@ public class HighNeedsDashboardPage(IPage page)
     });
     private ILocator ViewNationalRankingsButton => page.Locator(Selectors.CtaButton, new PageLocatorOptions
     {
-        HasText = "View full national view"
+        HasText = "View full national data"
     });
     private ILocator ViewHistoricSpendingButton => page.Locator(Selectors.CtaButton, new PageLocatorOptions
     {
         HasText = "View full historical spending"
-    });
-    private ILocator ViewHistoricDataButton => page.Locator(Selectors.CtaButton, new PageLocatorOptions
-    {
-        HasText = "View full historic data"
     });
     private ILocator BenchmarkHighNeedsCard => page.Locator(Selectors.GovSummaryCard, new PageLocatorOptions
     {
@@ -51,12 +47,12 @@ public class HighNeedsDashboardPage(IPage page)
         await NationalViewSection.ShouldBeVisible();
         await HistoricDataSection.ShouldBeVisible();
         await StartBenchmarkingButton.ShouldBeVisible();
-        await ViewHistoricSpendingButton.ShouldBeVisible();
+        await ViewHistoricSpendingButton.First.ShouldBeVisible();
         await HistoricalFundingVsOutturnTab.ShouldBeVisible();
         await HistoricalFundingVsOutturnTabPanel.ShouldBeVisible();
+        await ViewHistoricSpendingButton.Last.ShouldNotBeVisible();
         await HistoricalExpenditureVsOutturnTab.ShouldBeVisible();
         await HistoricalExpenditureVsOutturnTabPanel.ShouldNotBeVisible();
-        await ViewHistoricDataButton.ShouldNotBeVisible();
         await ViewNationalRankingsButton.ShouldBeVisible();
     }
 
@@ -74,7 +70,7 @@ public class HighNeedsDashboardPage(IPage page)
 
     public async Task<HighNeedsHistoricDataPage> ClickViewHistoricData()
     {
-        await ViewHistoricSpendingButton.Click();
+        await ViewHistoricSpendingButton.First.Click();
         return new HighNeedsHistoricDataPage(page);
     }
 

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsDashboard.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsDashboard.cs
@@ -42,7 +42,7 @@ public class WhenViewingHighNeeds(SchoolBenchmarkingWebAppClient client) : PageB
     {
         var (page, authority, _, _, _, _) = await SetupNavigateInitPage(nationalRankings);
 
-        var anchor = page.QuerySelectorAll("a").FirstOrDefault(x => x.TextContent.Trim() == "View full national view");
+        var anchor = page.QuerySelectorAll("a").FirstOrDefault(x => x.TextContent.Trim() == "View full national data");
         if (expectedButtonVisible)
         {
             Assert.NotNull(anchor);
@@ -61,7 +61,7 @@ public class WhenViewingHighNeeds(SchoolBenchmarkingWebAppClient client) : PageB
     {
         var (page, authority, _, _, _, _) = await SetupNavigateInitPage(historyYears: historyYears);
 
-        var anchor = page.QuerySelectorAll("a").FirstOrDefault(x => x.TextContent.Trim() == "View full historic data");
+        var anchor = page.QuerySelectorAll("a").FirstOrDefault(x => x.TextContent.Trim() == "View full historical spending");
         if (expectedButtonVisible)
         {
             Assert.NotNull(anchor);


### PR DESCRIPTION
### Context
[AB#265019](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/265019) [AB#265811](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/265811)

### Change proposed in this pull request
Resolves the following reported issues on High Needs dashboard (sic):
1. Buttoned mislabelled on 2nd tab (Planned expenditure vs. outturn). Should be "View full historical spending" as per the 1st tab.
1. Both tabs have a full stop next to vs i.e. DSG high needs funding allocation vs. outturn. Full stops should be removed
1. National view section: The CTA should be labelled 'View full national data' , currently it is 'View full national view'
1. ~~Key information: Can '2023-' be dropped a line so it sits on the same line as 2024? This is a knitpick , so please tell me to stop~~
1. Help and support section (on homepage): High needs budgets : effective management in LAs should be High needs budgets
1. Help and support section (on homepage): Section 251 (budget) should be Section 251 (planned expenditure)

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto ~~main~~ `feature/high-needs`
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

