### PR TITLE
feat: updates to high executive pay chart

### DIFF
--- a/front-end-components/index.html
+++ b/front-end-components/index.html
@@ -92,10 +92,10 @@
       ></div>
       <button type="submit">Submit</button>
     </form>-->
-    <!--<div id="compare-your-trust" 
+    <div id="compare-your-trust" 
       data-id="10279605"
       data-show-high-exec="true"
-    ></div>-->
+    ></div>
     <!--<div
       id="compare-your-costs"
       data-type="trust"
@@ -105,7 +105,7 @@
     <!-- <div id="compare-your-costs" data-type="school" data-id="990250" data-suppress-negative-or-zero="true" 
     data-cost-code-map="{&quot;teaching staff&quot;:&quot;BAE010&quot;,&quot;supply teaching staff&quot;:&quot;BAE020&quot;,&quot;agency supply teaching staff&quot;:&quot;BAE240&quot;,&quot;education support staff&quot;:&quot;BAE030&quot;,&quot;educational consultancy&quot;:&quot;BAE230&quot;,&quot;administrative and clerical staff&quot;:&quot;BAE040&quot;,&quot;auditor costs&quot;:&quot;BAE260&quot;,&quot;other staff&quot;:&quot;BAE070&quot;,&quot;professional services (non-curriculum)&quot;:&quot;BAE300&quot;,&quot;examination fees&quot;:&quot;BAE220&quot;,&quot;learning resources (not ICT equipment)&quot;:&quot;BAE200&quot;,&quot;ict learning resources&quot;:&quot;BAE210&quot;,&quot;cleaning and caretaking&quot;:&quot;BAE130&quot;,&quot;maintenance of premises&quot;:&quot;BAE120&quot;,&quot;other occupation costs&quot;:&quot;BAE180&quot;,&quot;premises staff&quot;:&quot;BAE050&quot;,&quot;energy&quot;:&quot;BAE150&quot;,&quot;water and sewerage&quot;:&quot;BAE140&quot;,&quot;administrative supplies (non-educational)&quot;:&quot;BAE280&quot;,&quot;catering staff&quot;:&quot;BAE060&quot;,&quot;catering supplies&quot;:&quot;BAE250&quot;,&quot;direct revenue financing&quot;:&quot;BAE290&quot;,&quot;grounds maintenance&quot;:&quot;BAE320&quot;,&quot;indirect employee expenses&quot;:&quot;BAE080&quot;,&quot;interest charges for loan and bank&quot;:&quot;BAE320&quot;,&quot;other insurance premiums&quot;:&quot;BAE270&quot;,&quot;private Finance Initiative (PFI) charges&quot;:&quot;BAE310&quot;,&quot;rent and rates&quot;:&quot;BAE160&quot;,&quot;special facilities&quot;:&quot;BAE190&quot;,&quot;staff development and training&quot;:&quot;BAE090&quot;,&quot;staff-related insurance&quot;:&quot;BAE110&quot;,&quot;supply teacher insurance&quot;:&quot;BAE100&quot;}" data-is-part-of-trust="true"></div> -->
     <!--<div id="historic-data" data-type="school" data-id="123456"></div>-->
-    <div id="historic-data-2" data-type="school" data-id="123456" data-phase="Primary" data-finance-type="Maintained"></div>
+    <!-- <div id="historic-data-2" data-type="school" data-id="123456" data-phase="Primary" data-finance-type="Maintained"></div> -->
     <!--<div
       id="compare-your-costs"
       data-type="local-authority"

