### PR TITLE
Track event telemetry after user successfully logs in via DSI

### DIFF
--- a/web/src/Web.App/Constants/TrackedEvents.cs
+++ b/web/src/Web.App/Constants/TrackedEvents.cs
@@ -1,0 +1,10 @@
+using Web.App.Attributes;
+namespace Web.App;
+
+public enum TrackedEvents
+{
+    [StringValue("user-sign-in-initiated")]
+    UserSignInInitiated,
+    [StringValue("user-sign-in-success")]
+    UserSignInSuccess
+}

--- a/web/src/Web.App/Extensions/ServiceCollectionExtensions.cs
+++ b/web/src/Web.App/Extensions/ServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 using System.Security.Claims;
 using FluentValidation;
 using IdentityModel.Client;
-using Microsoft.ApplicationInsights;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -21,6 +20,7 @@ using Web.App.Infrastructure.Apis.LocalAuthorities;
 using Web.App.Infrastructure.Apis.NonFinancial;
 using Web.App.Infrastructure.Storage;
 using Web.App.Services;
+using Web.App.Telemetry;
 using Web.App.Validators;
 
 namespace Web.App.Extensions;
@@ -299,9 +299,9 @@ public static class ServiceCollectionExtensions
                     },
                     OnTokenValidated = async context =>
                     {
-                        var telemetry = context.HttpContext.RequestServices.GetRequiredService<TelemetryClient>();
+                        var telemetry = context.HttpContext.RequestServices.GetRequiredService<ITelemetryClientWrapper>();
                         telemetry.TrackUserSignedInEvent(context);
-                        
+
                         try
                         {
                             var organisation = context.Principal?.Organisation();

--- a/web/src/Web.App/Extensions/ServiceCollectionExtensions.cs
+++ b/web/src/Web.App/Extensions/ServiceCollectionExtensions.cs
@@ -300,11 +300,12 @@ public static class ServiceCollectionExtensions
                     OnTokenValidated = async context =>
                     {
                         var telemetry = context.HttpContext.RequestServices.GetRequiredService<ITelemetryClientWrapper>();
-                        telemetry.TrackUserSignedInEvent(context);
 
                         try
                         {
                             var organisation = context.Principal?.Organisation();
+                            telemetry.TrackUserSignedInEvent(context, organisation);
+
                             var service = context.HttpContext.RequestServices.GetRequiredService<IClaimsIdentifierService>();
                             var (schools, trusts) = await service.IdentifyValidClaims(organisation);
 

--- a/web/src/Web.App/Extensions/ServiceCollectionExtensions.cs
+++ b/web/src/Web.App/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using FluentValidation;
 using IdentityModel.Client;
+using Microsoft.ApplicationInsights;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -298,6 +299,9 @@ public static class ServiceCollectionExtensions
                     },
                     OnTokenValidated = async context =>
                     {
+                        var telemetry = context.HttpContext.RequestServices.GetRequiredService<TelemetryClient>();
+                        telemetry.TrackUserSignedInEvent(context);
+                        
                         try
                         {
                             var organisation = context.Principal?.Organisation();

--- a/web/src/Web.App/Extensions/TelemetryClientExtensions.cs
+++ b/web/src/Web.App/Extensions/TelemetryClientExtensions.cs
@@ -1,43 +1,51 @@
 using System.Security.Claims;
-using Microsoft.ApplicationInsights;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Web.App.Identity.Models;
 using Web.App.Telemetry;
 
 namespace Web.App.Extensions;
 
 public static class TelemetryClientExtensions
 {
-    private static readonly string[] SensitiveClaims = [ClaimTypes.Email, ClaimTypes.GivenName, ClaimTypes.Surname, "sid", "nonce", "at_hash"];
-
-    public static void TrackUserSignedInEvent(this ITelemetryClientWrapper telemetry, TokenValidatedContext context)
+    public static void TrackUserSignedInEvent(this ITelemetryClientWrapper telemetry, TokenValidatedContext context, Organisation? organisation)
     {
         var user = string.Empty;
-        var claims = Array.Empty<string>();
         if (context.Principal?.Claims != null)
         {
             user = context.Principal.Claims
                 .Where(c => c.Type == ClaimTypes.NameIdentifier)
                 .Select(c => c.Value)
                 .SingleOrDefault() ?? string.Empty;
-
-            claims = context.Principal.Claims
-                .Select(c =>
-                {
-                    var value = c.Value;
-                    if (SensitiveClaims.Contains(c.Type))
-                    {
-                        value = new string('*', c.Value.Length);
-                    }
-
-                    return $"{c.Type}: {value}";
-                })
-                .ToArray();
         }
 
-        telemetry.TrackEvent(TrackedEvents.UserSignInSuccess.GetStringValue(), new Dictionary<string, string>
+        var organisationType = organisation?.Category?.Id switch
+        {
+            OrganisationCategories.SingleAcademyTrust or OrganisationCategories.MultiAcademyTrust => TrackedRequestEstablishmentType.Trust,
+            OrganisationCategories.LocalAuthority => TrackedRequestEstablishmentType.LocalAuthority,
+            null => (TrackedRequestEstablishmentType?)null,
+            _ => TrackedRequestEstablishmentType.School
+        };
+
+        var properties = new Dictionary<string, string>
         {
             { "User", user },
-            { "Claims", string.Join(Environment.NewLine, claims) }
-        });
+            { "Organisation Type", organisationType?.GetStringValue() ?? string.Empty }
+        };
+
+        // ReSharper disable once SwitchStatementHandlesSomeKnownEnumValuesWithDefault
+        switch (organisationType)
+        {
+            case TrackedRequestEstablishmentType.Trust:
+                properties[nameof(TrackedRequestRouteParameters.CompanyNumber)] = organisation?.CompanyRegistrationNumber?.ToString("00000000") ?? string.Empty;
+                break;
+            case TrackedRequestEstablishmentType.LocalAuthority:
+                properties[nameof(TrackedRequestRouteParameters.Code)] = organisation?.EstablishmentNumber?.ToString("000") ?? string.Empty;
+                break;
+            case TrackedRequestEstablishmentType.School:
+                properties[nameof(TrackedRequestRouteParameters.Urn)] = organisation?.URN?.ToString("000000") ?? string.Empty;
+                break;
+        }
+
+        telemetry.TrackEvent(TrackedEvents.UserSignInSuccess.GetStringValue(), properties);
     }
 }

--- a/web/src/Web.App/Extensions/TelemetryClientExtensions.cs
+++ b/web/src/Web.App/Extensions/TelemetryClientExtensions.cs
@@ -1,14 +1,15 @@
 using System.Security.Claims;
 using Microsoft.ApplicationInsights;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Web.App.Telemetry;
 
 namespace Web.App.Extensions;
 
 public static class TelemetryClientExtensions
 {
     private static readonly string[] SensitiveClaims = [ClaimTypes.Email, ClaimTypes.GivenName, ClaimTypes.Surname, "sid", "nonce", "at_hash"];
-    
-    public static void TrackUserSignedInEvent(this TelemetryClient telemetry, TokenValidatedContext context)
+
+    public static void TrackUserSignedInEvent(this ITelemetryClientWrapper telemetry, TokenValidatedContext context)
     {
         var user = string.Empty;
         var claims = Array.Empty<string>();
@@ -18,7 +19,7 @@ public static class TelemetryClientExtensions
                 .Where(c => c.Type == ClaimTypes.NameIdentifier)
                 .Select(c => c.Value)
                 .SingleOrDefault() ?? string.Empty;
-            
+
             claims = context.Principal.Claims
                 .Select(c =>
                 {
@@ -27,12 +28,12 @@ public static class TelemetryClientExtensions
                     {
                         value = new string('*', c.Value.Length);
                     }
-                    
+
                     return $"{c.Type}: {value}";
                 })
                 .ToArray();
         }
-        
+
         telemetry.TrackEvent(TrackedEvents.UserSignInSuccess.GetStringValue(), new Dictionary<string, string>
         {
             { "User", user },

--- a/web/src/Web.App/Extensions/TelemetryClientExtensions.cs
+++ b/web/src/Web.App/Extensions/TelemetryClientExtensions.cs
@@ -1,0 +1,42 @@
+using System.Security.Claims;
+using Microsoft.ApplicationInsights;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+
+namespace Web.App.Extensions;
+
+public static class TelemetryClientExtensions
+{
+    private static readonly string[] SensitiveClaims = [ClaimTypes.Email, ClaimTypes.GivenName, ClaimTypes.Surname, "sid", "nonce", "at_hash"];
+    
+    public static void TrackUserSignedInEvent(this TelemetryClient telemetry, TokenValidatedContext context)
+    {
+        var user = string.Empty;
+        var claims = Array.Empty<string>();
+        if (context.Principal?.Claims != null)
+        {
+            user = context.Principal.Claims
+                .Where(c => c.Type == ClaimTypes.NameIdentifier)
+                .Select(c => c.Value)
+                .SingleOrDefault() ?? string.Empty;
+            
+            claims = context.Principal.Claims
+                .Select(c =>
+                {
+                    var value = c.Value;
+                    if (SensitiveClaims.Contains(c.Type))
+                    {
+                        value = new string('*', c.Value.Length);
+                    }
+                    
+                    return $"{c.Type}: {value}";
+                })
+                .ToArray();
+        }
+        
+        telemetry.TrackEvent(TrackedEvents.UserSignInSuccess.GetStringValue(), new Dictionary<string, string>
+        {
+            { "User", user },
+            { "Claims", string.Join(Environment.NewLine, claims) }
+        });
+    }
+}

--- a/web/src/Web.App/Program.cs
+++ b/web/src/Web.App/Program.cs
@@ -37,6 +37,7 @@ builder.Services
     .AddApplicationInsightsTelemetry()
     .AddHttpContextAccessor()
     .AddSingleton<ITelemetryInitializer, AuthenticatedUserTelemetryInitializer>()
+    .AddSingleton<ITelemetryClientWrapper, TelemetryClientWrapper>()
     .AddScoped<IFinanceService, FinanceService>()
     .AddScoped<IFinancialPlanService, FinancialPlanService>()
     .AddScoped<ISchoolComparatorSetService, SchoolComparatorSetService>()

--- a/web/src/Web.App/Telemetry/TelemetryClientWrapper.cs
+++ b/web/src/Web.App/Telemetry/TelemetryClientWrapper.cs
@@ -1,0 +1,18 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.ApplicationInsights;
+
+namespace Web.App.Telemetry;
+
+public interface ITelemetryClientWrapper
+{
+    void TrackEvent(string eventName, IDictionary<string, string>? properties = null);
+}
+
+[ExcludeFromCodeCoverage]
+public class TelemetryClientWrapper(TelemetryClient telemetryClient) : ITelemetryClientWrapper
+{
+    public void TrackEvent(string eventName, IDictionary<string, string>? properties = null)
+    {
+        telemetryClient.TrackEvent(eventName, properties);
+    }
+}

--- a/web/tests/Web.Tests/Extensions/GivenATelemetryClient.cs
+++ b/web/tests/Web.Tests/Extensions/GivenATelemetryClient.cs
@@ -1,0 +1,92 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Web.App.Identity;
+using Web.App.Telemetry;
+using Xunit;
+using TelemetryClientExtensions = Web.App.Extensions.TelemetryClientExtensions;
+
+namespace Web.Tests.Extensions;
+
+public class GivenATelemetryClient
+{
+    private readonly Mock<ITelemetryClientWrapper> _telemetry = new();
+
+    [Fact]
+    public void TracksEventWhenTrackUserSignedInEventIsCalled()
+    {
+        // arrange
+        var identity = new ClaimsIdentity();
+        identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "user-id"));
+        identity.AddClaim(new Claim(ClaimTypes.Email, nameof(ClaimTypes.Email)));
+        identity.AddClaim(new Claim(ClaimTypes.GivenName, nameof(ClaimTypes.GivenName)));
+        identity.AddClaim(new Claim(ClaimTypes.Surname, nameof(ClaimTypes.Surname)));
+        identity.AddClaim(new Claim(ClaimNames.Organisation, "{}"));
+        identity.AddClaim(new Claim("sid", "sensitive"));
+        identity.AddClaim(new Claim("nonce", "sensitive"));
+        identity.AddClaim(new Claim("at_hash", "sensitive"));
+        identity.AddClaim(new Claim("aud", "FBIT"));
+        identity.AddClaim(new Claim("exp", "0000000000"));
+        identity.AddClaim(new Claim("iat", "0000000000"));
+        identity.AddClaim(new Claim("iss", "https://pp-oidc.signin.education.gov.uk:443"));
+
+        var principal = new ClaimsPrincipal(identity);
+
+        var context = new TokenValidatedContext(
+            new DefaultHttpContext(),
+            new AuthenticationScheme(string.Empty, null, typeof(FakeAuthHandler)),
+            Mock.Of<OpenIdConnectOptions>(),
+            principal,
+            Mock.Of<AuthenticationProperties>());
+
+        var actualEventName = string.Empty;
+        IDictionary<string, string> actualProperties = new Dictionary<string, string>();
+        _telemetry
+            .Setup(t => t.TrackEvent(It.IsAny<string>(), It.IsAny<IDictionary<string, string>>()))
+            .Callback<string, IDictionary<string, string>>((eventName, properties) =>
+            {
+                actualEventName = eventName;
+                actualProperties = properties;
+            })
+            .Verifiable();
+
+        // act
+        TelemetryClientExtensions.TrackUserSignedInEvent(_telemetry.Object, context);
+
+        // assert
+        _telemetry.VerifyAll();
+        Assert.Equal("user-sign-in-success", actualEventName);
+        Assert.Equal(2, actualProperties.Keys.Count);
+        Assert.Equal("user-id", actualProperties["User"]);
+        Assert.Equal("""
+                       http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier: user-id
+                       http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress: *****
+                       http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname: *********
+                       http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname: *******
+                       organisation: {}
+                       sid: *********
+                       nonce: *********
+                       at_hash: *********
+                       aud: FBIT
+                       exp: 0000000000
+                       iat: 0000000000
+                       iss: https://pp-oidc.signin.education.gov.uk:443
+                       """, actualProperties["Claims"]);
+    }
+
+    public class FakeAuthHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            var identity = new ClaimsIdentity();
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, Scheme.Name);
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+    }
+}


### PR DESCRIPTION
## 🧾 Summary

[AB#269145](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/269145) [AB#278825](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/278825)

- After a successful DSI login, track new event in App Insights with name `user-sign-in-success` and properties that include the user's auth ID and organisation
- Unit test coverage

<img width="504" height="385" alt="image" src="https://github.com/user-attachments/assets/4718b470-0d33-4c0b-9b29-939f533a4edc" />

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Unit and integration tests updated _(if applicable)_.
- [x] All unit/integration tests are executed and passed.
- [x] Tested by running locally.

</details>
<details>
<summary>Documentation updates</summary>


- [ ] Code-level documentation (e.g., inline comments, docstrings) is updated.
- [ ] README.md or relevant module-level docs are updated.
- [ ] API changes are reflected in API documentation _(if applicable)_.
- [ ] Links to external references are included instead of duplicating content.
- [ ] No outdated or incorrect documentation remains.

</details>
<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [x] Screenshots or Demo _(if applicable)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] Design (UX and/or content) review _(if applicable)_.
- [ ] Documentation changes have been explicitly reviewed.
- [ ] CI/CD pipeline checks pass.

</details>

## 🧪 Testing notes

To test locally update `launchSettings.json` to include real AppInsights configuration and run the application. Then sign in as normal and check App Insights Custom Events after a few minutes.
