### PR TITLE
Added 'Save chart images' button to filter panel for chart view only

### DIFF
--- a/web/src/Web.App/ViewModels/Enhancements/PageActionsViewModel.cs
+++ b/web/src/Web.App/ViewModels/Enhancements/PageActionsViewModel.cs
@@ -2,11 +2,12 @@ namespace Web.App.ViewModels.Enhancements;
 
 public record PageActionsViewModel
 {
+    public bool? All { get; init; }
+    public string? CostCodesAttr { get; init; }
     public string? ElementId { get; init; }
     public string? SaveClassName { get; init; }
     public string SaveEventId { get; init; } = "save-chart-as-image";
     public string? SaveFileName { get; init; }
     public string? SaveTitleAttr { get; init; }
-    public string? CostCodesAttr { get; init; }
-    public string? WaitForEventType { get; init; }
+    public bool? StartImmediately { get; init; }
 }

--- a/web/src/Web.App/Views/SchoolComparisonItSpend/Index.cshtml
+++ b/web/src/Web.App/Views/SchoolComparisonItSpend/Index.cshtml
@@ -1,5 +1,6 @@
 ﻿@using Web.App.Extensions
 @using Web.App.ViewModels
+@using Web.App.ViewModels.Enhancements
 @model Web.App.ViewModels.SchoolComparisonItSpendViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.ComparisonItSpend;
@@ -84,5 +85,15 @@
     @await Html.PartialAsync("_SchoolChartTooltip", new SchoolChartTooltipViewModel
     {
         Data = Model.TooltipData
+    })
+
+    @await Html.PartialAsync("Enhancements/_PageActions", new PageActionsViewModel
+    {
+        All = true,
+        ElementId = "page-actions-button",
+        SaveClassName = "costs-chart-container",
+        SaveFileName = $"benchmark-it-spending-{Model.Urn}.zip",
+        SaveTitleAttr = "data-title",
+        StartImmediately = true
     })
 }

--- a/web/src/Web.App/Views/SchoolComparisonItSpend/_ItSpendFilter.cshtml
+++ b/web/src/Web.App/Views/SchoolComparisonItSpend/_ItSpendFilter.cshtml
@@ -251,8 +251,12 @@
         }
 
         <div class="govuk-button-group govuk-!-margin-bottom-0">
+            @if (Model.ViewAs == SchoolComparisonItSpendViewModel.ViewAsOptions.Chart)
+            {
+                <div id="page-actions-button"></div>
+            }
             <a href="@Url.Action("Download", "SchoolComparisonItSpend", new { urn = Model.Urn })" role="button"
-               class="govuk-button govuk-button--secondary">
+               class="govuk-button govuk-button--secondary" data-module="govuk-button">
                 Download page data
             </a>
         </div>

--- a/web/src/Web.App/Views/Shared/Enhancements/_PageActions.cshtml
+++ b/web/src/Web.App/Views/Shared/Enhancements/_PageActions.cshtml
@@ -7,6 +7,7 @@
     const element = document.getElementById("@Model.ElementId");
 
     const pageActions = createApp(PageActions, {
+        all: @(Model.All == true ? "true" : "false"),
         buttonLabel: "Save chart images",
         costCodesAttr: "@Model.CostCodesAttr",
         elementClassName: "@Model.SaveClassName",
@@ -16,7 +17,8 @@
         overlayContentId: "main-content",
         saveEventId: "@Model.SaveEventId",
         showProgress: true,
-        showTitles: true
+        showTitles: true,
+        startImmediately: @(Model.StartImmediately == true ? "true" : "false"),
     });
 
     pageActions.mount(element);

--- a/web/tests/Web.E2ETests/Features/School/BenchmarkItSpending.feature
+++ b/web/tests/Web.E2ETests/Features/School/BenchmarkItSpending.feature
@@ -39,3 +39,10 @@
         Then the tooltip for 'Test school 263' is correctly displayed
         When I press tab to select the school with urn '777042' in a chart
         Then the tooltip for 'Test school 102' is correctly displayed
+        
+    Scenario: Save chart images button opens modal and starts download
+        Given I am on it spend page for school with URN '777042'
+        Then the save chart images button is visible
+        When I click the save chart images button
+        Then the save chart images modal is visible
+        And the 'benchmark-it-spending-777042.zip' file is downloaded

--- a/web/tests/Web.E2ETests/Pages/School/BenchmarkItSpendingPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/BenchmarkItSpendingPage.cs
@@ -18,6 +18,16 @@ public class BenchmarkItSpendPage(IPage page)
             });
     private ILocator ChartTooltip => page.Locator(Selectors.EnhancementSchoolChartTooltip);
     private ILocator FilterButtons => page.Locator(".app-filter .govuk-button");
