### PR TITLE
feat: create DB views for trust to trust IT spend benchmarking

### DIFF
--- a/core-infrastructure/src/db/Core.Database/Views/028-ItSpendTrust.sql
+++ b/core-infrastructure/src/db/Core.Database/Views/028-ItSpendTrust.sql
@@ -1,0 +1,47 @@
+DROP VIEW IF EXISTS VW_ItSpendTrustAllYearsActual;
+GO
+
+CREATE VIEW VW_ItSpendTrustAllYearsActual AS
+SELECT
+    Pivoted.RunId,
+    Pivoted.CompanyNumber,
+    t.TrustName,
+    Pivoted.Year,
+    Pivoted.[Administration software and systems] AS AdministrationSoftwareAndSystems,
+    Pivoted.[Connectivity],
+    Pivoted.[IT Learning resources] AS ItLearningResources,
+    Pivoted.[IT support and training] AS ItSupportAndTraining,
+    Pivoted.[Laptops, desktops and tablets] AS LaptopsDesktopsAndTablets,
+    Pivoted.[Onsite servers] AS OnsiteServers,
+    Pivoted.[Other hardware] AS OtherHardware
+FROM (
+    SELECT
+        b.RunId,
+        b.CompanyNumber,
+        b.Year,
+        b.Category,
+        b.Value
+    FROM BudgetForecastReturn b
+    INNER JOIN Parameters p
+        ON p.Name = 'LatestBFRYear'
+        AND b.RunId = p.Value
+    WHERE b.Year IN (
+        CAST(p.Value AS INT) - 1,
+        CAST(p.Value AS INT),
+        CAST(p.Value AS INT) + 1
+    )
+) AS Filtered
+PIVOT (
+    MAX(Value)
+    FOR Category IN (
+        [Administration software and systems],
+        [Connectivity],
+        [IT Learning resources],
+        [IT support and training],
+        [Laptops, desktops and tablets],
+        [Onsite servers],
+        [Other hardware]
+    )
+) AS Pivoted
+INNER JOIN Trust t
+    ON Pivoted.CompanyNumber = t.CompanyNumber;

--- a/core-infrastructure/src/db/Core.Database/Views/028-ItSpendTrust.sql
+++ b/core-infrastructure/src/db/Core.Database/Views/028-ItSpendTrust.sql
@@ -9,7 +9,7 @@ SELECT
     Pivoted.[Administration software and systems] AS AdministrationSoftwareAndSystems,
     Pivoted.[Connectivity],
     Pivoted.[IT Learning resources] AS ItLearningResources,
-    Pivoted.[IT support and training] AS ItSupportAndTraining,
+    Pivoted.[IT support and training] AS ItSupport,
     Pivoted.[Laptops, desktops and tablets] AS LaptopsDesktopsAndTablets,
     Pivoted.[Onsite servers] AS OnsiteServers,
     Pivoted.[Other hardware] AS OtherHardware
@@ -56,7 +56,7 @@ SELECT
     v.AdministrationSoftwareAndSystems,
     v.Connectivity,
     v.ItLearningResources,
-    v.ItSupportAndTraining,
+    v.ItSupport,
     v.LaptopsDesktopsAndTablets,
     v.OnsiteServers,
     v.OtherHardware

--- a/core-infrastructure/src/db/Core.Database/Views/028-ItSpendTrust.sql
+++ b/core-infrastructure/src/db/Core.Database/Views/028-ItSpendTrust.sql
@@ -1,9 +1,8 @@
-DROP VIEW IF EXISTS VW_ItSpendTrustAllYearsActual;
+DROP VIEW IF EXISTS VW_ItSpendTrustCurrentAllYearsActual;
 GO
 
-CREATE VIEW VW_ItSpendTrustAllYearsActual AS
+CREATE VIEW VW_ItSpendTrustCurrentAllYearsActual AS
 SELECT
-    Pivoted.RunId,
     Pivoted.CompanyNumber,
     t.TrustName,
     Pivoted.Year,

--- a/core-infrastructure/src/db/Core.Database/Views/028-ItSpendTrust.sql
+++ b/core-infrastructure/src/db/Core.Database/Views/028-ItSpendTrust.sql
@@ -44,3 +44,23 @@ PIVOT (
 ) AS Pivoted
 INNER JOIN Trust t
     ON Pivoted.CompanyNumber = t.CompanyNumber;
+GO
+
+DROP VIEW IF EXISTS VW_ItSpendTrustCurrentPreviousYearActual;
+GO
+
+CREATE VIEW VW_ItSpendTrustCurrentPreviousYearActual AS
+SELECT
+    v.CompanyNumber,
+    v.TrustName,
+    v.AdministrationSoftwareAndSystems,
+    v.Connectivity,
+    v.ItLearningResources,
+    v.ItSupportAndTraining,
+    v.LaptopsDesktopsAndTablets,
+    v.OnsiteServers,
+    v.OtherHardware
+FROM VW_ItSpendTrustCurrentAllYearsActual v
+         INNER JOIN Parameters p
+                    ON p.Name = 'LatestBFRYear'
+WHERE v.Year = CAST(p.Value AS INT) - 1;


### PR DESCRIPTION
## 🧾 Summary

[AB#266041](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/266041) [AB#283330](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/283330)

This PR introduces three views to support trust to trust IT spend benchmarking derived from the `BudgetForecastReturn` table.

- `VW_ItSpendTrustDefaultActual` pivots category values into columns for the IT spend values. Trust name included via a join to `Trust` table.
- `VW_ItSpendTrustCurrentAllYearsActual` filters for RunId for the `LatestBFRYear` and filters for the current, previous, and next years relative to the `LatestBFRYear`. Filtered via a join to the `Parameters` table. 
- `VW_ItSpendTrustCurrentPreviousYearActual` derived from the above view and filters specifically for the year prior to `LatestBFRYear` again using a join to `Parameters` table.

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Tested by running locally.

</details>

<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [x] CI/CD pipeline checks pass.

</details>

## 🔍 Reviewer notes

`TotalPupils` has intentionally been omitted as that value is not currently required downstream but later addition to this view and another derived view to support per-pupil dimension will be possible if required following similar patterns we have used elsewhere.

## 🧪 Testing notes

I have run the data pipeline locally for 2025 with the latest changes for ingestion of BFR IT spend values. Running these scripts against my local DB is successful and then taking a sample of trusts from these new views shows the values as expected when compared against `BudgetForecastReturn`.
