### PR TITLE
Wrapped SSR chart and stat boxes in `costs-chart-container` with `uuid` in order to include missing content in saved images

### DIFF
--- a/web/src/Web.App/Views/SchoolSpending/CustomDataSsr.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/CustomDataSsr.cshtml
@@ -84,7 +84,7 @@
     {
         CostCodesAttr = "data-cost-codes",
         ElementId = "page-actions-button",
-        SaveClassName = "costs-chart-wrapper",
+        SaveClassName = "costs-chart-container",
         SaveFileName = $"spending-priorities-{Model.Urn}.zip",
         SaveTitleAttr = "data-title"
     })

--- a/web/src/Web.App/Views/SchoolSpending/IndexSsr.cshtml
+++ b/web/src/Web.App/Views/SchoolSpending/IndexSsr.cshtml
@@ -95,7 +95,7 @@
     {
         CostCodesAttr = "data-cost-codes",
         ElementId = "page-actions-button",
-        SaveClassName = "costs-chart-wrapper",
+        SaveClassName = "costs-chart-container",
         SaveFileName = $"spending-priorities-{Model.Urn}.zip",
         SaveTitleAttr = "data-title"
     })

--- a/web/src/Web.App/Views/Shared/Components/SchoolSpendingCostsSsr/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/SchoolSpendingCostsSsr/Default.cshtml
@@ -82,62 +82,64 @@
 
             <div class="govuk-grid-row govuk-!-margin-bottom-4">
                 <div class="govuk-grid-column-two-thirds">
-                    <div id="@uuid" class="costs-chart-wrapper" data-title="@categoryHeading"
+                    <div id="@uuid" class="costs-chart-container" data-title="@categoryHeading"
                          data-cost-codes="@costCodes.ToJson(Formatting.None)">
-                        @if (string.IsNullOrWhiteSpace(cost?.ChartSvg))
-                        {
-                            <div
-                                class="govuk-warning-text govuk-!-margin-top-2 govuk-!-margin-bottom-2 ssr-chart-warning">
-                                <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                                <strong class="govuk-warning-text__text">
-                                    <span class="govuk-visually-hidden">Warning</span>
-                                    Unable to display chart
-                                </strong>
-                            </div>
-                        }
-                        else
-                        {
-                            @if (cost.HasNegativeOrZeroValues)
+                        <div class="costs-chart-wrapper">
+                            @if (string.IsNullOrWhiteSpace(cost?.ChartSvg))
                             {
-                                <div class="govuk-warning-text">
+                                <div
+                                    class="govuk-warning-text govuk-!-margin-top-2 govuk-!-margin-bottom-2 ssr-chart-warning">
                                     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
                                     <strong class="govuk-warning-text__text">
                                         <span class="govuk-visually-hidden">Warning</span>
-                                        Only displaying schools with positive expenditure.
+                                        Unable to display chart
                                     </strong>
                                 </div>
                             }
+                            else
+                            {
+                                @if (cost.HasNegativeOrZeroValues)
+                                {
+                                    <div class="govuk-warning-text">
+                                        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                                        <strong class="govuk-warning-text__text">
+                                            <span class="govuk-visually-hidden">Warning</span>
+                                            Only displaying schools with positive expenditure.
+                                        </strong>
+                                    </div>
+                                }
 
-                            <div class="govuk-!-margin-bottom-2 ssr-chart">
-                                @Html.Raw(cost.ChartSvg)
-                            </div>
-                        }
-                    </div>
+                                <div class="govuk-!-margin-bottom-2 ssr-chart">
+                                    @Html.Raw(cost.ChartSvg)
+                                </div>
+                            }
+                        </div>
 
-                    <div class="chart-stat-summary govuk-!-margin-bottom-5">
-                        @await Html.PartialAsync("_ChartStat", new ChartStatViewModel
-                        {
-                            Label = "This school spends",
-                            Value = schoolData?.Amount.ToCurrency(0),
-                            Suffix = unit,
-                            Highlight = true
-                        })
-                        @await Html.PartialAsync("_ChartStat", new ChartStatViewModel
-                        {
-                            Label = "Similar schools spend",
-                            Value = chartStats?.Average.ToCurrency(0),
-                            Suffix = $"{unit}, on average"
-                        })
-                        @if (chartStats?.Difference != null)
-                        {
+                        <div class="chart-stat-summary govuk-!-margin-bottom-5">
                             @await Html.PartialAsync("_ChartStat", new ChartStatViewModel
                             {
                                 Label = "This school spends",
-                                Value = Math.Abs(chartStats.Difference.Value).ToCurrency(0),
-                                ValueSuffix = chartStats.PercentDifference != null ? $"({Math.Abs(chartStats.PercentDifference.Value):F1}%)" : null,
-                                Suffix = $"<strong>{(chartStats.Difference < 0 ? "less" : "more")}</strong> {unit}"
+                                Value = schoolData?.Amount.ToCurrency(0),
+                                Suffix = unit,
+                                Highlight = true
                             })
-                        }
+                            @await Html.PartialAsync("_ChartStat", new ChartStatViewModel
+                            {
+                                Label = "Similar schools spend",
+                                Value = chartStats?.Average.ToCurrency(0),
+                                Suffix = $"{unit}, on average"
+                            })
+                            @if (chartStats?.Difference != null)
+                            {
+                                @await Html.PartialAsync("_ChartStat", new ChartStatViewModel
+                                {
+                                    Label = "This school spends",
+                                    Value = Math.Abs(chartStats.Difference.Value).ToCurrency(0),
+                                    ValueSuffix = chartStats.PercentDifference != null ? $"({Math.Abs(chartStats.PercentDifference.Value):F1}%)" : null,
+                                    Suffix = $"<strong>{(chartStats.Difference < 0 ? "less" : "more")}</strong> {unit}"
+                                })
+                            }
+                        </div>
                     </div>
 
                     @{


### PR DESCRIPTION
## 🧾 Summary
[AB#267134](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/267134) [AB#267294](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/267294)

Bug fix to include missing chart stat boxes when SSR charts are enabled on school spending and costs page.

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [ ] Unit and integration tests updated _(if applicable)_.
- [x] All unit/integration tests are executed and passed.
- [x] Tested by running locally.

</details>
<details>
<summary>Documentation updates</summary>


- [ ] Code-level documentation (e.g., inline comments, docstrings) is updated.
- [ ] README.md or relevant module-level docs are updated.
- [ ] API changes are reflected in API documentation _(if applicable)_.
- [ ] Links to external references are included instead of duplicating content.
- [ ] No outdated or incorrect documentation remains.

</details>
<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [ ] Screenshots or Demo _(if applicable)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] Design (UX and/or content) review _(if applicable)_.
- [ ] Documentation changes have been explicitly reviewed.
- [ ] CI/CD pipeline checks pass.

</details>

## 🔍 Reviewer notes

## 🧪 Testing notes
Only Web needs to be rebuilt to validate. No changes to enhancements Vue components required.
