### PR TITLE
bugfix: ensure chart dimension toggle is passed to API query

### DIFF
--- a/web/src/Web.App/Controllers/SchoolComparisonItSpendController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparisonItSpendController.cs
@@ -43,7 +43,7 @@ public class SchoolComparisonItSpendController(
             try
             {
                 ViewData[ViewDataKeys.BreadcrumbNode] = BreadcrumbNodes.SchoolComparisonItSpend(urn);
-                var (school, expenditures) = await GetItSpendForMaintainedSchool(urn);
+                var (school, expenditures) = await GetItSpendForMaintainedSchool(urn, resultAs);
                 if (school == null)
                 {
                     return StatusCode((int)HttpStatusCode.NotFound);
@@ -107,7 +107,7 @@ public class SchoolComparisonItSpendController(
         {
             try
             {
-                var (school, schoolItSpend) = await GetItSpendForMaintainedSchool(urn);
+                var (school, schoolItSpend) = await GetItSpendForMaintainedSchool(urn, Dimensions.ResultAsOptions.Actuals);
                 if (school == null)
                 {
                     return StatusCode((int)HttpStatusCode.NotFound);
@@ -164,7 +164,7 @@ public class SchoolComparisonItSpendController(
 
     private async Task<(School? school, SchoolItSpend[] schoolItSpend)> GetItSpendForMaintainedSchool(
         string urn,
-        Dimensions.ResultAsOptions resultAs = Dimensions.ResultAsOptions.Actuals)
+        Dimensions.ResultAsOptions resultAs)
     {
         var school = await establishmentApi
             .GetSchool(urn)


### PR DESCRIPTION
## 🧾 Summary
AB#270092 AB#276001

Ensure chart dimension toggle is passed to API query

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Unit and integration tests updated _(if applicable)_.
- [x] All unit/integration tests are executed and passed.
- [x] Tested by running locally.

</details>
<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [x] CI/CD pipeline checks pass.

</details>

## 🧪 Testing notes
Chart dimension should correctly toggle, as well as download showing just actuals
