### PR TITLE
Add pipeline run stats to CompletedPipelineRun table

### DIFF
--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -474,7 +474,7 @@ def pre_process_all_schools(run_type, run_id, data_ref):
     all_schools = pd.concat([academies, maintained_schools], axis=0)
     # TODO: Shouldn't need to filter this out
     all_schools = all_schools[~all_schools["Financial Position"].isna()]
-    stats_collector.log_combined_school_counts(all_schools)
+    stats_collector.collect_combined_school_counts(all_schools)
 
     write_blob(
         "pre-processed",
@@ -840,8 +840,8 @@ def pre_process_data(
             maintained_data_ref,
         ),
     )
-    stats_collector.log_academy_counts(academies)
-    stats_collector.log_la_maintained_school_counts(maintained_schools)
+    stats_collector.collect_academy_counts(academies)
+    stats_collector.collect_la_maintained_school_counts(maintained_schools)
 
     if (
         academies_ilr_data := pre_process_ilr_data(
@@ -955,9 +955,9 @@ def pre_process_custom_data(
         custom_data=custom_data,
         target_urn=target_urn,
     )
-    stats_collector.log_academy_counts(academies)
-    stats_collector.log_la_maintained_school_counts(maintained)
-    stats_collector.log_combined_school_counts(all_schools)
+    stats_collector.collect_academy_counts(academies)
+    stats_collector.collect_la_maintained_school_counts(maintained)
+    stats_collector.collect_combined_school_counts(all_schools)
 
     write_blob(
         "pre-processed",

--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -9,7 +9,7 @@ from azure.core.exceptions import ResourceNotFoundError
 from azure.storage.queue import QueueClient, QueueMessage
 from dotenv import load_dotenv
 
-from pipeline.stats_collector import StatsCollector
+from pipeline.stats_collector import stats_collector
 
 load_dotenv()
 
@@ -1456,9 +1456,7 @@ def receive_messages():
 
                         logger.info(f"received message {msg.content}")
                         stats_collector.start_pipeline_run()
-                        msg = handle_msg(
-                            msg, worker_queue, complete_queue
-                        )
+                        msg = handle_msg(msg, worker_queue, complete_queue)
                         logger.info(f"processed msg response: {msg}")
                     else:
                         time.sleep(1)
@@ -1470,12 +1468,7 @@ def receive_messages():
 
 
 if __name__ == "__main__":
-    with suppress(tornado.iostream.StreamClosedError):
-        with Client(memory_limit="16GB", heartbeat_interval=None) as client:
-            try:
-                if os.getenv("ENV") == "dev":
-                    receive_messages(client)
-                else:
-                    receive_one_message(client)
-            finally:
-                client.close()
+    if os.getenv("ENV") == "dev":
+        receive_messages()
+    else:
+        receive_one_message()

--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -1303,6 +1303,7 @@ def handle_msg(
         match get_message_type(message=msg_payload):
             case MessageType.Default:
                 logger.info("Starting default pipeline run...")
+                stats_collector.start_pipeline_run()
                 msg_payload["pre_process_duration"] = pre_process_data(
                     run_id=str(msg_payload["runId"]),
                     aar_year=msg_payload["year"]["aar"],
@@ -1333,6 +1334,7 @@ def handle_msg(
 
             case MessageType.Custom:
                 logger.info("Starting custom pipeline run...")
+                stats_collector.start_pipeline_run()
                 msg_payload["pre_process_duration"] = pre_process_custom_data(
                     run_id=msg_payload["runId"],
                     year=msg_payload["year"],
@@ -1455,7 +1457,6 @@ def receive_messages():
                         )
 
                         logger.info(f"received message {msg.content}")
-                        stats_collector.start_pipeline_run()
                         msg = handle_msg(msg, worker_queue, complete_queue)
                         logger.info(f"processed msg response: {msg}")
                     else:

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/cdc.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/cdc.py
@@ -35,7 +35,7 @@ def prepare_cdc_data(cdc_file_path, current_year):
         ~cdc_generated.index.duplicated(keep="first")
     ]
 
-    stats_collector.log_preprocessed_ancillary_data_shape(
+    stats_collector.collect_preprocessed_ancillary_data_shape(
         "cdc", cdc_generated_no_dupes.shape
     )
 

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/cdc.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/cdc.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pipeline.config as config
 import pipeline.input_schemas as input_schemas
 import pipeline.mappings as mappings
+from pipeline.stats_collector import stats_collector
 
 logger = logging.getLogger("fbit-data-pipeline")
 
@@ -29,6 +30,9 @@ def prepare_cdc_data(cdc_file_path, current_year):
     cdc["Building Age"] = (
         cdc.groupby(by=["URN"])["Indicative Age"].mean().astype("Int64")
     )
-    result = cdc[config.cdc_generated_columns]
+    cdc_generated = cdc[config.cdc_generated_columns]
+    cdc_generated_no_dupes = cdc_generated[~cdc_generated.index.duplicated(keep="first")]
 
-    return result[~result.index.duplicated(keep="first")]
+    stats_collector.log_preprocessed_ancillary_data_shape("cdc", cdc_generated_no_dupes.shape)
+
+    return cdc_generated_no_dupes

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/cdc.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/cdc.py
@@ -31,8 +31,12 @@ def prepare_cdc_data(cdc_file_path, current_year):
         cdc.groupby(by=["URN"])["Indicative Age"].mean().astype("Int64")
     )
     cdc_generated = cdc[config.cdc_generated_columns]
-    cdc_generated_no_dupes = cdc_generated[~cdc_generated.index.duplicated(keep="first")]
+    cdc_generated_no_dupes = cdc_generated[
+        ~cdc_generated.index.duplicated(keep="first")
+    ]
 
-    stats_collector.log_preprocessed_ancillary_data_shape("cdc", cdc_generated_no_dupes.shape)
+    stats_collector.log_preprocessed_ancillary_data_shape(
+        "cdc", cdc_generated_no_dupes.shape
+    )
 
     return cdc_generated_no_dupes

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/census.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/census.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 import pipeline.config as config
 import pipeline.input_schemas as input_schemas
+from pipeline.stats_collector import stats_collector
 
 logger = logging.getLogger("fbit-data-pipeline")
 
@@ -59,6 +60,8 @@ def prepare_census_data(
         year, input_schemas.workforce_census_column_eval["default"]
     ).items():
         school_workforce_census[column] = school_workforce_census.eval(eval_)
+        
+    stats_collector.log_preprocessed_ancillary_data_shape("census_workforce", school_workforce_census.shape)
 
     school_pupil_census = pd.read_csv(
         pupil_census_path,
@@ -86,6 +89,8 @@ def prepare_census_data(
     school_pupil_census["Pupil Dual Registrations"] = school_pupil_census.get(
         "Pupil Dual Registrations", pd.Series(0, index=school_pupil_census.index)
     ).fillna(0)
+
+    stats_collector.log_preprocessed_ancillary_data_shape("census_pupil", school_pupil_census.shape)
 
     census = school_pupil_census.join(
         school_workforce_census,

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/census.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/census.py
@@ -61,7 +61,7 @@ def prepare_census_data(
     ).items():
         school_workforce_census[column] = school_workforce_census.eval(eval_)
 
-    stats_collector.log_preprocessed_ancillary_data_shape(
+    stats_collector.collect_preprocessed_ancillary_data_shape(
         "census_workforce", school_workforce_census.shape
     )
 
@@ -92,7 +92,7 @@ def prepare_census_data(
         "Pupil Dual Registrations", pd.Series(0, index=school_pupil_census.index)
     ).fillna(0)
 
-    stats_collector.log_preprocessed_ancillary_data_shape(
+    stats_collector.collect_preprocessed_ancillary_data_shape(
         "census_pupil", school_pupil_census.shape
     )
 

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/census.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/census.py
@@ -60,8 +60,10 @@ def prepare_census_data(
         year, input_schemas.workforce_census_column_eval["default"]
     ).items():
         school_workforce_census[column] = school_workforce_census.eval(eval_)
-        
-    stats_collector.log_preprocessed_ancillary_data_shape("census_workforce", school_workforce_census.shape)
+
+    stats_collector.log_preprocessed_ancillary_data_shape(
+        "census_workforce", school_workforce_census.shape
+    )
 
     school_pupil_census = pd.read_csv(
         pupil_census_path,
@@ -90,7 +92,9 @@ def prepare_census_data(
         "Pupil Dual Registrations", pd.Series(0, index=school_pupil_census.index)
     ).fillna(0)
 
-    stats_collector.log_preprocessed_ancillary_data_shape("census_pupil", school_pupil_census.shape)
+    stats_collector.log_preprocessed_ancillary_data_shape(
+        "census_pupil", school_pupil_census.shape
+    )
 
     census = school_pupil_census.join(
         school_workforce_census,

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/cfo.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/cfo.py
@@ -34,7 +34,7 @@ def build_cfo_data(cfo_data_path, year: int) -> pd.DataFrame:
         year, input_schemas.cfo_column_eval["default"]
     ).items():
         cfo_data[column] = cfo_data.eval(eval_)
-    
+
     stats_collector.log_preprocessed_ancillary_data_shape("cfo", cfo_data.shape)
 
     return cfo_data[["Companies House Number", "CFO name", "CFO email"]]

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/cfo.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/cfo.py
@@ -35,6 +35,6 @@ def build_cfo_data(cfo_data_path, year: int) -> pd.DataFrame:
     ).items():
         cfo_data[column] = cfo_data.eval(eval_)
 
-    stats_collector.log_preprocessed_ancillary_data_shape("cfo", cfo_data.shape)
+    stats_collector.collect_preprocessed_ancillary_data_shape("cfo", cfo_data.shape)
 
     return cfo_data[["Companies House Number", "CFO name", "CFO email"]]

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/cfo.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/cfo.py
@@ -3,6 +3,7 @@ import logging
 import pandas as pd
 
 from pipeline import input_schemas
+from pipeline.stats_collector import stats_collector
 
 logger = logging.getLogger("fbit-data-pipeline")
 
@@ -33,5 +34,7 @@ def build_cfo_data(cfo_data_path, year: int) -> pd.DataFrame:
         year, input_schemas.cfo_column_eval["default"]
     ).items():
         cfo_data[column] = cfo_data.eval(eval_)
+    
+    stats_collector.log_preprocessed_ancillary_data_shape("cfo", cfo_data.shape)
 
     return cfo_data[["Companies House Number", "CFO name", "CFO email"]]

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/gias.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/gias.py
@@ -29,7 +29,9 @@ def predecessor_links(
 
     predecessors = gias_links[gias_links["LinkType"] == "Predecessor"]
 
-    stats_collector.collect_preprocessed_ancillary_data_shape("gias", predecessors.shape)
+    stats_collector.collect_preprocessed_ancillary_data_shape(
+        "gias", predecessors.shape
+    )
     logger.info(f"Read {len(predecessors.index):,} predecessor GIAS-links records.")
 
     return predecessors

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/gias.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/gias.py
@@ -2,8 +2,8 @@ import pandas as pd
 from pandas._typing import FilePath, ReadCsvBuffer
 
 import pipeline.input_schemas as input_schemas
-from pipeline.stats_collector import stats_collector
 from pipeline import log
+from pipeline.stats_collector import stats_collector
 
 logger = log.setup_logger(__name__)
 

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/gias.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/gias.py
@@ -2,6 +2,7 @@ import pandas as pd
 from pandas._typing import FilePath, ReadCsvBuffer
 
 import pipeline.input_schemas as input_schemas
+from pipeline.stats_collector import stats_collector
 from pipeline import log
 
 logger = log.setup_logger(__name__)
@@ -28,6 +29,7 @@ def predecessor_links(
 
     predecessors = gias_links[gias_links["LinkType"] == "Predecessor"]
 
+    stats_collector.log_preprocessed_ancillary_data_shape("gias", predecessors.shape)
     logger.info(f"Read {len(predecessors.index):,} predecessor GIAS-links records.")
 
     return predecessors

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/gias.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/gias.py
@@ -29,7 +29,7 @@ def predecessor_links(
 
     predecessors = gias_links[gias_links["LinkType"] == "Predecessor"]
 
-    stats_collector.log_preprocessed_ancillary_data_shape("gias", predecessors.shape)
+    stats_collector.collect_preprocessed_ancillary_data_shape("gias", predecessors.shape)
     logger.info(f"Read {len(predecessors.index):,} predecessor GIAS-links records.")
 
     return predecessors

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/high_exec_pay.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/high_exec_pay.py
@@ -4,6 +4,7 @@ import pandas as pd
 from pandas._typing import FilePath, ReadCsvBuffer
 
 from pipeline.input_schemas import high_exec_pay, high_exec_pay_column_mappings
+from pipeline.stats_collector import stats_collector
 
 logger = logging.getLogger("fbit-data-pipeline")
 
@@ -39,5 +40,7 @@ def build_high_exec_pay_data(
     high_exec_pay_data["Company Registration Number"] = high_exec_pay_data[
         "Company Registration Number"
     ].str[1:]
+
+    stats_collector.log_preprocessed_ancillary_data_shape("high_exex_pay", high_exec_pay_data.shape)
 
     return high_exec_pay_data

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/high_exec_pay.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/high_exec_pay.py
@@ -41,6 +41,8 @@ def build_high_exec_pay_data(
         "Company Registration Number"
     ].str[1:]
 
-    stats_collector.log_preprocessed_ancillary_data_shape("high_exex_pay", high_exec_pay_data.shape)
+    stats_collector.log_preprocessed_ancillary_data_shape(
+        "high_exex_pay", high_exec_pay_data.shape
+    )
 
     return high_exec_pay_data

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/high_exec_pay.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/high_exec_pay.py
@@ -41,7 +41,7 @@ def build_high_exec_pay_data(
         "Company Registration Number"
     ].str[1:]
 
-    stats_collector.log_preprocessed_ancillary_data_shape(
+    stats_collector.collect_preprocessed_ancillary_data_shape(
         "high_exex_pay", high_exec_pay_data.shape
     )
 

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/ilr.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/ilr.py
@@ -156,7 +156,7 @@ def build_ilr_data(
         )
         .rename(columns=columns)[columns.values()]
     )
-    stats_collector.log_preprocessed_ancillary_data_shape(
+    stats_collector.collect_preprocessed_ancillary_data_shape(
         "ilr", combined_ilr_data.shape
     )
 

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/ilr.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/ilr.py
@@ -3,6 +3,7 @@ from pandas._typing import FilePath, ReadCsvBuffer
 
 from pipeline import input_schemas, log
 from pipeline.part_year.common import map_has_pupil_comparator_data
+from pipeline.stats_collector import stats_collector
 
 from . import gias
 
@@ -138,7 +139,7 @@ def build_ilr_data(
         year, input_schemas.ilr_column_mappings["default"]
     )
 
-    return (
+    combined_ilr_data = (
         _build_ilr_fsm_data(filepath_or_buffer, year)
         .join(
             _build_ilr_ehcp_data(filepath_or_buffer, year),
@@ -155,6 +156,9 @@ def build_ilr_data(
         )
         .rename(columns=columns)[columns.values()]
     )
+    stats_collector.log_preprocessed_ancillary_data_shape("ilr", combined_ilr_data.shape)
+
+    return combined_ilr_data
 
 
 def patch_missing_sixth_form_data(

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/ilr.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/ilr.py
@@ -156,7 +156,9 @@ def build_ilr_data(
         )
         .rename(columns=columns)[columns.values()]
     )
-    stats_collector.log_preprocessed_ancillary_data_shape("ilr", combined_ilr_data.shape)
+    stats_collector.log_preprocessed_ancillary_data_shape(
+        "ilr", combined_ilr_data.shape
+    )
 
     return combined_ilr_data
 

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/ks2.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/ks2.py
@@ -33,6 +33,6 @@ def prepare_ks2_data(ks2_path):
         )
 
     ks2_with_index = ks2.set_index("URN")
-    stats_collector.log_preprocessed_ancillary_data_shape("ks2", ks2_with_index.shape)
+    stats_collector.collect_preprocessed_ancillary_data_shape("ks2", ks2_with_index.shape)
 
     return ks2_with_index

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/ks2.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/ks2.py
@@ -3,6 +3,7 @@ import logging
 import pandas as pd
 
 import pipeline.input_schemas as input_schemas
+from pipeline.stats_collector import stats_collector
 
 logger = logging.getLogger("fbit-data-pipeline")
 
@@ -30,4 +31,8 @@ def prepare_ks2_data(ks2_path):
         ks2 = pd.DataFrame(
             {"URN": pd.Series(dtype="Int64"), "Ks2Progress": pd.Series(dtype="float")}
         )
-    return ks2.set_index("URN")
+
+    ks2_with_index = ks2.set_index("URN")
+    stats_collector.log_preprocessed_ancillary_data_shape("ks2", ks2_with_index.shape)
+
+    return ks2_with_index

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/ks2.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/ks2.py
@@ -33,6 +33,8 @@ def prepare_ks2_data(ks2_path):
         )
 
     ks2_with_index = ks2.set_index("URN")
-    stats_collector.collect_preprocessed_ancillary_data_shape("ks2", ks2_with_index.shape)
+    stats_collector.collect_preprocessed_ancillary_data_shape(
+        "ks2", ks2_with_index.shape
+    )
 
     return ks2_with_index

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/ks4.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/ks4.py
@@ -44,7 +44,7 @@ def prepare_ks4_data(ks4_path):
                 "Progress8Banding": pd.Series(dtype="string"),
             }
         )
-    
+
     ks4_with_index = ks4.set_index("URN")
     stats_collector.log_preprocessed_ancillary_data_shape("ks4", ks4_with_index.shape)
 

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/ks4.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/ks4.py
@@ -3,6 +3,7 @@ import logging
 import pandas as pd
 
 import pipeline.input_schemas as input_schemas
+from pipeline.stats_collector import stats_collector
 
 logger = logging.getLogger("fbit-data-pipeline")
 
@@ -43,5 +44,8 @@ def prepare_ks4_data(ks4_path):
                 "Progress8Banding": pd.Series(dtype="string"),
             }
         )
+    
+    ks4_with_index = ks4.set_index("URN")
+    stats_collector.log_preprocessed_ancillary_data_shape("ks4", ks4_with_index.shape)
 
-    return ks4.set_index("URN")
+    return ks4_with_index

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/ks4.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/ks4.py
@@ -46,6 +46,6 @@ def prepare_ks4_data(ks4_path):
         )
 
     ks4_with_index = ks4.set_index("URN")
-    stats_collector.log_preprocessed_ancillary_data_shape("ks4", ks4_with_index.shape)
+    stats_collector.collect_preprocessed_ancillary_data_shape("ks4", ks4_with_index.shape)
 
     return ks4_with_index

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/ks4.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/ks4.py
@@ -46,6 +46,8 @@ def prepare_ks4_data(ks4_path):
         )
 
     ks4_with_index = ks4.set_index("URN")
-    stats_collector.collect_preprocessed_ancillary_data_shape("ks4", ks4_with_index.shape)
+    stats_collector.collect_preprocessed_ancillary_data_shape(
+        "ks4", ks4_with_index.shape
+    )
 
     return ks4_with_index

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/sen.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/sen.py
@@ -85,6 +85,6 @@ def prepare_sen_data(sen_path):
         (sen["Primary Need OTH"] / sen["Total pupils"]) * 100.0
     ).fillna(0)
 
-    stats_collector.log_preprocessed_ancillary_data_shape("sen", sen.shape)
+    stats_collector.collect_preprocessed_ancillary_data_shape("sen", sen.shape)
 
     return sen[config.sen_generated_columns]

--- a/data-pipeline/src/pipeline/pre_processing/ancillary/sen.py
+++ b/data-pipeline/src/pipeline/pre_processing/ancillary/sen.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 import pipeline.config as config
 import pipeline.input_schemas as input_schemas
+from pipeline.stats_collector import stats_collector
 
 logger = logging.getLogger("fbit-data-pipeline")
 
@@ -83,5 +84,7 @@ def prepare_sen_data(sen_path):
     sen["Percentage Primary Need OTH"] = (
         (sen["Primary Need OTH"] / sen["Total pupils"]) * 100.0
     ).fillna(0)
+
+    stats_collector.log_preprocessed_ancillary_data_shape("sen", sen.shape)
 
     return sen[config.sen_generated_columns]

--- a/data-pipeline/src/pipeline/stats_collector.py
+++ b/data-pipeline/src/pipeline/stats_collector.py
@@ -1,8 +1,4 @@
 import logging
-import threading
-import uuid
-from datetime import datetime
-from typing import Any, Dict, Optional
 
 import pandas as pd
 

--- a/data-pipeline/src/pipeline/stats_collector.py
+++ b/data-pipeline/src/pipeline/stats_collector.py
@@ -1,8 +1,8 @@
-import logging
-
 import pandas as pd
 
-stats_logger = logging.getLogger("stats")
+from pipeline.log import setup_logger
+
+stats_logger = setup_logger("stats")
 
 
 class StatsCollector:
@@ -48,7 +48,7 @@ class StatsCollector:
     def collect_preprocessed_ancillary_data_shape(
         self, name: str, shape: tuple[int, int]
     ):
-        stats_logger.info(f"{name=} preprocessed with {shape=}")
+        stats_logger.info(f"Ancillary file {name=} preprocessed with {shape=}")
         self.stats.setdefault("linked_data_school_counts", {})
         self.stats["linked_data_school_counts"].setdefault(name, {})
         self.stats["linked_data_school_counts"][name]["total"] = shape[0]

--- a/data-pipeline/src/pipeline/stats_collector.py
+++ b/data-pipeline/src/pipeline/stats_collector.py
@@ -23,11 +23,11 @@ class StatsCollector:
         self, school_df: pd.DataFrame, phase_col: str = "Overall Phase"
     ) -> dict:
         unique_school_count: int = school_df.shape[0]
-        unique_schools_per_phase_dict: dict[str, int] = (
+        unique_schools_per_phase: dict[str, int] = (
             school_df[phase_col].value_counts().to_dict()
         )
 
-        return {"total": unique_school_count, "by_phase": unique_schools_per_phase_dict}
+        return {"total": unique_school_count, "by_phase": unique_schools_per_phase}
 
     def collect_academy_counts(self, academies_data_preprocessed):
         self.stats.setdefault("school_counts", {})

--- a/data-pipeline/src/pipeline/stats_collector.py
+++ b/data-pipeline/src/pipeline/stats_collector.py
@@ -1,0 +1,178 @@
+import logging
+import threading
+
+import pandas as pd
+import uuid
+from datetime import datetime
+from typing import Optional, Dict, Any
+
+stats_logger = logging.getLogger("stats")
+
+
+# class StatsCollector:
+#     _instance = None
+#     _lock = threading.Lock()
+#     _initialized = False
+    
+#     def __new__(cls):
+#         # Double-checked locking pattern for thread safety
+#         if cls._instance is None:
+#             with cls._lock:
+#                 if cls._instance is None:
+#                     cls._instance = super().__new__(cls)
+#         return cls._instance
+    
+#     def __init__(self):
+#         # Only initialize once, even if __init__ is called multiple times
+#         if not StatsCollector._initialized:
+#             with StatsCollector._lock:
+#                 if not StatsCollector._initialized:
+#                     self.instance_id = str(uuid.uuid4())[:8]
+#                     print(f"StatsCollector singleton created: {self.instance_id}")
+#                     self._data_lock = threading.Lock()  # Separate lock for data operations
+#                     self.reset()
+#                     StatsCollector._initialized = True
+
+#     def start_pipeline_run(self, run_id: Optional[str] = None) -> str:
+#         """Start a new pipeline run with fresh stats"""
+#         with self._data_lock:
+#             print(f"Starting pipeline run on singleton {self.instance_id}")
+#             self.reset()
+#             self.run_id = run_id or str(uuid.uuid4())
+#             self.pipeline_start_time = datetime.now()
+#             return self.run_id
+
+#     def reset(self):
+#         # Note: This method assumes it's called within a lock context
+#         self.row_counts = {}
+#         self.pipeline_start_time = None
+#         self.run_id = None
+#         self.stats = {
+#             "school_counts": {},
+#             "linked_data_school_counts": {},
+#             "row_counts": {},
+#         }
+#         print(f"Stats reset on singleton {self.instance_id}")
+
+    # def _generate_school_counts(
+    #     self, school_df: pd.DataFrame, phase_col: str = "Overall Phase"
+    # ) -> dict:
+    #     unique_school_count: int = school_df.shape[0]
+    #     unique_schools_per_phase_dict: dict[str, int] = (
+    #         school_df[phase_col].value_counts().to_dict()
+    #     )
+
+    #     return {"total": unique_school_count, "by_phase": unique_schools_per_phase_dict}
+
+    # def log_academy_counts(self, academies_data_preprocessed):
+    #     with self._lock:
+    #         self.stats.setdefault("school_counts", {})
+    #         self.stats["school_counts"]["academies"] = self._generate_school_counts(
+    #             academies_data_preprocessed
+    #         )
+
+    # def log_la_maintained_school_counts(self, la_maintained_schools_data_preprocessed):
+    #     with self._lock:
+    #         self.stats.setdefault("school_counts", {})
+    #         self.stats["school_counts"]["la_maintained_schools"] = (
+    #             self._generate_school_counts(la_maintained_schools_data_preprocessed)
+    #         )
+
+    # def log_combined_school_counts(self, combined_schools_data_preprocessed):
+    #     with self._lock:
+    #         self.stats.setdefault("school_counts", {})
+    #         self.stats["school_counts"]["combined_schools"] = (
+    #             self._generate_school_counts(combined_schools_data_preprocessed)
+    #         )
+
+    # def log_preprocessed_ancillary_data_shape(self, name: str, shape: tuple[int, int]):
+    #     stats_logger.info(f"{name=} preprocessed with {shape=}")
+    #     with self._lock:
+    #         self.stats.setdefault("linked_data_school_counts", {})
+    #         self.stats["linked_data_school_counts"].setdefault(name, {})
+    #         self.stats["linked_data_school_counts"][name]["total"] = shape[0]
+
+    # def get_stats(self):
+    #     if "school_counts" not in self.stats.keys():
+    #         stats_logger.info("School counts have not been logged")
+    #     if "linked_data_counts" not in self.stats.keys():
+    #         stats_logger.info("Linked data counts have not been logged")
+    #     return self.stats
+
+
+class StatsCollector(logging.LoggerAdapter):
+    """Stats collector using LoggerAdapter for thread-safe operation"""
+    
+    _instance = None
+    
+    def __new__(cls):
+        if cls._instance is None:
+            # Create the base logger
+            logger = logging.getLogger('pipeline_stats')
+            logger.setLevel(logging.INFO)
+            
+            # Create the adapter instance
+            cls._instance = super().__new__(cls)
+            cls._instance.__init__(logger, {})
+            cls._instance._initialized = True
+            cls._instance.reset()
+        return cls._instance
+    
+    def __init__(self, logger, extra):
+        if not hasattr(self, '_initialized'):
+            super().__init__(logger, extra)
+    
+    def reset(self):
+        """Reset stats for new pipeline run"""
+        self.stats = {
+            "school_counts": {},
+            "linked_data_school_counts": {},
+            "row_counts": {},
+        }
+        self.run_id = None
+        self.pipeline_start_time = None
+    
+    def start_pipeline_run(self, run_id: Optional[str] = None) -> str:
+        """Start a new pipeline run"""
+        self.reset()
+        self.run_id = run_id or str(uuid.uuid4())
+        self.pipeline_start_time = datetime.now()
+        self.info(f"Started pipeline run: {self.run_id}")
+        return self.run_id
+    
+    def log_academy_counts(self, academies_data_preprocessed):
+        """Log academy counts"""
+        count = self._generate_school_counts(academies_data_preprocessed)
+        self.stats["school_counts"]["academies"] = count
+        self.info(f"Academy counts logged: {count}")
+    
+    def log_preprocessed_ancillary_data_shape(self, name: str, shape: tuple[int, int]):
+        """Log preprocessed ancillary data shape"""
+        if name not in self.stats["linked_data_school_counts"]:
+            self.stats["linked_data_school_counts"][name] = {}
+        self.stats["linked_data_school_counts"][name]["total"] = shape[0]
+        self.info(f"Ancillary data shape logged - {name}: {shape}")
+    
+    def get_stats(self) -> Dict[str, Any]:
+        """Get all collected statistics"""
+        stats = {}
+        stats.update(self.stats)
+        
+        if self.pipeline_start_time:
+            stats['_pipeline_duration'] = (datetime.now() - self.pipeline_start_time).total_seconds()
+            stats['_run_id'] = self.run_id
+            stats['_start_time'] = self.pipeline_start_time.isoformat()
+        
+        self.info(f"Stats retrieved: {len(stats)} categories")
+        return stats
+    
+    def _generate_school_counts(self, data):
+        """Generate school counts from data"""
+        return len(data) if hasattr(data, '__len__') else 0
+    
+    def process(self, msg, kwargs):
+        """Process log messages (required by LoggerAdapter)"""
+        return f"[STATS] {msg}", kwargs
+    
+
+stats_collector = StatsCollector(logger=stats_logger)

--- a/data-pipeline/src/pipeline/stats_collector.py
+++ b/data-pipeline/src/pipeline/stats_collector.py
@@ -31,7 +31,9 @@ class StatsCollector:
             academies_data_preprocessed
         )
 
-    def collect_la_maintained_school_counts(self, la_maintained_schools_data_preprocessed):
+    def collect_la_maintained_school_counts(
+        self, la_maintained_schools_data_preprocessed
+    ):
         self.stats.setdefault("school_counts", {})
         self.stats["school_counts"]["la_maintained_schools"] = (
             self._generate_school_counts(la_maintained_schools_data_preprocessed)
@@ -43,7 +45,9 @@ class StatsCollector:
             combined_schools_data_preprocessed
         )
 
-    def collect_preprocessed_ancillary_data_shape(self, name: str, shape: tuple[int, int]):
+    def collect_preprocessed_ancillary_data_shape(
+        self, name: str, shape: tuple[int, int]
+    ):
         stats_logger.info(f"{name=} preprocessed with {shape=}")
         self.stats.setdefault("linked_data_school_counts", {})
         self.stats["linked_data_school_counts"].setdefault(name, {})

--- a/data-pipeline/src/pipeline/stats_collector.py
+++ b/data-pipeline/src/pipeline/stats_collector.py
@@ -29,25 +29,25 @@ class StatsCollector:
 
         return {"total": unique_school_count, "by_phase": unique_schools_per_phase_dict}
 
-    def log_academy_counts(self, academies_data_preprocessed):
+    def collect_academy_counts(self, academies_data_preprocessed):
         self.stats.setdefault("school_counts", {})
         self.stats["school_counts"]["academies"] = self._generate_school_counts(
             academies_data_preprocessed
         )
 
-    def log_la_maintained_school_counts(self, la_maintained_schools_data_preprocessed):
+    def collect_la_maintained_school_counts(self, la_maintained_schools_data_preprocessed):
         self.stats.setdefault("school_counts", {})
         self.stats["school_counts"]["la_maintained_schools"] = (
             self._generate_school_counts(la_maintained_schools_data_preprocessed)
         )
 
-    def log_combined_school_counts(self, combined_schools_data_preprocessed):
+    def collect_combined_school_counts(self, combined_schools_data_preprocessed):
         self.stats.setdefault("school_counts", {})
         self.stats["school_counts"]["combined_schools"] = self._generate_school_counts(
             combined_schools_data_preprocessed
         )
 
-    def log_preprocessed_ancillary_data_shape(self, name: str, shape: tuple[int, int]):
+    def collect_preprocessed_ancillary_data_shape(self, name: str, shape: tuple[int, int]):
         stats_logger.info(f"{name=} preprocessed with {shape=}")
         self.stats.setdefault("linked_data_school_counts", {})
         self.stats["linked_data_school_counts"].setdefault(name, {})

--- a/data-pipeline/src/pipeline/stats_collector.py
+++ b/data-pipeline/src/pipeline/stats_collector.py
@@ -61,61 +61,8 @@ class StatsCollector:
         return self.stats
 
 
-# class StatsCollector(logging.LoggerAdapter):
-#     """Stats collector using LoggerAdapter for thread-safe operation"""
-
-#     _instance = None
-
-#     def __new__(cls):
-#         if cls._instance is None:
-#             # Create the base logger
-#             logger = logging.getLogger('pipeline_stats')
-#             logger.setLevel(logging.INFO)
-
-#             # Create the adapter instance
-#             cls._instance = super().__new__(cls)
-#             cls._instance.__init__(logger, {})
-#             cls._instance._initialized = True
-#             cls._instance.reset()
-#         return cls._instance
-
-#     def __init__(self, logger, extra):
-#         if not hasattr(self, '_initialized'):
-#             super().__init__(logger, extra)
-
-#     def reset(self):
-#         """Reset stats for new pipeline run"""
-#         self.stats = {
-#             "school_counts": {},
-#             "linked_data_school_counts": {},
-#             "row_counts": {},
-#         }
-#         self.run_id = None
-#         self.pipeline_start_time = None
-
-#     def start_pipeline_run(self, run_id: Optional[str] = None) -> str:
-#         """Start a new pipeline run"""
-#         self.reset()
-#         self.run_id = run_id or str(uuid.uuid4())
-#         self.pipeline_start_time = datetime.now()
-#         self.info(f"Started pipeline run: {self.run_id}")
-#         return self.run_id
-
-#     def log_academy_counts(self, academies_data_preprocessed):
-#         """Log academy counts"""
-#         count = self._generate_school_counts(academies_data_preprocessed)
-#         self.stats["school_counts"]["academies"] = count
-#         self.info(f"Academy counts logged: {count}")
-
-#     def log_preprocessed_ancillary_data_shape(self, name: str, shape: tuple[int, int]):
-#         """Log preprocessed ancillary data shape"""
-#         if name not in self.stats["linked_data_school_counts"]:
-#             self.stats["linked_data_school_counts"][name] = {}
-#         self.stats["linked_data_school_counts"][name]["total"] = shape[0]
-#         self.info(f"Ancillary data shape logged - {name}: {shape}")
-
-#     def get_stats(self) -> Dict[str, Any]:
-#         """Get all collected statistics"""
+stats_collector = StatsCollector()
+     """Get all collected statistics"""
 #         stats = {}
 #         stats.update(self.stats)
 
@@ -134,6 +81,3 @@ class StatsCollector:
 #     def process(self, msg, kwargs):
 #         """Process log messages (required by LoggerAdapter)"""
 #         return f"[STATS] {msg}", kwargs
-
-
-stats_collector = StatsCollector()

--- a/data-pipeline/src/pipeline/stats_collector.py
+++ b/data-pipeline/src/pipeline/stats_collector.py
@@ -1,178 +1,139 @@
 import logging
 import threading
-
-import pandas as pd
 import uuid
 from datetime import datetime
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
+
+import pandas as pd
 
 stats_logger = logging.getLogger("stats")
 
 
-# class StatsCollector:
-#     _instance = None
-#     _lock = threading.Lock()
-#     _initialized = False
-    
-#     def __new__(cls):
-#         # Double-checked locking pattern for thread safety
-#         if cls._instance is None:
-#             with cls._lock:
-#                 if cls._instance is None:
-#                     cls._instance = super().__new__(cls)
-#         return cls._instance
-    
-#     def __init__(self):
-#         # Only initialize once, even if __init__ is called multiple times
-#         if not StatsCollector._initialized:
-#             with StatsCollector._lock:
-#                 if not StatsCollector._initialized:
-#                     self.instance_id = str(uuid.uuid4())[:8]
-#                     print(f"StatsCollector singleton created: {self.instance_id}")
-#                     self._data_lock = threading.Lock()  # Separate lock for data operations
-#                     self.reset()
-#                     StatsCollector._initialized = True
+class StatsCollector:
+    def __init__(self):
+        self.stats = {}
 
-#     def start_pipeline_run(self, run_id: Optional[str] = None) -> str:
-#         """Start a new pipeline run with fresh stats"""
-#         with self._data_lock:
-#             print(f"Starting pipeline run on singleton {self.instance_id}")
-#             self.reset()
-#             self.run_id = run_id or str(uuid.uuid4())
-#             self.pipeline_start_time = datetime.now()
-#             return self.run_id
+    def start_pipeline_run(self):
+        self.reset()
+
+    def reset(self):
+        self.stats = {}
+
+    def _generate_school_counts(
+        self, school_df: pd.DataFrame, phase_col: str = "Overall Phase"
+    ) -> dict:
+        unique_school_count: int = school_df.shape[0]
+        unique_schools_per_phase_dict: dict[str, int] = (
+            school_df[phase_col].value_counts().to_dict()
+        )
+
+        return {"total": unique_school_count, "by_phase": unique_schools_per_phase_dict}
+
+    def log_academy_counts(self, academies_data_preprocessed):
+        self.stats.setdefault("school_counts", {})
+        self.stats["school_counts"]["academies"] = self._generate_school_counts(
+            academies_data_preprocessed
+        )
+
+    def log_la_maintained_school_counts(self, la_maintained_schools_data_preprocessed):
+        self.stats.setdefault("school_counts", {})
+        self.stats["school_counts"]["la_maintained_schools"] = (
+            self._generate_school_counts(la_maintained_schools_data_preprocessed)
+        )
+
+    def log_combined_school_counts(self, combined_schools_data_preprocessed):
+        self.stats.setdefault("school_counts", {})
+        self.stats["school_counts"]["combined_schools"] = self._generate_school_counts(
+            combined_schools_data_preprocessed
+        )
+
+    def log_preprocessed_ancillary_data_shape(self, name: str, shape: tuple[int, int]):
+        stats_logger.info(f"{name=} preprocessed with {shape=}")
+        self.stats.setdefault("linked_data_school_counts", {})
+        self.stats["linked_data_school_counts"].setdefault(name, {})
+        self.stats["linked_data_school_counts"][name]["total"] = shape[0]
+
+    def get_stats(self):
+        if "school_counts" not in self.stats.keys():
+            stats_logger.info("School counts have not been logged")
+        if "linked_data_counts" not in self.stats.keys():
+            stats_logger.info("Linked data counts have not been logged")
+        return self.stats
+
+
+# class StatsCollector(logging.LoggerAdapter):
+#     """Stats collector using LoggerAdapter for thread-safe operation"""
+
+#     _instance = None
+
+#     def __new__(cls):
+#         if cls._instance is None:
+#             # Create the base logger
+#             logger = logging.getLogger('pipeline_stats')
+#             logger.setLevel(logging.INFO)
+
+#             # Create the adapter instance
+#             cls._instance = super().__new__(cls)
+#             cls._instance.__init__(logger, {})
+#             cls._instance._initialized = True
+#             cls._instance.reset()
+#         return cls._instance
+
+#     def __init__(self, logger, extra):
+#         if not hasattr(self, '_initialized'):
+#             super().__init__(logger, extra)
 
 #     def reset(self):
-#         # Note: This method assumes it's called within a lock context
-#         self.row_counts = {}
-#         self.pipeline_start_time = None
-#         self.run_id = None
+#         """Reset stats for new pipeline run"""
 #         self.stats = {
 #             "school_counts": {},
 #             "linked_data_school_counts": {},
 #             "row_counts": {},
 #         }
-#         print(f"Stats reset on singleton {self.instance_id}")
+#         self.run_id = None
+#         self.pipeline_start_time = None
 
-    # def _generate_school_counts(
-    #     self, school_df: pd.DataFrame, phase_col: str = "Overall Phase"
-    # ) -> dict:
-    #     unique_school_count: int = school_df.shape[0]
-    #     unique_schools_per_phase_dict: dict[str, int] = (
-    #         school_df[phase_col].value_counts().to_dict()
-    #     )
+#     def start_pipeline_run(self, run_id: Optional[str] = None) -> str:
+#         """Start a new pipeline run"""
+#         self.reset()
+#         self.run_id = run_id or str(uuid.uuid4())
+#         self.pipeline_start_time = datetime.now()
+#         self.info(f"Started pipeline run: {self.run_id}")
+#         return self.run_id
 
-    #     return {"total": unique_school_count, "by_phase": unique_schools_per_phase_dict}
+#     def log_academy_counts(self, academies_data_preprocessed):
+#         """Log academy counts"""
+#         count = self._generate_school_counts(academies_data_preprocessed)
+#         self.stats["school_counts"]["academies"] = count
+#         self.info(f"Academy counts logged: {count}")
 
-    # def log_academy_counts(self, academies_data_preprocessed):
-    #     with self._lock:
-    #         self.stats.setdefault("school_counts", {})
-    #         self.stats["school_counts"]["academies"] = self._generate_school_counts(
-    #             academies_data_preprocessed
-    #         )
+#     def log_preprocessed_ancillary_data_shape(self, name: str, shape: tuple[int, int]):
+#         """Log preprocessed ancillary data shape"""
+#         if name not in self.stats["linked_data_school_counts"]:
+#             self.stats["linked_data_school_counts"][name] = {}
+#         self.stats["linked_data_school_counts"][name]["total"] = shape[0]
+#         self.info(f"Ancillary data shape logged - {name}: {shape}")
 
-    # def log_la_maintained_school_counts(self, la_maintained_schools_data_preprocessed):
-    #     with self._lock:
-    #         self.stats.setdefault("school_counts", {})
-    #         self.stats["school_counts"]["la_maintained_schools"] = (
-    #             self._generate_school_counts(la_maintained_schools_data_preprocessed)
-    #         )
+#     def get_stats(self) -> Dict[str, Any]:
+#         """Get all collected statistics"""
+#         stats = {}
+#         stats.update(self.stats)
 
-    # def log_combined_school_counts(self, combined_schools_data_preprocessed):
-    #     with self._lock:
-    #         self.stats.setdefault("school_counts", {})
-    #         self.stats["school_counts"]["combined_schools"] = (
-    #             self._generate_school_counts(combined_schools_data_preprocessed)
-    #         )
+#         if self.pipeline_start_time:
+#             stats['_pipeline_duration'] = (datetime.now() - self.pipeline_start_time).total_seconds()
+#             stats['_run_id'] = self.run_id
+#             stats['_start_time'] = self.pipeline_start_time.isoformat()
 
-    # def log_preprocessed_ancillary_data_shape(self, name: str, shape: tuple[int, int]):
-    #     stats_logger.info(f"{name=} preprocessed with {shape=}")
-    #     with self._lock:
-    #         self.stats.setdefault("linked_data_school_counts", {})
-    #         self.stats["linked_data_school_counts"].setdefault(name, {})
-    #         self.stats["linked_data_school_counts"][name]["total"] = shape[0]
+#         self.info(f"Stats retrieved: {len(stats)} categories")
+#         return stats
 
-    # def get_stats(self):
-    #     if "school_counts" not in self.stats.keys():
-    #         stats_logger.info("School counts have not been logged")
-    #     if "linked_data_counts" not in self.stats.keys():
-    #         stats_logger.info("Linked data counts have not been logged")
-    #     return self.stats
+#     def _generate_school_counts(self, data):
+#         """Generate school counts from data"""
+#         return len(data) if hasattr(data, '__len__') else 0
+
+#     def process(self, msg, kwargs):
+#         """Process log messages (required by LoggerAdapter)"""
+#         return f"[STATS] {msg}", kwargs
 
 
-class StatsCollector(logging.LoggerAdapter):
-    """Stats collector using LoggerAdapter for thread-safe operation"""
-    
-    _instance = None
-    
-    def __new__(cls):
-        if cls._instance is None:
-            # Create the base logger
-            logger = logging.getLogger('pipeline_stats')
-            logger.setLevel(logging.INFO)
-            
-            # Create the adapter instance
-            cls._instance = super().__new__(cls)
-            cls._instance.__init__(logger, {})
-            cls._instance._initialized = True
-            cls._instance.reset()
-        return cls._instance
-    
-    def __init__(self, logger, extra):
-        if not hasattr(self, '_initialized'):
-            super().__init__(logger, extra)
-    
-    def reset(self):
-        """Reset stats for new pipeline run"""
-        self.stats = {
-            "school_counts": {},
-            "linked_data_school_counts": {},
-            "row_counts": {},
-        }
-        self.run_id = None
-        self.pipeline_start_time = None
-    
-    def start_pipeline_run(self, run_id: Optional[str] = None) -> str:
-        """Start a new pipeline run"""
-        self.reset()
-        self.run_id = run_id or str(uuid.uuid4())
-        self.pipeline_start_time = datetime.now()
-        self.info(f"Started pipeline run: {self.run_id}")
-        return self.run_id
-    
-    def log_academy_counts(self, academies_data_preprocessed):
-        """Log academy counts"""
-        count = self._generate_school_counts(academies_data_preprocessed)
-        self.stats["school_counts"]["academies"] = count
-        self.info(f"Academy counts logged: {count}")
-    
-    def log_preprocessed_ancillary_data_shape(self, name: str, shape: tuple[int, int]):
-        """Log preprocessed ancillary data shape"""
-        if name not in self.stats["linked_data_school_counts"]:
-            self.stats["linked_data_school_counts"][name] = {}
-        self.stats["linked_data_school_counts"][name]["total"] = shape[0]
-        self.info(f"Ancillary data shape logged - {name}: {shape}")
-    
-    def get_stats(self) -> Dict[str, Any]:
-        """Get all collected statistics"""
-        stats = {}
-        stats.update(self.stats)
-        
-        if self.pipeline_start_time:
-            stats['_pipeline_duration'] = (datetime.now() - self.pipeline_start_time).total_seconds()
-            stats['_run_id'] = self.run_id
-            stats['_start_time'] = self.pipeline_start_time.isoformat()
-        
-        self.info(f"Stats retrieved: {len(stats)} categories")
-        return stats
-    
-    def _generate_school_counts(self, data):
-        """Generate school counts from data"""
-        return len(data) if hasattr(data, '__len__') else 0
-    
-    def process(self, msg, kwargs):
-        """Process log messages (required by LoggerAdapter)"""
-        return f"[STATS] {msg}", kwargs
-    
-
-stats_collector = StatsCollector(logger=stats_logger)
+stats_collector = StatsCollector()

--- a/data-pipeline/src/pipeline/stats_collector.py
+++ b/data-pipeline/src/pipeline/stats_collector.py
@@ -62,22 +62,3 @@ class StatsCollector:
 
 
 stats_collector = StatsCollector()
-     """Get all collected statistics"""
-#         stats = {}
-#         stats.update(self.stats)
-
-#         if self.pipeline_start_time:
-#             stats['_pipeline_duration'] = (datetime.now() - self.pipeline_start_time).total_seconds()
-#             stats['_run_id'] = self.run_id
-#             stats['_start_time'] = self.pipeline_start_time.isoformat()
-
-#         self.info(f"Stats retrieved: {len(stats)} categories")
-#         return stats
-
-#     def _generate_school_counts(self, data):
-#         """Generate school counts from data"""
-#         return len(data) if hasattr(data, '__len__') else 0
-
-#     def process(self, msg, kwargs):
-#         """Process log messages (required by LoggerAdapter)"""
-#         return f"[STATS] {msg}", kwargs

--- a/data-pipeline/tests/unit/test_stats_collector.py
+++ b/data-pipeline/tests/unit/test_stats_collector.py
@@ -1,0 +1,234 @@
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from pipeline.stats_collector import StatsCollector
+
+
+class TestStatsCollector:
+    """Test suite for StatsCollector class."""
+
+    @pytest.fixture
+    def stats_collector(self):
+        return StatsCollector()
+
+    @pytest.fixture
+    def sample_school_df(self):
+        return pd.DataFrame(
+            {
+                "School Name": ["School A", "School B", "School C", "School D"],
+                "Overall Phase": ["Primary", "Secondary", "Primary", "All-through"],
+            }
+        )
+
+    @pytest.fixture
+    def empty_school_df(self):
+        return pd.DataFrame(columns=["School Name", "Overall Phase"])
+
+    @pytest.fixture
+    def not_school_df(self):
+        return pd.DataFrame(columns=["test", "test"])
+
+    def test_init(self, stats_collector):
+        assert stats_collector.stats == {}
+        assert not hasattr(stats_collector, "pipeline_start_time")
+
+    def test_start_pipeline_run(self, stats_collector):
+        stats_collector.stats = {"test": "data"}
+        stats_collector.start_pipeline_run()
+
+        assert stats_collector.stats == {}
+
+    def test_reset(self, stats_collector):
+        stats_collector.stats = {"test": "data"}
+        stats_collector.reset()
+
+        assert stats_collector.stats == {}
+
+    def test_generate_school_counts_normal(self, stats_collector, sample_school_df):
+        result = stats_collector._generate_school_counts(sample_school_df)
+
+        expected = {
+            "total": 4,
+            "by_phase": {"Primary": 2, "Secondary": 1, "All-through": 1},
+        }
+        assert result == expected
+
+    def test_generate_school_counts_empty_df(self, stats_collector, empty_school_df):
+        result = stats_collector._generate_school_counts(empty_school_df)
+
+        expected = {"total": 0, "by_phase": {}}
+        assert result == expected
+
+    def test_generate_school_counts_custom_phase_col(self, stats_collector):
+        df = pd.DataFrame(
+            {
+                "School Name": ["School A", "School B"],
+                "Custom Phase": ["Type1", "Type2"],
+            }
+        )
+
+        result = stats_collector._generate_school_counts(df, phase_col="Custom Phase")
+
+        expected = {"total": 2, "by_phase": {"Type1": 1, "Type2": 1}}
+        assert result == expected
+
+    def test_generate_school_counts_missing_phase_col(
+        self, stats_collector, sample_school_df
+    ):
+        with pytest.raises(KeyError):
+            stats_collector._generate_school_counts(
+                sample_school_df, phase_col="NonExistent"
+            )
+
+    def test_log_academy_counts(self, stats_collector, sample_school_df):
+        stats_collector.stats["school_counts"] = {}
+        stats_collector.log_academy_counts(sample_school_df)
+
+        expected = {
+            "total": 4,
+            "by_phase": {"Primary": 2, "Secondary": 1, "All-through": 1},
+        }
+        assert stats_collector.stats["school_counts"]["academies"] == expected
+
+    def test_log_academy_counts_keyerror(self, stats_collector, not_school_df):
+        """Test logging academy counts when school_counts key doesn't exist."""
+        with pytest.raises(KeyError):
+            stats_collector.log_academy_counts(not_school_df)
+
+    def test_log_la_maintained_school_counts(self, stats_collector, sample_school_df):
+        """Test logging LA maintained school counts."""
+        stats_collector.stats["school_counts"] = {}
+
+        stats_collector.log_la_maintained_school_counts(sample_school_df)
+
+        expected = {
+            "total": 4,
+            "by_phase": {"Primary": 2, "Secondary": 1, "All-through": 1},
+        }
+        assert (
+            stats_collector.stats["school_counts"]["la_maintained_schools"] == expected
+        )
+
+    def test_log_combined_school_counts(self, stats_collector, sample_school_df):
+        stats_collector.stats["school_counts"] = {}
+        stats_collector.log_combined_school_counts(sample_school_df)
+
+        expected = {
+            "total": 4,
+            "by_phase": {"Primary": 2, "Secondary": 1, "All-through": 1},
+        }
+        assert stats_collector.stats["school_counts"]["combined_schools"] == expected
+
+    @patch("pipeline.stats_collector.stats_logger")
+    def test_log_preprocessed_ancillary_data_shape(self, mock_logger, stats_collector):
+        name, shape = "test_data", (100, 5)
+        stats_collector.log_preprocessed_ancillary_data_shape(name, shape)
+
+        # Check logging call
+        mock_logger.info.assert_called_once_with(f"{name=} preprocessed with {shape=}")
+
+        # Check stats structure
+        assert "linked_data_school_counts" in stats_collector.stats
+        assert name in stats_collector.stats["linked_data_school_counts"]
+        assert stats_collector.stats["linked_data_school_counts"][name]["total"] == 100
+
+    @patch("pipeline.stats_collector.stats_logger")
+    def test_log_preprocessed_ancillary_data_shape_multiple_calls(
+        self, mock_logger, stats_collector
+    ):
+        """Test multiple calls to log_preprocessed_ancillary_data_shape."""
+        stats_collector.log_preprocessed_ancillary_data_shape("data1", (50, 3))
+        stats_collector.log_preprocessed_ancillary_data_shape("data2", (75, 4))
+
+        expected_stats = {
+            "linked_data_school_counts": {
+                "data1": {"total": 50},
+                "data2": {"total": 75},
+            }
+        }
+        assert stats_collector.stats == expected_stats
+        assert mock_logger.info.call_count == 2
+
+    @patch("pipeline.stats_collector.stats_logger")
+    def test_get_stats_with_school_counts(self, mock_logger, stats_collector):
+        """Test get_stats when school_counts exist."""
+        stats_collector.stats = {
+            "school_counts": {"academies": {"total": 10}},
+            "linked_data_counts": {"test": 5},
+        }
+
+        result = stats_collector.get_stats()
+
+        assert result == stats_collector.stats
+        mock_logger.info.assert_not_called()
+
+    @patch("pipeline.stats_collector.stats_logger")
+    def test_get_stats_missing_school_counts(self, mock_logger, stats_collector):
+        """Test get_stats when school_counts are missing."""
+        stats_collector.stats = {"linked_data_counts": "value"}
+
+        result = stats_collector.get_stats()
+
+        assert result == stats_collector.stats
+        mock_logger.info.assert_called_with("School counts have not been logged")
+
+    @patch("pipeline.stats_collector.stats_logger")
+    def test_get_stats_missing_linked_data_counts(self, mock_logger, stats_collector):
+        """Test get_stats when linked_data_counts are missing."""
+        stats_collector.stats = {"school_counts": {"test": 1}}
+
+        result = stats_collector.get_stats()
+
+        assert result == stats_collector.stats
+        mock_logger.info.assert_called_with("Linked data counts have not been logged")
+
+    def test_phase_column_with_nan_values(self, stats_collector):
+        """Test handling of NaN values in phase column."""
+        df_with_nan = pd.DataFrame(
+            {
+                "School Name": ["School A", "School B", "School C"],
+                "Overall Phase": ["Primary", None, "Secondary"],
+            }
+        )
+
+        result = stats_collector._generate_school_counts(df_with_nan)
+
+        # pandas value_counts() excludes NaN by default
+        expected = {"total": 3, "by_phase": {"Primary": 1, "Secondary": 1}}
+        assert result == expected
+
+    def test_integration_workflow(self, stats_collector):
+        stats_collector.start_pipeline_run()
+
+        academy_df = pd.DataFrame(
+            {
+                "School Name": ["Academy A", "Academy B"],
+                "Overall Phase": ["Primary", "Secondary"],
+            }
+        )
+        stats_collector.log_academy_counts(academy_df)
+
+        la_df = pd.DataFrame(
+            {"School Name": ["LA School A"], "Overall Phase": ["Primary"]}
+        )
+        stats_collector.log_la_maintained_school_counts(la_df)
+
+        with patch("pipeline.stats_collector.stats_logger"):
+            stats_collector.log_preprocessed_ancillary_data_shape(
+                "pupil_data", (1000, 10)
+            )
+
+        # Get final stats
+        with patch("pipeline.stats_collector.stats_logger"):
+            final_stats = stats_collector.get_stats()
+
+        expected_stats = {
+            "school_counts": {
+                "academies": {"total": 2, "by_phase": {"Primary": 1, "Secondary": 1}},
+                "la_maintained_schools": {"total": 1, "by_phase": {"Primary": 1}},
+            },
+            "linked_data_school_counts": {"pupil_data": {"total": 1000}},
+        }
+        assert final_stats == expected_stats

--- a/data-pipeline/tests/unit/test_stats_collector.py
+++ b/data-pipeline/tests/unit/test_stats_collector.py
@@ -81,9 +81,9 @@ class TestStatsCollector:
                 sample_school_df, phase_col="NonExistent"
             )
 
-    def test_log_academy_counts(self, stats_collector, sample_school_df):
+    def test_collect_academy_counts(self, stats_collector, sample_school_df):
         stats_collector.stats["school_counts"] = {}
-        stats_collector.log_academy_counts(sample_school_df)
+        stats_collector.collect_academy_counts(sample_school_df)
 
         expected = {
             "total": 4,
@@ -91,16 +91,16 @@ class TestStatsCollector:
         }
         assert stats_collector.stats["school_counts"]["academies"] == expected
 
-    def test_log_academy_counts_keyerror(self, stats_collector, not_school_df):
+    def test_collect_academy_counts_keyerror(self, stats_collector, not_school_df):
         """Test logging academy counts when school_counts key doesn't exist."""
         with pytest.raises(KeyError):
-            stats_collector.log_academy_counts(not_school_df)
+            stats_collector.collect_academy_counts(not_school_df)
 
-    def test_log_la_maintained_school_counts(self, stats_collector, sample_school_df):
+    def test_collect_la_maintained_school_counts(self, stats_collector, sample_school_df):
         """Test logging LA maintained school counts."""
         stats_collector.stats["school_counts"] = {}
 
-        stats_collector.log_la_maintained_school_counts(sample_school_df)
+        stats_collector.collect_la_maintained_school_counts(sample_school_df)
 
         expected = {
             "total": 4,
@@ -110,9 +110,9 @@ class TestStatsCollector:
             stats_collector.stats["school_counts"]["la_maintained_schools"] == expected
         )
 
-    def test_log_combined_school_counts(self, stats_collector, sample_school_df):
+    def test_collect_combined_school_counts(self, stats_collector, sample_school_df):
         stats_collector.stats["school_counts"] = {}
-        stats_collector.log_combined_school_counts(sample_school_df)
+        stats_collector.collect_combined_school_counts(sample_school_df)
 
         expected = {
             "total": 4,
@@ -121,9 +121,9 @@ class TestStatsCollector:
         assert stats_collector.stats["school_counts"]["combined_schools"] == expected
 
     @patch("pipeline.stats_collector.stats_logger")
-    def test_log_preprocessed_ancillary_data_shape(self, mock_logger, stats_collector):
+    def test_collect_preprocessed_ancillary_data_shape(self, mock_logger, stats_collector):
         name, shape = "test_data", (100, 5)
-        stats_collector.log_preprocessed_ancillary_data_shape(name, shape)
+        stats_collector.collect_preprocessed_ancillary_data_shape(name, shape)
 
         # Check logging call
         mock_logger.info.assert_called_once_with(f"{name=} preprocessed with {shape=}")
@@ -134,12 +134,12 @@ class TestStatsCollector:
         assert stats_collector.stats["linked_data_school_counts"][name]["total"] == 100
 
     @patch("pipeline.stats_collector.stats_logger")
-    def test_log_preprocessed_ancillary_data_shape_multiple_calls(
+    def test_collect_preprocessed_ancillary_data_shape_multiple_calls(
         self, mock_logger, stats_collector
     ):
-        """Test multiple calls to log_preprocessed_ancillary_data_shape."""
-        stats_collector.log_preprocessed_ancillary_data_shape("data1", (50, 3))
-        stats_collector.log_preprocessed_ancillary_data_shape("data2", (75, 4))
+        """Test multiple calls to collect_preprocessed_ancillary_data_shape."""
+        stats_collector.collect_preprocessed_ancillary_data_shape("data1", (50, 3))
+        stats_collector.collect_preprocessed_ancillary_data_shape("data2", (75, 4))
 
         expected_stats = {
             "linked_data_school_counts": {
@@ -207,15 +207,15 @@ class TestStatsCollector:
                 "Overall Phase": ["Primary", "Secondary"],
             }
         )
-        stats_collector.log_academy_counts(academy_df)
+        stats_collector.collect_academy_counts(academy_df)
 
         la_df = pd.DataFrame(
             {"School Name": ["LA School A"], "Overall Phase": ["Primary"]}
         )
-        stats_collector.log_la_maintained_school_counts(la_df)
+        stats_collector.collect_la_maintained_school_counts(la_df)
 
         with patch("pipeline.stats_collector.stats_logger"):
-            stats_collector.log_preprocessed_ancillary_data_shape(
+            stats_collector.collect_preprocessed_ancillary_data_shape(
                 "pupil_data", (1000, 10)
             )
 

--- a/data-pipeline/tests/unit/test_stats_collector.py
+++ b/data-pipeline/tests/unit/test_stats_collector.py
@@ -130,7 +130,7 @@ class TestStatsCollector:
         stats_collector.collect_preprocessed_ancillary_data_shape(name, shape)
 
         # Check logging call
-        mock_logger.info.assert_called_once_with(f"{name=} preprocessed with {shape=}")
+        mock_logger.info.assert_called_once_with(f"Ancillary file {name=} preprocessed with {shape=}")
 
         # Check stats structure
         assert "linked_data_school_counts" in stats_collector.stats

--- a/data-pipeline/tests/unit/test_stats_collector.py
+++ b/data-pipeline/tests/unit/test_stats_collector.py
@@ -32,7 +32,6 @@ class TestStatsCollector:
 
     def test_init(self, stats_collector):
         assert stats_collector.stats == {}
-        assert not hasattr(stats_collector, "pipeline_start_time")
 
     def test_start_pipeline_run(self, stats_collector):
         stats_collector.stats = {"test": "data"}

--- a/data-pipeline/tests/unit/test_stats_collector.py
+++ b/data-pipeline/tests/unit/test_stats_collector.py
@@ -96,7 +96,9 @@ class TestStatsCollector:
         with pytest.raises(KeyError):
             stats_collector.collect_academy_counts(not_school_df)
 
-    def test_collect_la_maintained_school_counts(self, stats_collector, sample_school_df):
+    def test_collect_la_maintained_school_counts(
+        self, stats_collector, sample_school_df
+    ):
         """Test logging LA maintained school counts."""
         stats_collector.stats["school_counts"] = {}
 
@@ -121,7 +123,9 @@ class TestStatsCollector:
         assert stats_collector.stats["school_counts"]["combined_schools"] == expected
 
     @patch("pipeline.stats_collector.stats_logger")
-    def test_collect_preprocessed_ancillary_data_shape(self, mock_logger, stats_collector):
+    def test_collect_preprocessed_ancillary_data_shape(
+        self, mock_logger, stats_collector
+    ):
         name, shape = "test_data", (100, 5)
         stats_collector.collect_preprocessed_ancillary_data_shape(name, shape)
 


### PR DESCRIPTION
## 🧾 Summary

[AB#266558](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/266558)

* Add a new StatsCollector object which is used to log stats across the pipeline run.
* Add relevant stats logic
* Add tests for StatsCollector

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Unit and integration tests updated _(if applicable)_.
- [x] All unit/integration tests are executed and passed.
- [x] Tested by running locally.

</details>
<details>
<summary>Documentation updates</summary>


- [ ] Code-level documentation (e.g., inline comments, docstrings) is updated.
- [ ] README.md or relevant module-level docs are updated.
- [ ] API changes are reflected in API documentation _(if applicable)_.
- [ ] Links to external references are included instead of duplicating content.
- [ ] No outdated or incorrect documentation remains.

</details>
<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [ ] Screenshots or Demo _(if applicable)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] Design (UX and/or content) review _(if applicable)_.
- [ ] Documentation changes have been explicitly reviewed.
- [x] CI/CD pipeline checks pass.

</details>

## 🔍 Reviewer notes
>Add any additional context or questions for reviewers. Include any dependencies that are required for this change. 

## 🧪 Testing notes

I've run the pipeline for 2023 and 2024 and I can see the stats formed correctly in the `msg_payload` in `stdout`. The orchestrator updates the `CompletedPipelineRun` table so this PR needs to be merged to see the stats reflected there.
