### PR TITLE
feat: update width for horizontal bar chart

### DIFF
--- a/web/src/Web.App/Domain/Charts/SchoolComparisonItSpendHorizontalBarChartRequest.cs
+++ b/web/src/Web.App/Domain/Charts/SchoolComparisonItSpendHorizontalBarChartRequest.cs
@@ -22,7 +22,7 @@ public record SchoolComparisonItSpendHorizontalBarChartRequest : PostHorizontalB
         LabelFormat = "%2$s";
         LinkFormat = linkFormatter("%1$s");
         Sort = "desc";
-        Width = 600;
+        Width = 610;
         ValueField = nameof(SchoolComparisonDatum.Expenditure).ToLower();
         ValueType = resultsAs.GetValueType();
         XAxisLabel = resultsAs.GetXAxisLabel();


### PR DESCRIPTION
## 🧾 Summary

[AB#270080](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/270080)
[AB#273906](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/273906)

With certain school names there is still clipping observed on this page

<img width="963" height="891" alt="image" src="https://github.com/user-attachments/assets/ad2b7ee3-278c-4bcb-8117-32176acec403" />

Rather than alter the logic to truncate these labels (see #2703) a minor adjustment to the width results in the desired behaviour.

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] All unit/integration tests are executed and passed.
- [x] Tested by running locally.

</details>

<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [x] Screenshots or Demo _(if applicable)_.

</details>
<details>
<summary>Review & approval</summary>

- [ ] CI/CD pipeline checks pass.

</details>

## 🔍 Reviewer notes

See the results following this change

<img width="993" height="889" alt="image" src="https://github.com/user-attachments/assets/924ebd4f-2be1-4cab-893a-39079f12f413" />
