### PR TITLE
Hotfix/data pipeline dockerfile

### DIFF
--- a/data-pipeline/README.md
+++ b/data-pipeline/README.md
@@ -239,7 +239,6 @@ make e2e-test-local
 
 ### Creating and running Docker images
 
-
 Build images with:
 
 ```sh

--- a/data-pipeline/README.md
+++ b/data-pipeline/README.md
@@ -201,12 +201,12 @@ To run the pipeline locally, follow these steps:
     ```json
     {
       "type": "default",
-      "runId": 2025,
+      "runId": <year>,
         "year": {
-            "aar": 2024,
-            "cfr": 2025,
-            "bfr": 2024,
-            "s251": 2024
+            "aar": <year>,
+            "cfr": <year>,
+            "bfr": <year>,
+            "s251": <year>
         }
     }
     ```

--- a/data-pipeline/README.md
+++ b/data-pipeline/README.md
@@ -7,7 +7,7 @@ For more information on the FBIT pipelines see either
 * [The documentation folder in this repository](https://github.com/DFE-Digital/education-benchmarking-and-insights/tree/main/documentation)
 * Or in the FBIT sharepoint technical folder.
 
-Within the FBIT service, there is an [Azure container app](terraform/container_apps.tf) for each type of run in the data pipeline (default/custom). 
+Within the FBIT service, there is an [Azure container app](terraform/container_apps.tf) for each type of run in the data pipeline (default/custom).
 When a message is placed in a run queue, a worker container is triggered to spawn from the container app. The worker processes one message and if successful places the message in the completed queue.
 
 ## Developers

--- a/data-pipeline/README.md
+++ b/data-pipeline/README.md
@@ -7,6 +7,9 @@ For more information on the FBIT pipelines see either
 * [The documentation folder in this repository](https://github.com/DFE-Digital/education-benchmarking-and-insights/tree/main/documentation)
 * Or in the FBIT sharepoint technical folder.
 
+Within the FBIT service, there is an [Azure container app](terraform/container_apps.tf) for each type of run in the data pipeline (default/custom). 
+When a message is placed in a run queue, a worker container is triggered to spawn from the container app. The worker processes one message and if successful places the message in the completed queue.
+
 ## Developers
 
 ### Dependencies
@@ -198,12 +201,12 @@ To run the pipeline locally, follow these steps:
     ```json
     {
       "type": "default",
-      "runId": <year>,
+      "runId": 2025,
         "year": {
-            "aar": <year>,
-            "cfr": <year>,
-            "bfr": <year>,
-            "s251": <year>
+            "aar": 2024,
+            "cfr": 2025,
+            "bfr": 2024,
+            "s251": 2024
         }
     }
     ```
@@ -235,6 +238,7 @@ make e2e-test-local
 ```
 
 ### Creating and running Docker images
+
 
 Build images with:
 

--- a/data-pipeline/docker/pipeline-worker/Dockerfile
+++ b/data-pipeline/docker/pipeline-worker/Dockerfile
@@ -1,9 +1,8 @@
 # Dockerfile
 # Uses multi-stage builds requiring Docker 17.05 or higher
 # See https://docs.docker.com/develop/develop-images/multistage-build/
+FROM python:3.13-slim AS python-base
 
-# Creating a python base with shared environment variables
-FROM python:3.13-slim as python-base
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=off \
@@ -13,59 +12,69 @@ ENV PYTHONUNBUFFERED=1 \
     POETRY_VIRTUALENVS_IN_PROJECT=true \
     POETRY_NO_INTERACTION=1 \
     PYSETUP_PATH="/opt/pysetup" \
-    VENV_PATH="/opt/pysetup/.venv"
+    VENV_PATH="/opt/pysetup/.venv" \
+    POETRY_VERSION=1.8.2
 
 ENV PATH="$POETRY_HOME/bin:$VENV_PATH/bin:$PATH"
 
-
 # builder-base is used to build dependencies
-FROM python-base as builder-base
+FROM python-base AS builder-base
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         curl \
         build-essential \
-        libatlas-base-dev \
+        # libatlas-base-dev \
         gnupg2 \
