### PR TITLE
 Populated High Needs and General glossary, rendering to view from markdown

### DIFF
--- a/web/Directory.Packages.props
+++ b/web/Directory.Packages.props
@@ -17,6 +17,7 @@
         <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.1.0"/>
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
         <PackageVersion Include="Swashbuckle.AspNetCore" Version="8.1.4"/>
+        <PackageVersion Include="Westwind.AspNetCore.Markdown" Version="3.23.0"/>
         <PackageVersion Include="xunit" Version="2.9.3"/>
         <PackageVersion Include="xunit.abstractions" Version="2.0.3"/>
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0">

--- a/web/Web.sln.DotSettings
+++ b/web/Web.sln.DotSettings
@@ -32,12 +32,14 @@
 	<s:String x:Key="/Default/Housekeeping/UnitTestingMru/UnitTestRunner/LoggingInternal/@EntryValue">VERBOSE</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=actuals/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=backfill/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ehcp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=esfa/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fbis/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fbit/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=gias/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=govuk/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=icfp/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=idaci/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=nfer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=nonfile/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=noopener/@EntryIndexedValue">True</s:Boolean>

--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -808,14 +808,12 @@ table#current-comparators-la {
   @include govuk-font(16);
 }
 
-.markdown {
-  > p {
-    &:first-of-type {
-      margin-top: govuk-spacing(0);
-    }
-
-    &:last-of-type {
-      margin-bottom: govuk-spacing(0);
+.govuk-table {
+  .markdown {
+    > p, ul {
+      &:last-child {
+        margin-bottom: govuk-spacing(0);
+      }
     }
   }
 }

--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -807,3 +807,15 @@ table#current-comparators-la {
 .chart-stat-title {
   @include govuk-font(16);
 }
+
+.markdown {
+  > p {
+    &:first-of-type {
+      margin-top: govuk-spacing(0);
+    }
+
+    &:last-of-type {
+      margin-bottom: govuk-spacing(0);
+    }
+  }
+}

--- a/web/src/Web.App/Middleware/Markdown/GdsMarkdownExtension.cs
+++ b/web/src/Web.App/Middleware/Markdown/GdsMarkdownExtension.cs
@@ -1,0 +1,76 @@
+using Markdig;
+using Markdig.Extensions.Tables;
+using Markdig.Renderers;
+using Markdig.Renderers.Html;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+
+namespace Web.App.Middleware.Markdown;
+
+/// <summary>
+///     Post-processes markdown document to enhance with GDS class names for the following elements:
+///     <ul>
+///         <li>
+///             <c>&lt;a&gt;</c>
+///         </li>
+///         <li>
+///             <c>&lt;ul&gt;</c>
+///         </li>
+///         <li>
+///             <c>&lt;p&gt;</c>
+///         </li>
+///         <li>
+///             <c>&lt;table&gt;</c>
+///         </li>
+///         <li>
+///             <c>&lt;tr&gt;</c>
+///         </li>
+///         <li>
+///             <c>&lt;td&gt;</c>
+///         </li>
+///     </ul>
+/// </summary>
+public class GdsMarkdownExtension : IMarkdownExtension
+{
+    public void Setup(MarkdownPipelineBuilder pipeline)
+    {
+        // ensure delegate is only registered once
+        pipeline.DocumentProcessed -= PipelineOnDocumentProcessed;
+        pipeline.DocumentProcessed += PipelineOnDocumentProcessed;
+    }
+
+    public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
+    {
+        // no renderer extensions registered here
+    }
+
+    private static void PipelineOnDocumentProcessed(MarkdownDocument document)
+    {
+        foreach (var node in document.Descendants())
+        {
+            var attributes = node.GetAttributes();
+            switch (node)
+            {
+                case LinkInline:
+                    attributes.AddClass("govuk-link");
+                    break;
+                case ListBlock:
+                    attributes.AddClass("govuk-list");
+                    attributes.AddClass("govuk-list--bullet");
+                    break;
+                case ParagraphBlock:
+                    attributes.AddClass("govuk-body");
+                    break;
+                case Table:
+                    attributes.AddClass("govuk-table");
+                    break;
+                case TableCell:
+                    attributes.AddClass("govuk-table__cell");
+                    break;
+                case TableRow:
+                    attributes.AddClass("govuk-table__row");
+                    break;
+            }
+        }
+    }
+}

--- a/web/src/Web.App/Program.cs
+++ b/web/src/Web.App/Program.cs
@@ -16,6 +16,7 @@ using Web.App.HealthChecks;
 using Web.App.Middleware;
 using Web.App.Services;
 using Web.App.Telemetry;
+using Westwind.AspNetCore.Markdown;
 
 [assembly: InternalsVisibleTo("Web.Tests")]
 
@@ -46,7 +47,8 @@ builder.Services
     .AddScoped<ISearchService, SearchService>()
     .AddScoped<ICommercialResourcesService, CommercialResourcesService>()
     .AddValidation()
-    .AddActionResults();
+    .AddActionResults()
+    .AddMarkdown();
 
 builder.Services.AddHealthChecks()
     .AddCheck<ApiHealthCheck>("API Health Check");
@@ -148,7 +150,8 @@ app
     .UseHttpsRedirection()
     .UseRouting()
     .UseAuthorization()
-    .UseSession();
+    .UseSession()
+    .UseMarkdown();
 
 app.MapHealthChecks(
     "/health",

--- a/web/src/Web.App/Program.cs
+++ b/web/src/Web.App/Program.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using CorrelationId.DependencyInjection;
+using Markdig;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -14,6 +15,7 @@ using Web.App.Extensions;
 using Web.App.Handlers;
 using Web.App.HealthChecks;
 using Web.App.Middleware;
+using Web.App.Middleware.Markdown;
 using Web.App.Services;
 using Web.App.Telemetry;
 using Westwind.AspNetCore.Markdown;
@@ -47,8 +49,7 @@ builder.Services
     .AddScoped<ISearchService, SearchService>()
     .AddScoped<ICommercialResourcesService, CommercialResourcesService>()
     .AddValidation()
-    .AddActionResults()
-    .AddMarkdown();
+    .AddActionResults();
 
 builder.Services.AddHealthChecks()
     .AddCheck<ApiHealthCheck>("API Health Check");
@@ -70,6 +71,13 @@ builder.Services.AddMemoryCache();
 builder.Services.Configure<CacheOptions>(builder.Configuration.GetSection("CacheOptions"));
 
 builder.AddSessionService();
+
+builder.Services
+    .AddMarkdown(config => config.ConfigureMarkdigPipeline = b =>
+    {
+        b.Extensions.AddIfNotAlready<GdsMarkdownExtension>();
+        b.DisableHtml();
+    });
 
 if (!builder.Environment.IsIntegration())
 {

--- a/web/src/Web.App/ViewModels/HighNeedsGlossaryViewModel.cs
+++ b/web/src/Web.App/ViewModels/HighNeedsGlossaryViewModel.cs
@@ -63,9 +63,9 @@ public class HighNeedsGlossaryViewModel : GlossaryViewModel
         },
         new()
         {
-            Term = "National Funding",
+            Term = "National Funding Formula",
             Meaning = """
-                      Formula The methodology used by the DfE to determine the per 
+                      The methodology used by the DfE to determine the per 
                       pupil amount allocated to the schools block for each local 
                       authority.  
                       """

--- a/web/src/Web.App/ViewModels/HighNeedsGlossaryViewModel.cs
+++ b/web/src/Web.App/ViewModels/HighNeedsGlossaryViewModel.cs
@@ -1,18 +1,326 @@
+// ReSharper disable RawStringCanBeSimplified
 namespace Web.App.ViewModels;
 
-public class HighNeedsGlossaryViewModel
+public class HighNeedsGlossaryViewModel : GlossaryViewModel
 {
-    public HighNeedsGlossaryItem[] Glossary =>
+    public GlossaryItem[] HighNeedsGlossary =>
     [
         new()
         {
-            Term = "AAR",
-            Meaning = "Academy Accounts Return"
+            Term = "Balance carried forward",
+            Meaning = """
+                      Balance carried forward is a cumulative number that is 
+                      decreased each year by any shortfall amount and 
+                      increased each year by any excess amount.   
+
+                      The s251 outturn statement will show the overall deficit 
+                      or surplus the local authority is carrying compared to the 
+                      funding they receive for the provision of education.
+                      """
+        },
+        new()
+        {
+            Term = "Budget",
+            Meaning = """
+                      A financial plan outlining how allocated funds will be 
+                      spent over the upcoming period. In this service this refers 
+                      to the s251 budget statement. 
+
+                      The budget calculations are carried out inclusive of the 
+                      academy allocation. 
+                      """
+        },
+        new()
+        {
+            Term = "DSG allocation",
+            Meaning = """
+                      Dedicated Schools Grant. Money allocated by 
+                      Department for Education to local authorities for specific 
+                      education related services. 
+
+                      This is divided into the blocks it should be spent in and 
+                      includes: 
+
+                      * schools block (calculated based on national funding formula)
+                      * high needs block
+                      * early years block
+                      * central school services block 
+                      """
+        },
+        new()
+        {
+            Term = "In year balance",
+            Meaning = """
+                      The financial balance of a school or a local authority 
+                      within a specific year, considering both income and 
+                      expenditure.  
+
+                      The in-year balance determines whether the school or 
+                      authority has a surplus (spending less than income) or a 
+                      deficit (spending more than income) for that particular 
+                      year.
+                      """
+        },
+        new()
+        {
+            Term = "National Funding",
+            Meaning = """
+                      Formula The methodology used by the DfE to determine the per 
+                      pupil amount allocated to the schools block for each local 
+                      authority.  
+                      """
+        },
+        new()
+        {
+            Term = "Outturn",
+            Meaning = """
+                      The outturn is the actual amount spent on high needs by 
+                      local authorities in each financial year.  This is taken from 
+                      the s251 outturn statement.
+
+                      **Use of outturn in this service** 
+
+                      In this service the academy recoupment amount is added 
+                      to the high needs spend reported by local authorities in 
+                      their s251 outturn statement. This combined figure can 
+                      then be compared against the high needs block amount 
+                      from the DSG for the year.
+                      """
+        },
+        new()
+        {
+            Term = "Place funding",
+            Meaning = """
+                      Place funding is allocated as an annual amount of core 
+                      high needs funding for schools and colleges.  
+
+                      Place funding is allocated at a standard rate for a number 
+                      of places, reflecting the number of high needs 
+                      placements which commissioning local authorities are 
+                      expected to require in the period.
+                      """
+        },
+        new()
+        {
+            Term = "S251",
+            Meaning = """
+                      The regulatory requirement to prepare and submit 
+                      annual, education and children and young people s 
+                      services, budget and outturn statements for each 
+                      financial year.
+                      """
+        },
+        new()
+        {
+            Term = "Top-up funding",
+            Meaning = """
+                      The additional financial support allocated by local 
+                      authorities to schools for pupils with Education, Health, 
+                      and Care Plans (EHCPs). This makes up the difference 
+                      between the cost of meeting the needs in the EHCP and 
+                      the place funding element of high needs for each pupil.
+                      """
         }
     ];
 }
 
-public class HighNeedsGlossaryItem
+public class GlossaryViewModel
+{
+    public GlossaryItem[] GeneralGlossary =>
+    [
+        new()
+        {
+            Term = "AAR",
+            Meaning = """
+                      Academy Accounts Return
+                      """
+        },
+        new()
+        {
+            Term = "AP",
+            Meaning = """
+                      Alternative provision. This relates to academies.
+                      """
+        },
+        new()
+        {
+            Term = "BFR",
+            Meaning = """
+                      Budget forecast return. Data collected for academic and 
+                      financial year analysis by Department for Education.  This 
+                      applies to the academy sector only.
+                      """
+        },
+        new()
+        {
+            Term = "CFP",
+            Meaning = """
+                      Curriculum and Financial Planning. This is a management 
+                      process that has been tailored for FBIT from the Integrated 
+                      Curriculum and Financial Planning (ICFP) process. This 
+                      helps schools plan the best curriculum for their pupils with 
+                      the funding they have available.
+                      """
+        },
+        new()
+        {
+            Term = "CFR",
+            Meaning = """
+                      Consistent Financial Reporting. The consistent financial 
+                      reporting (CFR) framework provides a standard template 
+                      for schools to collect information about their income and 
+                      expenditure by financial years. Maintained schools then 
+                      provide this information to their local authorities in a 
+                      financial statement each year
+                      """
+        },
+        new()
+        {
+            Term = "FBIS",
+            Meaning = """
+                      A summary showing highlights of your schools spending
+                      compared with a number of similar schools. This replaced
+                      Benchmarking Report Cards (BRC).
+                      """
+        },
+        new()
+        {
+            Term = "FSM",
+            Meaning = """
+                      Free school meals
+                      """
+        },
+        new()
+        {
+            Term = "High executive pay",
+            Meaning = """
+                      Financial compensation for senior executive staff in 
+                      academy trusts.
+                      """
+        },
+        new()
+        {
+            Term = "IDACI",
+            Meaning = """
+                      Income deprivation affecting children index
+                      """
+        },
+        new()
+        {
+            Term = "KS2",
+            Meaning = """
+                      Key stage 2
+                      """
+        },
+        new()
+        {
+            Term = "KS4",
+            Meaning = """
+                      Key stage 4
+                      """
+        },
+        new()
+        {
+            Term = "LA",
+            Meaning = """
+                      Local authority
+                      """
+        },
+        new()
+        {
+            Term = "National funding formula",
+            Meaning = """
+                      The way government decides how much core funding 
+                      should be allocated for mainstream state funded schools.
+                      """
+        },
+        new()
+        {
+            Term = "NMSS",
+            Meaning = """
+                      Non maintained special school (or independent special 
+                      school)
+                      """
+        },
+        new()
+        {
+            Term = "Ofsted rating",
+            Meaning = """
+                      A grade given to schools and other educational 
+                      establishments by the Office for Standards in Education, 
+                      Children's Services and Skills.
+                      """
+
+        },
+        new()
+        {
+            Term = "ONS",
+            Meaning = """
+                      Office for National Statistics
+                      """
+        },
+        new()
+        {
+            Term = "Post-school",
+            Meaning = """
+                      Further education (FE) colleges, sixth form colleges, 
+                      independent colleges, special post-16 institutions and 
+                      other post-16 providers that do not provide for pupils of 
+                      compulsory school age, including 16-19 maintained 
+                      schools and academies.
+                      """
+        },
+        new()
+        {
+            Term = "PRU",
+            Meaning = """
+                      Pupil referral unit. These are local authority maintained.
+                      """
+        },
+        new()
+        {
+            Term = "RAG",
+            Meaning = """
+                      Red, amber and green (RAG) priority ratings are shown 
+                      to give an indication of the spending compared to similar 
+                      schools. 
+                              
+                      The rating is not an indication of performance. It is used to
+                      display if spending is significantly more or less than similar 
+                      schools. This does not consider any individual spending 
+                      strategies which might apply. 
+                              
+                      The ratings are intended for schools and trusts to identify 
+                      potential areas to help them make informed spending 
+                      decisions. 
+                      """
+        },
+        new()
+        {
+            Term = "SEN",
+            Meaning = """
+                      Special educational needs
+                      """
+        },
+        new()
+        {
+            Term = "SEN2",
+            Meaning = """
+                      A statutory annual data collection of special educational 
+                      needs.
+                      """
+        },
+        new()
+        {
+            Term = "VCU",
+            Meaning = """
+                      Vulnerable children's unit
+                      """
+        }
+    ];
+}
+
+public class GlossaryItem
 {
     public string? Term { get; init; }
     public string? Meaning { get; init; }

--- a/web/src/Web.App/Views/StaticContent/HighNeedsGlossary.cshtml
+++ b/web/src/Web.App/Views/StaticContent/HighNeedsGlossary.cshtml
@@ -1,4 +1,5 @@
 ﻿@using Web.App.Extensions
+@using Westwind.AspNetCore.Markdown
 @model Web.App.ViewModels.HighNeedsGlossaryViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.HighNeedsGlossary;
@@ -9,25 +10,47 @@
         <h1 class="govuk-heading-l">@PageTitles.HighNeedsGlossary</h1>
 
         <p class="govuk-body">
-            The table details some of the terms used in the high needs benchmarking service.
+            These are terms which are used in the Financial Benchmarking and Insights Tool which will help you
+            understand and use the tool more effectively.
         </p>
 
         <table class="govuk-table">
-            <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden">High needs benchmarking
-                glossary
+            <caption class="govuk-table__caption govuk-table__caption--m">
+                High needs glossary
             </caption>
             <thead class="govuk-table__head">
             <tr class="govuk-table__row">
-                <th scope="col" class="govuk-table__header">Term</th>
-                <th scope="col" class="govuk-table__header">Meaning</th>
+                <th scope="col" class="govuk-table__header govuk-!-width-one-third">Term</th>
+                <th scope="col" class="govuk-table__header govuk-!-width-two-thirds">Meaning</th>
             </tr>
             </thead>
             <tbody class="govuk-table__body">
-            @foreach (var item in Model.Glossary)
+            @foreach (var item in Model.HighNeedsGlossary)
             {
                 <tr class="govuk-table__row" id="high-needs-glossary-@item.Term?.ToSlug()">
                     <td class="govuk-table__cell">@item.Term</td>
-                    <td class="govuk-table__cell">@item.Meaning</td>
+                    <td class="govuk-table__cell markdown">@Markdown.ParseHtmlString(item.Meaning)</td>
+                </tr>
+            }
+            </tbody>
+        </table>
+
+        <table class="govuk-table">
+            <caption class="govuk-table__caption govuk-table__caption--m">
+                Other terms used in the Financial Benchmarking and Insights Tool
+            </caption>
+            <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header govuk-!-width-one-third">Term</th>
+                <th scope="col" class="govuk-table__header govuk-!-width-two-thirds">Meaning</th>
+            </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+            @foreach (var item in Model.GeneralGlossary)
+            {
+                <tr class="govuk-table__row" id="general-glossary-@item.Term?.ToSlug()">
+                    <td class="govuk-table__cell">@item.Term</td>
+                    <td class="govuk-table__cell markdown">@Markdown.ParseHtmlString(item.Meaning)</td>
                 </tr>
             }
             </tbody>

--- a/web/src/Web.App/Web.App.csproj
+++ b/web/src/Web.App/Web.App.csproj
@@ -34,5 +34,6 @@
         <PackageReference Include="Serilog.Sinks.ApplicationInsights"/>
         <PackageReference Include="SmartBreadcrumbs"/>
         <PackageReference Include="Swashbuckle.AspNetCore"/>
+        <PackageReference Include="Westwind.AspNetCore.Markdown"/>
     </ItemGroup>
 </Project>

--- a/web/src/Web.App/packages.lock.json
+++ b/web/src/Web.App/packages.lock.json
@@ -229,6 +229,15 @@
           "Swashbuckle.AspNetCore.SwaggerUI": "8.1.4"
         }
       },
+      "Westwind.AspNetCore.Markdown": {
+        "type": "Direct",
+        "requested": "[3.23.0, )",
+        "resolved": "3.23.0",
+        "contentHash": "2EoMkcJkG7VINFPU0wG9ihQI4Y7t2zUnbfIaSmD2dJChoorwXbmFDlUuF1bNCtIB7n47c7ckp8L8RrhvNApAAQ==",
+        "dependencies": {
+          "Markdig": "0.40.0"
+        }
+      },
       "Azure.Core": {
         "type": "Transitive",
         "resolved": "1.46.1",
@@ -247,6 +256,11 @@
           "Azure.Core": "1.44.1",
           "System.IO.Hashing": "6.0.0"
         }
+      },
+      "Markdig": {
+        "type": "Transitive",
+        "resolved": "0.40.0",
+        "contentHash": "4ve14zs+gt1irldTQE3y5FLAHuzmhW7T99lAAvVipe/q2LWT/nUCO0iICb9TXGvMX6n7Z1OZroFXkdSy91rO8w=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",

--- a/web/tests/Web.E2ETests/Features/HighNeedsGlossary.feature
+++ b/web/tests/Web.E2ETests/Features/HighNeedsGlossary.feature
@@ -1,5 +1,9 @@
 ﻿Feature: High needs glossary
 
-    Scenario: Terms displayed in the glossary table
+    Scenario: Terms displayed in the high needs glossary table
         Given I am on high needs glossary page
-        Then there are 1 items in the glossary
+        Then there are 9 items in the high needs glossary
+        
+    Scenario: Terms displayed in the general glossary table
+        Given I am on high needs glossary page
+        Then there are 22 items in the general glossary

--- a/web/tests/Web.E2ETests/Pages/HighNeedsGlossaryPage.cs
+++ b/web/tests/Web.E2ETests/Pages/HighNeedsGlossaryPage.cs
@@ -12,9 +12,16 @@ public class HighNeedsGlossaryPage(IPage page) : BasePage(page)
         await PageH1Heading.ShouldBeVisible();
     }
 
-    public async Task AssertGlossary(int count)
+    public async Task AssertHighNeedsGlossary(int count)
     {
         var glossaryRows = _page.Locator("[id^=high-needs-glossary-]");
+        var actualCount = await glossaryRows.CountAsync();
+        Assert.Equal(count, actualCount);
+    }
+
+    public async Task AssertGeneralGlossary(int count)
+    {
+        var glossaryRows = _page.Locator("[id^=general-glossary-]");
         var actualCount = await glossaryRows.CountAsync();
         Assert.Equal(count, actualCount);
     }

--- a/web/tests/Web.E2ETests/Steps/HighNeedsGlossarySteps.cs
+++ b/web/tests/Web.E2ETests/Steps/HighNeedsGlossarySteps.cs
@@ -21,11 +21,18 @@ public class HighNeedsGlossarySteps(PageDriver driver)
         await _highNeedsGlossaryPage.IsDisplayed();
     }
 
-    [Then("there are (.*) items in the glossary")]
-    public async Task ThenThereAreItemsInTheGlossary(int count)
+    [Then("there are (.*) items in the high needs glossary")]
+    public async Task ThenThereAreItemsInTheHighNeedsGlossary(int count)
     {
         Assert.NotNull(_highNeedsGlossaryPage);
-        await _highNeedsGlossaryPage.AssertGlossary(count);
+        await _highNeedsGlossaryPage.AssertHighNeedsGlossary(count);
+    }
+
+    [Then("there are (.*) items in the general glossary")]
+    public async Task ThenThereAreItemsInTheGeneralGlossary(int count)
+    {
+        Assert.NotNull(_highNeedsGlossaryPage);
+        await _highNeedsGlossaryPage.AssertGeneralGlossary(count);
     }
 
     private static string HighNeedsGlossaryUrl()

--- a/web/tests/Web.Integration.Tests/WebAppClientBase.cs
+++ b/web/tests/Web.Integration.Tests/WebAppClientBase.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Xunit;
 using Xunit.Abstractions;
+
 namespace Web.Integration.Tests;
 
 public abstract class WebAppClientBase<TStartup> : WebApplicationFactory<TStartup> where TStartup : class
@@ -40,7 +41,10 @@ public abstract class WebAppClientBase<TStartup> : WebApplicationFactory<TStartu
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.ConfigureServices(_ => { });
-        builder.UseEnvironment("Integration");
+        builder.UseEnvironment("Integration")
+            // prevent `ArgumentNullException` from test run in ADO pipeline in
+            // Westwind.AspNetCore.Markdown.MarkdownPageProcessorMiddleware
+            .UseWebRoot($"{builder.GetSetting("contentRoot")}/wwwroot");
     }
 
     protected abstract void Configure(IServiceCollection services);

--- a/web/tests/Web.Integration.Tests/packages.lock.json
+++ b/web/tests/Web.Integration.Tests/packages.lock.json
@@ -189,6 +189,11 @@
           "System.Reflection.TypeExtensions": "4.1.0"
         }
       },
