### PR TITLE
feat: revised warning banner for postivie values only

### DIFF
--- a/web/src/Web.App/Controllers/SchoolComparisonItSpendController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparisonItSpendController.cs
@@ -65,9 +65,9 @@ public class SchoolComparisonItSpendController(
                         {
                             category.ChartSvg = chart.Html;
                         }
-                    }    
+                    }
                 }
-                
+
                 var viewModel = new SchoolComparisonItSpendViewModel(school, subCategories)
                 {
                     SelectedSubCategories = selectedSubCategories,
@@ -112,7 +112,7 @@ public class SchoolComparisonItSpendController(
 
         return query;
     }
-    
+
     private async Task<ChartResponse[]> BuildCharts(string urn, Dimensions.ResultAsOptions resultAs,
         SchoolComparisonSubCategoriesViewModel subCategories)
     {

--- a/web/src/Web.App/Controllers/SchoolComparisonItSpendController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparisonItSpendController.cs
@@ -54,36 +54,20 @@ public class SchoolComparisonItSpendController(
                     .GetResultOrDefault<SchoolItSpend[]>() ?? [];
 
                 var subCategories = new SchoolComparisonSubCategoriesViewModel(urn, expenditures, selectedSubCategories);
-                var requests = subCategories.Select(c => new SchoolComparisonItSpendHorizontalBarChartRequest(
-                    c.Uuid!,
-                    urn,
-                    c.Data!,
-                    format => Uri.UnescapeDataString(
-                        Url.Action("Index", "School", new { urn = format }) ?? string.Empty),
-                    resultAs
-                    ));
+                if (viewAs == SchoolComparisonItSpendViewModel.ViewAsOptions.Chart)
+                {
+                    var charts = await BuildCharts(urn, resultAs, subCategories);
 
-                ChartResponse[] charts = [];
-                try
-                {
-                    charts = await chartRenderingApi
-                        .PostHorizontalBarCharts(new PostHorizontalBarChartsRequest<SchoolComparisonDatum>(requests))
-                        .GetResultOrDefault<ChartResponse[]>() ?? [];
-                }
-                catch (Exception e)
-                {
-                    logger.LogWarning(e, "Unable to load charts from API");
-                }
-
-                foreach (var chart in charts)
-                {
-                    var category = subCategories.FirstOrDefault(r => r.Uuid == chart.Id);
-                    if (category != null)
+                    foreach (var chart in charts)
                     {
-                        category.ChartSvg = chart.Html;
-                    }
+                        var category = subCategories.FirstOrDefault(r => r.Uuid == chart.Id);
+                        if (category != null)
+                        {
+                            category.ChartSvg = chart.Html;
+                        }
+                    }    
                 }
-
+                
                 var viewModel = new SchoolComparisonItSpendViewModel(school, subCategories)
                 {
                     SelectedSubCategories = selectedSubCategories,
@@ -127,5 +111,32 @@ public class SchoolComparisonItSpendController(
 
 
         return query;
+    }
+    
+    private async Task<ChartResponse[]> BuildCharts(string urn, Dimensions.ResultAsOptions resultAs,
+        SchoolComparisonSubCategoriesViewModel subCategories)
+    {
+        var requests = subCategories.Select(c => new SchoolComparisonItSpendHorizontalBarChartRequest(
+            c.Uuid!,
+            urn,
+            c.Data!,
+            format => Uri.UnescapeDataString(
+                Url.Action("Index", "School", new { urn = format }) ?? string.Empty),
+            resultAs
+        ));
+
+        ChartResponse[] charts = [];
+        try
+        {
+            charts = await chartRenderingApi
+                .PostHorizontalBarCharts(new PostHorizontalBarChartsRequest<SchoolComparisonDatum>(requests))
+                .GetResultOrDefault<ChartResponse[]>() ?? [];
+        }
+        catch (Exception e)
+        {
+            logger.LogWarning(e, "Unable to load charts from API");
+        }
+
+        return charts;
     }
 }

--- a/web/src/Web.App/Views/SchoolComparisonItSpend/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolComparisonItSpend/Index.cshtml
@@ -283,17 +283,12 @@
         {
             var subCategory = Model.SubCategories.ElementAt(i);
             var uuid = Guid.NewGuid();
-
-            if (i > 0)
-            {
-                <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-6">
-            }
-
+            
             <section id="cost-sub-category-@subCategory.SubCategory?.ToSlug()">
                 <h2 class="govuk-heading-m">@subCategory.SubCategory</h2>
                 <div id="@uuid" class="costs-chart-container" data-title="@subCategory.SubCategory">
                     <div class="costs-chart-wrapper">
-                        @if (string.IsNullOrWhiteSpace(subCategory.ChartSvg))
+                        @if (string.IsNullOrWhiteSpace(subCategory.ChartSvg) && Model.ViewAs == SchoolComparisonItSpendViewModel.ViewAsOptions.Chart)
                         {
                             <div
                                 class="govuk-warning-text govuk-!-margin-top-2 govuk-!-margin-bottom-2 ssr-chart-warning">
@@ -308,13 +303,7 @@
                         {
                             @if (subCategory.HasNegativeOrZeroValues)
                             {
-                                <div class="govuk-warning-text">
-                                    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                                    <strong class="govuk-warning-text__text">
-                                        <span class="govuk-visually-hidden">Warning</span>
-                                        Only displaying schools with positive expenditure.
-                                    </strong>
-                                </div>
+                                    <p class="govuk-body">Only displaying schools with positive expenditure.</p>
                             }
                             @if (Model.ViewAs == SchoolComparisonItSpendViewModel.ViewAsOptions.Chart)
                             {
@@ -338,46 +327,50 @@
                                 else
                                 {
                                     <table class="govuk-table">
-                                            <thead class="govuk-table__head">
-                                            <tr class="govuk-table__row">
-                                                <th scope="col" class="govuk-table__header">School name</th>
-                                                <th scope="col" class="govuk-table__header">Local Authority</th>
-                                                <th scope="col" class="govuk-table__header">School type</th>
-                                                <th scope="col" class="govuk-table__header">Number of pupils</th>
-                                                <th scope="col" class="govuk-table__header">@Model.ResultAs.GetTableHeader()</th>
-                                            </tr>
-                                            </thead>
-                                            <tbody class="govuk-table__body">
-                                            @foreach (var row in subCategory.Data)
-                                            {
+                                        <thead class="govuk-table__head">
+                                        <tr class="govuk-table__row">
+                                            <th scope="col" class="govuk-table__header">School name</th>
+                                            <th scope="col" class="govuk-table__header">Local Authority</th>
+                                            <th scope="col" class="govuk-table__header">School type</th>
+                                            <th scope="col" class="govuk-table__header">Number of pupils</th>
+                                            <th scope="col" class="govuk-table__header">@Model.ResultAs.GetTableHeader()</th>
+                                        </tr>
+                                        </thead>
+                                        <tbody class="govuk-table__body">
+                                        @foreach (var row in subCategory.Data)
+                                        {
                                                 
-                                                <tr class="govuk-table__row">
-                                                    <td class="govuk-table__cell">
-                                                        @if (row.Urn == Model.Urn)
-                                                        {
-                                                            <strong>
-                                                                <a class="govuk-link govuk-link--no-visited-state" href=@($"/school/{row.Urn}")>@row.SchoolName</a>
-                                                            </strong>
-                                                        }
-                                                        else
-                                                        {
+                                            <tr class="govuk-table__row">
+                                                <td class="govuk-table__cell">
+                                                    @if (row.Urn == Model.Urn)
+                                                    {
+                                                        <strong>
                                                             <a class="govuk-link govuk-link--no-visited-state" href=@($"/school/{row.Urn}")>@row.SchoolName</a>
-                                                        }
+                                                        </strong>
+                                                    }
+                                                    else
+                                                    {
+                                                        <a class="govuk-link govuk-link--no-visited-state" href=@($"/school/{row.Urn}")>@row.SchoolName</a>
+                                                    }
                                                         
-                                                    </td>
-                                                    <td class="govuk-table__cell">@row.LAName</td>
-                                                    <td class="govuk-table__cell">@row.SchoolType</td>
-                                                    <td class="govuk-table__cell">@row.TotalPupils.ToSimpleDisplay()</td>
-                                                    <td class="govuk-table__cell">@Model.ResultAs.GetFormattedValue(row.Expenditure)</td>
-                                                </tr>
-                                            }
-                                            </tbody>
-                                        </table>
+                                                </td>
+                                                <td class="govuk-table__cell">@row.LAName</td>
+                                                <td class="govuk-table__cell">@row.SchoolType</td>
+                                                <td class="govuk-table__cell">@row.TotalPupils.ToSimpleDisplay()</td>
+                                                <td class="govuk-table__cell">@Model.ResultAs.GetFormattedValue(row.Expenditure)</td>
+                                            </tr>
+                                        }
+                                        </tbody>
+                                    </table>
                                 }
                             }    
                         }
                     </div>
                 </div>
+                @if (i <= Model.SubCategories.Count && Model.ViewAs == SchoolComparisonItSpendViewModel.ViewAsOptions.Chart)
+                {
+                <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-6">
+                }
             </section>
         }
     </div>

--- a/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenViewingComparisonItSpend.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenViewingComparisonItSpend.cs
@@ -236,7 +236,7 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
         var adminSoftwareSection = page.QuerySelector("#cost-sub-category-administration-software-and-systems-e20d");
         Assert.NotNull(adminSoftwareSection);
         var warningParagraph = adminSoftwareSection.QuerySelectorAll("p").FirstOrDefault();
-        
+
         if (hasNegativeValues)
         {
             Assert.NotNull(warningParagraph);

--- a/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenViewingComparisonItSpend.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenViewingComparisonItSpend.cs
@@ -235,18 +235,16 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
 
         var adminSoftwareSection = page.QuerySelector("#cost-sub-category-administration-software-and-systems-e20d");
         Assert.NotNull(adminSoftwareSection);
-
+        var warningParagraph = adminSoftwareSection.QuerySelectorAll("p").FirstOrDefault();
+        
         if (hasNegativeValues)
         {
-            var warningText = adminSoftwareSection.QuerySelector(".govuk-warning-text__text");
-            Assert.NotNull(warningText);
-
-            DocumentAssert.TextMatches(warningText, new Regex(@"^Warning\s+Only displaying schools with positive expenditure\.$"));
+            Assert.NotNull(warningParagraph);
+            DocumentAssert.TextEqual(warningParagraph, "Only displaying schools with positive expenditure.");
         }
         else
         {
-            var warningText = adminSoftwareSection.QuerySelector(".govuk-warning-text__text");
-            Assert.Null(warningText);
+            Assert.Null(warningParagraph);
         }
     }
 


### PR DESCRIPTION
## 🧾 Summary
[AB#270080](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/270080) [AB#275418](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/275418)

Following design review, agreed that current warning banner is jarring within the new filter layout (especially when repeated across several charts).

Includes a refactor to only create the charts when needed.

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Unit and integration tests updated _(if applicable)_.
- [x] All unit/integration tests are executed and passed.
- [x] Tested by running locally.

</details>
<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [x] Screenshots or Demo _(if applicable)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [x] Design (UX and/or content) review _(if applicable)_.
- [x] CI/CD pipeline checks pass.

</details>

## 🧪 Testing notes
Agreed with Suly then new layout. It's only application to Benchmark IT Spending.

<img width="1383" height="763" alt="image" src="https://github.com/user-attachments/assets/5f8bc714-96fa-4579-86fb-82b1ea554c02" />

<img width="1368" height="566" alt="image" src="https://github.com/user-attachments/assets/fd959da6-a5ea-40a3-993b-4e83ebd019e5" />

