### PR TITLE
Feature/269159/verify 2025 cfr file

### DIFF
--- a/data-pipeline/src/pipeline/database.py
+++ b/data-pipeline/src/pipeline/database.py
@@ -575,13 +575,13 @@ def insert_financial_data(
         "Income_Pre Post 16_CS": "PrePost16FundingCS",
         "Income_Pre Post 16": "PrePost16Funding",
         "Other costs_Grounds maintenance_CS": "GroundsMaintenanceCostsCS",
-        "E20A Connectivity": "ConnectivityCosts",
-        "E20B Onsite servers": "OnsiteServersCosts",
-        "E20C IT learning resources": "ItLearningResourcesCosts",
-        "E20D Administration software and systems": "AdministrationSoftwareAndSystemsCosts",
-        "E20E Laptops, desktops and tablets": "LaptopsDesktopsAndTabletsCosts",
-        "E20F Other hardware": "OtherHardwareCosts",
-        "E20G IT support": "ItSupportCosts",
+        "E20A  Connectivity": "ConnectivityCosts",
+        "E20B  Onsite servers": "OnsiteServersCosts",
+        "E20C  IT learning resources": "ItLearningResourcesCosts",
+        "E20D  Administration software and systems": "AdministrationSoftwareAndSystemsCosts",
+        "E20E  Laptops, desktops and tablets": "LaptopsDesktopsAndTabletsCosts",
+        "E20F  Other hardware": "OtherHardwareCosts",
+        "E20G  IT support": "ItSupportCosts",
     }
 
     write_frame = df.reset_index().rename(columns=projections)[[*projections.values()]]

