### PR TITLE
Replaced 'DOM' based `d3` horizontal chart implementation with string templates

### DIFF
--- a/platform/src/apis/Platform.Api.ChartRendering/src/assets/openapi.json
+++ b/platform/src/apis/Platform.Api.ChartRendering/src/assets/openapi.json
@@ -2546,6 +2546,64 @@
         }
       }
     },
+    "/api/horizontalBarChart/dom": {
+      "post": {
+        "operationId": "GetHorizontalBarChartDomApi",
+        "tags": [
+          "DOM"
+        ],
+        "description": "Generates a single or multiple horizontal bar chart(s) based on whether payload in a single object or an array",
+        "summary": "Builds a horizontal bar chart using D3 in the DOM",
+        "requestBody": {
+          "description": "Bar chart payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HorizontalBarChartPayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ChartBuilderResult"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "title": "error"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/verticalBarChart": {
       "post": {
         "operationId": "GetVerticalBarChartApi",

--- a/platform/src/apis/Platform.Api.ChartRendering/src/functions/horizontalBarChart/dom/builder.ts
+++ b/platform/src/apis/Platform.Api.ChartRendering/src/functions/horizontalBarChart/dom/builder.ts
@@ -4,7 +4,7 @@ import {
   HorizontalBarChartBuilderOptions,
   ChartBuilderResult,
   DatumKey,
-} from "..";
+} from "../..";
 import { DOMImplementation } from "@xmldom/xmldom";
 import enGB from "d3-format/locale/en-GB" with { type: "json" };
 import { BaseType, FormatLocaleDefinition, ValueFn } from "d3";
@@ -15,11 +15,11 @@ import {
   getValueFormat,
   getGroups,
   normaliseData,
-} from "../utils";
+} from "../../utils";
 
 export default class HorizontalBarChartBuilder {
   // https://observablehq.com/@d3/bar-chart/2
-  async buildChart<T>({
+  static async buildChart<T>({
     data,
     barHeight,
     groupedKeys,

--- a/platform/src/apis/Platform.Api.ChartRendering/src/functions/horizontalBarChart/dom/function.ts
+++ b/platform/src/apis/Platform.Api.ChartRendering/src/functions/horizontalBarChart/dom/function.ts
@@ -1,0 +1,87 @@
+import {
+  HttpRequest,
+  HttpResponseInit,
+  InvocationContext,
+} from "@azure/functions";
+import { ChartBuilderResult } from "../..";
+import { HorizontalBarChartPayload } from "..";
+import { v4 as uuidv4 } from "uuid";
+import HorizontalBarChartBuilder from "./builder";
+
+export async function horizontalBarChartDom(
+  request: HttpRequest,
+  context: InvocationContext,
+): Promise<HttpResponseInit> {
+  context.debug(
+    `Received HTTP request for horizontal bar chart using D3 in the DOM`,
+  );
+
+  const payload = (await request.json()) as HorizontalBarChartPayload;
+
+  let charts: ChartBuilderResult[] = [];
+  const definitions = Array.isArray(payload) ? payload : [payload];
+  const buildChartPromises = definitions.map(
+    ({
+      barHeight,
+      data,
+      id,
+      keyField,
+      labelField,
+      labelFormat,
+      linkFormat,
+      valueField,
+      valueType,
+      width,
+      xAxisLabel,
+      ...rest
+    }) =>
+      HorizontalBarChartBuilder.buildChart({
+        barHeight: barHeight || 25,
+        data,
+        id: id || uuidv4(),
+        keyField: keyField as never,
+        labelField: labelField as never,
+        labelFormat: labelFormat as never,
+        linkFormat: linkFormat as never,
+        valueField: valueField as never,
+        valueType: valueType as never,
+        width: width || 928,
+        xAxisLabel: xAxisLabel as never,
+        ...rest,
+      }),
+  );
+
+  try {
+    charts = await Promise.all(buildChartPromises);
+  } catch (e) {
+    context.error(e);
+
+    return {
+      jsonBody: { error: [(e as Error)?.message ?? e] },
+      status: 500,
+    };
+  }
+
+  let result: HttpResponseInit;
+  if (Array.isArray(payload)) {
+    result = {
+      jsonBody: charts,
+    };
+  } else if (request.headers.get("x-accept") === "image/svg+xml") {
+    // for single chart requests with HTML requested, just return the chart element
+    const body = charts[0].html ?? "<svg />";
+    return {
+      body,
+      headers: {
+        "Content-Length": Buffer.byteLength(body, "utf-8").toString(),
+        "Content-Type": "image/svg+xml; charset=utf-8",
+      },
+    };
+  } else {
+    result = {
+      jsonBody: charts[0],
+    };
+  }
+
+  return result;
+}

--- a/platform/src/apis/Platform.Api.ChartRendering/src/functions/horizontalBarChart/route.ts
+++ b/platform/src/apis/Platform.Api.ChartRendering/src/functions/horizontalBarChart/route.ts
@@ -1,8 +1,16 @@
 import { app } from "@azure/functions";
 import { horizontalBarChart } from "./function";
+import { horizontalBarChartDom } from "./dom/function";
 
 app.http("horizontalBarChart", {
   methods: ["POST"],
   authLevel: "admin",
   handler: horizontalBarChart,
+});
+
+app.http("horizontalBarChartDom", {
+  route: "horizontalBarChart/dom",
+  methods: ["POST"],
+  authLevel: "admin",
+  handler: horizontalBarChartDom,
 });

--- a/platform/src/apis/Platform.Api.ChartRendering/src/functions/horizontalBarChart/template.ts
+++ b/platform/src/apis/Platform.Api.ChartRendering/src/functions/horizontalBarChart/template.ts
@@ -1,0 +1,248 @@
+const _d3 = import("d3");
+import classnames from "classnames";
+import {
+  HorizontalBarChartBuilderOptions,
+  ChartBuilderResult,
+  DatumKey,
+} from "..";
+import enGB from "d3-format/locale/en-GB" with { type: "json" };
+import { FormatLocaleDefinition } from "d3";
+import { sprintf } from "sprintf-js";
+import {
+  getTextWidth,
+  getValueFormat,
+  getGroups,
+  normaliseData,
+  escapeXml,
+} from "../utils";
+
+export default class HorizontalBarChartTemplate {
+  async buildChart<T>({
+    data,
+    barHeight,
+    groupedKeys,
+    highlightKey,
+    id,
+    keyField,
+    labelField,
+    labelFormat,
+    linkFormat,
+    sort,
+    valueField,
+    valueType,
+    width,
+    xAxisLabel,
+  }: HorizontalBarChartBuilderOptions<T>): Promise<ChartBuilderResult> {
+    const suggestedXAxisTickCount = 4;
+
+    const d3 = await _d3;
+    const locale = enGB as FormatLocaleDefinition;
+    d3.formatDefaultLocale(locale);
+
+    // Declare the chart dimensions and margins.
+    const marginTop = 20;
+    const marginRight = 40;
+    const marginBottom = 20;
+    const marginLeft = 3;
+    const labelHeight = 40;
+    let height =
+      Math.ceil((data.length + 0.1) * barHeight) + marginTop + marginBottom;
+    if (xAxisLabel) {
+      height += labelHeight;
+    }
+
+    const tickSize = 6;
+    const tickWidth = width / 3;
+    const truncateLabelAt = width ? Math.floor(width / 22) : 30;
+
+    const normalisedData = normaliseData(data, valueField, valueType);
+    const valueFormat = getValueFormat(valueType);
+    const groups = (key: DatumKey) => getGroups(groupedKeys, key);
+
+    // Create the scales.
+    normalisedData.sort((a, b) =>
+      sort === "asc"
+        ? d3.ascending(a[valueField] as number, b[valueField] as number)
+        : d3.descending(a[valueField] as number, b[valueField] as number),
+    );
+    const x = d3
+      .scaleLinear()
+      .domain([0, d3.max(normalisedData, (d) => d[valueField] as number)!])
+      .range([marginLeft + tickWidth + 5, width - marginRight - 5])
+      .nice(suggestedXAxisTickCount);
+
+    const y = d3
+      .scaleBand()
+      .domain(normalisedData.map((d) => d[keyField] as string))
+      .range([
+        marginTop,
+        height - marginBottom - (xAxisLabel ? labelHeight : 0),
+      ])
+      .paddingInner(0.2)
+      .paddingOuter(0.1);
+
+    // Create a value format.
+    const format = x.tickFormat(20, valueFormat);
+
+    // Append a rect for each bar.
+    const rects = normalisedData.map((d) => {
+      const xAttr = x(0);
+      const yAttr = y(d[keyField] as string)!;
+      let widthAttr = x(d[valueField] as number) - x(0);
+
+      // do not allow negative bars at this time
+      if (widthAttr < 0) {
+        widthAttr = 0;
+      }
+
+      const heightAttr = y.bandwidth();
+      const dataKeyAttr = d[keyField] as string;
+      const classAttr = classnames(
+        "chart-cell",
+        "chart-cell__series-0",
+        {
+          "chart-cell__highlight": d[keyField] === highlightKey,
+        },
+        groups(d[keyField] as DatumKey).map((g) => `chart-cell__group-${g}`),
+      );
+
+      return `<rect x="${xAttr}" y="${yAttr}" width="${widthAttr}" height="${heightAttr}" data-key="${dataKeyAttr}" class="${classAttr}"/>`;
+    });
+
+    // Append a label for each bar.
+    const labels = normalisedData.map((d) => {
+      let value = d[valueField] as number;
+
+      // do not allow negative labels at this time
+      if (value < 0) {
+        value = 0;
+      }
+
+      const xAttr = x(value) + Math.sign(value - 0) * 8;
+      const yAttr = y(d[keyField] as string)! + y.bandwidth() / 2;
+      const text = format(d[valueField] as number);
+      const classAttr = classnames("chart-label", "chart-label__series-0", {
+        "chart-label__highlight": d[keyField] === highlightKey,
+        "chart-label__negative": (d[valueField] as number) < 0,
+      });
+
+      return `<text x="${xAttr}" y="${yAttr}" dy="0.35em" class="${classAttr}">${text}</text>`;
+    });
+
+    const barsAndLabels = `<g>${rects.join("")}</g><g>${labels.join("")}</g>`;
+
+    // Create the axes.
+    const xAxisTicks = x.ticks(suggestedXAxisTickCount);
+    const xAxisTickOffset = 0.5;
+    const xAxisChartTicks = xAxisTicks.map((t) => {
+      const value = d3.format(valueFormat)(t);
+      return `<g class="chart-tick" transform="translate(${x(t) + xAxisTickOffset},0)">
+  <line y2="${tickSize}" x1="1" x2="1"/>
+  <text y="${tickSize + 3}" dy="0.71em" x1="1" x2="1">${value}</text>
+</g>`;
+    });
+
+    const xAxis = `<g class="chart-axis chart-axis__x" transform="translate(-2,${height - marginBottom - (xAxisLabel ? labelHeight : 0)})">
+  <path class="domain" stroke="currentColor" d="M${x(xAxisTicks[0]) + xAxisTickOffset},1V0.5H${x(xAxisTicks[xAxisTicks.length - 1]) + xAxisTickOffset}V1"/>
+  ${xAxisChartTicks.join("")}
+  ${xAxisLabel ? `<text x="${(width - tickWidth) / 2 + tickWidth - marginRight}" y="${marginBottom + labelHeight / 1.5}">${xAxisLabel}</text>` : ""}
+    </g>`;
+
+    const formatTick = (domainValue: string, index: number): string => {
+      const item = normalisedData[index];
+      return item && labelFormat
+        ? sprintf(labelFormat, item[keyField], item[labelField])
+        : domainValue;
+    };
+
+    const templateGrouping = (datum: string, label: string) => {
+      const hasGroup = groups(datum as DatumKey).length > 0;
+      if (!hasGroup) {
+        return;
+      }
+
+      const textWidth = getTextWidth(label, datum === highlightKey);
+      if (!textWidth) {
+        return;
+      }
+
+      // approximate repositioning due to no getBBox() and unknown client fonts
+      return `<g class="grouping-tick" transform="translate(${-(textWidth + 35)},-13)">
+  <path transform="scale(0.75,0.75)" d="M18,6A12,12,0,1,0,30,18,12,12,0,0,0,18,6Zm-1.49,6a1.49,1.49,0,0,1,3,0v6.89a1.49,1.49,0,1,1-3,0ZM18,25.5a1.72,1.72,0,1,1,1.72-1.72A1.72,1.72,0,0,1,18,25.5Z"/>
+</g>`;
+    };
+
+    const templateTickLink = (datum: string, index: number) => {
+      let label = formatTick(datum, index);
+
+      const classAttr = classnames("link-tick", {
+        "link-tick__highlight": datum === highlightKey,
+      });
+
+      // replace text node contents with <a> and add initially hidden sibling <rect>
+      const focusRect = `<rect x="${-tickWidth}" y="-8" width="${tickWidth - 8}" height="${barHeight - 5}" class="active-tick" />`;
+
+      const groupingTick = templateGrouping(datum, label) ?? "";
+
+      const hrefAttr = sprintf(linkFormat, datum);
+      label = escapeXml(label);
+
+      const labelParts = truncateLabel(label, truncateLabelAt)
+        .split(" ")
+        .join(` </tspan><tspan>`);
+
+      const textLink = `<text x="-${tickSize + 3}" dy="0.32em" class="${classAttr}">
+  <a data-key="${datum}" href="${hrefAttr}" class="govuk-link" aria-label="${label}" xmlns="http://www.w3.org/1999/xlink">
+    <tspan>${labelParts}</tspan>
+  </a>
+</text>`;
+
+      return `${focusRect}${groupingTick}${textLink}`;
+    };
+
+    function truncateLabel(label: string, maxLength: number) {
+      if (label.length <= maxLength) {
+        return label;
+      }
+
+      // Cut the string at maxLength
+      let truncated = label.slice(0, maxLength);
+
+      // Find the last space within the truncated string
+      const lastSpace = truncated.lastIndexOf(" ");
+      if (lastSpace > 0) {
+        truncated = truncated.slice(0, lastSpace);
+      }
+
+      return truncated + "...";
+    }
+
+    const yAxisChartTicks = normalisedData.map((d, i) => {
+      const value = formatTick(d[keyField] as string, i);
+      const yAttr = y(d[keyField] as string)! + y.bandwidth() / 2;
+
+      return `<g class="chart-tick" transform="translate(0,${yAttr})">
+  <line x2="-${tickSize}"/>
+  ${
+    linkFormat
+      ? templateTickLink(d[keyField] as string, i)
+      : `<text x="-9" dy="0.32em">${escapeXml(value)}</text>`
+  }
+</g>`;
+    });
+
+    const yAxis = `<g class="chart-axis chart-axis__y" transform="translate(${marginLeft + tickWidth + 2},0)">
+  <path class="domain" stroke="currentColor" d="M0,20.5H0.5V${height - marginBottom - (xAxisLabel ? labelHeight : 0)}.5H0" transform="translate(0,0)"/>
+  ${yAxisChartTicks.join("")}
+</g>`;
+
+    // Create the SVG container.
+    const svg = `<svg width="${width}" height="${height}" viewBox="0,0,${width},${height}" data-chart-id="${id}" xmlns="http://www.w3.org/2000/svg">
+  ${barsAndLabels}
+  ${xAxis}
+  ${yAxis}
+</svg>`;
+
+    return { id, html: svg.replace(/\n\s*/g, "") };
+  }
+}

--- a/platform/src/apis/Platform.Api.ChartRendering/src/functions/shared/worker.ts
+++ b/platform/src/apis/Platform.Api.ChartRendering/src/functions/shared/worker.ts
@@ -1,12 +1,12 @@
 import { v4 as uuidv4 } from "uuid";
-import HorizontalBarChartBuilder from "../horizontalBarChart/builder";
+import HorizontalBarChartTemplate from "../horizontalBarChart/template";
 import {
   HorizontalBarChartDefinition,
   VerticalBarChartDefinition,
 } from "../index";
 import VerticalBarChartBuilder from "../verticalBarChart/builder";
 
-const horizontalBarChartBuilder = new HorizontalBarChartBuilder();
+const horizontalBarChartTemplate = new HorizontalBarChartTemplate();
 const verticalBarChartBuilder = new VerticalBarChartBuilder();
 
 export function HorizontalBarChart({
@@ -29,7 +29,7 @@ export function HorizontalBarChart({
       xAxisLabel,
       ...rest
     }) =>
-      horizontalBarChartBuilder.buildChart({
+      horizontalBarChartTemplate.buildChart({
         barHeight: barHeight || 25,
         data,
         id: id || uuidv4(),

--- a/platform/src/apis/Platform.Api.ChartRendering/src/functions/utils.ts
+++ b/platform/src/apis/Platform.Api.ChartRendering/src/functions/utils.ts
@@ -63,3 +63,21 @@ const { getTextWidth: getServerTextWidth } = init(TEXT_WIDTH_LOOKUP_TABLE);
 export function getTextWidth(text: string, bold?: boolean) {
   return getServerTextWidth(text, { fontWeight: bold ? "700" : "400" });
 }
+
+export function escapeXml(unsafe: string | undefined) {
+  return (
+    unsafe?.replace(
+      /[<>&'"]/g,
+      (char) =>
+        `&${
+          {
+            "<": "lt",
+            ">": "gt",
+            "&": "amp",
+            "'": "apos",
+            '"': "quot",
+          }[char]
+        };`,
+    ) ?? ""
+  );
+}

--- a/platform/src/apis/Platform.Api.ChartRendering/src/openapi/horizontalBarChart/api.ts
+++ b/platform/src/apis/Platform.Api.ChartRendering/src/openapi/horizontalBarChart/api.ts
@@ -28,3 +28,26 @@ export type GetHorizontalBarChartApi = ApiMapper<{
     "500": { error: string };
   };
 }>;
+
+/**
+ * Generates a single or multiple horizontal bar chart(s) based on whether payload in a single object or an array
+ * @summary Builds a horizontal bar chart using D3 in the DOM
+ * @tags DOM
+ * @body.description Bar chart payload
+ * @body.contentType application/json
+ */
+export type GetHorizontalBarChartDomApi = ApiMapper<{
+  path: "/api/horizontalBarChart/dom";
+  method: "POST";
+  body: HorizontalBarChartPayload;
+  responses: {
+    /**
+     * @contentType application/json
+     */
+    "200": ChartBuilderResult | string;
+    /**
+     * @contentType application/json
+     */
+    "500": { error: string };
+  };
+}>;

--- a/platform/src/apis/Platform.Api.ChartRendering/src/openapi/index.ts
+++ b/platform/src/apis/Platform.Api.ChartRendering/src/openapi/index.ts
@@ -1,3 +1,6 @@
 export { GetHealthApi } from "./healthCheck/api";
-export { GetHorizontalBarChartApi } from "./horizontalBarChart/api";
+export {
+  GetHorizontalBarChartApi,
+  GetHorizontalBarChartDomApi,
+} from "./horizontalBarChart/api";
 export { GetVerticalBarChartApi } from "./verticalBarChart/api";

--- a/platform/src/apis/Platform.Api.ChartRendering/tests/functions/utils.test.ts
+++ b/platform/src/apis/Platform.Api.ChartRendering/tests/functions/utils.test.ts
@@ -4,6 +4,7 @@ import {
   getValueFormat,
   getGroups,
   getTextWidth,
+  escapeXml,
 } from "../../src/functions/utils";
 import { ValueType } from "../../src/functions/index";
 import theoretically from "jest-theories";
@@ -92,6 +93,27 @@ describe("getTextWidth", () => {
       theories,
       ({ text, bold, expected }) => {
         expect(getTextWidth(text, bold)).toBe(expected);
+      },
+    );
+  });
+});
+
+describe("escapeXml", () => {
+  describe("should return expected escaped value", () => {
+    const theories: { text?: string; expected: string }[] = [
+      { expected: "" },
+      { text: "Hello, world", expected: "Hello, world" },
+      { text: "Hello & world", expected: "Hello &amp; world" },
+      { text: "Hello, <world>", expected: "Hello, &lt;world&gt;" },
+      { text: "'Hello', world", expected: "&apos;Hello&apos;, world" },
+      { text: '"Hello", world', expected: "&quot;Hello&quot;, world" },
+    ];
+
+    theoretically(
+      "the string {text} returns the expected escaped value {expected}",
+      theories,
+      ({ text, expected }) => {
+        expect(escapeXml(text)).toBe(expected);
       },
     );
   });

--- a/platform/tests/Platform.ApiTests/Assertion/AssertionExtensions.cs
+++ b/platform/tests/Platform.ApiTests/Assertion/AssertionExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System.Xml.Linq;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Platform.ApiTests.Assertion;
+
+public static class AssertionExtensions
+{
+    public static void AssertDeepEquals(this JToken actual, JToken expected)
+    {
+        Assert.True(JToken.DeepEquals(expected, actual), $"Expected: {expected}{Environment.NewLine}Actual: {actual}");
+    }
+
+    public static void AssertDeepEquals(this XDocument actual, XDocument expected)
+    {
+        Assert.True(XNode.DeepEquals(expected, actual), $"Expected: {expected}{Environment.NewLine}Actual: {actual}");
+    }
+}

--- a/platform/tests/Platform.ApiTests/Steps/ChartRenderingHorizontalBarChartSteps.cs
+++ b/platform/tests/Platform.ApiTests/Steps/ChartRenderingHorizontalBarChartSteps.cs
@@ -6,7 +6,6 @@ using Platform.ApiTests.Drivers;
 using Platform.ApiTests.Models;
 using Platform.ApiTests.TestDataHelpers;
 using Platform.Json;
-using Xunit;
 
 namespace Platform.ApiTests.Steps;
 
@@ -15,10 +14,9 @@ namespace Platform.ApiTests.Steps;
 public class ChartRenderingHorizontalBarChartSteps(ChartRenderingApiDriver api)
 {
     private const string SingleKey = "horizontal-bar-charts";
-    private const string MultipleKey = "horizontal-bar-charts";
 
     [Given("a single horizontal bar chart request with accept header '(.*)', highlighted item '(.*)', sort '(.*)', width '(.*)', bar height '(.*)', id '(.*)', valueType '(.*)' and the following data:")]
-    public void GivenASingleHorizontalBarChartRequestWithAcceptHeaderHighlightedItemSortWidthHeightAndTheFollowingData(string accept, string highlight, string sort, int width, int barHeight, string id, string valueType, DataTable table)
+    public void GivenASingleHorizontalBarChartRequestWithAcceptHeaderHighlightedItemSortWidthBarHeightIdValueTypeAndTheFollowingData(string accept, string highlight, string sort, int width, int barHeight, string id, string valueType, DataTable table)
     {
         var data = table.Rows.Select(row => new TestDatum
         {
@@ -75,7 +73,7 @@ public class ChartRenderingHorizontalBarChartSteps(ChartRenderingApiDriver api)
     }
 
     [Then("the response should be ok, contain a JSON array and match the expected output of '(.*)'")]
-    public async Task ThenTheResponseShouldBeOkAnArrayAndMatchTheExpectedOutput(string testFile)
+    public async Task ThenTheResponseShouldBeOkContainAJsonArrayAndMatchTheExpectedOutputOf(string testFile)
     {
         var response = api[SingleKey].Response;
         AssertHttpResponse.IsOk(response);
@@ -85,11 +83,11 @@ public class ChartRenderingHorizontalBarChartSteps(ChartRenderingApiDriver api)
 
         var expected = TestDataProvider.GetJsonArrayData(testFile);
 
-        Assert.True(JToken.DeepEquals(expected, actual));
+        actual.AssertDeepEquals(expected);
     }
 
     [Then("the response should be ok, contain a JSON object and match the expected output of '(.*)'")]
-    public async Task ThenTheResponseShouldBeOkAnObjectAndMatchTheExpectedOutput(string testFile)
+    public async Task ThenTheResponseShouldBeOkContainAJsonObjectAndMatchTheExpectedOutputOf(string testFile)
     {
         var response = api[SingleKey].Response;
         AssertHttpResponse.IsOk(response);
@@ -99,11 +97,11 @@ public class ChartRenderingHorizontalBarChartSteps(ChartRenderingApiDriver api)
 
         var expected = TestDataProvider.GetJsonObjectData(testFile);
 
-        Assert.True(JToken.DeepEquals(expected, actual));
+        actual.AssertDeepEquals(expected);
     }
 
     [Then("the response should be ok, contain an SVG document and match the expected output of '(.*)'")]
-    public async Task ThenTheResponseShouldBeOkXmlAndMatchTheExpectedOutput(string testFile)
+    public async Task ThenTheResponseShouldBeOkContainAnSvgDocumentAndMatchTheExpectedOutputOf(string testFile)
     {
         var response = api[SingleKey].Response;
         AssertHttpResponse.IsOk(response);
@@ -113,11 +111,11 @@ public class ChartRenderingHorizontalBarChartSteps(ChartRenderingApiDriver api)
 
         var expected = TestDataProvider.GetXmlData(testFile);
 
-        Assert.True(XNode.DeepEquals(expected, actual));
+        actual.AssertDeepEquals(expected);
     }
 
     [Then("the chart response should be bad request, contain a JSON object and match the expected output of '(.*)'")]
-    public async Task ThenTheResponseShouldBeBadRequestAndMatchTheExpectedOutput(string testFile)
+    public async Task ThenTheChartResponseShouldBeBadRequestContainAJsonObjectAndMatchTheExpectedOutputOf(string testFile)
     {
         var response = api[SingleKey].Response;
         AssertHttpResponse.IsBadRequest(response);
@@ -127,7 +125,7 @@ public class ChartRenderingHorizontalBarChartSteps(ChartRenderingApiDriver api)
 
         var expected = TestDataProvider.GetJsonObjectData(testFile);
 
-        Assert.True(JToken.DeepEquals(expected, actual));
+        actual.AssertDeepEquals(expected);
     }
 
     private static PostHorizontalBarChartRequest<TestDatum> BuildRequest(string highlight, string sort, int width, int barHeight, IEnumerable<TestDatum> data, string id, string valueType) => new()


### PR DESCRIPTION
## 🧾 Summary

AB#270080 AB#275643

- Modified horizontal chart endpoint in API to use string templates rather than a stubbed DOM with `d3` 
- Moved original DOM implementation to its own route, without any worker configuration, validation or explicit telemetry
- Validated API tests unaffected after changes made

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Unit and integration tests updated _(if applicable)_.
- [x] All unit/integration tests are executed and passed.
- [x] Tested by running locally.

</details>
<details>
<summary>Documentation updates</summary>


- [ ] Code-level documentation (e.g., inline comments, docstrings) is updated.
- [ ] README.md or relevant module-level docs are updated.
- [ ] API changes are reflected in API documentation _(if applicable)_.
- [ ] Links to external references are included instead of duplicating content.
- [ ] No outdated or incorrect documentation remains.

</details>
<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [ ] Screenshots or Demo _(if applicable)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] Design (UX and/or content) review _(if applicable)_.
- [ ] Documentation changes have been explicitly reviewed.
- [ ] CI/CD pipeline checks pass.

</details>

## 🔍 Reviewer notes

See task and spike for motivation for this change. The intention is that the load tests will be re-executed once this is released in order to compare performance at different app service plans.

## 🧪 Testing notes

API tests offer assurance over changes for basic versions of the chart. Elsewhere, IT spend charts may be validated to be identical to the 'DOM' version of the chart builder.
