### PR TITLE
Ensured currency formatted with SI units in charts display a single decimal place

### DIFF
--- a/front-end-components/src/components/charts/utils.test.ts
+++ b/front-end-components/src/components/charts/utils.test.ts
@@ -111,8 +111,10 @@ describe("Chart utils", () => {
         { input: 0.27, expected: "£0" },
         { input: 0.9, expected: "£1" },
         { input: 55.3, expected: "£55" },
-        { input: 12345.67, expected: "£12k" },
-        { input: 890123456, expected: "£890m" },
+        { input: 12345.67, expected: "£12.3k" },
+        { input: 890123456, expected: "£890.1m" },
+        { input: 8507, expected: "£8.5k" },
+        { input: 1001111, expected: "£1m" },
         { input: "not-a-number", expected: "not-a-number" },
       ];
 
@@ -205,8 +207,10 @@ describe("Chart utils", () => {
         { input: 0, expected: "£0" },
         { input: 1, expected: "£1" },
         { input: 2.3456789, expected: "£2" },
-        { input: 12345.67, expected: "£12k" },
-        { input: 890123456, expected: "£890m" },
+        { input: 12345.67, expected: "£12.3k" },
+        { input: 890123456, expected: "£890.1m" },
+        { input: 8507, expected: "£8.5k" },
+        { input: 1001111, expected: "£1m" },
         { input: "not-a-number", expected: "not-a-number" },
       ];
 

--- a/front-end-components/src/components/charts/utils.ts
+++ b/front-end-components/src/components/charts/utils.ts
@@ -41,7 +41,9 @@ export function shortValueFormatter(
     currency: options?.valueUnit === "currency" ? "GBP" : undefined,
     maximumFractionDigits:
       options?.valueUnit === "currency"
-        ? 0
+        ? value > 1000
+          ? 1
+          : 0
         : options?.valueUnit === "%"
           ? 1
           : 2,
@@ -75,7 +77,9 @@ export function statValueFormatter(
         ? 1
         : options?.compact
           ? options?.valueUnit === "currency"
-            ? 0
+            ? value > 1000
+              ? 1
+              : 0
             : undefined
           : 0,
     minimumFractionDigits:


### PR DESCRIPTION
## 🧾 Summary

[AB#276748](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/276748) [AB#277652](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/277652)

- `stat` and `short` value formatters updated to display single decimal place if currency value is > 1000 (due to regression)
  - ...or no decimal places if `.0`, as per current production implementation

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Unit and integration tests updated _(if applicable)_.
- [x] All unit/integration tests are executed and passed.
- [x] Tested by running locally.

</details>
<details>
<summary>Documentation updates</summary>


- [ ] Code-level documentation (e.g., inline comments, docstrings) is updated.
- [ ] README.md or relevant module-level docs are updated.
- [ ] API changes are reflected in API documentation _(if applicable)_.
- [ ] Links to external references are included instead of duplicating content.
- [ ] No outdated or incorrect documentation remains.

</details>
<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [ ] Screenshots or Demo _(if applicable)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] Design (UX and/or content) review _(if applicable)_.
- [ ] Documentation changes have been explicitly reviewed.
- [ ] CI/CD pipeline checks pass.

</details>

## 🔍 Reviewer notes

`front-end` will be bumped in follow-up PR

## 🧪 Testing notes

This will require a bump of `front-end` in `Web` to validate end-to-end.
