### PR TITLE
New `Banner` table definition and 'active' rows view

### DIFF
--- a/core-infrastructure/src/db/Core.Database/Scripts/117-CreateBannerTable.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/117-CreateBannerTable.sql
@@ -1,0 +1,16 @@
+IF NOT EXISTS(SELECT *
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE table_name = 'Banner')
+BEGIN
+    CREATE TABLE [dbo].[Banner]
+    (
+        Id          integer identity (1,1)  NOT NULL,
+        Title       nvarchar(255)           NOT NULL,
+        Body        nvarchar(max)           NOT NULL,
+        Target      nvarchar(255)           NOT NULL,
+        ValidFrom   datetimeoffset          NOT NULL DEFAULT GETUTCDATE(),
+        ValidTo     datetimeoffset          NULL,
+
+        CONSTRAINT PK_Banner PRIMARY KEY (Id),
+    );
+END;

--- a/core-infrastructure/src/db/Core.Database/Views/025-Banners.sql
+++ b/core-infrastructure/src/db/Core.Database/Views/025-Banners.sql
@@ -1,0 +1,10 @@
+DROP VIEW IF EXISTS VW_ActiveBanners
+GO
+
+CREATE VIEW VW_ActiveBanners
+AS
+  SELECT [Title], [Body], [Target]
+  FROM [dbo].[Banner]
+  WHERE [ValidFrom] < GETUTCDATE()
+    AND ([ValidTo] IS NULL OR [ValidTo] > GETUTCDATE())
+GO


### PR DESCRIPTION
### Context
[AB#264114](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/264114) [AB#266408](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/266408)

### Change proposed in this pull request
- New table to store banner title, content, target pages and validity
- View over above to only return 'active' rows based on validity date range

### Guidance to review 
Run migrations against a local database to validate.

### Checklist (add/remove as appropriate)
- [x] Work items have been linked [(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)
- [x] Your code builds clean without any errors or warnings
- [ ] ~~You have run all unit/integration tests and they pass~~
- [x] Your branch has been rebased onto main
- [x] You have tested by running locally
- [ ] ~~You have reviewed with UX/Design~~

