### PR TITLE
Tweak federation workforce aggregations

### DIFF
--- a/data-pipeline/src/pipeline/pre_processing/cfr/calculations.py
+++ b/data-pipeline/src/pipeline/pre_processing/cfr/calculations.py
@@ -199,18 +199,13 @@ def _federation_lead_school_agg(df: pd.DataFrame) -> pd.DataFrame:
     df["_Number of pupils SEN"] = (df["Percentage SEN"] / 100.0) * df[
         "Number of pupils"
     ]
+    df["_Teachers with QTS (Headcount)"] = (
+        (df["Teachers with Qualified Teacher Status (%) (Headcount)"] / 100.0)
+        * df["Total Number of Teachers (Headcount)"]
+    )
 
     lead_schools_agg = (
-        df[df["Lead school in federation"] != "0"][
-            [
-                "Lead school in federation",
-                "Number of pupils",
-                "_Number of pupils FSM",
-                "_Number of pupils SEN",
-                "Total Internal Floor Area",
-                "Building Age",
-            ]
-        ]
+        df[df["Lead school in federation"] != "0"]
         .rename(columns={"Lead school in federation": "Federation LAEstab"})
         .groupby(["Federation LAEstab"])
         .agg(
@@ -220,6 +215,19 @@ def _federation_lead_school_agg(df: pd.DataFrame) -> pd.DataFrame:
                 "_Number of pupils SEN": "sum",
                 "Total Internal Floor Area": "sum",
                 "Building Age": "mean",
+                "Total School Workforce (Headcount)": "sum",
+                "Total School Workforce (Full-Time Equivalent)": "sum",
+                "Total Number of Teachers (Headcount)": "sum",
+                "Total Number of Teachers (Full-Time Equivalent)": "sum",
+                "SeniorLeadershipHeadcount": "sum",
+                "SeniorLeadershipFTE": "sum",
+                "Total Number of Teaching Assistants (Headcount)": "sum",
+                "Total Number of Teaching Assistants (Full-Time Equivalent)": "sum",
+                "NonClassroomSupportStaffHeadcount": "sum",
+                "NonClassroomSupportStaffFTE": "sum",
+                "Total Number of Auxiliary Staff (Headcount)": "sum",
+                "Total Number of Auxiliary Staff (Full-Time Equivalent)": "sum",
+                "_Teachers with QTS (Headcount)": "sum",
             }
         )
     )
@@ -230,11 +238,19 @@ def _federation_lead_school_agg(df: pd.DataFrame) -> pd.DataFrame:
     lead_schools_agg["Percentage SEN"] = (
         lead_schools_agg["_Number of pupils SEN"] / lead_schools_agg["Number of pupils"]
     ) * 100.0
+    # Workforce percentages
+    if "_Teachers with QTS (Headcount)" in lead_schools_agg.columns:
+        with np.errstate(invalid="ignore", divide="ignore"):
+            lead_schools_agg["Teachers with Qualified Teacher Status (%) (Headcount)"] = (
+                lead_schools_agg["_Teachers with QTS (Headcount)"]
+                / lead_schools_agg["Total Number of Teachers (Headcount)"]
+            ) * 100.0
 
     return lead_schools_agg.drop(
         columns=[
             "_Number of pupils FSM",
             "_Number of pupils SEN",
+            "_Teachers with QTS (Headcount)",
         ]
     )
 

--- a/data-pipeline/tests/unit/pre_processing/test_maintained_schools.py
+++ b/data-pipeline/tests/unit/pre_processing/test_maintained_schools.py
@@ -235,7 +235,6 @@ def test_federation_lead_school_agg_index():
             "Lead school in federation": ["10000", "10001", "10002", "10000"],
             "Total Internal Floor Area": [1_000, 1_000, 1_000, 1_000],
             "Building Age": [1990, 1990, 1990, 2000],
-            # Workforce aggregation inputs (new requirements)
             "Total School Workforce (Headcount)": [50, 55, 60, 65],
             "Total School Workforce (Full-Time Equivalent)": [45.0, 50.0, 55.0, 60.0],
             "Total Number of Teachers (Headcount)": [10, 10, 10, 10],
@@ -267,7 +266,6 @@ def test_federation_lead_school_agg_pupils():
             "Lead school in federation": ["10000", "10001", "10002", "10000"],
             "Total Internal Floor Area": [1_000, 1_000, 1_000, 1_000],
             "Building Age": [1990, 1990, 1990, 2000],