--- a/front-end-components/src/components/charts/utils.test.ts
+++ b/front-end-components/src/components/charts/utils.test.ts
@@ -418,24 +418,25 @@ describe("Chart utils", () => {
     });
 
     describe("when given a number", () => {
-      describe("and value is 0", () => {
-        it("returns '0-10'", () => {
-          expect(payBandFormatter(0)).toBe("0-10");
+      describe("and value is less than or equal to 10", () => {
+        it("returns '£0-£10k'", () => {
+          expect(payBandFormatter(0)).toBe("£0-£10k");
+          expect(payBandFormatter(10)).toBe("£0-£10k");
         });
       });
 
-      describe("and value is greater than or equal to 380", () => {
-        it("returns '380+'", () => {
-          expect(payBandFormatter(380)).toBe("380+");
-          expect(payBandFormatter(400)).toBe("380+");
+      describe("and value is greater than 380", () => {
+        it("returns '£380k+'", () => {
+          expect(payBandFormatter(390)).toBe("£380k+");
+          expect(payBandFormatter(400)).toBe("£380k+");
         });
       });
 
-      describe("and value is between 1 and 379", () => {
-        it("returns a range in the format 'x-380'", () => {
-          expect(payBandFormatter(10)).toBe("0-10");
-          expect(payBandFormatter(50)).toBe("40-50");
-          expect(payBandFormatter(379)).toBe("369-379");
+      describe("and value is between 11 and 380", () => {
+        it("returns a range in the format '£{x-10}k-{x}k'", () => {
+          expect(payBandFormatter(11)).toBe("£1k-£11k");
+          expect(payBandFormatter(50)).toBe("£40k-£50k");
+          expect(payBandFormatter(380)).toBe("£370k-£380k");
         });
       });
     });

--- a/front-end-components/src/components/charts/utils.ts
+++ b/front-end-components/src/components/charts/utils.ts
@@ -128,11 +128,11 @@ export function payBandFormatter(value: ValueFormatterValue): string {
     return value ? String(value) : "";
   }
 
-  if (value >= 380) {
-    return "380+";
+  if (value > 380) {
+    return "£380k+";
   }
-  if (value === 0) {
-    return "0-10";
+  if (value <= 10) {
+    return "£0-£10k";
   }
-  return `${value - 10}-${value}`;
+  return `£${value - 10}k-£${value}k`;
 }

--- a/front-end-components/src/composed/dimensioned-chart/types.tsx
+++ b/front-end-components/src/composed/dimensioned-chart/types.tsx
@@ -27,6 +27,7 @@ export type DimensionChartOverride = {
   valueFormatter: ValueFormatterType;
   suppressNegativeOrZero: SuppressNegativeOrZero;
   customTooltip?: "highExec";
+  summary: string;
 };
 
 export type DimensionedChartProps<

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -79,6 +79,7 @@ export function HorizontalBarChartWrapper<
 
   const valueLabel = override?.valueLabel ?? xAxisLabel ?? dimension.label;
   const resolvedValueUnit = override?.valueUnit ?? valueUnit ?? dimension.unit;
+  const summary = override?.summary;
 
   const tableValueFormatter = override?.valueFormatter ?? fullValueFormatter;
   const chartValueFormatter = override?.valueFormatter ?? shortValueFormatter;
@@ -245,6 +246,11 @@ export function HorizontalBarChartWrapper<
               showTitle
               title={chartTitle}
             />
+          </div>
+        )}
+        {summary && (
+          <div className="govuk-grid-column-two-thirds">
+            <p className="govuk-body">{summary}</p>
           </div>
         )}
       </div>

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/non-educational-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/non-educational-support-staff.tsx
@@ -220,6 +220,8 @@ export const NonEducationalSupportStaff: React.FC<{
           message: "Only displaying trusts with pay band data.",
         },
         customTooltip: "highExec",
+        summary:
+          "Emoluments are payments made to executive members of staff. The figure noted includes salary, other taxable benefits in cash or in kind, termination payments and employer pension as reported by the trust in the AAR.",
       },
     };
     charts.push(highExecutivePayChart);

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/non-educational-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/non-educational-support-staff.tsx
@@ -210,7 +210,7 @@ export const NonEducationalSupportStaff: React.FC<{
   if (showHighExecutivePay) {
     const highExecutivePayChart = {
       data: highestSalaryBandBarData,
-      title: "High executive pay",
+      title: "Highest paid individual at a Trust (FTE equivalent)",
       override: {
         valueUnit: "amount",
         valueLabel: "Highest emolument band",

--- a/front-end-components/src/views/compare-your-trust/partials/accordion-sections/non-educational-support-staff.tsx
+++ b/front-end-components/src/views/compare-your-trust/partials/accordion-sections/non-educational-support-staff.tsx
@@ -217,7 +217,8 @@ export const NonEducationalSupportStaff: React.FC<{
         valueFormatter: payBandFormatter,
         suppressNegativeOrZero: {
           suppressNegativeOrZero: true,
-          message: "Only displaying trusts with pay band data.",
+          message:
+            "Only data for Trusts with pay bands above £60,000 is shown.",
         },
         customTooltip: "highExec",
         summary:


### PR DESCRIPTION
## 🧾 Summary

[AB#265181](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/265181) [AB#267471](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/267471)

Following design input this PR updates the following

- Chart title.
- Adds summary below the title to explain the data.
- Updates the warning text for suppression of negative and zero values
- Updates the values used as part of the labels to display as abbreviated currency rather than just a range. ie `£190k-£200k` rather than `190-200`

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Unit and integration tests updated _(if applicable)_.
- [x] All unit/integration tests are executed and passed.
- [x] Tested by running locally.

</details>
<details>
<summary>Documentation updates</summary>


- [ ] Code-level documentation (e.g., inline comments, docstrings) is updated.
- [ ] README.md or relevant module-level docs are updated.
- [ ] API changes are reflected in API documentation _(if applicable)_.
- [ ] Links to external references are included instead of duplicating content.
- [ ] No outdated or incorrect documentation remains.

</details>
<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [ ] Screenshots or Demo _(if applicable)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] Design (UX and/or content) review _(if applicable)_.
- [ ] Documentation changes have been explicitly reviewed.
- [ ] CI/CD pipeline checks pass.

</details>

## 🔍 Reviewer notes

This PR intentionally excludes the required changes to add total pupils numbers to the tooltip as specified in the parent work item. This will be added on a future PR. Following that another PR will be required to bump the front-end version and update e2e tests and then this can be demoed for sign off.

## 🧪 Testing notes

The changes can be observed either by copying the assets from `front-end-components` see `./copy-js.sh` or  `./copy-js.ps1` and running the web app locally or directly using Vite `npm run dev`

Note either will require a pre prod DSI login as the proxy api will require auth even if just running Vite. Will also need to have created a comparator set.
