### PR TITLE
chore: update `Web.Shutter` dependencies

### DIFF
--- a/web/src/Web.Shutter/package-lock.json
+++ b/web/src/Web.Shutter/package-lock.json
@@ -23,17 +23,16 @@
         "winston": "^3.17.0"
       },
       "devDependencies": {
-        "@dotenvx/dotenvx": "^1.48.3",
-        "@types/dotenv": "^6.1.1",
+        "@dotenvx/dotenvx": "^1.48.4",
         "@types/express": "^5.0.3",
-        "@types/node": "^22.16.2",
+        "@types/node": "^24.1.0",
         "@types/nunjucks": "^3.2.6",
         "@types/trusted-types": "^2.0.7",
         "gts": "^6.0.2",
         "nodemon": "^3.1.10",
         "shx": "^0.4.0",
         "ts-node": "^10.9.2",
-        "typescript": "^5.6.3"
+        "typescript": "^5.9.2"
       },
       "engines": {
         "node": ">=22.15.0"
@@ -345,14 +344,14 @@
       }
     },
     "node_modules/@dotenvx/dotenvx": {
-      "version": "1.48.3",
-      "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.48.3.tgz",
-      "integrity": "sha512-7Tk0Rzgz0SEkaJRGijbKtVDHHztHz9fyXwcDT86VtD1fGVRirk4aBKUud1PEQdhwcg+jDblKGoXeA+I7J60CxQ==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.49.0.tgz",
+      "integrity": "sha512-M1cyP6YstFQCjih54SAxCqHLMMi8QqV8tenpgGE48RTXWD7vfMYJiw/6xcCDpS2h28AcLpTsFCZA863Ge9yxzA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "commander": "^11.1.0",
-        "dotenv": "^16.4.5",
+        "dotenv": "^17.2.1",
         "eciesjs": "^0.4.10",
         "execa": "^5.1.1",
         "fdir": "^6.2.0",
@@ -2361,16 +2360,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/dotenv": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-6.1.1.tgz",
-      "integrity": "sha512-ftQl3DtBvqHl9L16tpqqzA4YzCSXZfi7g8cQceTz5rOlYtk/IZbFjAv3mLOQlNIgOaylCQWQoBdDQHPgEBJPHg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/express": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
@@ -2443,12 +2432,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.16.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.5.tgz",
-      "integrity": "sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.10.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -3568,9 +3557,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -7518,9 +7507,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7539,9 +7528,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/web/src/Web.Shutter/package.json
+++ b/web/src/Web.Shutter/package.json
@@ -33,17 +33,16 @@
     "winston": "^3.17.0"
   },
   "devDependencies": {
-    "@dotenvx/dotenvx": "^1.48.3",
-    "@types/dotenv": "^6.1.1",
+    "@dotenvx/dotenvx": "^1.48.4",
     "@types/express": "^5.0.3",
-    "@types/node": "^22.16.2",
+    "@types/node": "^24.1.0",
     "@types/nunjucks": "^3.2.6",
     "@types/trusted-types": "^2.0.7",
     "gts": "^6.0.2",
     "nodemon": "^3.1.10",
     "shx": "^0.4.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.6.3"
+    "typescript": "^5.9.2"
   },
   "engines": {
     "node": ">=22.15.0"


### PR DESCRIPTION
## 🧾 Summary

[AB#265000](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/265000) [AB#275477](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/275477)

Updates npm dependencies for `Web.Shutter`. Removes `@types/dotenv` as now [deprecated](https://www.npmjs.com/package/@types/dotenv)

This should close the following dependabot PRs
#2677
#2676 
#2675 
#2674 

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Tested by running locally.

</details>

<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] CI/CD pipeline checks pass.

</details>

## 🧪 Testing notes

Shutter site runs locally following package updates
