### PR TITLE
fix: margins for secondary title on la national ranking page

### DIFF
--- a/front-end-components/src/views/la-national-rank/view.tsx
+++ b/front-end-components/src/views/la-national-rank/view.tsx
@@ -22,7 +22,9 @@ export const LaNationalRankView: React.FC<LaNationalRankViewProps> = ({
 
   return (
     <>
-      <h2 className="govuk-heading-m">{title}</h2>
+      <h2 className="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-5">
+        {title}
+      </h2>
       <div className="govuk-tabs" data-module="govuk-tabs">
         <ul className="govuk-tabs__list">
           <li className="govuk-tabs__list-item govuk-tabs__list-item--selected">


### PR DESCRIPTION
### Context
[AB#265025](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/265025) [AB#265935](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/265935)

see screenshots on parent and task work items

### Change proposed in this pull request

fix to the margins for the leading h2 element in the `LaNationalRankView` component to match design.
adds margin to top and bottom of this title

### Guidance to review 
output has been validated with design

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto feature branch
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