-        g++ &&\
+        g++ && \
         rm -rf /var/lib/apt/lists/*
 
-
 # Install Poetry - respects $POETRY_VERSION & $POETRY_HOME
-ENV POETRY_VERSION=1.8.2
 RUN curl -sSL https://install.python-poetry.org | python
 
-# We copy our Python requirements here to cache them
-# and install only runtime deps using poetry
+# Install and cache runtime dependencies with poetry
 WORKDIR $PYSETUP_PATH
 COPY ./poetry.lock ./pyproject.toml ./
-RUN poetry install --no-dev  # respects
+RUN poetry install --only=main --no-root && \
+    poetry cache clear pypi --all
 
-
-# 'production' stage uses the clean 'python-base' stage and copyies
+# 'production' stage uses the clean 'python-base' stage and copies
 # in only our runtime deps that were installed in the 'builder-base'
-FROM python-base as production
-RUN apt-get update \
-    && apt-get install --no-install-recommends -y \
-        curl \
-        gnupg2
-RUN curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
-RUN curl https://packages.microsoft.com/config/debian/12/prod.list > /etc/apt/sources.list.d/mssql-release.list
-RUN apt-get update
-RUN ACCEPT_EULA=Y apt-get install -y msodbcsql18 unixodbc-dev
-RUN ACCEPT_EULA=Y apt-get install -y mssql-tools18
-RUN echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc
-RUN /bin/bash -c "source ~/.bashrc"
-RUN apt-get install -y unixodbc-dev
+FROM python-base AS production
 
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        curl \
+        gnupg2 \
+        unixodbc-dev && \
+    # Add Microsoft repository
+    curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg && \
+    curl -fsSL https://packages.microsoft.com/config/debian/12/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
+    apt-get update && \
+    # Install Microsoft SQL Server tools
+    DEBIAN_FRONTEND=noninteractive ACCEPT_EULA=Y apt-get install --no-install-recommends -y \
+        msodbcsql18 \
+        mssql-tools18 && \
+    # Clean up package cache to reduce image size
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Add SQL Server tools to PATH for all users
+ENV PATH="$PATH:/opt/mssql-tools18/bin"
+
+# Copy virtual environment from builder stage
 COPY --from=builder-base $VENV_PATH $VENV_PATH
 COPY ./docker/pipeline-worker/docker-entrypoint.sh /docker-entrypoint.sh
-RUN chmod +x /docker-entrypoint.sh
-
 COPY ./docker/pipeline-worker/odbc.ini /odbc.ini
-RUN odbcinst -i -s -f /odbc.ini -l
-RUN cat /etc/odbc.ini
 COPY ./src/pipeline /pipeline
 
-ENTRYPOINT /docker-entrypoint.sh $0 $@
+RUN chmod +x /docker-entrypoint.sh && \
+    odbcinst -i -s -f /odbc.ini -l && \
+    cat /etc/odbc.ini
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD [ "python", "-m", "pipeline.main"]
+
+LABEL description="FBIT data pipeline worker" \
+      python.version="${PYTHON_VERSION}" \
+      poetry.version="${POETRY_VERSION}"

--- a/data-pipeline/docker/pipeline-worker/Dockerfile
+++ b/data-pipeline/docker/pipeline-worker/Dockerfile
@@ -72,7 +72,7 @@ RUN chmod +x /docker-entrypoint.sh && \
     odbcinst -i -s -f /odbc.ini -l && \
     cat /etc/odbc.ini
 
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
 CMD [ "python", "-m", "pipeline.main"]
 
 LABEL description="FBIT data pipeline worker" \

--- a/data-pipeline/docker/pipeline-worker/Dockerfile
+++ b/data-pipeline/docker/pipeline-worker/Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         curl \
         build-essential \
-        # libatlas-base-dev \
         gnupg2 \
         g++ && \
         rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## 🧾 Summary
* Remove libatlas-base-dev from the Dockerfile as apt-get can't find it any more. It's a dependency for numpy but the code works without it so I think it gets it from the numpy wheel anyway.
* Minor reformatting of the Dockerfile eg combine lots of run commands into one big command to reduce the number of layers

## Testing notes 🧪 
I have tested that the pipeline still works by rebuilding the container locally and checking it still accepts jobs. When this is merged it needs e2e running in dev as well.