### PR TITLE
feat: fixes when no value for eml band. Hover tooltip should be shown.

### DIFF
--- a/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
+++ b/front-end-components/src/components/charts/horizontal-bar-chart/component.tsx
@@ -253,7 +253,7 @@ function HorizontalBarChartInner<TData extends ChartDataSeries>(
           className={classNames({ "recharts-text__bold": highlight })}
         >
           {valueFormatter
-            ? valueFormatter(value as ChartSeriesValue)
+            ? valueFormatter(value as ChartSeriesValue, { forDisplay: true })
             : String(value)}
         </Text>
       </g>

--- a/front-end-components/src/components/charts/pay-band-tooltip/component.tsx
+++ b/front-end-components/src/components/charts/pay-band-tooltip/component.tsx
@@ -20,40 +20,38 @@ export function PayBandDataTooltip<
     .payload as TrustChartData;
   const label = "Highest emolument band";
   return (
-    totalValue && (
-      <table className="govuk-table govuk-table--small-text-until-tablet tooltip-table">
-        <caption className="govuk-table__caption govuk-table__caption--s">
-          {trustName}
-        </caption>
-        <thead className="govuk-table__head govuk-visually-hidden">
-          <tr className="govuk-table__row">
-            <th scope="col" className="govuk-table__header">
-              Item
-            </th>
-            <th scope="col" className="govuk-table__header">
-              Value
-            </th>
-          </tr>
-        </thead>
-        <tbody className="govuk-table__body">
-          <tr className="govuk-table__row">
-            <th scope="row" className="govuk-table__header">
-              {label}
-            </th>
-            <td className="govuk-table__cell">
-              {payBandFormatter(totalValue)}
-            </td>
-          </tr>
-          <tr className="govuk-table__row">
-            <th scope="row" className="govuk-table__header">
-              Number of pupils
-            </th>
-            <td className="govuk-table__cell">
-              {statValueFormatter(totalPupils)}
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    )
+    <table className="govuk-table govuk-table--small-text-until-tablet tooltip-table">
+      <caption className="govuk-table__caption govuk-table__caption--s">
+        {trustName}
+      </caption>
+      <thead className="govuk-table__head govuk-visually-hidden">
+        <tr className="govuk-table__row">
+          <th scope="col" className="govuk-table__header">
+            Item
+          </th>
+          <th scope="col" className="govuk-table__header">
+            Value
+          </th>
+        </tr>
+      </thead>
+      <tbody className="govuk-table__body">
+        <tr className="govuk-table__row">
+          <th scope="row" className="govuk-table__header">
+            {label}
+          </th>
+          <td className="govuk-table__cell">
+            {payBandFormatter(totalValue, { forDisplay: true })}
+          </td>
+        </tr>
+        <tr className="govuk-table__row">
+          <th scope="row" className="govuk-table__header">
+            Number of pupils
+          </th>
+          <td className="govuk-table__cell">
+            {statValueFormatter(totalPupils)}
+          </td>
+        </tr>
+      </tbody>
+    </table>
   );
 }

--- a/front-end-components/src/components/charts/types.tsx
+++ b/front-end-components/src/components/charts/types.tsx
@@ -95,6 +95,7 @@ export interface ValueFormatterOptions {
   valueUnit: ChartSeriesValueUnit;
   compact: boolean;
   currencyAsName: boolean;
+  forDisplay: boolean;
 }
 
 export interface ValueFormatterProps {

--- a/front-end-components/src/components/charts/utils.test.ts
+++ b/front-end-components/src/components/charts/utils.test.ts
@@ -404,16 +404,9 @@ describe("Chart utils", () => {
 
   describe("payBandFormatter()", () => {
     describe("when given a non-number", () => {
-      describe("and it's truthy", () => {
-        it("returns the string version of the value", () => {
-          expect(payBandFormatter("Band A")).toBe("Band A");
-        });
-      });
-
-      describe("and it's falsy", () => {
-        it("returns an empty string", () => {
-          expect(payBandFormatter(undefined)).toBe("");
-        });
+      it("returns message", () => {
+        expect(payBandFormatter(undefined)).toBe("No data available");
+        expect(payBandFormatter("string")).toBe("No data available");
       });
     });
 

--- a/front-end-components/src/components/charts/utils.ts
+++ b/front-end-components/src/components/charts/utils.ts
@@ -123,9 +123,15 @@ export function fullValueFormatter(
     .toLowerCase();
 }
 
-export function payBandFormatter(value: ValueFormatterValue): string {
-  if (typeof value !== "number") {
-    return value ? String(value) : "";
+export function payBandFormatter(
+  value: ValueFormatterValue,
+  options?: Partial<ValueFormatterOptions>
+): string {
+  if (
+    typeof value !== "number" ||
+    (options?.forDisplay === true && value == 0)
+  ) {
+    return "No data available";
   }
 
   if (value > 380) {


### PR DESCRIPTION
## 🧾 Summary
[AB#265181](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/265181) [AB#268711](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/268711)

Resolve when no value for eml band hover tooltip should show range for eml band and pupil numbers.

As specified by policy team, word "No data available" is shown.

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Unit and integration tests updated _(if applicable)_.
- [x] All unit/integration tests are executed and passed.
- [x] Tested by running locally.

</details>
<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [x] Screenshots or Demo _(if applicable)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [x] CI/CD pipeline checks pass.
</details>

## 🔍 Reviewer notes
Front-end build required

## 🧪 Testing notes
As a side effect, the correct wording is shown at the end of the bar (i.e. rather than incorrectly showing a band, message is shown)

<img width="1008" height="211" alt="image" src="https://github.com/user-attachments/assets/a4d15ead-fbc5-49d7-99a9-5981edea702f" />

