### PR TITLE
Added warning message to historical charts when no data available

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -92,10 +92,10 @@
       ></div>
       <button type="submit">Submit</button>
     </form>-->
-    <div id="compare-your-trust" 
+    <!--<div id="compare-your-trust" 
       data-id="10279605"
       data-show-high-exec="true"
-    ></div>
+    ></div>-->
     <!--<div
       id="compare-your-costs"
       data-type="trust"
@@ -104,8 +104,8 @@
     ></div>-->
     <!-- <div id="compare-your-costs" data-type="school" data-id="990250" data-suppress-negative-or-zero="true" 
     data-cost-code-map="{&quot;teaching staff&quot;:&quot;BAE010&quot;,&quot;supply teaching staff&quot;:&quot;BAE020&quot;,&quot;agency supply teaching staff&quot;:&quot;BAE240&quot;,&quot;education support staff&quot;:&quot;BAE030&quot;,&quot;educational consultancy&quot;:&quot;BAE230&quot;,&quot;administrative and clerical staff&quot;:&quot;BAE040&quot;,&quot;auditor costs&quot;:&quot;BAE260&quot;,&quot;other staff&quot;:&quot;BAE070&quot;,&quot;professional services (non-curriculum)&quot;:&quot;BAE300&quot;,&quot;examination fees&quot;:&quot;BAE220&quot;,&quot;learning resources (not ICT equipment)&quot;:&quot;BAE200&quot;,&quot;ict learning resources&quot;:&quot;BAE210&quot;,&quot;cleaning and caretaking&quot;:&quot;BAE130&quot;,&quot;maintenance of premises&quot;:&quot;BAE120&quot;,&quot;other occupation costs&quot;:&quot;BAE180&quot;,&quot;premises staff&quot;:&quot;BAE050&quot;,&quot;energy&quot;:&quot;BAE150&quot;,&quot;water and sewerage&quot;:&quot;BAE140&quot;,&quot;administrative supplies (non-educational)&quot;:&quot;BAE280&quot;,&quot;catering staff&quot;:&quot;BAE060&quot;,&quot;catering supplies&quot;:&quot;BAE250&quot;,&quot;direct revenue financing&quot;:&quot;BAE290&quot;,&quot;grounds maintenance&quot;:&quot;BAE320&quot;,&quot;indirect employee expenses&quot;:&quot;BAE080&quot;,&quot;interest charges for loan and bank&quot;:&quot;BAE320&quot;,&quot;other insurance premiums&quot;:&quot;BAE270&quot;,&quot;private Finance Initiative (PFI) charges&quot;:&quot;BAE310&quot;,&quot;rent and rates&quot;:&quot;BAE160&quot;,&quot;special facilities&quot;:&quot;BAE190&quot;,&quot;staff development and training&quot;:&quot;BAE090&quot;,&quot;staff-related insurance&quot;:&quot;BAE110&quot;,&quot;supply teacher insurance&quot;:&quot;BAE100&quot;}" data-is-part-of-trust="true"></div> -->
-    <!--<div id="historic-data" data-type="school" data-id="150963"></div>-->
-    <!--<div id="historic-data-2" data-type="school" data-id="150963" data-phase="Primary" data-finance-type="Maintained"></div>-->
+    <!--<div id="historic-data" data-type="school" data-id="123456"></div>-->
+    <div id="historic-data-2" data-type="school" data-id="123456" data-phase="Primary" data-finance-type="Maintained"></div>
     <!--<div
       id="compare-your-costs"
       data-type="local-authority"

--- a/front-end-components/src/composed/historic-chart-2-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-2-composed/component.tsx
@@ -16,6 +16,7 @@ import { HistoryBase } from "src/services";
 import { HistoricDataTooltip } from "src/components/charts/historic-data-tooltip";
 import { ResolvedStat } from "src/components/charts/resolved-stat";
 import { ShareContent } from "src/components/share-content";
