### PR TITLE
hotfix: resolve incorrect function names

### DIFF
--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -14,7 +14,7 @@ load_dotenv()
 
 from pipeline.comparator_sets import compute_comparator_sets
 from pipeline.pre_processing import pre_process_custom_data, pre_process_data
-from pipeline.rag import compute_rag, compute_user_defined_rag
+from pipeline.rag import compute_rag, run_user_defined_rag
 from pipeline.utils.log import setup_logger
 from pipeline.utils.message import MessageType, get_message_type
 from pipeline.utils.storage import (
@@ -75,7 +75,7 @@ def handle_msg(
 
             case MessageType.DefaultUserDefined:
                 logger.info("Starting user defined RAG pipeline run...")
-                msg_payload["rag_duration"] = compute_user_defined_rag(
+                msg_payload["rag_duration"] = run_user_defined_rag(
                     year=msg_payload["year"],
                     run_id=msg_payload["runId"],
                     target_urn=int(msg_payload["urn"]),

--- a/data-pipeline/src/pipeline/rag/main.py
+++ b/data-pipeline/src/pipeline/rag/main.py
@@ -7,7 +7,7 @@ from pipeline.utils.database import insert_metric_rag
 from pipeline.utils.log import setup_logger
 from pipeline.utils.storage import get_blob, write_blob
 
-from .calculations import calculate_rag
+from .calculations import calculate_rag, compute_user_defined_rag
 
 logger = setup_logger("rag")
 
@@ -123,7 +123,7 @@ def compute_rag(
     return time_taken
 
 
-def compute_user_defined_rag(
+def run_user_defined_rag(
     year: int,
     run_id: str,
     target_urn: int,

--- a/data-pipeline/src/pipeline/utils/message.py
+++ b/data-pipeline/src/pipeline/utils/message.py
@@ -45,18 +45,40 @@ def get_message_type(message: dict) -> MessageType:
 
     ```json
     {
-        "jobId": "24463424-9642-4314-bb55-45424af6e812",
-        "type": "comparator-set",
-        "runId": "c321ef6a-3b1c-4ce2-8e32-0d0167bf2fa7",
-        "year": 2022,
-        "urn": "106057",
+        "runId": "a6db019c-d45f-44f3-8af0-71d82c1c6257",
+        "year": 2025,
+        "urn": "100449",
         "payload": {
+            "_type": "ComparatorSetPipelinePayload",
             "kind": "ComparatorSetPayload",
             "set": [
-                "145799",
-                "142875"
-            ]
-        }
+                "100218",
+                "100240",
+                "102272",
+                "132266",
+                "100022",
+                "101258",
+                "100585",
+                "131871",
+                "102890",
+                "102830",
+                "102084",
+                "100852",
+                "100163",
+                "101526",
+                "102324",
+                "103072",
+                "101893",
+                "100023",
+                "101277",
+                "130302",
+                "102131",
+                "100449",
+            ],
+        },
+        "jobId": "7af1abc5-88a9-4447-bdf7-92f4f95dc772",
+        "type": "comparator-set",
+        "runType": "default",
     }
     ```
 


### PR DESCRIPTION
## 🧾 Summary
* There are 2 functions `run_user_defined_rag` and `compute_user_defined_rag` - the incorrect function was being used

## Testing
* I tested this with the payload, with which I've updated the example payload in the docs
```
{"runId":"a6db019c-d45f-44f3-8af0-71d82c1c6257","year":2025,"urn":"100449","payload":{"_type":"ComparatorSetPipelinePayload","kind":"ComparatorSetPayload","set":["100218","100240","102272","132266","100022","101258","100585","131871","102890","102830","102084","100852","100163","101526","102324","103072","101893","100023","101277","130302","102131","100449"]},"jobId":"7af1abc5-88a9-4447-bdf7-92f4f95dc772","type":"comparator-set","runType":"default"}
```
