### PR TITLE
chore: add check to documentation pipeline to verify pdf created

### DIFF
--- a/pipelines/documentation/build.yaml
+++ b/pipelines/documentation/build.yaml
@@ -67,7 +67,7 @@ stages:
   - stage: GenerateDocumentation
     dependsOn: [ Validate ]
     displayName: 'Generate'
-    # condition: and(succeeded(), eq(variables['ShouldDeploy'],'true'))
+    condition: and(succeeded(), eq(variables['ShouldDeploy'],'true'))
     jobs:
       - job: BuildDocumentation
         displayName: 'Build and publish documentation'
@@ -115,24 +115,24 @@ stages:
             parameters:
               folder: 'data'
 
-          # - task: PublishPipelineArtifact@1
-          #   displayName: 'Publish artifacts'
-          #   inputs:
-          #     targetPath: '$(WorkingDir)/pub'
-          #     artifact: 'docs'
-          #     publishLocation: 'pipeline'
+          - task: PublishPipelineArtifact@1
+            displayName: 'Publish artifacts'
+            inputs:
+              targetPath: '$(WorkingDir)/pub'
+              artifact: 'docs'
+              publishLocation: 'pipeline'
               
-      # - job: SharePointPublish
-      #   displayName: 'Publish artifacts to SharePoint'
-      #   dependsOn: [ BuildDocumentation ]
-      #   steps:
-      #     - checkout: self
+      - job: SharePointPublish
+        displayName: 'Publish artifacts to SharePoint'
+        dependsOn: [ BuildDocumentation ]
+        steps:
+          - checkout: self
 
-      #     - template: ..\common\publish-sharepoint-artifacts.yaml
-      #       parameters:
-      #         ArtifactName: 'docs'
-      #         ArtifactPattern: '**/*.pdf'
-      #         TargetPath: 'FBIT support\Documentation'
-      #         SiteUrl: $(SharePoint_SiteUrl)
-      #         ClientId: $(SharePoint_ClientId)
-      #         ClientSecret: $(SharePoint_ClientSecret)
+          - template: ..\common\publish-sharepoint-artifacts.yaml
+            parameters:
+              ArtifactName: 'docs'
+              ArtifactPattern: '**/*.pdf'
+              TargetPath: 'FBIT support\Documentation'
+              SiteUrl: $(SharePoint_SiteUrl)
+              ClientId: $(SharePoint_ClientId)
+              ClientSecret: $(SharePoint_ClientSecret)

--- a/pipelines/documentation/build.yaml
+++ b/pipelines/documentation/build.yaml
@@ -67,7 +67,7 @@ stages:
   - stage: GenerateDocumentation
     dependsOn: [ Validate ]
     displayName: 'Generate'
-    condition: and(succeeded(), eq(variables['ShouldDeploy'],'true'))
+    # condition: and(succeeded(), eq(variables['ShouldDeploy'],'true'))
     jobs:
       - job: BuildDocumentation
         displayName: 'Build and publish documentation'
@@ -115,24 +115,24 @@ stages:
             parameters:
               folder: 'data'
 
-          - task: PublishPipelineArtifact@1
-            displayName: 'Publish artifacts'
-            inputs:
-              targetPath: '$(WorkingDir)/pub'
-              artifact: 'docs'
-              publishLocation: 'pipeline'
+          # - task: PublishPipelineArtifact@1
+          #   displayName: 'Publish artifacts'
+          #   inputs:
+          #     targetPath: '$(WorkingDir)/pub'
+          #     artifact: 'docs'
+          #     publishLocation: 'pipeline'
               
-      - job: SharePointPublish
-        displayName: 'Publish artifacts to SharePoint'
-        dependsOn: [ BuildDocumentation ]
-        steps:
-          - checkout: self
+      # - job: SharePointPublish
+      #   displayName: 'Publish artifacts to SharePoint'
+      #   dependsOn: [ BuildDocumentation ]
+      #   steps:
+      #     - checkout: self
 
