### PR TITLE
View news article page based on `slug` in route

### DIFF
--- a/web/src/Web.App/Controllers/NewsController.cs
+++ b/web/src/Web.App/Controllers/NewsController.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement.Mvc;
+using Web.App.Domain.Content;
+using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Apis.Content;
+using Web.App.Infrastructure.Extensions;
+using Web.App.ViewModels;
+
+namespace Web.App.Controllers;
+
+[Controller]
+[FeatureGate(FeatureFlags.News)]
+[Route("news")]
+public class NewsController(ILogger<NewsController> logger, INewsApi newsApi) : Controller
+{
+    [HttpGet]
+    [Route("{slug}")]
+    public async Task<IActionResult> Article(string slug)
+    {
+        using (logger.BeginScope(new
+        {
+            slug
+        }))
+        {
+            try
+            {
+                var news = await newsApi
+                    .GetNewsArticle(slug)
+                    .GetResultOrDefault<News>();
+                if (news == null)
+                {
+                    return NotFound();
+                }
+
+                return View(new NewsArticleViewModel(news));
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "An error displaying news article: {DisplayUrl}", Request.GetDisplayUrl());
+                return e is StatusCodeException s ? StatusCode((int)s.Status) : StatusCode(500);
+            }
+        }
+    }
+}

