### PR TITLE
fix: disable Mermaid CLI sandbox and exit on failure in documentation pipeline

### DIFF
--- a/documentation/tools/build-docs.sh
+++ b/documentation/tools/build-docs.sh
@@ -25,7 +25,15 @@ do
         mkdir -p work/$dir
     fi;
     echo $(pwd)/$fname
-    mmdc -e png -i $(pwd)/$fname -o work/$fname
+
+    # NOTE:
+    # In Ubuntu 24.04+ AppArmor restricts unprivileged user namespaces.
+    # This breaks Chromium's internal sandbox used by Mermaid CLI (via Puppeteer).
+    # To work around this we pass a Puppeteer config that disables the sandbox.
+    # For our use case diagrams are trusted and the environment is ephemeral.
+    # See: https://github.com/mermaid-js/mermaid-cli/blob/340561040b6b0621a486e3fc96723139e5718268/docs/linux-sandbox-issue.md
+    # https://github.com/mermaid-js/mermaid-cli/issues/730
+    mmdc -e png -i $(pwd)/$fname -o work/$fname -p "$SCRIPT_DIR/puppeteer-config.json"
 done 
 
 cp -a images/. work/images

--- a/documentation/tools/puppeteer-config.json
+++ b/documentation/tools/puppeteer-config.json
@@ -1,0 +1,3 @@
+{
+  "args": ["--no-sandbox"]
+}

--- a/pipelines/documentation/build.yaml
+++ b/pipelines/documentation/build.yaml
@@ -67,7 +67,7 @@ stages:
   - stage: GenerateDocumentation
     dependsOn: [ Validate ]
     displayName: 'Generate'
-    condition: and(succeeded(), eq(variables['ShouldDeploy'],'true'))
+    # condition: and(succeeded(), eq(variables['ShouldDeploy'],'true'))
     jobs:
       - job: BuildDocumentation
         displayName: 'Build and publish documentation'
@@ -115,24 +115,24 @@ stages:
             parameters:
               folder: 'data'
 
-          - task: PublishPipelineArtifact@1
-            displayName: 'Publish artifacts'
-            inputs:
-              targetPath: '$(WorkingDir)/pub'
-              artifact: 'docs'
-              publishLocation: 'pipeline'
+      #     - task: PublishPipelineArtifact@1
+      #       displayName: 'Publish artifacts'
+      #       inputs:
+      #         targetPath: '$(WorkingDir)/pub'
+      #         artifact: 'docs'
+      #         publishLocation: 'pipeline'
               
-      - job: SharePointPublish
-        displayName: 'Publish artifacts to SharePoint'
-        dependsOn: [ BuildDocumentation ]
-        steps:
-          - checkout: self
+      # - job: SharePointPublish
+      #   displayName: 'Publish artifacts to SharePoint'
+      #   dependsOn: [ BuildDocumentation ]
+      #   steps:
+      #     - checkout: self
 
-          - template: ..\common\publish-sharepoint-artifacts.yaml
-            parameters:
-              ArtifactName: 'docs'
-              ArtifactPattern: '**/*.pdf'
-              TargetPath: 'FBIT support\Documentation'
-              SiteUrl: $(SharePoint_SiteUrl)
-              ClientId: $(SharePoint_ClientId)
-              ClientSecret: $(SharePoint_ClientSecret)
+      #     - template: ..\common\publish-sharepoint-artifacts.yaml
+      #       parameters:
+      #         ArtifactName: 'docs'
+      #         ArtifactPattern: '**/*.pdf'
+      #         TargetPath: 'FBIT support\Documentation'
+      #         SiteUrl: $(SharePoint_SiteUrl)
+      #         ClientId: $(SharePoint_ClientId)
+      #         ClientSecret: $(SharePoint_ClientSecret)


### PR DESCRIPTION
## 🧾 Summary

AB#266112 AB#266595 AB#267930

PDF generation is currently incomplete due to a change in Ubuntu’s AppArmor policy, which restricts unprivileged user namespaces. This breaks the Chromium sandbox used internally by Mermaid CLI, resulting in errors during diagram rendering. See pipeline logs and/or AB#267473 for an example.

This PR introduces a workaround by disabling the Chromium sandbox via a Puppeteer configuration. This aligns with our use case, where:

- Diagrams are trusted
- The environment is ephemeral

With this change, Mermaid CLI should function as expected, and complete PDFs will be generated restoring behavior to what it was prior to the AppArmor changes introduced in late April.

# TODO - testing

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [ ] Code follows project coding standards.
- [ ] Code builds clean without any errors or warnings.
- [ ] Branch has been rebased onto main.
- [ ] Unit and integration tests updated _(if applicable)_.
- [ ] All unit/integration tests are executed and passed.
- [ ] Tested by running locally.

</details>
<details>
<summary>Documentation updates</summary>


- [ ] Code-level documentation (e.g., inline comments, docstrings) is updated.
- [ ] README.md or relevant module-level docs are updated.
- [ ] API changes are reflected in API documentation _(if applicable)_.
- [ ] Links to external references are included instead of duplicating content.
- [ ] No outdated or incorrect documentation remains.

</details>
<details>
<summary>UX & metadata</summary>

- [ ] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [ ] Screenshots or Demo _(if applicable)_.
- [ ] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] Design (UX and/or content) review _(if applicable)_.
- [ ] Documentation changes have been explicitly reviewed.
- [ ] CI/CD pipeline checks pass.

</details>

## 🔍 Reviewer notes

I would appreciate feedback on this approach and any suggestions if there is a better way. I believe for our use case this approach is suitable and should restore previous behaviour.

## 🧪 Testing notes

See the most recent documentation pipeline runs. Tested by run the pipeline but only for generation steps not publishing to SharePoint