+    private ILocator SaveImagesButton =>
+        page.Locator(Selectors.Button, new PageLocatorOptions
+        {
+            HasText = "Save chart images"
+        });
+    private ILocator SaveImagesModal =>
+        page.Locator(Selectors.Modal, new PageLocatorOptions
+        {
+            HasText = "Save chart images"
+        });
 
     public async Task IsDisplayed()
     {
@@ -72,6 +82,21 @@ public class BenchmarkItSpendPage(IPage page)
     public async Task PressTab()
     {
         await page.Keyboard.PressAsync("Tab");
+    }
+
+    public async Task IsSaveImagesButtonDisplayed()
+    {
+        await SaveImagesButton.ShouldBeVisible();
+    }
+
+    public async Task ClickSaveImagesButton()
+    {
+        await SaveImagesButton.ClickAsync();
+    }
+
+    public async Task IsSaveImagesModalDisplayed()
+    {
+        await SaveImagesModal.ShouldBeVisible();
     }
 
     private async Task AssertVisibleCharts(IEnumerable<string> expectedTitles)

--- a/web/tests/Web.E2ETests/Steps/School/BenchmarkItSpendingSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/BenchmarkItSpendingSteps.cs
@@ -1,4 +1,5 @@
-﻿using Web.E2ETests.Drivers;
+﻿using Microsoft.Playwright;
+using Web.E2ETests.Drivers;
 using Web.E2ETests.Pages.School;
 using Xunit;
 
@@ -10,6 +11,7 @@ public class BenchmarkItSpendSteps(PageDriver driver)
 {
     private BenchmarkItSpendPage? _itSpendPage;
     private HomePage? _schoolHomePage;
+    private IDownload? _download;
 
     [Given("I am on it spend page for school with URN '(.*)'")]
     public async Task GivenIAmOnItSpendPageForSchoolWithUrn(string urn)
@@ -53,6 +55,15 @@ public class BenchmarkItSpendSteps(PageDriver driver)
         await _itSpendPage.PressTab();
     }
 
+    [When("I click the save chart images button")]
+    public async Task WhenIClickTheSaveChartImagesButton()
+    {
+        Assert.NotNull(_itSpendPage);
+
+        var page = await driver.Current;
+        _download = await page.RunAndWaitForDownloadAsync(() => _itSpendPage.ClickSaveImagesButton(), new TimeSpan(0, 2, 0));
+    }
+
     [Then("I should see the following IT spend charts:")]
     public async Task ThenIShouldSeeTheFollowingITSpendCharts(Table table)
     {
@@ -81,6 +92,28 @@ public class BenchmarkItSpendSteps(PageDriver driver)
     {
         Assert.NotNull(_itSpendPage);
         await _itSpendPage.TooltipIsDisplayedWithPartYearWarning(name, months);
+    }
+
+    [Then("the save chart images button is visible")]
+    public async Task ThenTheSaveChartImagesButtonIsVisible()
+    {
+        Assert.NotNull(_itSpendPage);
+        await _itSpendPage.IsSaveImagesButtonDisplayed();
+    }
+
+    [Then("the save chart images modal is visible")]
+    public async Task ThenTheSaveChartImagesModalIsVisible()
+    {
+        Assert.NotNull(_itSpendPage);
+        await _itSpendPage.IsSaveImagesModalDisplayed();
+    }
+
+    [Then("the '(.*)' file is downloaded")]
+    public void ThenTheFileIsDownloaded(string fileName)
+    {
+        Assert.NotNull(_itSpendPage);
+        var downloadedFilePath = _download?.SuggestedFilename;
+        Assert.Equal(fileName, downloadedFilePath);
     }
 
     private async Task<BenchmarkItSpendPage> LoadItSpendPageForSchoolWithUrn(string urn)

--- a/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenViewingComparisonItSpend.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenViewingComparisonItSpend.cs
@@ -4,6 +4,7 @@ using AngleSharp.Html.Dom;
 using AutoFixture;
 using Web.App.Domain;
 using Web.App.Domain.Charts;
+using Web.App.ViewModels;
 using Xunit;
 
 namespace Web.Integration.Tests.Pages.Schools.Comparison;
@@ -276,6 +277,24 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
         var newPage = await Client.Follow(anchor);
 
         DocumentAssert.AssertPageUrl(newPage, Paths.SchoolComparisonItSpendDownload(school.URN).ToAbsolute());
+    }
+
+    [Theory]
+    [InlineData(SchoolComparisonItSpendViewModel.ViewAsOptions.Chart, true)]
+    [InlineData(SchoolComparisonItSpendViewModel.ViewAsOptions.Table, false)]
+    public async Task CanSaveChartImages(SchoolComparisonItSpendViewModel.ViewAsOptions viewAs, bool expected)
+    {
+        var (page, _, _) = await SetupNavigateInitPage(EstablishmentTypes.Maintained, queryParams: $"?viewAs={(int)viewAs}");
+
+        var button = page.QuerySelector("#page-actions-button");
+        if (expected)
+        {
+            Assert.NotNull(button);
+        }
+        else
+        {
+            Assert.Null(button);
+        }
     }
 
     private async Task<(IHtmlDocument page, School school, SchoolItSpend[] spend)> SetupNavigateInitPage(


### PR DESCRIPTION
## 🧾 Summary

AB#270093 AB#276023 AB#276024

- Progressively enhance IT spend page with PageActions button/modal with 'start immediately' config
- E2E test coverage
- Integration test coverage

<img width="324" height="881" alt="image" src="https://github.com/user-attachments/assets/b8b97242-9164-4b01-8d26-45c52b67d199" />

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Unit and integration tests updated _(if applicable)_.
- [x] All unit/integration tests are executed and passed.
- [x] Tested by running locally.

</details>
<details>
<summary>Documentation updates</summary>


- [ ] Code-level documentation (e.g., inline comments, docstrings) is updated.
- [ ] README.md or relevant module-level docs are updated.
- [ ] API changes are reflected in API documentation _(if applicable)_.
- [ ] Links to external references are included instead of duplicating content.
- [ ] No outdated or incorrect documentation remains.

</details>
<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [x] Screenshots or Demo _(if applicable)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] Design (UX and/or content) review _(if applicable)_.
- [ ] Documentation changes have been explicitly reviewed.
- [ ] CI/CD pipeline checks pass.

</details>

## 🧪 Testing notes

Although this change is independent of #2745, the requirement to start the download automatically will not be available until that PR is merged.