--- a/web/src/Web.App/Controllers/NewsController.cs
+++ b/web/src/Web.App/Controllers/NewsController.cs
@@ -16,7 +16,7 @@ public class NewsController(ILogger<NewsController> logger, INewsApi newsApi) : 
 {
     [HttpGet]
     [Route("{slug}")]
-    public async Task<IActionResult> Article(string slug)
+    public async Task<IActionResult> Article(string slug, CancellationToken cancellationToken = default)
     {
         using (logger.BeginScope(new
         {
@@ -26,7 +26,7 @@ public class NewsController(ILogger<NewsController> logger, INewsApi newsApi) : 
             try
             {
                 var news = await newsApi
-                    .GetNewsArticle(slug)
+                    .GetNewsArticle(slug, cancellationToken)
                     .GetResultOrDefault<News>();
                 if (news == null)
                 {

--- a/web/src/Web.App/Domain/Content/News.cs
+++ b/web/src/Web.App/Domain/Content/News.cs
@@ -1,0 +1,8 @@
+namespace Web.App.Domain.Content;
+
+public record News
+{
+    public string? Title { get; set; }
+    public string? Slug { get; set; }
+    public string? Body { get; set; }
+}

--- a/web/src/Web.App/Extensions/ServiceCollectionExtensions.cs
+++ b/web/src/Web.App/Extensions/ServiceCollectionExtensions.cs
@@ -126,6 +126,7 @@ public static class ServiceCollectionExtensions
         services.AddHttpClient<IBannerApi, BannerApi>().Configure<BannerApi>(section);
         services.AddHttpClient<ICommercialResourcesApi, CommercialResourcesApi>().Configure<CommercialResourcesApi>(section);
         services.AddHttpClient<IFilesApi, FilesApi>().Configure<FilesApi>(section);
+        services.AddHttpClient<INewsApi, NewsApi>().Configure<BannerApi>(section);
         services.AddHttpClient<IYearsApi, YearsApi>().Configure<YearsApi>(section);
 
         return services;
@@ -305,7 +306,6 @@ public static class ServiceCollectionExtensions
 
                             context.Principal?.ApplyClaims(context.TokenEndpointResponse?.AccessToken, schools, trusts);
                             opts.Events.OnValidatedPrincipal(context);
-
                         }
                         catch (Exception ex)
                         {

--- a/web/src/Web.App/Infrastructure/Apis/Content/Api.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Content/Api.cs
@@ -20,6 +20,14 @@ public static class Api
         public static string Transparency => "api/files/transparency";
     }
 
+    public static class News
+    {
+        public static string Article(string slug)
+        {
+            return $"api/news/{slug}";
+        }
+    }
+
     public static class Years
     {
         public static string CurrentReturnYears => "api/current-return-years";

--- a/web/src/Web.App/Infrastructure/Apis/Content/NewsApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Content/NewsApi.cs
@@ -2,13 +2,13 @@ namespace Web.App.Infrastructure.Apis.Content;
 
 public interface INewsApi
 {
-    Task<ApiResult> GetNewsArticle(string slug);
+    Task<ApiResult> GetNewsArticle(string slug, CancellationToken cancellationToken = default);
 }
 
 public class NewsApi(HttpClient httpClient, string? key = default) : ApiBase(httpClient, key), INewsApi
 {
-    public async Task<ApiResult> GetNewsArticle(string slug)
+    public async Task<ApiResult> GetNewsArticle(string slug, CancellationToken cancellationToken = default)
     {
-        return await GetAsync(Api.News.Article(slug));
+        return await GetAsync(Api.News.Article(slug), cancellationToken);
     }
 }

--- a/web/src/Web.App/Infrastructure/Apis/Content/NewsApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Content/NewsApi.cs
@@ -1,0 +1,14 @@
+namespace Web.App.Infrastructure.Apis.Content;
+
+public interface INewsApi
+{
+    Task<ApiResult> GetNewsArticle(string slug);
+}
+
+public class NewsApi(HttpClient httpClient, string? key = default) : ApiBase(httpClient, key), INewsApi
+{
+    public async Task<ApiResult> GetNewsArticle(string slug)
+    {
+        return await GetAsync(Api.News.Article(slug));
+    }
+}

--- a/web/src/Web.App/Middleware/Markdown/GdsMarkdownExtension.cs
+++ b/web/src/Web.App/Middleware/Markdown/GdsMarkdownExtension.cs
@@ -14,7 +14,16 @@ namespace Web.App.Middleware.Markdown;
 ///             <c>&lt;a&gt;</c>
 ///         </li>
 ///         <li>
-///             <c>&lt;ul&gt;</c>
+///             <c>&lt;h1&gt;</c>
+///         </li>
+///         <li>
+///             <c>&lt;h2&gt;</c>
+///         </li>
+///         <li>
+///             <c>&lt;h3&gt;</c>
+///         </li>
+///         <li>
+///             <c>&lt;ol&gt;</c>
 ///         </li>
 ///         <li>
 ///             <c>&lt;p&gt;</c>
@@ -23,10 +32,13 @@ namespace Web.App.Middleware.Markdown;
 ///             <c>&lt;table&gt;</c>
 ///         </li>
 ///         <li>
+///             <c>&lt;td&gt;</c>
+///         </li>
+///         <li>
 ///             <c>&lt;tr&gt;</c>
 ///         </li>
 ///         <li>
-///             <c>&lt;td&gt;</c>
+///             <c>&lt;ul&gt;</c>
 ///         </li>
 ///     </ul>
 /// </summary>
@@ -51,8 +63,21 @@ public class GdsMarkdownExtension : IMarkdownExtension
             var attributes = node.GetAttributes();
             switch (node)
             {
+                case HeadingBlock { Level: 1 }:
+                    attributes.AddClass("govuk-heading-l");
+                    break;
+                case HeadingBlock { Level: 2 }:
+                    attributes.AddClass("govuk-heading-m");
+                    break;
+                case HeadingBlock:
+                    attributes.AddClass("govuk-heading-s");
+                    break;
                 case LinkInline:
                     attributes.AddClass("govuk-link");
+                    break;
+                case ListBlock { IsOrdered: true }:
+                    attributes.AddClass("govuk-list");
+                    attributes.AddClass("govuk-list--number");
                     break;
                 case ListBlock:
                     attributes.AddClass("govuk-list");

--- a/web/src/Web.App/ViewModels/NewsArticleViewModel.cs
+++ b/web/src/Web.App/ViewModels/NewsArticleViewModel.cs
@@ -1,7 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
 using Web.App.Domain.Content;
 
 namespace Web.App.ViewModels;
 
+[ExcludeFromCodeCoverage]
 public class NewsArticleViewModel(News? news)
 {
     public string? Body => news?.Body;

--- a/web/src/Web.App/ViewModels/NewsArticleViewModel.cs
+++ b/web/src/Web.App/ViewModels/NewsArticleViewModel.cs
@@ -1,0 +1,9 @@
+using Web.App.Domain.Content;
+
+namespace Web.App.ViewModels;
+
+public class NewsArticleViewModel(News? news)
+{
+    public string? Body => news?.Body;
+    public string? Title => news?.Title;
+}

--- a/web/src/Web.App/Views/News/Article.cshtml
+++ b/web/src/Web.App/Views/News/Article.cshtml
@@ -1,0 +1,17 @@
+﻿@using Westwind.AspNetCore.Markdown
+@model Web.App.ViewModels.NewsArticleViewModel
+
+@{
+    ViewData[ViewDataKeys.Title] = Model.Title;
+}
+
+@if (Model.Body == null)
+{
+    return;
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds markdown">
+        @Markdown.ParseHtmlString(Model.Body)
+    </div>
+</div>

--- a/web/src/Web.App/appsettings.Development.json
+++ b/web/src/Web.App/appsettings.Development.json
@@ -12,7 +12,8 @@
     "HighExecutivePay": true,
     "HighNeeds": true,
     "SchoolSpendingPrioritiesSsrCharts": true,
-    "CfrItSpendBreakdown": true
+    "CfrItSpendBreakdown": true,
+    "News": true
   },
   "Apis": {
     "Insight": {

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -740,14 +740,14 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     public BenchmarkingWebAppClient SetupNewsArticle(News? news)
     {
         NewsApi.Reset();
-        NewsApi.Setup(api => api.GetNewsArticle(It.IsAny<string>())).ReturnsAsync(news == null ? ApiResult.NotFound() : ApiResult.Ok(news));
+        NewsApi.Setup(api => api.GetNewsArticle(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(news == null ? ApiResult.NotFound() : ApiResult.Ok(news));
         return this;
     }
 
     public BenchmarkingWebAppClient SetupNewsWithException()
     {
         NewsApi.Reset();
-        NewsApi.Setup(api => api.GetNewsArticle(It.IsAny<string>())).Throws(new Exception());
+        NewsApi.Setup(api => api.GetNewsArticle(It.IsAny<string>(), It.IsAny<CancellationToken>())).Throws(new Exception());
         return this;
     }
 

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -68,6 +68,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     public Mock<ICommercialResourcesApi> CommercialResourcesApi { get; } = new();
     public Mock<IBannerApi> BannerApi { get; } = new();
     public Mock<IItSpendApi> ItSpendApi { get; } = new();
+    public Mock<INewsApi> NewsApi { get; } = new();
     public IOptions<CacheOptions> CacheOptions { get; } = Options.Create(new CacheOptions
     {
         ReturnYears = new CacheSettings { Disabled = true },
@@ -104,6 +105,7 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         services.AddSingleton(CommercialResourcesApi.Object);
         services.AddSingleton(BannerApi.Object);
         services.AddSingleton(ItSpendApi.Object);
+        services.AddSingleton(NewsApi.Object);
         services.AddSingleton(CacheOptions);
 
         EnableFeatures();
@@ -732,6 +734,20 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     {
         BannerApi.Reset();
         BannerApi.Setup(api => api.GetBanner(It.IsAny<string>())).ReturnsAsync(banner == null ? ApiResult.NotFound() : ApiResult.Ok(banner));
+        return this;
+    }
+
+    public BenchmarkingWebAppClient SetupNewsArticle(News? news)
+    {
+        NewsApi.Reset();
+        NewsApi.Setup(api => api.GetNewsArticle(It.IsAny<string>())).ReturnsAsync(news == null ? ApiResult.NotFound() : ApiResult.Ok(news));
+        return this;
+    }
+
+    public BenchmarkingWebAppClient SetupNewsWithException()
+    {
+        NewsApi.Reset();
+        NewsApi.Setup(api => api.GetNewsArticle(It.IsAny<string>())).Throws(new Exception());
         return this;
     }
 

--- a/web/tests/Web.Integration.Tests/Pages/WhenAFeatureIsDisabled.cs
+++ b/web/tests/Web.Integration.Tests/Pages/WhenAFeatureIsDisabled.cs
@@ -109,4 +109,14 @@ public class WhenAFeatureIsDisabled(SchoolBenchmarkingWebAppClient client)
         PageAssert.IsFeatureDisabledPage(page);
         DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeedsDashboard("123").ToAbsolute(), HttpStatusCode.Forbidden);
     }
+
+    [Fact]
+    public async Task NewsArticleRedirectsToFeatureDisabled()
+    {
+        var page = await Client.SetupDisableFeatureFlags(FeatureFlags.News)
+            .Navigate(Paths.News("slug"));
+
+        PageAssert.IsFeatureDisabledPage(page);
+        DocumentAssert.AssertPageUrl(page, Paths.News("slug").ToAbsolute(), HttpStatusCode.Forbidden);
+    }
 }

--- a/web/tests/Web.Integration.Tests/Pages/WhenViewingNewsArticle.cs
+++ b/web/tests/Web.Integration.Tests/Pages/WhenViewingNewsArticle.cs
@@ -1,0 +1,64 @@
+﻿using System.Net;
+using Web.App.Domain.Content;
+using Xunit;
+
+namespace Web.Integration.Tests.Pages;
+
+public class WhenViewingNewsArticle(SchoolBenchmarkingWebAppClient client) : PageBase<SchoolBenchmarkingWebAppClient>(client)
+{
+    [Fact]
+    public async Task CanDisplay()
+    {
+        const string slug = nameof(slug);
+        const string title = nameof(title);
+        const string heading = nameof(heading);
+        var news = new News
+        {
+            Title = title,
+            Slug = slug,
+            Body = $"""
+                   # {heading}
+
+                   Content
+                   """
+        };
+
+        var page = await Client
+            .SetupNewsArticle(news)
+            .Navigate(Paths.News(slug));
+
+        DocumentAssert.AssertPageUrl(page, Paths.News(slug).ToAbsolute());
+        DocumentAssert.TitleAndH1(page, $"{title} - Financial Benchmarking and Insights Tool - GOV.UK", heading);
+
+        var content = page.QuerySelector(".markdown");
+        Assert.NotNull(content);
+
+        const string expected = $"""
+                                 <h1 class="govuk-heading-l">{heading}</h1>
+                                 <p class="govuk-body">Content</p>
+                                 """;
+        Assert.Equal(expected.Replace(Environment.NewLine, "\n"), content.InnerHtml.Trim());
+    }
+
+    [Fact]
+    public async Task CanDisplayNotFound()
+    {
+        const string slug = nameof(slug);
+        var page = await Client.SetupNewsArticle(null)
+            .Navigate(Paths.News(slug));
+
+        PageAssert.IsNotFoundPage(page);
+        DocumentAssert.AssertPageUrl(page, Paths.News(slug).ToAbsolute(), HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task CanDisplayProblemWithService()
+    {
+        const string slug = nameof(slug);
+        var page = await Client.SetupNewsWithException()
+            .Navigate(Paths.News(slug));
+
+        PageAssert.IsProblemPage(page);
+        DocumentAssert.AssertPageUrl(page, Paths.News(slug).ToAbsolute(), HttpStatusCode.InternalServerError);
+    }
+}

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -21,116 +21,144 @@ public static class Paths
     {
         return $"/error/{statusCode}";
     }
+
     public static string SchoolHome(string? urn)
     {
         return $"/school/{urn}";
     }
+
     public static string SchoolSpendingComparison(string? urn)
     {
         return $"/school/{urn}/spending-comparison";
     }
+
     public static string TrustHome(string? companyNumber)
     {
         return $"/trust/{companyNumber}";
     }
+
     public static string TrustDetails(string? companyNumber)
     {
         return $"/trust/{companyNumber}/details";
     }
+
     public static string TrustComparison(string? companyNumber)
     {
         return $"/trust/{companyNumber}/comparison";
     }
+
     public static string TrustCensus(string? companyNumber)
     {
         return $"/trust/{companyNumber}/census";
     }
+
     public static string TrustFinancialPlanning(string? companyNumber)
     {
         return $"/trust/{companyNumber}/financial-planning";
     }
+
     public static string TrustSpending(string? companyNumber, string[] categories, string[] priorities)
     {
         return $"/trust/{companyNumber}/spending-and-costs" +
                $"?{string.Join("&", priorities.Select(p => $"priority={p.ToLower().Replace(" ", "%20")}"))}" +
                $"&{string.Join("&", categories.Select(c => $"category={c.ToLower().Replace(" ", "%20")}"))}";
     }
+
     public static string TrustForecast(string? companyNumber)
     {
         return $"/trust/{companyNumber}/forecast";
     }
+
     public static string TrustResources(string? companyNumber)
     {
         return $"/trust/{companyNumber}/find-ways-to-spend-less";
     }
+
     public static string SchoolComparatorSet(string? urn, string referrer)
     {
         return $"/school/{urn}/comparator-set?referrer={referrer}";
     }
+
     public static string SchoolComparison(string? urn)
     {
         return $"/school/{urn}/comparison";
     }
+
     public static string SchoolComparisonItSpend(string? urn)
     {
         return $"/school/{urn}/benchmark-it-spending";
     }
+
     public static string SchoolComparisonCustomData(string? urn)
     {
         return $"/school/{urn}/comparison/custom-data";
     }
+
     public static string SchoolComparisonDownload(string? urn)
     {
         return $"/school/{urn}/comparison/download";
     }
+
     public static string SchoolComparisonItSpendDownload(string? urn)
     {
         return $"/school/{urn}/benchmark-it-spending/download";
     }
+
     public static string SchoolCensus(string? urn)
     {
         return $"/school/{urn}/census";
     }
+
     public static string SchoolFinancialBenchmarkingInsightsSummary(string? urn, string? referrer = null)
     {
         return $"/school/{urn}/summary{(referrer == null ? string.Empty : $"?referrer={referrer}")}";
     }
+
     public static string SchoolCensusCustomData(string? urn)
     {
         return $"/school/{urn}/census/custom-data";
     }
+
     public static string SchoolCensusDownload(string? urn)
     {
         return $"/school/{urn}/census/download";
     }
+
     public static string SchoolSpending(string? urn)
     {
         return $"/school/{urn}/spending-and-costs";
     }
+
     public static string SchoolSpendingCustomData(string? urn)
     {
         return $"/school/{urn}/spending-and-costs/custom-data";
     }
+
     public static string SchoolInvestigation(string? urn)
     {
         return $"/school/{urn}/investigation";
     }
+
     public static string SchoolFinancialPlanning(string? urn)
     {
         return $"/school/{urn}/financial-planning";
     }
+
     public static string SchoolHistory(string? urn)
     {
         return $"/school/{urn}/history";
     }
+
     public static string SchoolDetails(string? urn)
     {
         return $"/school/{urn}/details";
     }
+
     public static string SchoolCustomData(string? urn)
     {
         return $"/school/{urn}/custom-data";
     }
+
     public static string SchoolCustomisedData(string? urn)
     {
         return $"/school/{urn}/customised-data";
@@ -140,146 +168,182 @@ public static class Paths
     {
         return $"/school/{urn}/financial-planning/create/start";
     }
+
     public static string SchoolFinancialPlanningSelectYear(string? urn)
     {
         return $"/school/{urn}/financial-planning/create/select-year";
     }
+
     public static string SchoolFinancialPlanningTotalIncome(string? urn, int year)
     {
         return $"/school/{urn}/financial-planning/create/total-income?year={year}";
     }
+
     public static string SchoolFinancialPlanningPrePopulatedData(string? urn, int year)
     {
         return $"/school/{urn}/financial-planning/create/pre-populate-data?year={year}";
     }
+
     public static string SchoolFinancialPlanningTimetableCycle(string? urn, int year)
     {
         return $"/school/{urn}/financial-planning/create/timetable-cycle?year={year}";
     }
+
     public static string SchoolFinancialPlanningHelp(string? urn)
     {
         return $"/school/{urn}/financial-planning/create/help";
     }
+
     public static string SchoolFinancialPlanningTotalExpenditure(string? urn, int year)
     {
         return $"/school/{urn}/financial-planning/create/total-expenditure?year={year}";
     }
+
     public static string SchoolFinancialPlanningTotalTeacherCost(string? urn, int year)
     {
         return $"/school/{urn}/financial-planning/create/total-teacher-costs?year={year}";
     }
+
     public static string SchoolFinancialPlanningTotalNumberTeachers(string? urn, int year)
     {
         return $"/school/{urn}/financial-planning/create/total-number-teachers?year={year}";
     }
+
     public static string SchoolFinancialPlanningTotalEducationSupport(string? urn, int year)
     {
         return $"/school/{urn}/financial-planning/create/total-education-support?year={year}";
     }
+
     public static string SchoolFinancialPlanningHasMixedAgeClasses(string? urn, int year)
     {
         return $"/school/{urn}/financial-planning/create/primary-has-mixed-age-classes?year={year}";
     }
+
     public static string SchoolFinancialPlanningMixedAgeClasses(string? urn, int year)
     {
         return $"/school/{urn}/financial-planning/create/primary-mixed-age-classes?year={year}";
     }
+
     public static string SchoolFinancialPlanningPupilFigures(string? urn, int year)
     {
         return $"/school/{urn}/financial-planning/create/pupil-figures?year={year}";
     }
+
     public static string SchoolFinancialPlanningPrimaryPupilFigures(string? urn, int year)
     {
         return $"/school/{urn}/financial-planning/create/primary-pupil-figures?year={year}";
     }
+
     public static string SchoolFinancialPlanningTeacherPeriodAllocation(string? urn, int year)
     {
         return $"/school/{urn}/financial-planning/create/teacher-period-allocation?year={year}";
     }
+
     public static string SchoolFinancialPlanningTeachingAssistantFigures(string? urn, int year)
     {
         return $"/school/{urn}/financial-planning/create/teaching-assistant-figures?year={year}";
     }
+
     public static string SchoolFinancialPlanningOtherTeachingPeriods(string? urn, int year)
     {
         return $"/school/{urn}/financial-planning/create/other-teaching-periods?year={year}";
     }
+
     public static string SchoolFinancialPlanningOtherTeachingPeriodsConfirm(string? urn, int year)
     {
         return $"/school/{urn}/financial-planning/create/other-teaching-periods-confirmation?year={year}";
     }
+
     public static string SchoolFinancialPlanningOtherTeachingPeriodsReview(string? urn, int year)
     {
         return $"/school/{urn}/financial-planning/create/other-teaching-periods-review?year={year}";
     }
+
     public static string SchoolFinancialPlanningManagementRoles(string? urn, int year)
     {
         return $"/school/{urn}/financial-planning/create/management-roles?year={year}";
     }
+
     public static string SchoolFinancialPlanningManagersPerRole(string? urn, int year)
     {
         return $"/school/{urn}/financial-planning/create/managers-per-role?year={year}";
     }
+
     public static string SchoolCustomDataFinancialData(string? urn)
     {
         return $"/school/{urn}/custom-data/financial-data";
     }
+
     public static string SchoolCustomDataNonFinancialData(string? urn)
     {
         return $"/school/{urn}/custom-data/school-characteristics";
     }
+
     public static string SchoolCustomDataRevert(string? urn)
     {
         return $"/school/{urn}/custom-data/revert";
     }
+
     public static string SchoolCustomDataWorkforceData(string? urn)
     {
         return $"/school/{urn}/custom-data/workforce";
     }
+
     public static string SchoolCustomDataSubmit(string? urn)
     {
         return $"/school/{urn}/custom-data/submit";
     }
+
     public static string SchoolCustomDataSubmitted(string? urn)
     {
         return $"/school/{urn}/custom-data/submitted";
     }
+
     public static string SchoolComparators(string? urn)
     {
         return $"/school/{urn}/comparators";
     }
+
     public static string SchoolComparatorsCreate(string? urn)
     {
         return $"/school/{urn}/comparators/create";
     }
+
     public static string SchoolComparatorsCreateBy(string? urn)
     {
         return $"/school/{urn}/comparators/create/by";
     }
+
     public static string SchoolComparatorsCreateByName(string? urn)
     {
         return $"/school/{urn}/comparators/create/by/name";
     }
+
     public static string SchoolComparatorsCreateByCharacteristic(string? urn)
     {
         return $"/school/{urn}/comparators/create/by/characteristic";
     }
+
     public static string SchoolComparatorsCreatePreview(string? urn)
     {
         return $"/school/{urn}/comparators/create/preview";
     }
+
     public static string SchoolComparatorsCreateSubmit(string? urn)
     {
         return $"/school/{urn}/comparators/create/submit";
     }
+
     public static string SchoolComparatorsCreateSubmitted(string? urn, bool? isEdit)
     {
         return $"/school/{urn}/comparators/create/submitted{(isEdit == true ? "?updating=true" : string.Empty)}";
     }
+
     public static string SchoolComparatorsRevert(string? urn)
     {
         return $"/school/{urn}/comparators/revert";
     }
+
     public static string SchoolSearchResults(string? term = null, string? sort = null, string[]? phases = null, int? page = null)
     {
         var queryString = new QueryString();
@@ -305,6 +369,7 @@ public static class Paths
 
         return $"/school/search{queryString.ToUriComponent()}";
     }
+
     public static string TrustSearchResults(string? term = null, string? sort = null, int? page = null)
     {
         var queryString = new QueryString();
@@ -325,6 +390,7 @@ public static class Paths
 
         return $"/trust/search{queryString.ToUriComponent()}";
     }
+
     public static string LocalAuthoritySearchResults(string? term = null, string? sort = null, int? page = null)
     {
         var queryString = new QueryString();
@@ -350,34 +416,42 @@ public static class Paths
     {
         return $"/trust/{companyNumber}/comparators";
     }
+
     public static string TrustComparatorsCreateBy(string? companyNumber)
     {
         return $"/trust/{companyNumber}/comparators/create/by";
     }
+
     public static string TrustComparatorsCreateByName(string? companyNumber)
     {
         return $"/trust/{companyNumber}/comparators/create/by/name";
     }
+
     public static string TrustComparatorsCreateByCharacteristic(string? companyNumber)
     {
         return $"/trust/{companyNumber}/comparators/create/by/characteristic";
     }
+
     public static string TrustComparatorsCreatePreview(string? companyNumber)
     {
         return $"/trust/{companyNumber}/comparators/create/preview";
     }
+
     public static string TrustComparatorsCreateSubmit(string? companyNumber)
     {
         return $"/trust/{companyNumber}/comparators/create/submit";
     }
+
     public static string TrustComparatorsCreateSubmitted(string? companyNumber, bool? isEdit)
     {
         return $"/trust/{companyNumber}/comparators/create/submitted{(isEdit == true ? "?updating=true" : string.Empty)}";
     }
+
     public static string TrustComparatorsRevert(string? companyNumber)
     {
         return $"/trust/{companyNumber}/comparators/revert";
     }
+
     public static string TrustUserDefined(string? companyNumber, string? identifier)
     {
         return $"/trust/{companyNumber}/user-defined/{identifier}";
@@ -387,62 +461,77 @@ public static class Paths
     {
         return $"api/suggest?search={search}&type={type}";
     }
+
     public static string ApiExpenditure(string? type, string? id, string category, string dimension)
     {
         return $"api/expenditure?type={type}&id={id}&category={category}&dimension={dimension}";
     }
+
     public static string ApiExpenditureHistoryComparison(string? type, string? id, string dimension, string? phase, string? financeType)
     {
         return $"api/expenditure/history/comparison?type={type}&id={id}&dimension={dimension}&phase={phase}&financeType={financeType}";
     }
+
     public static string ApiExpenditureUserDefined(string? type, string? id, string dimension, string? category)
     {
         return $"api/expenditure/user-defined?type={type}&id={id}&dimension={dimension}&category={category}";
     }
+
     public static string ApiCensus(string id, string type, string category, string dimension)
     {
         return $"api/census?id={id}&type={type}&category={category}&dimension={dimension}";
     }
+
     public static string ApiCensusHistoryComparison(string id, string dimension, string? phase, string? financeType)
     {
         return $"api/census/history/comparison?id={id}&dimension={dimension}&phase={phase}&financeType={financeType}";
     }
+
     public static string ApiNationalRank(string ranking, string? sort)
     {
         return $"api/local-authorities/national-rank?ranking={ranking}&sort={sort}";
     }
+
     public static string ApiHighNeedsComparison(string code, string[] set)
     {
         return $"api/local-authorities/high-needs/comparison?code={code}&set={string.Join("&set=", set)}";
     }
+
     public static string ApiHighNeedsHistory(string code)
     {
         return $"api/local-authorities/high-needs/history?code={code}";
     }
+
     public static string ApiEducationHealthCarePlansComparison(string code, string[] set)
     {
         return $"api/local-authorities/education-health-care-plans/comparison?code={code}&set={string.Join("&set=", set)}";
     }
+
     public static string ApiEducationHealthCarePlansHistory(string code)
     {
         return $"api/local-authorities/education-health-care-plans/history?code={code}";
     }
+
     public static string LocalAuthorityHome(string? code)
     {
         return $"/local-authority/{code}";
     }
+
     public static string LocalAuthorityResources(string? code)
     {
         return $"/local-authority/{code}/find-ways-to-spend-less";
     }
+
     public static string LocalAuthorityHighNeedsDashboard(string? code)
     {
         return $"/local-authority/{code}/high-needs";
     }
+
     public static string LocalAuthorityHighNeedsBenchmarking(string? code)
     {
         return $"/local-authority/{code}/high-needs/benchmarking";
     }
+
     public static string LocalAuthorityHighNeedsStartBenchmarking(string? code, string? referrer = null)
     {
         var suffix = string.Empty;
@@ -453,18 +542,27 @@ public static class Paths
 
         return $"/local-authority/{code}/high-needs/benchmarking/comparators{suffix}";
     }
+
     public static string LocalAuthorityHighNeedsNationalRankings(string? code)
     {
         return $"/local-authority/{code}/high-needs/national-rank";
     }
+
     public static string LocalAuthorityHighNeedsHistoricData(string? code)
     {
         return $"/local-authority/{code}/high-needs/history";
     }
+
     public static string SchoolResources(string? urn)
     {
         return $"/school/{urn}/find-ways-to-spend-less";
     }
+
+    public static string News(string? slug)
+    {
+        return $"/news/{slug}";
+    }
+
     public static string ToAbsolute(this string path)
     {
         return $"https://localhost{path}";

--- a/web/tests/Web.Tests/Infrastructure/GivenANewsApi.cs
+++ b/web/tests/Web.Tests/Infrastructure/GivenANewsApi.cs
@@ -1,0 +1,26 @@
+using Web.App.Infrastructure.Apis.Content;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Web.Tests.Infrastructure;
+
+public class GivenANewsApi(ITestOutputHelper testOutputHelper) : ApiClientTestBase(testOutputHelper)
+{
+    [Fact]
+    public void SetsFunctionKeyIfProvided()
+    {
+        _ = new NewsApi(HttpClient, "my-key");
+        Assert.Equal("my-key", HttpClient.DefaultRequestHeaders.GetValues("x-functions-key").First());
+    }
+
+    [Fact]
+    public async Task GetNewsArticleShouldCallCorrectUrl()
+    {
+        var api = new NewsApi(HttpClient);
+        const string slug = nameof(slug);
+
+        await api.GetNewsArticle(slug);
+
+        VerifyCall(HttpMethod.Get, $"api/news/{slug}");
+    }
+}

--- a/web/tests/Web.Tests/Middleware/WhenGdsMarkdownExtensionIsProcessed.cs
+++ b/web/tests/Web.Tests/Middleware/WhenGdsMarkdownExtensionIsProcessed.cs
@@ -18,6 +18,17 @@ public class WhenGdsMarkdownExtensionIsProcessed
         _pipeline = pipeline.Build();
     }
 
+    [Theory]
+    [InlineData("# Heading 1", "<h1 class=\"govuk-heading-l\">Heading 1</h1>\n")]
+    [InlineData("## Heading 2", "<h2 class=\"govuk-heading-m\">Heading 2</h2>\n")]
+    [InlineData("### Heading 3", "<h3 class=\"govuk-heading-s\">Heading 3</h3>\n")]
+    public void ShouldRenderGdsHeading(string markdown, string expected)
+    {
+        var actual = Markdown.ToHtml(markdown, _pipeline);
+
+        Assert.Equal(expected, actual);
+    }
+
     [Fact]
     public void ShouldRenderGdsLink()
     {
@@ -27,13 +38,14 @@ public class WhenGdsMarkdownExtensionIsProcessed
         Assert.Equal("<p class=\"govuk-body\"><a href=\"https://example.com\" class=\"govuk-link\">Example link</a></p>\n", actual);
     }
 
-    [Fact]
-    public void ShouldRenderGdsList()
+    [Theory]
+    [InlineData("* Example item 1\n* Example item 2", "<ul class=\"govuk-list govuk-list--bullet\">\n<li>Example item 1</li>\n<li>Example item 2</li>\n</ul>\n")]
+    [InlineData("1. Example item 1\n1. Example item 2", "<ol class=\"govuk-list govuk-list--number\">\n<li>Example item 1</li>\n<li>Example item 2</li>\n</ol>\n")]
+    public void ShouldRenderGdsList(string markdown, string expected)
     {
-        const string markdown = "* Example item 1\n* Example item 2";
         var actual = Markdown.ToHtml(markdown, _pipeline);
 
-        Assert.Equal("<ul class=\"govuk-list govuk-list--bullet\">\n<li>Example item 1</li>\n<li>Example item 2</li>\n</ul>\n", actual);
+        Assert.Equal(expected, actual);
     }
 
     [Theory]
@@ -53,6 +65,8 @@ public class WhenGdsMarkdownExtensionIsProcessed
         const string markdown = "| Item | Value |\n| --- | --- |\n| 001 | 123 |\n| 002 | 456 |";
         var actual = Markdown.ToHtml(markdown, _pipeline);
 
-        Assert.Equal("<table class=\"govuk-table\">\n<thead>\n<tr class=\"govuk-table__row\">\n<th class=\"govuk-table__cell\">Item</th>\n<th class=\"govuk-table__cell\">Value</th>\n</tr>\n</thead>\n<tbody>\n<tr class=\"govuk-table__row\">\n<td class=\"govuk-table__cell\">001</td>\n<td class=\"govuk-table__cell\">123</td>\n</tr>\n<tr class=\"govuk-table__row\">\n<td class=\"govuk-table__cell\">002</td>\n<td class=\"govuk-table__cell\">456</td>\n</tr>\n</tbody>\n</table>\n", actual);
+        Assert.Equal(
+            "<table class=\"govuk-table\">\n<thead>\n<tr class=\"govuk-table__row\">\n<th class=\"govuk-table__cell\">Item</th>\n<th class=\"govuk-table__cell\">Value</th>\n</tr>\n</thead>\n<tbody>\n<tr class=\"govuk-table__row\">\n<td class=\"govuk-table__cell\">001</td>\n<td class=\"govuk-table__cell\">123</td>\n</tr>\n<tr class=\"govuk-table__row\">\n<td class=\"govuk-table__cell\">002</td>\n<td class=\"govuk-table__cell\">456</td>\n</tr>\n</tbody>\n</table>\n",
+            actual);
     }
 }


### PR DESCRIPTION
## 🧾 Summary

[AB#264127](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/264127) [AB#277309](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/277309) [AB#277316](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/277316) #2781 #2782

- Added Heading support to GDS markdown middleware
- View news article by rendering Body as markdown if API lookup using `slug` in route is successful
- View error/not found page according to unsuccessful API response type
- Integration and unit test coverage

Dependency on #2781 and #2782

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Unit and integration tests updated _(if applicable)_.
- [x] All unit/integration tests are executed and passed.
- [x] Tested by running locally.

</details>
<details>
<summary>Documentation updates</summary>


- [ ] Code-level documentation (e.g., inline comments, docstrings) is updated.
- [ ] README.md or relevant module-level docs are updated.
- [ ] API changes are reflected in API documentation _(if applicable)_.
- [ ] Links to external references are included instead of duplicating content.
- [ ] No outdated or incorrect documentation remains.

</details>
<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [ ] Screenshots or Demo _(if applicable)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] Design (UX and/or content) review _(if applicable)_.
- [ ] Documentation changes have been explicitly reviewed.
- [ ] CI/CD pipeline checks pass.

</details>

## 🔍 Reviewer notes

There is intentionally no validation on route-resolved `slug` at this stage. At some future point the user will be restricted to use a slug that matches the regex `[a-z\-]+`, or this would be derived from the `Title` automatically.

## 🧪 Testing notes

Ensure previously committed test data is seeded to the `News` table, or else define own test data in order to browse to e.g. `https://localhost:7095/news/the-slug`.