### PR TITLE
Endpoint to allow the download of IT Spend data as CSV

### DIFF
--- a/web/src/Web.App/Domain/Insight/ItSpend.cs
+++ b/web/src/Web.App/Domain/Insight/ItSpend.cs
@@ -1,3 +1,5 @@
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+// ReSharper disable ClassNeverInstantiated.Global
 namespace Web.App.Domain;
 
 public abstract record ItSpend

--- a/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenRequestingComparisonDownload.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenRequestingComparisonDownload.cs
@@ -1,4 +1,3 @@
-using System.IO.Compression;
 using System.Net;
 using AutoFixture;
 using Web.App.Domain;
@@ -37,7 +36,7 @@ public class WhenRequestingComparisonDownload : PageBase<SchoolBenchmarkingWebAp
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var expectedFileNames = new[] { "comparison-123456-pupil.csv", "comparison-123456-building.csv" };
-        await foreach (var tuple in GetFilesFromZip(response))
+        await foreach (var tuple in response.GetFilesFromZip())
         {
             Assert.Contains(tuple.fileName, expectedFileNames);
 
@@ -58,20 +57,5 @@ public class WhenRequestingComparisonDownload : PageBase<SchoolBenchmarkingWebAp
             .Get(Paths.SchoolComparisonDownload(urn));
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
-    }
-
-    private static async IAsyncEnumerable<(string fileName, string content)> GetFilesFromZip(HttpResponseMessage response)
-    {
-        var bytes = await response.Content.ReadAsByteArrayAsync();
-
-        using var zipStream = new MemoryStream(bytes);
-        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
-        foreach (var entry in archive.Entries)
-        {
-            await using var entryStream = entry.Open();
-            using var reader = new StreamReader(entryStream);
-            var content = await reader.ReadToEndAsync();
-            yield return (entry.Name, content);
-        }
     }
 }

--- a/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenRequestingComparisonItSpendDownload.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenRequestingComparisonItSpendDownload.cs
@@ -1,0 +1,62 @@
+using System.Net;
+using AutoFixture;
+using Web.App.Domain;
+using Xunit;
+
+namespace Web.Integration.Tests.Pages.Schools.Comparison;
+
+public class WhenRequestingComparisonItSpendDownload : PageBase<SchoolBenchmarkingWebAppClient>
+{
+    private readonly SchoolBenchmarkingWebAppClient _client;
+    private readonly SchoolItSpend[] _schoolItSpend;
+
+    public WhenRequestingComparisonItSpendDownload(SchoolBenchmarkingWebAppClient client) : base(client)
+    {
+        _client = client;
+        _schoolItSpend = Fixture.Build<SchoolItSpend>().CreateMany().ToArray();
+    }
+
+    [Fact]
+    public async Task CanReturnOk()
+    {
+        var school = Fixture.Build<School>()
+            .With(x => x.URN, "123456")
+            .With(x => x.FinanceType, EstablishmentTypes.Maintained)
+            .Create();
+
+        var comparatorSet = Fixture.Build<SchoolComparatorSet>()
+            .With(c => c.Pupil, Fixture.CreateMany<string>().ToArray())
+            .Without(c => c.Building)
+            .Create();
+
+        var response = await _client
+            .SetupEstablishment(school)
+            .SetupComparatorSet(school, comparatorSet)
+            .SetupItSpend(_schoolItSpend)
+            .Get(Paths.SchoolComparisonItSpendDownload(school.URN!));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var expectedFileNames = new[] { "benchmark-it-spending-123456.csv" };
+        await foreach (var tuple in response.GetFilesFromZip())
+        {
+            Assert.Contains(tuple.fileName, expectedFileNames);
+
+            var csvLines = tuple.content.Split(Environment.NewLine);
+            Assert.Equal(
+                "URN,SchoolName,SchoolType,LAName,PeriodCoveredByReturn,TotalPupils,Connectivity,OnsiteServers,ItLearningResources,AdministrationSoftwareAndSystems,LaptopsDesktopsAndTablets,OtherHardware,ItSupport",
+                csvLines.First());
+            Assert.Equal(_schoolItSpend.Length, csvLines.Length - 1);
+        }
+    }
+
+    [Fact]
+    public async Task CanReturnInternalServerError()
+    {
+        const string urn = "123456";
+        var response = await _client
+            .SetupEstablishmentWithException()
+            .Get(Paths.SchoolComparisonItSpendDownload(urn));
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+}

--- a/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenViewingComparisonItSpend.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenViewingComparisonItSpend.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net;
-using System.Text.RegularExpressions;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using AutoFixture;

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -83,6 +83,10 @@ public static class Paths
     {
         return $"/school/{urn}/comparison/download";
     }
+    public static string SchoolComparisonItSpendDownload(string? urn)
+    {
+        return $"/school/{urn}/benchmark-it-spending/download";
+    }
     public static string SchoolCensus(string? urn)
     {
         return $"/school/{urn}/census";


### PR DESCRIPTION
## 🧾 Summary

[AB#270092](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/270092) [AB#275508](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/275508) [AB#275511](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/275511)

- New endpoint to support download functionality
- Integration test coverage

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Unit and integration tests updated _(if applicable)_.
- [x] All unit/integration tests are executed and passed.
- [x] Tested by running locally.

</details>
<details>
<summary>Documentation updates</summary>


- [ ] Code-level documentation (e.g., inline comments, docstrings) is updated.
- [ ] README.md or relevant module-level docs are updated.
- [ ] API changes are reflected in API documentation _(if applicable)_.
- [ ] Links to external references are included instead of duplicating content.
- [ ] No outdated or incorrect documentation remains.

</details>
<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [ ] Screenshots or Demo _(if applicable)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] Design (UX and/or content) review _(if applicable)_.
- [ ] Documentation changes have been explicitly reviewed.
- [ ] CI/CD pipeline checks pass.

</details>

## 🧪 Testing notes

From any school IT spend page, append `/download` to the URL to generate and download the IT spend 'actuals' for the default Pupil comparator set for the current school.
