### PR TITLE
Reverted earlier attempts to resolve currency formatting and re-implemented fix

### DIFF
--- a/front-end-components/src/components/charts/utils.test.ts
+++ b/front-end-components/src/components/charts/utils.test.ts
@@ -111,10 +111,12 @@ describe("Chart utils", () => {
         { input: 0.27, expected: "£0" },
         { input: 0.9, expected: "£1" },
         { input: 55.3, expected: "£55" },
-        { input: 12345.67, expected: "£12.3k" },
-        { input: 890123456, expected: "£890.1m" },
+        { input: 12345.67, expected: "£12k" },
+        { input: 890123456, expected: "£890m" },
+        { input: 89123456, expected: "£89m" },
         { input: 8507, expected: "£8.5k" },
         { input: 1001111, expected: "£1m" },
+        { input: 350220, expected: "£350k" },
         { input: "not-a-number", expected: "not-a-number" },
       ];
 
@@ -203,14 +205,20 @@ describe("Chart utils", () => {
 
     describe("with compact currency option", () => {
       const theories: { input: ValueFormatterValue; expected: string }[] = [
+        { input: 987.65, expected: "£988" },
         { input: -987.65, expected: "-£988" },
         { input: 0, expected: "£0" },
         { input: 1, expected: "£1" },
         { input: 2.3456789, expected: "£2" },
-        { input: 12345.67, expected: "£12.3k" },
-        { input: 890123456, expected: "£890.1m" },
+        { input: 0.27, expected: "£0" },
+        { input: 0.9, expected: "£1" },
+        { input: 55.3, expected: "£55" },
+        { input: 12345.67, expected: "£12k" },
+        { input: 890123456, expected: "£890m" },
+        { input: 89123456, expected: "£89m" },
         { input: 8507, expected: "£8.5k" },
         { input: 1001111, expected: "£1m" },
+        { input: 350220, expected: "£350k" },
         { input: "not-a-number", expected: "not-a-number" },
       ];
 

--- a/front-end-components/src/components/charts/utils.ts
+++ b/front-end-components/src/components/charts/utils.ts
@@ -41,13 +41,16 @@ export function shortValueFormatter(
     currency: options?.valueUnit === "currency" ? "GBP" : undefined,
     maximumFractionDigits:
       options?.valueUnit === "currency"
-        ? value > 1000
-          ? 1
-          : 0
+        ? value % 1 && Math.abs(value) < 1000 // decimal less than 1000 and greater than -1000
+          ? 0
+          : undefined
         : options?.valueUnit === "%"
           ? 1
           : 2,
-    minimumFractionDigits: 0,
+    minimumFractionDigits:
+      options?.valueUnit === "currency" && value % 1 && Math.abs(value) < 1000
+        ? 0
+        : undefined,
   })
     .format(options?.valueUnit === "%" ? value / 100 : value)
     .toLowerCase();
@@ -76,14 +79,16 @@ export function statValueFormatter(
       options?.valueUnit === "%"
         ? 1
         : options?.compact
-          ? options?.valueUnit === "currency"
-            ? value > 1000
-              ? 1
-              : 0
+          ? options?.valueUnit === "currency" && Math.abs(value) < 1000
+            ? 0
             : undefined
           : 0,
     minimumFractionDigits:
-      options?.compact && options?.valueUnit === "currency" ? 0 : undefined,
+      options?.compact &&
+      options?.valueUnit === "currency" &&
+      Math.abs(value) < 1000
+        ? 0
+        : undefined,
   })
     .format(options?.valueUnit === "%" ? value / 100 : value)
     .toLowerCase();


### PR DESCRIPTION
## 🧾 Summary

[AB#276748](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/276748) [AB#277652](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/277652) 

- Earlier changes to attempt to resolve reverted
- `stat` and `short` value formatters updated to display zero decimal places if currency value is < 1000
- Updated unit tests

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Unit and integration tests updated _(if applicable)_.
- [x] All unit/integration tests are executed and passed.
- [x] Tested by running locally.

</details>
<details>
<summary>Documentation updates</summary>


- [ ] Code-level documentation (e.g., inline comments, docstrings) is updated.
- [ ] README.md or relevant module-level docs are updated.
- [ ] API changes are reflected in API documentation _(if applicable)_.
- [ ] Links to external references are included instead of duplicating content.
- [ ] No outdated or incorrect documentation remains.

</details>
<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [ ] Screenshots or Demo _(if applicable)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] Design (UX and/or content) review _(if applicable)_.
- [ ] Documentation changes have been explicitly reviewed.
- [ ] CI/CD pipeline checks pass.

</details>

## 🔍 Reviewer notes

`front-end` will be bumped in follow-up PR

## 🧪 Testing notes

This will require a bump of `front-end` in `Web` to validate end-to-end.
