### PR TITLE
fix failing documentation pipeline

### DIFF
--- a/documentation/quality-assurance/4_Performance-Testing.md
+++ b/documentation/quality-assurance/4_Performance-Testing.md
@@ -90,9 +90,12 @@ However, the logs do not include POST-ed data, but do include Secret parameters.
 - **Use Apache JMeter™ GUI to author, not run `.jmx` tests:** For `.jmx` based tests, such as the Web tests that also resolve embedded resources, [Apache JMeter™](https://jmeter.apache.org/) should be used for configuration after installing [Microsoft OpenJDK](https://www.microsoft.com/openjdk). This should be done whilst also bearing in mind [best practises](https://www.blazemeter.com/blog/web-testing-jmeter), including not executing the tests from within JMeter itself, rather uploading to Azure Load Testing for execution.
 
 - **Use Plugins in Apache JMeter for extended functionality:** If running on DfE kit the VPN proxy SSL certificates will need to be [exported from the certificate chain](https://mattferderer.com/fix-git-self-signed-certificate-in-certificate-chain-on-windows) and then imported into the Java `cacerts` file to avoid SSL errors in the Plugin Manager. This may be achieved from an administrator command prompt with (using the default Java password for the `cacerts` file of `changeit`):
+
+``` sh
   - keytool -import -cacerts -alias PKI-ROOT-CA -trustcacerts -file "C:\Path\To\PKI-ROOT-CA.crt"
   - keytool -import -cacerts -alias PKI-SUB-CA01 -trustcacerts -file "C:\Path\To\PKI-SUB-CA01.crt"
   - keytool -import -cacerts -alias decryption.education.gov.uk -trustcacerts -file "C:\Path\To\decryption.education.gov.uk.crt"
+```
 
 <!-- Leave the rest of this page blank -->
 \newpage

--- a/documentation/tools/build-docs.sh
+++ b/documentation/tools/build-docs.sh
@@ -31,6 +31,10 @@ done
 cp -a images/. work/images
 cd work
 workfiles=$(find . -name '*.md' -and ! -name '*.md.exclude' | sort -V)
+
+echo "[DEBUG] Markdown files passed to Pandoc:"
+echo "$workfiles"
+
 pandoc "${@:4}" --verbose  -s $workfiles  -o "$output"
 cd ..
 rm -rf work


### PR DESCRIPTION
## 🧾 Summary

[AB#266112](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/266112) [AB#266595](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/266595)

The failures in the documentation pipeline observed following #2515 are caused by a section in `quality-assurance/4_Performance-Testing.md` that is being intepreted as a command while running `pandoc` to generate the PDF.

To resolve this PR simply wraps the offending lines in a code block and the pipeline will now succeed.

This PR also adds additional logging that was helpful while pinpointing the issue.

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [ ] Unit and integration tests updated _(if applicable)_.
- [ ] All unit/integration tests are executed and passed.
- [ ] Tested by running locally.

</details>
<details>
<summary>Documentation updates</summary>


- [x] Code-level documentation (e.g., inline comments, docstrings) is updated.
- [ ] README.md or relevant module-level docs are updated.
- [ ] API changes are reflected in API documentation _(if applicable)_.
- [ ] Links to external references are included instead of duplicating content.
- [x] No outdated or incorrect documentation remains.

</details>
<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [ ] Screenshots or Demo _(if applicable)_.
- [ ] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] Design (UX and/or content) review _(if applicable)_.
- [ ] Documentation changes have been explicitly reviewed.
- [x] CI/CD pipeline checks pass.

</details>

## 🔍 Reviewer notes
>Add any additional context or questions for reviewers. Include any dependencies that are required for this change. 

There are additional warnings in the logs related to Mermaid CLI rendering. These were initially suspected as the cause of the PDF generation failure but have since been ruled out. While they do not currently break the build, they may affect the visual output of diagrams in the generated PDF.

If rendering issues persist after this fix is merged, further investigation into Mermaid configuration or diagram formatting may be required.

## 🧪 Testing notes
>Briefly describe how this was tested and any special setup or edge cases to verify.

This has been tested without the publish steps but verifying PDF generation and the pipeline succeeds. See the parent work item for a link to a test run.

Following merge the pipeline should succeed and the output can be verified. As mentioned in Reviewer notes special attention will be given to mermaid diagrams to validate these are correct.
