### PR TITLE
Content and design pass over latest High Needs pages

### DIFF
--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -830,3 +830,19 @@ table#current-comparators-la {
 .chart-stat-title {
   @include govuk-font(16);
 }
+
+.govuk-body {
+  &.govuk-body--pretty {
+    text-wrap: pretty;
+  }
+}
+
+#funding-vs-outturn, #expenditure-vs-outturn {
+  .govuk-table {
+    .govuk-table__header--numeric, .govuk-table__cell--numeric {
+      &:not(:last-of-type) {
+        text-align: left;
+      }
+    }
+  }
+}

--- a/web/src/Web.App/Constants/PageTitles.cs
+++ b/web/src/Web.App/Constants/PageTitles.cs
@@ -66,7 +66,7 @@ public static class PageTitles
     public const string LocalAuthorityComparison = "View school spending";
     public const string LocalAuthorityCensus = "View pupil and workforce data";
     public const string LocalAuthorityHighNeeds = "High needs benchmarking overview";
-    public const string LocalAuthorityHighNeedsBenchmarking = "Benchmark High needs";
+    public const string LocalAuthorityHighNeedsBenchmarking = "Benchmark high needs";
     public const string LocalAuthorityHighNeedsStartBenchmarking = "Choose local authorities to benchmark against";
     public const string LocalAuthorityHighNeedsHistoricData = "High needs historical spending";
     public const string LocalAuthorityHighNeedsNationalRankings = "High needs national view";

--- a/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsHeadlines/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/LocalAuthorityHighNeedsHeadlines/Default.cshtml
@@ -29,6 +29,6 @@
     </tbody>
 </table>
 
-<p class="govuk-body">
+<p class="govuk-body govuk-body--pretty">
     @Model.Commentary
 </p>

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsBenchmarking.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsBenchmarking.cs
@@ -70,7 +70,7 @@ public class WhenViewingHighNeedsBenchmarking(SchoolBenchmarkingWebAppClient cli
         DocumentAssert.Breadcrumbs(page, expectedBreadcrumbs);
 
         Assert.NotNull(authority.Name);
-        DocumentAssert.TitleAndH1(page, "Benchmark High needs - Financial Benchmarking and Insights Tool - GOV.UK", "Benchmark High needs");
+        DocumentAssert.TitleAndH1(page, "Benchmark high needs - Financial Benchmarking and Insights Tool - GOV.UK", "Benchmark high needs");
 
         var backLink = page.QuerySelector("a.govuk-back-link") as IHtmlAnchorElement;
         Assert.NotNull(backLink);


### PR DESCRIPTION
### Context
[AB#265019](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/265019) [AB#265991](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/265991)

### Change proposed in this pull request
#### Homepage ####
- Key information box - year information to be on the same line (i.e. 2023-2024)
- ~~National view CTA - needs to be labelled 'View full national data'~~
- Historical spending - table content should all be left aligned with the exception of the last column.
#### Benchmarking page ####
- Title 'Benchmark High needs' should be a lower case 'h' to be: 'Benchmark high needs'

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto ~~main~~ `feature/high-needs`
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