+      "Markdig": {
+        "type": "Transitive",
+        "resolved": "0.40.0",
+        "contentHash": "4ve14zs+gt1irldTQE3y5FLAHuzmhW7T99lAAvVipe/q2LWT/nUCO0iICb9TXGvMX6n7Z1OZroFXkdSy91rO8w=="
+      },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
         "resolved": "2.23.0",
@@ -2086,7 +2091,8 @@
           "Serilog.Enrichers.CorrelationId": "[3.0.1, )",
           "Serilog.Sinks.ApplicationInsights": "[4.0.0, )",
           "SmartBreadcrumbs": "[3.6.1, )",
-          "Swashbuckle.AspNetCore": "[8.1.4, )"
+          "Swashbuckle.AspNetCore": "[8.1.4, )",
+          "Westwind.AspNetCore.Markdown": "[3.23.0, )"
         }
       },
       "Azure.Identity": {
@@ -2276,6 +2282,15 @@
           "Swashbuckle.AspNetCore.Swagger": "8.1.4",
           "Swashbuckle.AspNetCore.SwaggerGen": "8.1.4",
           "Swashbuckle.AspNetCore.SwaggerUI": "8.1.4"
+        }
+      },
+      "Westwind.AspNetCore.Markdown": {
+        "type": "CentralTransitive",
+        "requested": "[3.23.0, )",
+        "resolved": "3.23.0",
+        "contentHash": "2EoMkcJkG7VINFPU0wG9ihQI4Y7t2zUnbfIaSmD2dJChoorwXbmFDlUuF1bNCtIB7n47c7ckp8L8RrhvNApAAQ==",
+        "dependencies": {
+          "Markdig": "0.40.0"
         }
       },
       "xunit.abstractions": {

--- a/web/tests/Web.Tests/Middleware/WhenGdsMarkdownExtensionIsProcessed.cs
+++ b/web/tests/Web.Tests/Middleware/WhenGdsMarkdownExtensionIsProcessed.cs
@@ -1,0 +1,58 @@
+using Markdig;
+using Web.App.Middleware.Markdown;
+using Xunit;
+
+namespace Web.Tests.Middleware;
+
+public class WhenGdsMarkdownExtensionIsProcessed
+{
+    private readonly MarkdownPipeline _pipeline;
+
+    public WhenGdsMarkdownExtensionIsProcessed()
+    {
+        var extension = new GdsMarkdownExtension();
+        var pipeline = new MarkdownPipelineBuilder()
+            .UsePipeTables();
+
+        extension.Setup(pipeline);
+        _pipeline = pipeline.Build();
+    }
+
+    [Fact]
+    public void ShouldRenderGdsLink()
+    {
+        const string markdown = "[Example link](https://example.com)";
+        var actual = Markdown.ToHtml(markdown, _pipeline);
+
+        Assert.Equal("<p class=\"govuk-body\"><a href=\"https://example.com\" class=\"govuk-link\">Example link</a></p>\n", actual);
+    }
+
+    [Fact]
+    public void ShouldRenderGdsList()
+    {
+        const string markdown = "* Example item 1\n* Example item 2";
+        var actual = Markdown.ToHtml(markdown, _pipeline);
+
+        Assert.Equal("<ul class=\"govuk-list govuk-list--bullet\">\n<li>Example item 1</li>\n<li>Example item 2</li>\n</ul>\n", actual);
+    }
+
+    [Theory]
+    [InlineData("Single paragraph", "<p class=\"govuk-body\">Single paragraph</p>\n")]
+    [InlineData("Split\nsingle paragraph", "<p class=\"govuk-body\">Split\nsingle paragraph</p>\n")]
+    [InlineData("Double\n\nparagraph", "<p class=\"govuk-body\">Double</p>\n<p class=\"govuk-body\">paragraph</p>\n")]
+    public void ShouldRenderGdsParagraph(string markdown, string expected)
+    {
+        var actual = Markdown.ToHtml(markdown, _pipeline);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ShouldRenderGdsTable()
+    {
+        const string markdown = "| Item | Value |\n| --- | --- |\n| 001 | 123 |\n| 002 | 456 |";
+        var actual = Markdown.ToHtml(markdown, _pipeline);
+
+        Assert.Equal("<table class=\"govuk-table\">\n<thead>\n<tr class=\"govuk-table__row\">\n<th class=\"govuk-table__cell\">Item</th>\n<th class=\"govuk-table__cell\">Value</th>\n</tr>\n</thead>\n<tbody>\n<tr class=\"govuk-table__row\">\n<td class=\"govuk-table__cell\">001</td>\n<td class=\"govuk-table__cell\">123</td>\n</tr>\n<tr class=\"govuk-table__row\">\n<td class=\"govuk-table__cell\">002</td>\n<td class=\"govuk-table__cell\">456</td>\n</tr>\n</tbody>\n</table>\n", actual);
+    }
+}

--- a/web/tests/Web.Tests/packages.lock.json
+++ b/web/tests/Web.Tests/packages.lock.json
@@ -110,6 +110,11 @@
           "NETStandard.Library": "1.6.1"
         }
       },
