### PR TITLE
Included `/web/src/Web.Shutter` in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -134,10 +134,6 @@
         interval: "monthly"
       commit-message:
         prefix: "[nuget] "
-      # License changes impact v8, so stick to v7 major version instead
-      ignore:
-        - dependency-name: "FluentAssertions"
-          versions: ["8.*"]
 
     - package-ecosystem: "nuget"
       directory: "/platform/tests/Platform.Tests"
@@ -198,10 +194,6 @@
         interval: "monthly"
       commit-message:
         prefix: "[nuget] "
-      # License changes impact v8, so stick to v7 major version instead
-      ignore:
-        - dependency-name: "FluentAssertions"
-          versions: ["8.*"]
 
     - package-ecosystem: "nuget"
       directory: "/web/tests/Web.E2ETests"
@@ -209,10 +201,6 @@
         interval: "monthly"
       commit-message:
         prefix: "[nuget] "
-      # License changes impact v8, so stick to v7 major version instead
-      ignore:
-        - dependency-name: "FluentAssertions"
-          versions: ["8.*"]
 
     - package-ecosystem: "nuget"
       directory: "/web/tests/Web.Integration.Tests"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,10 +21,10 @@
       commit-message:
         prefix: "[npm] "
       open-pull-requests-limit: 10
-      # React v18 to v19 major version upgrade affects other packages as at 
+      # React v18 to v19 major version upgrade affects other packages as at
       # Feb 2025 due to broken peer dependencies. Ignore for the time being.
       # Feb 2025 html-to-image versions after 1.11.11 cause issues for
-      # the styling of front-end-components charts in images. 
+      # the styling of front-end-components charts in images.
       # Ignore until resolved.
       ignore:
         - dependency-name: "react"
@@ -101,6 +101,13 @@
         prefix: "[nuget] "
 
     - package-ecosystem: "nuget"
+      directory: "/platform/src/apis/Platform.Api.Content"
+      schedule:
+        interval: "monthly"
+      commit-message:
+        prefix: "[nuget] "
+
+    - package-ecosystem: "nuget"
       directory: "/platform/src/search/Platform.Search"
       schedule:
         interval: "monthly"
@@ -138,7 +145,7 @@
         interval: "monthly"
       commit-message:
         prefix: "[nuget] "
-          
+
     - package-ecosystem: "npm"
       directory: "/prototype/src"
       schedule:
@@ -176,6 +183,15 @@
       commit-message:
         prefix: "[nuget] "
 
+    - package-ecosystem: "npm"
+      directory: "/web/src/Web.Shutter"
+      registries:
+        - npm-azure-artifacts
+      schedule:
+        interval: "monthly"
+      commit-message:
+        prefix: "[npm] "
+
     - package-ecosystem: "nuget"
       directory: "/web/tests/Web.A11yTests"
       schedule:
@@ -197,7 +213,7 @@
       ignore:
         - dependency-name: "FluentAssertions"
           versions: ["8.*"]
-          
+
     - package-ecosystem: "nuget"
       directory: "/web/tests/Web.Integration.Tests"
       schedule:


### PR DESCRIPTION
## 🧾 Summary

[AB#227179](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/227179) [AB#270020](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/270020) #2600

Add this folder to dependabot config to ensure checks take place monthly rather than ad-hoc (such as #2600), whilst also allowing fine tuning of pinned/excluded package versions.

Also removed `FluentAssertions` from `ignore` blocks as this package is no longer referenced.

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [ ] Code follows project coding standards.
- [ ] Code builds clean without any errors or warnings.
- [ ] Branch has been rebased onto main.
- [ ] Unit and integration tests updated _(if applicable)_.
- [ ] All unit/integration tests are executed and passed.
- [ ] Tested by running locally.

</details>
<details>
<summary>Documentation updates</summary>


- [ ] Code-level documentation (e.g., inline comments, docstrings) is updated.
- [ ] README.md or relevant module-level docs are updated.
- [ ] API changes are reflected in API documentation _(if applicable)_.
- [ ] Links to external references are included instead of duplicating content.
- [ ] No outdated or incorrect documentation remains.

</details>
<details>
<summary>UX & metadata</summary>

- [ ] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [ ] Screenshots or Demo _(if applicable)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] Design (UX and/or content) review _(if applicable)_.
- [ ] Documentation changes have been explicitly reviewed.
- [ ] CI/CD pipeline checks pass.

</details>

## 🔍 Reviewer notes. 

## 🧪 Testing notes

It is possible that merging this changed file will cause an immediate dependabot run to take place, opening a significant number of new PRs. It may therefore be worth holding off the merge until the end of the month.