--- a/data-pipeline/src/pipeline/input_schemas/maintained_schools_master_list.py
+++ b/data-pipeline/src/pipeline/input_schemas/maintained_schools_master_list.py
@@ -103,13 +103,13 @@ maintained_schools_master_list_cols = {
         "E17  Rates": "float",
         "E18  Other occupation costs": "float",
         "E19  Learning resources (not ICT equipment)": "float",
-        "E20A Connectivity": "float",
-        "E20B Onsite servers": "float",
-        "E20C IT learning resources": "float",
-        "E20D Administration software and systems": "float",
-        "E20E Laptops, desktops and tablets": "float",
-        "E20F Other hardware": "float",
-        "E20G IT support": "float",
+        "E20A  Connectivity": "float",
+        "E20B  Onsite servers": "float",
+        "E20C  IT learning resources": "float",
+        "E20D  Administration software and systems": "float",
+        "E20E  Laptops, desktops and tablets": "float",
+        "E20F  Other hardware": "float",
+        "E20G  IT support": "float",
         "E21  Exam fees": "float",
         "E22 Administrative supplies": "float",
         "E23  Other insurance premiums": "float",
@@ -140,15 +140,15 @@ maintained_schools_master_list_column_eval = {
     },
     2025: {
         "Educational ICT_ICT learning resources": (
-            "`E20A Connectivity`.fillna(0.0) + "
-            "`E20B Onsite servers`.fillna(0.0) + "
-            "`E20C IT learning resources`.fillna(0.0) + "
-            "`E20E Laptops, desktops and tablets`.fillna(0.0) + "
-            "`E20F Other hardware`.fillna(0.0) + "
-            "`E20G IT support`.fillna(0.0)"
+            "`E20A  Connectivity`.fillna(0.0) + "
+            "`E20B  Onsite servers`.fillna(0.0) + "
+            "`E20C  IT learning resources`.fillna(0.0) + "
+            "`E20E  Laptops, desktops and tablets`.fillna(0.0) + "
+            "`E20F  Other hardware`.fillna(0.0) + "
+            "`E20G  IT support`.fillna(0.0)"
         ),
         "Administrative supplies_Administrative supplies (non educational)": (
-            "`E20D Administration software and systems`.fillna(0.0) + "
+            "`E20D  Administration software and systems`.fillna(0.0) + "
             "`E22 Administrative supplies`.fillna(0.0)"
         ),
     },

--- a/data-pipeline/src/pipeline/maintained_schools.py
+++ b/data-pipeline/src/pipeline/maintained_schools.py
@@ -252,7 +252,7 @@ def join_federations(df: pd.DataFrame) -> pd.DataFrame:
     :param df: Maintained School data
     :return: data updated with Federation data
     """
-    lead_schools = df[df["Lead school in federation"] == df["LAEstab"]][
+    schools_who_lead_federations = df[df["Lead school in federation"] == df["LAEstab"]][
         ["URN", "School Name", "LAEstab"]
     ].rename(
         columns={
@@ -261,21 +261,24 @@ def join_federations(df: pd.DataFrame) -> pd.DataFrame:
             "LAEstab": "Federation LAEstab",
         }
     )
+    schools_who_lead_federations_aggregated_metrics = _federation_lead_school_agg(df)
 
-    df = df.merge(
-        lead_schools,
+    schools_with_federation_lead_details = df.merge(
+        schools_who_lead_federations,
         left_on="Lead school in federation",
         right_on="Federation LAEstab",
         how="left",
     )
 
-    lead_schools_agg = _federation_lead_school_agg(df)
-
-    return (
-        lead_schools_agg.combine_first(df.set_index("LAEstab"))
+    schools_with_federation_details_and_metrics = (
+        schools_who_lead_federations_aggregated_metrics.combine_first(
+            schools_with_federation_lead_details.set_index("LAEstab")
+        )
         .sort_values("URN")
-        .reset_index()
+        .reset_index(names=["index"])
     )
+
+    return schools_with_federation_details_and_metrics
 
 
 def ensure_it_spend_breakdown_columns_are_present(df: pd.DataFrame) -> pd.DataFrame:
@@ -290,13 +293,13 @@ def ensure_it_spend_breakdown_columns_are_present(df: pd.DataFrame) -> pd.DataFr
     :return: Original DataFrame with missing IT spend columns appended if needed
     """
     it_spend_cols = [
-        "E20A Connectivity",
-        "E20B Onsite servers",
-        "E20C IT learning resources",
-        "E20D Administration software and systems",
-        "E20E Laptops, desktops and tablets",
-        "E20F Other hardware",
-        "E20G IT support",
+        "E20A  Connectivity",
+        "E20B  Onsite servers",
+        "E20C  IT learning resources",
+        "E20D  Administration software and systems",
+        "E20E  Laptops, desktops and tablets",
+        "E20F  Other hardware",
+        "E20G  IT support",
     ]
 
     for col in it_spend_cols:

--- a/data-pipeline/tests/unit/pre_processing/test_maintained_schools.py
+++ b/data-pipeline/tests/unit/pre_processing/test_maintained_schools.py
@@ -354,13 +354,13 @@ def test_ensure_it_spend_columns_adds_missing_cols_with_nan():
     urns = [100000, 100001]
 
     cols = [
-        "E20A Connectivity",
-        "E20B Onsite servers",
-        "E20C IT learning resources",
-        "E20D Administration software and systems",
-        "E20E Laptops, desktops and tablets",
-        "E20F Other hardware",
-        "E20G IT support",
+        "E20A  Connectivity",
+        "E20B  Onsite servers",
+        "E20C  IT learning resources",
+        "E20D  Administration software and systems",
+        "E20E  Laptops, desktops and tablets",
+        "E20F  Other hardware",
+        "E20G  IT support",
     ]
 
     result = maintained_schools.ensure_it_spend_breakdown_columns_are_present(df)
@@ -375,13 +375,13 @@ def test_ensure_it_spend_columns_leaves_existing_columns_unchanged():
     df = pd.DataFrame(
         {
             "URN": [100000, 100001],
-            "E20A Connectivity": [10, 11],
-            "E20B Onsite servers": [12, 13],
-            "E20C IT learning resources": [14, 15],
-            "E20D Administration software and systems": [16, 17],
-            "E20E Laptops, desktops and tablets": [18, 19],
-            "E20F Other hardware": [20, 21],
-            "E20G IT support": [22, 23],
+            "E20A  Connectivity": [10, 11],
+            "E20B  Onsite servers": [12, 13],
+            "E20C  IT learning resources": [14, 15],
+            "E20D  Administration software and systems": [16, 17],
+            "E20E  Laptops, desktops and tablets": [18, 19],
+            "E20F  Other hardware": [20, 21],
+            "E20G  IT support": [22, 23],
         }
     )
 
@@ -390,13 +390,13 @@ def test_ensure_it_spend_columns_leaves_existing_columns_unchanged():
         100001: [11, 13, 15, 17, 19, 21, 23],
     }
     cols = [
-        "E20A Connectivity",
-        "E20B Onsite servers",
-        "E20C IT learning resources",
-        "E20D Administration software and systems",
-        "E20E Laptops, desktops and tablets",
-        "E20F Other hardware",
-        "E20G IT support",
+        "E20A  Connectivity",
+        "E20B  Onsite servers",
+        "E20C  IT learning resources",
+        "E20D  Administration software and systems",
+        "E20E  Laptops, desktops and tablets",
+        "E20F  Other hardware",
+        "E20G  IT support",
     ]
 
     result = maintained_schools.ensure_it_spend_breakdown_columns_are_present(df)


### PR DESCRIPTION
## 🧾 Summary

- The new IT spend breakdown columns needed two spaces between the code and the text description
- As I was debugging the federation funnies breaking the pipeline, I clearcoded the variable names in join_federations. It's an improvement so I have left it in