### PR TITLE
hotfix: correct imports in init

### DIFF
--- a/data-pipeline/src/pipeline/rag/__init__.py
+++ b/data-pipeline/src/pipeline/rag/__init__.py
@@ -1,1 +1,1 @@
-from .main import compute_rag, compute_user_defined_rag
+from .main import compute_rag, run_user_defined_rag


### PR DESCRIPTION
## 🧾 Summary
* Commit changes to __init__ which allow the correct function to import