-            # Workforce aggregation inputs (new requirements)
             "Total School Workforce (Headcount)": [50, 55, 60, 65],
             "Total School Workforce (Full-Time Equivalent)": [45.0, 50.0, 55.0, 60.0],
             "Total Number of Teachers (Headcount)": [10, 10, 10, 10],
@@ -300,7 +298,6 @@ def test_federation_lead_school_agg_fsm():
             "Lead school in federation": ["10000", "10001", "10002", "10000"],
             "Total Internal Floor Area": [1_000, 1_000, 1_000, 1_000],
             "Building Age": [1990, 1990, 1990, 2000],
-            # Workforce aggregation inputs (new requirements)
             "Total School Workforce (Headcount)": [50, 55, 60, 65],
             "Total School Workforce (Full-Time Equivalent)": [45.0, 50.0, 55.0, 60.0],
             "Total Number of Teachers (Headcount)": [10, 10, 10, 10],
@@ -333,7 +330,6 @@ def test_federation_lead_school_agg_sen():
             "Lead school in federation": ["10000", "10001", "10002", "10000"],
             "Total Internal Floor Area": [1_000, 1_000, 1_000, 1_000],
             "Building Age": [1990, 1990, 1990, 2000],
-            # Workforce aggregation inputs (new requirements)
             "Total School Workforce (Headcount)": [50, 55, 60, 65],
             "Total School Workforce (Full-Time Equivalent)": [45.0, 50.0, 55.0, 60.0],
             "Total Number of Teachers (Headcount)": [10, 10, 10, 10],
@@ -366,7 +362,6 @@ def test_federation_lead_school_agg_building_age():
             "Lead school in federation": ["10000", "10001", "10002", "10000"],
             "Total Internal Floor Area": [1_000, 1_000, 1_000, 1_000],
             "Building Age": [1990, 1990, 1990, 2000],
-            # Workforce aggregation inputs (new requirements)
             "Total School Workforce (Headcount)": [50, 55, 60, 65],
             "Total School Workforce (Full-Time Equivalent)": [45.0, 50.0, 55.0, 60.0],
             "Total Number of Teachers (Headcount)": [10, 10, 10, 10],
@@ -402,7 +397,6 @@ def test_join_federations_unmodified():
             "Lead school in federation": ["10000", "10001", "10002", "10000"],
             "Total Internal Floor Area": [1_000, 1_000, 1_000, 1_000],
             "Building Age": [1990, 1990, 1990, 2000],
-            # Workforce aggregation inputs (new requirements)
             "Total School Workforce (Headcount)": [0, 0, 0, 0],
             "Total School Workforce (Full-Time Equivalent)": [0.0, 0.0, 0.0, 0.0],
             "Total Number of Teachers (Headcount)": [10, 10, 10, 10],

--- a/data-pipeline/tests/unit/pre_processing/test_maintained_schools.py
+++ b/data-pipeline/tests/unit/pre_processing/test_maintained_schools.py
@@ -235,6 +235,20 @@ def test_federation_lead_school_agg_index():
             "Lead school in federation": ["10000", "10001", "10002", "10000"],
             "Total Internal Floor Area": [1_000, 1_000, 1_000, 1_000],
             "Building Age": [1990, 1990, 1990, 2000],
+            # Workforce aggregation inputs (new requirements)
+            "Total School Workforce (Headcount)": [50, 55, 60, 65],
+            "Total School Workforce (Full-Time Equivalent)": [45.0, 50.0, 55.0, 60.0],
+            "Total Number of Teachers (Headcount)": [10, 10, 10, 10],
+            "Total Number of Teachers (Full-Time Equivalent)": [9.0, 9.5, 9.0, 10.0],
+            "SeniorLeadershipHeadcount": [3, 2, 2, 3],
+            "SeniorLeadershipFTE": [2.5, 2.0, 2.0, 2.5],
+            "Total Number of Teaching Assistants (Headcount)": [8, 7, 6, 5],
+            "Total Number of Teaching Assistants (Full-Time Equivalent)": [6.0, 5.5, 5.0, 4.0],
+            "NonClassroomSupportStaffHeadcount": [4, 4, 3, 3],
+            "NonClassroomSupportStaffFTE": [3.5, 3.0, 2.5, 2.5],
+            "Total Number of Auxiliary Staff (Headcount)": [2, 2, 1, 1],
+            "Total Number of Auxiliary Staff (Full-Time Equivalent)": [1.5, 1.5, 1.0, 1.0],
+            "Teachers with Qualified Teacher Status (%) (Headcount)": [80.0, 80.0, 80.0, 80.0],
         }
     )
 
