### PR TITLE
fix: correct VW_ItSpendSchoolPerUnit calculation

### DIFF
--- a/core-infrastructure/src/db/Core.Database/Views/026-ItSpendSchool.sql
+++ b/core-infrastructure/src/db/Core.Database/Views/026-ItSpendSchool.sql
@@ -64,13 +64,13 @@ SELECT  RunId,
         URN,
         TotalPupils,
         PeriodCoveredByReturn,
-        IIF(TotalPupils > 0.0, (ConnectivityCosts / TotalPupils) * 100, NULL)                       AS Connectivity,
-        IIF(TotalPupils > 0.0, (OnsiteServersCosts / TotalPupils) * 100, NULL)                      AS OnsiteServers,
-        IIF(TotalPupils > 0.0, (ItLearningResourcesCosts / TotalPupils) * 100, NULL)                AS ItLearningResources,
-        IIF(TotalPupils > 0.0, (AdministrationSoftwareAndSystemsCosts / TotalPupils) * 100, NULL)   AS AdministrationSoftwareAndSystems,
-        IIF(TotalPupils > 0.0, (LaptopsDesktopsAndTabletsCosts / TotalPupils) * 100, NULL)          AS LaptopsDesktopsAndTablets,
-        IIF(TotalPupils > 0.0, (OtherHardwareCosts / TotalPupils) * 100, NULL)                      AS OtherHardware,
-        IIF(TotalPupils > 0.0, (ItSupportCosts / TotalPupils) * 100, NULL)                          AS ItSupport
+        IIF(TotalPupils > 0.0, ConnectivityCosts / TotalPupils, NULL)                       AS Connectivity,
+        IIF(TotalPupils > 0.0, OnsiteServersCosts / TotalPupils, NULL)                      AS OnsiteServers,
+        IIF(TotalPupils > 0.0, ItLearningResourcesCosts / TotalPupils, NULL)                AS ItLearningResources,
+        IIF(TotalPupils > 0.0, AdministrationSoftwareAndSystemsCosts / TotalPupils, NULL)   AS AdministrationSoftwareAndSystems,
+        IIF(TotalPupils > 0.0, LaptopsDesktopsAndTabletsCosts / TotalPupils, NULL)          AS LaptopsDesktopsAndTablets,
+        IIF(TotalPupils > 0.0, OtherHardwareCosts / TotalPupils, NULL)                      AS OtherHardware,
+        IIF(TotalPupils > 0.0, ItSupportCosts / TotalPupils, NULL)                          AS ItSupport
 FROM Financial
     GO
 


### PR DESCRIPTION
## 🧾 Summary

[AB#270080](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/270080)

fixes error in the `VW_ItSpendSchoolPerUnit` view where values are incorrectly scaled as if percentages

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Tested by running locally.

</details>
<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] CI/CD pipeline checks pass.

</details>

## 🔍 Reviewer notes

Following merge platform api tests will require updating, this will be addressed on future PR

## 🧪 Testing notes

scripts run successfully against a local DB
