### PR TITLE
Negate the CarriedForwardBalance

### DIFF
--- a/data-pipeline/src/pipeline/input_schemas/local_authority.py
+++ b/data-pipeline/src/pipeline/input_schemas/local_authority.py
@@ -413,6 +413,8 @@ la_outturn_column_eval = {
             "`1.2.8 Support for inclusion__net_expenditure`.fillna(0.0) + "
             "`1.2.9 Special schools and PRUs in financial difficulty__net_expenditure`.fillna(0.0)"
         ),
+        # https://www.gov.uk/government/publications/section-251-2025-to-2026/section-251-budget-guidance#dsg-carry-forward-to-2026-to-2027
+        "CarriedForwardBalance": "-1.0 * `1.9.3 Dedicated Schools Grant carried forward to next year__gross_expenditure`",
     },
 }
 
@@ -443,7 +445,6 @@ la_section_251_column_mappings = {
         "1.0.2 Secondary": "PlaceFundingSecondary",
         "1.0.2 SENSpecial": "PlaceFundingSpecial",
         "1.0.2 APPRU": "PlaceFundingAlternativeProvision",
-        "1.9.3 Dedicated Schools Grant carried forward to next year__gross_expenditure": "CarriedForwardBalance",
     },
 }
 


### PR DESCRIPTION
### Context

see the                                                                                                                                                                                                        [official guidance](https://www.gov.uk/government/publications/section-251-2025-to-2026/section-251-budget-guidance#dsg-carry-forward-to-2026-to-2027): we're deriving the `CarriedForwardBalance` from the negative form of the                                                                                                                                1.9.3/gross-expenditure.

[AB#265019](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/265019)  
[AB#265294](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/265294)

### Change proposed in this pull request

Change the input-schema for S251/Outturn from a rename to a calculated column.

### Guidance to review 

Verified locally: the data becomes the negated version of the values now present in d12.

### Checklist (add/remove as appropriate)

- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~You have reviewed with UX/Design~