@@ -253,6 +267,20 @@ def test_federation_lead_school_agg_pupils():
             "Lead school in federation": ["10000", "10001", "10002", "10000"],
             "Total Internal Floor Area": [1_000, 1_000, 1_000, 1_000],
             "Building Age": [1990, 1990, 1990, 2000],
+            # Workforce aggregation inputs (new requirements)
+            "Total School Workforce (Headcount)": [50, 55, 60, 65],
+            "Total School Workforce (Full-Time Equivalent)": [45.0, 50.0, 55.0, 60.0],
+            "Total Number of Teachers (Headcount)": [10, 10, 10, 10],
+            "Total Number of Teachers (Full-Time Equivalent)": [9.0, 9.5, 9.0, 10.0],
+            "SeniorLeadershipHeadcount": [3, 2, 2, 3],
+            "SeniorLeadershipFTE": [2.5, 2.0, 2.0, 2.5],
+            "Total Number of Teaching Assistants (Headcount)": [8, 7, 6, 5],
+            "Total Number of Teaching Assistants (Full-Time Equivalent)": [6.0, 5.5, 5.0, 4.0],
+            "NonClassroomSupportStaffHeadcount": [4, 4, 3, 3],
+            "NonClassroomSupportStaffFTE": [3.5, 3.0, 2.5, 2.5],
+            "Total Number of Auxiliary Staff (Headcount)": [2, 2, 1, 1],
+            "Total Number of Auxiliary Staff (Full-Time Equivalent)": [1.5, 1.5, 1.0, 1.0],
+            "Teachers with Qualified Teacher Status (%) (Headcount)": [80.0, 80.0, 80.0, 80.0],
         }
     )
 
@@ -272,6 +300,20 @@ def test_federation_lead_school_agg_fsm():
             "Lead school in federation": ["10000", "10001", "10002", "10000"],
             "Total Internal Floor Area": [1_000, 1_000, 1_000, 1_000],
             "Building Age": [1990, 1990, 1990, 2000],
+            # Workforce aggregation inputs (new requirements)
+            "Total School Workforce (Headcount)": [50, 55, 60, 65],
+            "Total School Workforce (Full-Time Equivalent)": [45.0, 50.0, 55.0, 60.0],
+            "Total Number of Teachers (Headcount)": [10, 10, 10, 10],
+            "Total Number of Teachers (Full-Time Equivalent)": [9.0, 9.5, 9.0, 10.0],
+            "SeniorLeadershipHeadcount": [3, 2, 2, 3],
+            "SeniorLeadershipFTE": [2.5, 2.0, 2.0, 2.5],
+            "Total Number of Teaching Assistants (Headcount)": [8, 7, 6, 5],
+            "Total Number of Teaching Assistants (Full-Time Equivalent)": [6.0, 5.5, 5.0, 4.0],
+            "NonClassroomSupportStaffHeadcount": [4, 4, 3, 3],
+            "NonClassroomSupportStaffFTE": [3.5, 3.0, 2.5, 2.5],
+            "Total Number of Auxiliary Staff (Headcount)": [2, 2, 1, 1],
+            "Total Number of Auxiliary Staff (Full-Time Equivalent)": [1.5, 1.5, 1.0, 1.0],
+            "Teachers with Qualified Teacher Status (%) (Headcount)": [80.0, 80.0, 80.0, 80.0],
         }
     )
 
@@ -291,6 +333,20 @@ def test_federation_lead_school_agg_sen():
             "Lead school in federation": ["10000", "10001", "10002", "10000"],
             "Total Internal Floor Area": [1_000, 1_000, 1_000, 1_000],
             "Building Age": [1990, 1990, 1990, 2000],