+import { DataWarning } from "src/components/charts/data-warning";
 
 export function HistoricChart2<TData extends HistoryBase>({
   axisLabel,
@@ -109,6 +110,18 @@ export function HistoricChart2<TData extends HistoryBase>({
       setImageCopied(false);
     }, 2000);
   };
+
+  const hasOwnData = mergedData.some((d) => !!d.school);
+  if (!hasOwnData) {
+    return (
+      <div className="govuk-grid-row govuk-!-margin-bottom-5">
+        <div className="govuk-grid-column-full">{children}</div>
+        <div className="govuk-grid-column-full">
+          <DataWarning>No data available for this category.</DataWarning>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <>

--- a/front-end-components/src/composed/historic-chart-composed/component.tsx
+++ b/front-end-components/src/composed/historic-chart-composed/component.tsx
@@ -12,6 +12,7 @@ import { ResolvedStat } from "src/components/charts/resolved-stat";
 import { ChartDataSeries } from "src/components/charts/types";
 import { ChartDimensionContext, useChartModeContext } from "src/contexts";
 import { ShareContent } from "src/components/share-content";
+import { DataWarning } from "src/components/charts/data-warning";
 
 export function HistoricChart<TData extends ChartDataSeries>({
   axisLabel,
@@ -36,6 +37,18 @@ export function HistoricChart<TData extends ChartDataSeries>({
       setImageCopied(false);
     }, 2000);
   };
+
+  const hasOwnData = data.some((d) => !!d[valueField]);
+  if (!hasOwnData) {
+    return (
+      <div className="govuk-grid-row govuk-!-margin-bottom-5">
+        <div className="govuk-grid-column-full">{children}</div>
+        <div className="govuk-grid-column-full">
+          <DataWarning>No data available for this category.</DataWarning>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <>

--- a/web/tests/Web.E2ETests/Features/School/HistoricData.feature
+++ b/web/tests/Web.E2ETests/Features/School/HistoricData.feature
@@ -28,13 +28,14 @@
         Given I am on '<tab>' history page for school with URN '777042'
         And all sections are shown on '<tab>'
         Then there should be '<charts>' charts displayed on '<tab>'
+        And there should be '<warnings>' warnings displayed on '<tab>'
 
         Examples:
-          | tab      | charts |
-          | spending | 42     |
-          | income   | 17     |
-          | balance  | 2      |
-          | census   | 9      |
+          | tab      | charts | warnings |
+          | spending | 33     | 9        |
+          | income   | 11     | 6        |
+          | balance  | 2      | 0        |
+          | census   | 8      | 1        |
 
     Scenario Outline: Change all charts to table view
         Given I am on '<tab>' history page for school with URN '777042'

--- a/web/tests/Web.E2ETests/Steps/School/HistoricDataSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/HistoricDataSteps.cs
@@ -2,6 +2,7 @@
 using Web.E2ETests.Drivers;
 using Web.E2ETests.Pages.School;
 using Xunit;
+
 namespace Web.E2ETests.Steps.School;
 
 [Binding]
@@ -71,6 +72,13 @@ public class HistoricDataSteps(PageDriver driver)
     {
         Assert.NotNull(_historicDataPage);
         await _historicDataPage.HasChartCount(TabNamesFromFriendlyNames(tab), int.Parse(count));
+    }
+
+    [Then("there should be '(.*)' warnings displayed on '(.*)'")]
+    public async Task ThenThereShouldBeWarningsDisplayedOn(string count, string tab)
+    {
+        Assert.NotNull(_historicDataPage);
+        await _historicDataPage.HasWarningCount(TabNamesFromFriendlyNames(tab), int.Parse(count));
     }
 
     [Then("are showing table view on '(.*)' tab")]


### PR DESCRIPTION
### Context
AB#217962 AB#266346 AB#266347

### Change proposed in this pull request
- Add warning message on School Historic data charts (original, and multi series) when school has no data over the entire range of years
- E2E test coverage 

### Guidance to review 
Build and copy `front-end` to `Web` to validate changes locally with a school with part-missing data (e.g. URN `123546`).

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] You have run all unit/integration tests and they pass
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [x] You have reviewed with UX/Design

