### PR TITLE
Skeleton school IT spending controller/action/model/view

### DIFF
--- a/web/src/Web.App/Constants/BreadcrumbNodes.cs
+++ b/web/src/Web.App/Constants/BreadcrumbNodes.cs
@@ -20,6 +20,15 @@ public static class BreadcrumbNodes
         Parent = SchoolHome(urn)
     };
 
+    public static MvcBreadcrumbNode SchoolComparisonItSpend(string urn) => new("Index", "SchoolComparisonItSpendController", PageTitles.ComparisonItSpend)
+    {
+        RouteValues = new
+        {
+            urn
+        },
+        Parent = SchoolHome(urn)
+    };
+
     public static MvcBreadcrumbNode SchoolSpending(string urn) => new("Index", "SchoolSpending", PageTitles.Spending)
     {
         RouteValues = new

--- a/web/src/Web.App/Constants/FinanceTools.cs
+++ b/web/src/Web.App/Constants/FinanceTools.cs
@@ -8,6 +8,7 @@ public enum FinanceTools
     CentralServices,
     ForecastRisk,
     SpendingComparison,
+    SpendingComparisonIt,
     Spending,
     HighNeeds
 }

--- a/web/src/Web.App/Constants/PageTitles.cs
+++ b/web/src/Web.App/Constants/PageTitles.cs
@@ -13,6 +13,7 @@ public static class PageTitles
     public const string ContactDetails = "Contact details";
     public const string SchoolHome = "Your school";
     public const string Comparison = "Benchmark spending";
+    public const string ComparisonItSpend = "Benchmark your IT spending";
     public const string Spending = "Spending priorities for this school";
     public const string Resources = "Find ways to spend less";
     public const string Census = "Benchmark pupil and workforce data";

--- a/web/src/Web.App/Constants/TrackedRequestType.cs
+++ b/web/src/Web.App/Constants/TrackedRequestType.cs
@@ -30,6 +30,8 @@ public enum TrackedRequestFeature
     BenchmarkCosts,
     [StringValue("benchmark-central-costs")]
     BenchmarkCentralCosts,
+    [StringValue("benchmark-it-spending")]
+    BenchmarkItSpend,
     [StringValue("customised-data")]
     CustomisedData,
     [StringValue("details")]

--- a/web/src/Web.App/Controllers/SchoolComparisonItSpendController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparisonItSpendController.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement.Mvc;
+using Web.App.Attributes;
+using Web.App.Attributes.RequestTelemetry;
+using Web.App.Infrastructure.Apis;
+using Web.App.ViewModels;
+
+namespace Web.App.Controllers;
+
+[Controller]
+[Route("school/{urn}/comparison/it")]
+[ValidateUrn]
+[FeatureGate(FeatureFlags.CfrItSpendBreakdown)]
+public class SchoolComparisonItSpendController(ILogger<SchoolComparisonController> logger) : Controller
+{
+    [HttpGet]
+    [SchoolRequestTelemetry(TrackedRequestFeature.BenchmarkItSpend)]
+    public async Task<IActionResult> Index(string urn)
+    {
+        using (logger.BeginScope(new
+        {
+            urn
+        }))
+        {
+            try
+            {
+                ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.SchoolComparisonItSpend(urn);
+                var viewModel = new SchoolComparisonItSpendViewModel();
+                return await Task.FromResult(View(viewModel));
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "An error displaying school IT spending comparison: {DisplayUrl}", Request.GetDisplayUrl());
+                return e is StatusCodeException s ? StatusCode((int)s.Status) : StatusCode(500);
+            }
+        }
+    }
+}

--- a/web/src/Web.App/ViewModels/SchoolComparisonItSpendViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolComparisonItSpendViewModel.cs
@@ -1,0 +1,3 @@
+﻿namespace Web.App.ViewModels;
+
+public class SchoolComparisonItSpendViewModel;

--- a/web/src/Web.App/Views/School/Index.cshtml
+++ b/web/src/Web.App/Views/School/Index.cshtml
@@ -116,15 +116,24 @@
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-@await Component.InvokeAsync("SchoolFinanceTools", new
-{
-    identifier = Model.Urn,
-    tools = new[]
+@{
+    var tools = new List<FinanceTools>
     {
         FinanceTools.CompareYourCosts,
         FinanceTools.FinancialPlanning,
         FinanceTools.BenchmarkCensus
+    };
+    
+    // IT comparison only applicable to maintained schools
+    if (!Model.IsPartOfTrust)
+    {
+        tools.Insert(1, FinanceTools.SpendingComparisonIt);
     }
+}
+@await Component.InvokeAsync("SchoolFinanceTools", new
+{
+    identifier = Model.Urn,
+    tools = tools.ToArray()
 })
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/web/src/Web.App/Views/SchoolComparisonItSpend/CustomData.cshtml
+++ b/web/src/Web.App/Views/SchoolComparisonItSpend/CustomData.cshtml
@@ -1,0 +1,41 @@
+﻿@using Newtonsoft.Json
+@using Web.App.Extensions
+@model Web.App.ViewModels.SchoolComparisonViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.Comparison;
+}
+
+@await Component.InvokeAsync("EstablishmentHeading", new
+{
+    title = PageTitles.Comparison,
+    name = Model.Name,
+    id = Model.Urn,
+    kind = OrganisationTypes.School
+})
+
+@await Component.InvokeAsync("CustomDataBanner", new
+{
+    name = Model.Name,
+    id = Model.Urn
+})
+
+<div
+    id="compare-your-costs"
+    data-type="@OrganisationTypes.School"
+    data-id="@Model.Urn"
+    data-custom-data-id="@Model.CustomDataId"
+    data-suppress-negative-or-zero="true"
+    data-cost-code-map="@Model.CostCodeMap.ToJson(Formatting.None)"
+    data-is-part-of-trust="@Model.IsPartOfTrust.ToString().ToLower()">
+</div>
+
+@await Component.InvokeAsync("CustomDataFinanceTools", new
+{
+    identifier = Model.Urn,
+    tools = new[]
+    {
+        FinanceTools.SpendingComparison,
+        FinanceTools.Spending,
+        FinanceTools.BenchmarkCensus
+    }
+})

--- a/web/src/Web.App/Views/SchoolComparisonItSpend/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolComparisonItSpend/Index.cshtml
@@ -1,0 +1,4 @@
+﻿@model Web.App.ViewModels.SchoolComparisonItSpendViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.ComparisonItSpend;
+}

--- a/web/src/Web.App/Views/Shared/Components/SchoolFinanceTools/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/SchoolFinanceTools/Default.cshtml
@@ -50,6 +50,18 @@
                             </p>
                         </li>
                         break;
+                    case FinanceTools.SpendingComparisonIt:
+                        <feature name="@FeatureFlags.CfrItSpendBreakdown">
+                            <li>
+                                <h3 class="govuk-heading-s">
+                                    <a href="@Url.Action("Index", "SchoolComparisonItSpend", new { urn = Model.Identifier })" class="govuk-link govuk-link--no-visited-state">Benchmark IT spending</a>
+                                </h3>
+                                <p class="govuk-body">
+                                    This cost category has been broken down into 7 sub categories to give a more detailed view of IT spending.
+                                </p>
+                            </li>
+                        </feature>
+                        break;
                 }
             }
         </ul>

--- a/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenViewingComparisonItSpend.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenViewingComparisonItSpend.cs
@@ -1,0 +1,44 @@
+﻿using AngleSharp.Html.Dom;
+using AutoFixture;
+using Web.App.Domain;
+using Xunit;
+
+namespace Web.Integration.Tests.Pages.Schools.Comparison;
+
+public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client) : PageBase<SchoolBenchmarkingWebAppClient>(client)
+{
+    [Theory]
+    [InlineData(EstablishmentTypes.Academies)]
+    [InlineData(EstablishmentTypes.Maintained)]
+    public async Task CanDisplay(string financeType)
+    {
+        var (page, school) = await SetupNavigateInitPage(financeType);
+
+        AssertPageLayout(page, school);
+    }
+
+    private async Task<(IHtmlDocument page, School school)> SetupNavigateInitPage(string financeType)
+    {
+        var school = Fixture.Build<School>()
+            .With(x => x.URN, "123456")
+            .With(x => x.FinanceType, financeType)
+            .Create();
+
+        var page = await Client
+            .Navigate(Paths.SchoolComparisonItSpend(school.URN));
+
+        return (page, school);
+    }
+
+    private static void AssertPageLayout(IHtmlDocument page, School school)
+    {
+        var expectedBreadcrumbs = new[]
+        {
+            ("Home", Paths.ServiceHome.ToAbsolute()),
+            ("Your school", Paths.SchoolHome(school.URN).ToAbsolute())
+        };
+
+        DocumentAssert.AssertPageUrl(page, Paths.SchoolComparisonItSpend(school.URN).ToAbsolute());
+        DocumentAssert.Breadcrumbs(page, expectedBreadcrumbs);
+    }
+}

--- a/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingHomeAsFederation.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingHomeAsFederation.cs
@@ -36,12 +36,26 @@ public class WhenViewingHomeAsFederation(SchoolBenchmarkingWebAppClient client) 
     }
 
     [Fact]
-    public async Task CanNavigateToCurriculumPlanning()
+    public async Task CanNavigateToComparisonItSpend()
     {
         var (page, school, _) = await SetupNavigateInitPage();
 
         var liElements = page.QuerySelectorAll("ul.app-links > li");
         var anchor = liElements[1].QuerySelector("h3 > a");
+        Assert.NotNull(anchor);
+
+        var newPage = await Client.Follow(anchor);
+
+        DocumentAssert.AssertPageUrl(newPage, Paths.SchoolComparisonItSpend(school.URN).ToAbsolute());
+    }
+
+    [Fact]
+    public async Task CanNavigateToCurriculumPlanning()
+    {
+        var (page, school, _) = await SetupNavigateInitPage();
+
+        var liElements = page.QuerySelectorAll("ul.app-links > li");
+        var anchor = liElements[2].QuerySelector("h3 > a");
         Assert.NotNull(anchor);
 
         var newPage = await Client.Follow(anchor);
@@ -55,7 +69,7 @@ public class WhenViewingHomeAsFederation(SchoolBenchmarkingWebAppClient client) 
         var (page, school, _) = await SetupNavigateInitPage();
 
         var liElements = page.QuerySelectorAll("ul.app-links > li");
-        var anchor = liElements[2].QuerySelector("h3 > a");
+        var anchor = liElements[3].QuerySelector("h3 > a");
         Assert.NotNull(anchor);
 
         var newPage = await Client.Follow(anchor);
@@ -69,7 +83,7 @@ public class WhenViewingHomeAsFederation(SchoolBenchmarkingWebAppClient client) 
         var (page, school, _) = await SetupNavigateInitPage();
 
         var liElements = page.QuerySelectorAll("ul.app-links > li");
-        var anchor = liElements[7].QuerySelector("h3 > a");
+        var anchor = liElements[8].QuerySelector("h3 > a");
         Assert.NotNull(anchor);
 
         var newPage = await Client.Follow(anchor);
@@ -226,11 +240,12 @@ public class WhenViewingHomeAsFederation(SchoolBenchmarkingWebAppClient client) 
             DocumentAssert.Heading2(toolsSection, "Benchmarking and planning tools");
 
             var toolsLinks = toolsSection?.ChildNodes.QuerySelectorAll("ul> li > h3 > a").ToList();
-            Assert.Equal(3, toolsLinks?.Count);
+            Assert.Equal(4, toolsLinks?.Count);
 
             DocumentAssert.Link(toolsLinks?.ElementAtOrDefault(0), "Benchmark spending", Paths.SchoolComparison(school.URN).ToAbsolute());
-            DocumentAssert.Link(toolsLinks?.ElementAtOrDefault(1), "Curriculum and financial planning", Paths.SchoolFinancialPlanning(school.URN).ToAbsolute());
-            DocumentAssert.Link(toolsLinks?.ElementAtOrDefault(2), "Benchmark pupil and workforce data", Paths.SchoolCensus(school.URN).ToAbsolute());
+            DocumentAssert.Link(toolsLinks?.ElementAtOrDefault(1), "Benchmark IT spending", Paths.SchoolComparisonItSpend(school.URN).ToAbsolute());
+            DocumentAssert.Link(toolsLinks?.ElementAtOrDefault(2), "Curriculum and financial planning", Paths.SchoolFinancialPlanning(school.URN).ToAbsolute());
+            DocumentAssert.Link(toolsLinks?.ElementAtOrDefault(3), "Benchmark pupil and workforce data", Paths.SchoolCensus(school.URN).ToAbsolute());
         }
     }
 

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -71,6 +71,10 @@ public static class Paths
     {
         return $"/school/{urn}/comparison";
     }
+    public static string SchoolComparisonItSpend(string? urn)
+    {
+        return $"/school/{urn}/comparison/it";
+    }
     public static string SchoolComparisonCustomData(string? urn)
     {
         return $"/school/{urn}/comparison/custom-data";


### PR DESCRIPTION
## 🧾 Summary

[AB#270078](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/270078) [AB#270291](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/270291)

- New empty page for School IT spend, behind feature flag
- Conditionally show link through to new page from School home based on finance type and feature flag
- Integration test coverage

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Unit and integration tests updated _(if applicable)_.
- [x] All unit/integration tests are executed and passed.
- [x] Tested by running locally.

</details>
<details>
<summary>Documentation updates</summary>


- [ ] Code-level documentation (e.g., inline comments, docstrings) is updated.
- [ ] README.md or relevant module-level docs are updated.
- [ ] API changes are reflected in API documentation _(if applicable)_.
- [ ] Links to external references are included instead of duplicating content.
- [ ] No outdated or incorrect documentation remains.

</details>
<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [ ] Screenshots or Demo _(if applicable)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] Design (UX and/or content) review _(if applicable)_.
- [ ] Documentation changes have been explicitly reviewed.
- [ ] CI/CD pipeline checks pass.

</details>

## 🔍 Reviewer notes

Intentionally do not perform a school lookup as part of this work item. Future work will cover this, and performing finance type check as required.

## 🧪 Testing notes

Browse to a maintained school home page when the feature flag is enabled to click through to new blank page. When feature disabled, or academy being viewed the link should not be present.