+      "Markdig": {
+        "type": "Transitive",
+        "resolved": "0.40.0",
+        "contentHash": "4ve14zs+gt1irldTQE3y5FLAHuzmhW7T99lAAvVipe/q2LWT/nUCO0iICb9TXGvMX6n7Z1OZroFXkdSy91rO8w=="
+      },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
         "resolved": "2.23.0",
@@ -1858,7 +1863,8 @@
           "Serilog.Enrichers.CorrelationId": "[3.0.1, )",
           "Serilog.Sinks.ApplicationInsights": "[4.0.0, )",
           "SmartBreadcrumbs": "[3.6.1, )",
-          "Swashbuckle.AspNetCore": "[8.1.4, )"
+          "Swashbuckle.AspNetCore": "[8.1.4, )",
+          "Westwind.AspNetCore.Markdown": "[3.23.0, )"
         }
       },
       "Azure.Identity": {
@@ -2071,6 +2077,15 @@
           "Swashbuckle.AspNetCore.Swagger": "8.1.4",
           "Swashbuckle.AspNetCore.SwaggerGen": "8.1.4",
           "Swashbuckle.AspNetCore.SwaggerUI": "8.1.4"
+        }
+      },
+      "Westwind.AspNetCore.Markdown": {
+        "type": "CentralTransitive",
+        "requested": "[3.23.0, )",
+        "resolved": "3.23.0",
+        "contentHash": "2EoMkcJkG7VINFPU0wG9ihQI4Y7t2zUnbfIaSmD2dJChoorwXbmFDlUuF1bNCtIB7n47c7ckp8L8RrhvNApAAQ==",
+        "dependencies": {
+          "Markdig": "0.40.0"
         }
       },
       "xunit.abstractions": {


### PR DESCRIPTION
### Context
[AB#260743](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/260743) [AB#263950](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/263950)

### Change proposed in this pull request
- Modified High Needs glossary page to render High Needs and general glossary in separate tables
- Added markdown support for custom formatted definitions
- Updated E2E tests

### Guidance to review 
See user story for signed off glossary items included here.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

