### PR TITLE
feat: new alert added to trigger on any failure on nightly commercial resources check

### DIFF
--- a/documentation/features/9_Commercial-Resources.md
+++ b/documentation/features/9_Commercial-Resources.md
@@ -138,7 +138,11 @@ Resources for each category are managed using view components, view models, and 
 
 ## Updating resources
 
-From time-to-time the commercial resources will need to be updated. In order to track the history of updates, relevant SQL scripts should be persisted to the repo in the [scripts/content](../../scripts/content) folder.
+From time-to-time the commercial resources will need to be updated. An alert is set up to trigger based on a nightly check of the commercial resources to verify a `GET` returns a successful Http status code for each resource. Any failures will trigger this alert and the logs will display any resources that are unsuccessful.
+
+See `Commercial resource check failures detected alert` in the [Monitoring and Alerting runbook](https://educationgovuk.sharepoint.com/:w:/r/sites/DfEFinancialBenchmarking/Shared%20Documents/Runbooks/Monitoring%20and%20Alerting.docx?d=wecb5ba87e68f486fa6fe919d5b921214&csf=1&web=1&e=yFckI0) for more information. Note this SharePoint resource requires authentication.
+
+In order to track the history of updates, relevant SQL scripts should be persisted to the repo in the [scripts/content](../../scripts/content) folder.
 
 In the future the management of commercial resources, and other resources handled by the Content API, will be done by an administrative front-end. This supports self-service of parts of the platform via a paired-down CMS to reduce the dependency on the development team.
 

--- a/support-analytics/terraform/README.md
+++ b/support-analytics/terraform/README.md
@@ -92,6 +92,7 @@ No modules.
 | [azurerm_monitor_metric_alert.memory_alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.non_financial_api_error_alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.web_app_error_alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert_v2.commercial_resource_check_failures](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert_v2.failed-finished-pipeline-messages](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert_v2.polly-warnings-429-alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert_v2.polly-warnings-alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |

--- a/support-analytics/terraform/queries/commercial-resources-check.kql
+++ b/support-analytics/terraform/queries/commercial-resources-check.kql
@@ -1,0 +1,13 @@
+customEvents
+| where name == "commercial-resource-check"
+| where timestamp >= ago(1d)
+| where tostring(customDimensions["Success"]) == false
+| extend
+    Title = tostring(customDimensions["Title"]),
+    Url = tostring(customDimensions["Url"]),
+    StatusCode = tostring(customDimensions["StatusCode"]),
+    Success = tostring(customDimensions["Success"]),
+    RedirectLocation = tostring(customDimensions["RedirectLocation"]),
+    Exception = tostring(customDimensions["Exception"])
+| project Title, Url, StatusCode, RedirectLocation, Exception
+| sort by Title asc


### PR DESCRIPTION
## 🧾 Summary

[AB#266568](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/266568) [AB#279256](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/279256)

Adds a new alert to trigger on any failures following the nightly check on commercial resources see #2954 

The alert will trigger once daily if any failures are detected in the last 24 hours. The alert will continue to trigger daily as long as any commercial resource checks are failures.

The logs will show all failures and can be viewed quickly from the alert itself. View the alert in Azure Monitor > Query > View results in Logs

<img width="1941" height="377" alt="image" src="https://github.com/user-attachments/assets/29050d2a-4139-440d-a9a8-732c55702675" />

Also updates feature documentation for Commercial Resources and the terrform docs for support-analytics

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.

</details>
<details>
<summary>Documentation updates</summary>


- [x] README.md or relevant module-level docs are updated.
- [x] Links to external references are included instead of duplicating content.

</details>
<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] CI/CD pipeline checks pass.

</details>

## 🧪 Testing notes

This has been deployed to feature environment `d11` in addition to the changes proposed on #2954. An example of this alert in Teams under `FBIT Alerts - Development` timestamped 07:14 can be observed triggered in this environment.
