### PR TITLE
Added 'News' link to site footer based off feature flag setting

### DIFF
--- a/web/src/Web.App/Views/Shared/_Layout.cshtml
+++ b/web/src/Web.App/Views/Shared/_Layout.cshtml
@@ -128,6 +128,13 @@
                             Contact
                         </a>
                     </li>
+                    <feature name="@FeatureFlags.News">
+                        <li class="govuk-footer__inline-list-item">
+                            <a class="govuk-footer__link" href="@Url.Action("Index", "News")">
+                                News
+                            </a>
+                        </li>
+                    </feature>
                 </ul>
                 <svg
                     aria-hidden="true"

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -560,7 +560,7 @@ public static class Paths
 
     public static string News(string? slug = null)
     {
-        return $"/news/{slug}";
+        return $"/news/{slug}".TrimEnd('/');
     }
 
     public static string ToAbsolute(this string path)


### PR DESCRIPTION
## 🧾 Summary

[AB#265001](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/265001) [AB#277315](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/277315) [AB#277316](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/277316) #2851

- Added footer link only if feature flag is enabled
- Integration test coverage

<img width="1016" height="256" alt="image" src="https://github.com/user-attachments/assets/61326b81-3265-4c1a-8ef0-a3d1fa52d593" />

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Unit and integration tests updated _(if applicable)_.
- [x] All unit/integration tests are executed and passed.
- [x] Tested by running locally.

</details>
<details>
<summary>Documentation updates</summary>


- [ ] Code-level documentation (e.g., inline comments, docstrings) is updated.
- [ ] README.md or relevant module-level docs are updated.
- [ ] API changes are reflected in API documentation _(if applicable)_.
- [ ] Links to external references are included instead of duplicating content.
- [ ] No outdated or incorrect documentation remains.

</details>
<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [x] Screenshots or Demo _(if applicable)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] Design (UX and/or content) review _(if applicable)_.
- [ ] Documentation changes have been explicitly reviewed.
- [ ] CI/CD pipeline checks pass.

</details>

## 🔍 Reviewer notes

Dependency on #2851