-          - template: ..\common\publish-sharepoint-artifacts.yaml
-            parameters:
-              ArtifactName: 'docs'
-              ArtifactPattern: '**/*.pdf'
-              TargetPath: 'FBIT support\Documentation'
-              SiteUrl: $(SharePoint_SiteUrl)
-              ClientId: $(SharePoint_ClientId)
-              ClientSecret: $(SharePoint_ClientSecret)
+      #     - template: ..\common\publish-sharepoint-artifacts.yaml
+      #       parameters:
+      #         ArtifactName: 'docs'
+      #         ArtifactPattern: '**/*.pdf'
+      #         TargetPath: 'FBIT support\Documentation'
+      #         SiteUrl: $(SharePoint_SiteUrl)
+      #         ClientId: $(SharePoint_ClientId)
+      #         ClientSecret: $(SharePoint_ClientSecret)

--- a/pipelines/documentation/generate-docs.yaml
+++ b/pipelines/documentation/generate-docs.yaml
@@ -18,5 +18,6 @@ steps:
         exit 1
       else
         echo "Found PDF output at: $output"
+      fi
     displayName: 'Verify ${{ parameters.folder }} output'
     workingDirectory: $(WorkingDir)

--- a/pipelines/documentation/generate-docs.yaml
+++ b/pipelines/documentation/generate-docs.yaml
@@ -9,3 +9,14 @@ steps:
   - bash: cp -a build/. pub
     displayName: 'Copy ${{ parameters.folder }} output'
     workingDirectory: $(WorkingDir)
+
+  - bash: |
+      output="./pub/${{ parameters.folder }}.pdf"
+      if [ ! -f "$output" ]; then
+        echo "Documentation PDF not generated for folder: ${{ parameters.folder }}"
+        echo "Expected at: $output"
+        exit 1
+      else
+        echo "Found PDF output at: $output"
+    displayName: 'Verify ${{ parameters.folder }} output'
+    workingDirectory: $(WorkingDir)

--- a/pipelines/documentation/generate-docs.yaml
+++ b/pipelines/documentation/generate-docs.yaml
@@ -2,22 +2,20 @@ parameters:
   folder: ''
 
 steps:
-  - bash: ./tools/build-docs.sh ${{ parameters.folder }} ${{ parameters.folder }}.pdf build --strip-comments --toc -f markdown -t pdf --pdf-engine=pdflatex --wrap=preserve --data-dir=$(DataDir) --template=pdf-template
-    displayName: 'Generate ${{ parameters.folder }} docs'
-    workingDirectory: $(WorkingDir)
-
-  - bash: cp -a build/. pub
-    displayName: 'Copy ${{ parameters.folder }} output'
-    workingDirectory: $(WorkingDir)
-
   - bash: |
-      output="./pub/${{ parameters.folder }}.pdf"
+      ./tools/build-docs.sh ${{ parameters.folder }} ${{ parameters.folder }}.pdf build --strip-comments --toc -f markdown -t pdf --pdf-engine=pdflatex --wrap=preserve --data-dir=$(DataDir) --template=pdf-template
+      
+      output="./build/${{ parameters.folder }}.pdf"
       if [ ! -f "$output" ]; then
         echo "Documentation PDF not generated for folder: ${{ parameters.folder }}"
         echo "Expected at: $output"
         exit 1
       else
-        echo "Found PDF output at: $output"
+        echo "Documentation PDF generated for folder: ${{ parameters.folder }}"
       fi
-    displayName: 'Verify ${{ parameters.folder }} output'
+    displayName: 'Generate ${{ parameters.folder }} docs'
+    workingDirectory: $(WorkingDir)
+
+  - bash: cp -a build/. pub
+    displayName: 'Copy ${{ parameters.folder }} output'
     workingDirectory: $(WorkingDir)


### PR DESCRIPTION
### Context
[AB#266112](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/266112) [AB#266334](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/266334)

### Change proposed in this pull request
As part of `generate-docs.yaml` template extends the existing generate step to verify the correct file is found and exit if not

### Guidance to review 
proposed fix should meet the ACs detailed in the parent work item. 

To validate behaviour, a pipeline was executed after disabling specific checks in commit faa68b6. The pipeline failed correctly when appropriate, and the existing logs appear sufficient for diagnosing issues. See description/comments for a link to the test run on [AB#266339](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/266339)

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally

