### PR TITLE
IT spend improved x axis rendering

### DIFF
--- a/platform/src/apis/Platform.Api.ChartRendering/src/functions/horizontalBarChart/builder.ts
+++ b/platform/src/apis/Platform.Api.ChartRendering/src/functions/horizontalBarChart/builder.ts
@@ -33,7 +33,7 @@ export default class HorizontalBarChartBuilder {
       null,
     );
 
-    const suggestedXAxisTickCount = 5;
+    const suggestedXAxisTickCount = 4;
 
     // polyfill DOM methods not supported by XMLDOM as per
     // https://github.com/xmldom/xmldom/issues/92#issuecomment-718091535


### PR DESCRIPTION
## 🧾 Summary

[AB#270078](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/270078)
[AB#271709](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/271709)

- Adds `suggestedXAxisTickCount` to `HorizontalBarChartBuilder` in the ChartRendering API
- Applies it during scale construction to guide `.nice()` and `.ticks()`
- Allows D3 to choose rounded intervals based on the suggestion
- Improves visual consistency of x-axis ticks

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] All unit/integration tests are executed and passed.
- [x] Tested by running locally.

</details>

<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [x] Screenshots or Demo _(if applicable)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] CI/CD pipeline checks pass.

</details>

## 🔍 Reviewer notes

Prior to change

<img width="937" height="124" alt="image" src="https://github.com/user-attachments/assets/251bbdb4-2c24-4e02-8296-3ec529d9fae6" />

<img width="935" height="119" alt="image" src="https://github.com/user-attachments/assets/2efe8e65-8d92-4b88-9dad-c59c819e1b99" />

And examples following this proposed change

<img width="948" height="119" alt="image" src="https://github.com/user-attachments/assets/084d75d5-6b5b-4ec8-bf24-8541932b657a" />

<img width="958" height="120" alt="image" src="https://github.com/user-attachments/assets/ae5be3ef-13ed-4c37-9af3-efd8331bb064" />

There is the potential that the width of the container may need to be updated but until we have realistic data to work with I have kept any changes for this out of scope of this PR.