+            # Workforce aggregation inputs (new requirements)
+            "Total School Workforce (Headcount)": [50, 55, 60, 65],
+            "Total School Workforce (Full-Time Equivalent)": [45.0, 50.0, 55.0, 60.0],
+            "Total Number of Teachers (Headcount)": [10, 10, 10, 10],
+            "Total Number of Teachers (Full-Time Equivalent)": [9.0, 9.5, 9.0, 10.0],
+            "SeniorLeadershipHeadcount": [3, 2, 2, 3],
+            "SeniorLeadershipFTE": [2.5, 2.0, 2.0, 2.5],
+            "Total Number of Teaching Assistants (Headcount)": [8, 7, 6, 5],
+            "Total Number of Teaching Assistants (Full-Time Equivalent)": [6.0, 5.5, 5.0, 4.0],
+            "NonClassroomSupportStaffHeadcount": [4, 4, 3, 3],
+            "NonClassroomSupportStaffFTE": [3.5, 3.0, 2.5, 2.5],
+            "Total Number of Auxiliary Staff (Headcount)": [2, 2, 1, 1],
+            "Total Number of Auxiliary Staff (Full-Time Equivalent)": [1.5, 1.5, 1.0, 1.0],
+            "Teachers with Qualified Teacher Status (%) (Headcount)": [80.0, 80.0, 80.0, 80.0],
         }
     )
 
@@ -310,6 +366,20 @@ def test_federation_lead_school_agg_building_age():
             "Lead school in federation": ["10000", "10001", "10002", "10000"],
             "Total Internal Floor Area": [1_000, 1_000, 1_000, 1_000],
             "Building Age": [1990, 1990, 1990, 2000],
+            # Workforce aggregation inputs (new requirements)
+            "Total School Workforce (Headcount)": [50, 55, 60, 65],
+            "Total School Workforce (Full-Time Equivalent)": [45.0, 50.0, 55.0, 60.0],
+            "Total Number of Teachers (Headcount)": [10, 10, 10, 10],
+            "Total Number of Teachers (Full-Time Equivalent)": [9.0, 9.5, 9.0, 10.0],
+            "SeniorLeadershipHeadcount": [3, 2, 2, 3],
+            "SeniorLeadershipFTE": [2.5, 2.0, 2.0, 2.5],
+            "Total Number of Teaching Assistants (Headcount)": [8, 7, 6, 5],
+            "Total Number of Teaching Assistants (Full-Time Equivalent)": [6.0, 5.5, 5.0, 4.0],
+            "NonClassroomSupportStaffHeadcount": [4, 4, 3, 3],
+            "NonClassroomSupportStaffFTE": [3.5, 3.0, 2.5, 2.5],
+            "Total Number of Auxiliary Staff (Headcount)": [2, 2, 1, 1],
+            "Total Number of Auxiliary Staff (Full-Time Equivalent)": [1.5, 1.5, 1.0, 1.0],
+            "Teachers with Qualified Teacher Status (%) (Headcount)": [80.0, 80.0, 80.0, 80.0],
         }
     )
 
@@ -332,6 +402,20 @@ def test_join_federations_unmodified():
             "Lead school in federation": ["10000", "10001", "10002", "10000"],
             "Total Internal Floor Area": [1_000, 1_000, 1_000, 1_000],
             "Building Age": [1990, 1990, 1990, 2000],
+            # Workforce aggregation inputs (new requirements)
+            "Total School Workforce (Headcount)": [0, 0, 0, 0],
+            "Total School Workforce (Full-Time Equivalent)": [0.0, 0.0, 0.0, 0.0],
+            "Total Number of Teachers (Headcount)": [10, 10, 10, 10],
+            "Total Number of Teachers (Full-Time Equivalent)": [10.0, 10.0, 10.0, 10.0],
+            "SeniorLeadershipHeadcount": [0, 0, 0, 0],
+            "SeniorLeadershipFTE": [0.0, 0.0, 0.0, 0.0],
+            "Total Number of Teaching Assistants (Headcount)": [0, 0, 0, 0],
+            "Total Number of Teaching Assistants (Full-Time Equivalent)": [0.0, 0.0, 0.0, 0.0],
+            "NonClassroomSupportStaffHeadcount": [0, 0, 0, 0],
+            "NonClassroomSupportStaffFTE": [0.0, 0.0, 0.0, 0.0],
+            "Total Number of Auxiliary Staff (Headcount)": [0, 0, 0, 0],
+            "Total Number of Auxiliary Staff (Full-Time Equivalent)": [0.0, 0.0, 0.0, 0.0],
+            "Teachers with Qualified Teacher Status (%) (Headcount)": [80.0, 80.0, 80.0, 80.0],
         }
     )
 


### PR DESCRIPTION
## 🧾 Summary
[AB#278246](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/278246)
Workforce aggregations for federations were previously not being done correctly - all schools in a federation should be benchmarked against the federation's aggregated workforce figures, just like how we do for pupil numbers.

## Testing notes
* Workforce benchmarking numbers for federation schools go up as expected in the NonFinancial table