### PR TITLE
Added non-sensitive charts to Trust IT spend

### DIFF
--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -790,20 +790,25 @@ table#current-comparators-la {
       }
     }
 
-    .chart-cell {
-      &.chart-cell__series-0:hover {
-        cursor: pointer;
+    &:not(.horizontal-bar-chart__no-hover) {
+      .chart-cell {
+        &.chart-cell__series-0:hover {
+          cursor: pointer;
 
-        &:not(.chart-cell__highlight,
-        .chart-cell__group-part-year,
-        .chart-cell__group-previous,
-        .chart-cell__group-current,
-        .chart-cell__group-forecast) {
-          fill: govuk-colour("dark-grey");
-          stroke: govuk-colour("dark-grey");
+          &:not(
+            .chart-cell__highlight,
+            .chart-cell__group-part-year,
+            .chart-cell__group-previous,
+            .chart-cell__group-current,
+            .chart-cell__group-forecast) {
+            fill: govuk-colour("dark-grey");
+            stroke: govuk-colour("dark-grey");
+          }
         }
       }
+    }
 
+    .chart-cell {
       &.chart-cell__group-previous {
         fill: $chart-bar-group-1-colour;
         stroke: $chart-bar-group-1-colour;

--- a/web/src/Web.App/Domain/Charts/TrustComparisonItSpendHorizontalBarChartRequest.cs
+++ b/web/src/Web.App/Domain/Charts/TrustComparisonItSpendHorizontalBarChartRequest.cs
@@ -1,6 +1,37 @@
+using Web.App.Infrastructure.Apis;
+
 // ReSharper disable ClassNeverInstantiated.Global
 
 namespace Web.App.Domain.Charts;
+
+public record TrustComparisonItSpendHorizontalBarChartRequest : PostHorizontalBarChartRequest<TrustComparisonDatum>
+{
+    public TrustComparisonItSpendHorizontalBarChartRequest(
+        string uuid,
+        string companyNumber,
+        TrustComparisonDatum[] filteredData,
+        Func<string, string?> linkFormatter,
+        Dimensions.ResultAsOptions resultsAs)
+    {
+        BarHeight = 24;
+        Data = filteredData;
+        HighlightKey = companyNumber;
+        Id = uuid;
+        KeyField = nameof(companyNumber);
+        LabelField = "trustName";
+        LabelFormat = "%2$s";
+        LinkFormat = linkFormatter("%1$s");
+        MissingDataLabel = "No data submitted";
+        MissingDataLabelWidth = 115;
+        PaddingInner = 0.6m;
+        PaddingOuter = 0.2m;
+        Sort = "desc";
+        Width = 610;
+        ValueField = nameof(TrustComparisonDatum.Expenditure).ToLower();
+        ValueType = resultsAs.GetValueType();
+        XAxisLabel = resultsAs.GetXAxisLabel();
+    }
+}
 
 public class TrustComparisonDatum
 {

--- a/web/src/Web.App/Infrastructure/Apis/ApiRequests/PostHorizontalBarChartRequest.cs
+++ b/web/src/Web.App/Infrastructure/Apis/ApiRequests/PostHorizontalBarChartRequest.cs
@@ -1,6 +1,7 @@
 ﻿// ReSharper disable ClassNeverInstantiated.Global
 // ReSharper disable UnusedAutoPropertyAccessor.Global
 // ReSharper disable UnusedMember.Global
+// ReSharper disable PropertyCanBeMadeInitOnly.Global
 
 namespace Web.App.Infrastructure.Apis;
 
@@ -10,6 +11,10 @@ public record PostHorizontalBarChartRequest<T> : ChartRequest<T>
     public string? LabelField { get; set; }
     public string? LabelFormat { get; set; }
     public string? LinkFormat { get; set; }
+    public string? MissingDataLabel { get; set; }
+    public int? MissingDataLabelWidth { get; set; }
+    public decimal? PaddingInner { get; set; }
+    public decimal? PaddingOuter { get; set; }
     public string? ValueType { get; set; }
     public string? XAxisLabel { get; set; }
 }

--- a/web/src/Web.App/ViewModels/TrustComparisonItSpendViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustComparisonItSpendViewModel.cs
@@ -27,3 +27,11 @@ public class TrustComparisonItSpendViewModel(
     public Dimensions.ResultAsOptions ResultAs { get; init; } = Dimensions.ResultAsOptions.Actuals;
     public ItSpendingCategories.SubCategoryFilter[] SelectedSubCategories { get; init; } = [];
 }
+
+public class TrustComparisonItSpendChartViewModel(
+    Guid uuid,
+    BenchmarkingViewModelCostSubCategory<TrustComparisonDatum> subCategory)
+{
+    public Guid Uuid => uuid;
+    public BenchmarkingViewModelCostSubCategory<TrustComparisonDatum> SubCategory => subCategory;
+}

--- a/web/src/Web.App/ViewModels/TrustComparisonItSpendViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustComparisonItSpendViewModel.cs
@@ -8,11 +8,12 @@ public class TrustComparisonItSpendViewModel(
     bool? comparatorGenerated,
     string? redirectUri,
     string[]? userDefinedSet,
-    TrustComparisonSubCategoriesViewModel subCategories)
+    TrustComparisonSubCategoriesViewModel subCategories,
+    int currentBfrYear)
 {
     public static readonly Dimensions.ResultAsOptions[] FilterDimensions =
     [
-        Dimensions.ResultAsOptions.Actuals,
+        Dimensions.ResultAsOptions.Actuals
     ];
 
     public string? CompanyNumber => trust.CompanyNumber;
@@ -22,6 +23,7 @@ public class TrustComparisonItSpendViewModel(
     public string? RedirectUri => redirectUri;
     public string[]? UserDefinedSet => userDefinedSet;
     public List<BenchmarkingViewModelCostSubCategory<TrustComparisonDatum>> SubCategories => subCategories.Items;
+    public int CurrentBfrYear => currentBfrYear;
 
     public Views.ViewAsOptions ViewAs { get; init; } = Views.ViewAsOptions.Chart;
     public Dimensions.ResultAsOptions ResultAs { get; init; } = Dimensions.ResultAsOptions.Actuals;
@@ -30,8 +32,10 @@ public class TrustComparisonItSpendViewModel(
 
 public class TrustComparisonItSpendChartViewModel(
     Guid uuid,
-    BenchmarkingViewModelCostSubCategory<TrustComparisonDatum> subCategory)
+    BenchmarkingViewModelCostSubCategory<TrustComparisonDatum> subCategory,
+    int currentBfrYear)
 {
     public Guid Uuid => uuid;
     public BenchmarkingViewModelCostSubCategory<TrustComparisonDatum> SubCategory => subCategory;
+    public int CurrentBfrYear => currentBfrYear;
 }

--- a/web/src/Web.App/Views/TrustComparisonItSpend/Index.cshtml
+++ b/web/src/Web.App/Views/TrustComparisonItSpend/Index.cshtml
@@ -1,5 +1,7 @@
 ﻿@using Web.App.Attributes
+@using Web.App.Domain.Charts
 @using Web.App.Extensions
+@using Web.App.ViewModels
 @model Web.App.ViewModels.TrustComparisonItSpendViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.ComparisonItSpend;
@@ -70,9 +72,19 @@
         @for (var i = 0; i < Model.SubCategories.Count; i++)
         {
             var subCategory = Model.SubCategories.ElementAt(i);
+            var uuid = Guid.NewGuid();
 
             <section id="cost-sub-category-@subCategory.SubCategory?.ToSlug()">
                 <h2 class="govuk-heading-m">@subCategory.SubCategory</h2>
+
+                @if (Model.ViewAs == Views.ViewAsOptions.Chart)
+                {
+                    @await Html.PartialAsync("_ItSpendChart", new TrustComparisonItSpendChartViewModel(uuid, subCategory))
+                    @if (i <= Model.SubCategories.Count)
+                    {
+                        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-6">
+                    }
+                }
             </section>
         }
     </div>

--- a/web/src/Web.App/Views/TrustComparisonItSpend/Index.cshtml
+++ b/web/src/Web.App/Views/TrustComparisonItSpend/Index.cshtml
@@ -79,7 +79,7 @@
 
                 @if (Model.ViewAs == Views.ViewAsOptions.Chart)
                 {
-                    @await Html.PartialAsync("_ItSpendChart", new TrustComparisonItSpendChartViewModel(uuid, subCategory))
+                    @await Html.PartialAsync("_ItSpendChart", new TrustComparisonItSpendChartViewModel(uuid, subCategory, Model.CurrentBfrYear))
                     @if (i <= Model.SubCategories.Count)
                     {
                         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-6">

--- a/web/src/Web.App/Views/TrustComparisonItSpend/_ItSpendChart.cshtml
+++ b/web/src/Web.App/Views/TrustComparisonItSpend/_ItSpendChart.cshtml
@@ -1,0 +1,22 @@
+@model Web.App.ViewModels.TrustComparisonItSpendChartViewModel
+
+@if (string.IsNullOrWhiteSpace(Model.SubCategory.ChartSvg))
+{
+    <div
+        class="govuk-warning-text govuk-!-margin-top-2 govuk-!-margin-bottom-2 ssr-chart-warning">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+            <span class="govuk-visually-hidden">Warning</span>
+            Unable to display chart
+        </strong>
+    </div>
+    return;
+}
+
+<div id="@Model.Uuid" class="costs-chart-container" data-title="@Model.SubCategory.SubCategory">
+    <div class="costs-chart-wrapper">
+        <div class="govuk-!-margin-bottom-2 ssr-chart horizontal-bar-chart horizontal-bar-chart__no-hover">
+            @Html.Raw(Model.SubCategory.ChartSvg)
+        </div>
+    </div>
+</div>

--- a/web/src/Web.App/Views/TrustComparisonItSpend/_ItSpendChart.cshtml
+++ b/web/src/Web.App/Views/TrustComparisonItSpend/_ItSpendChart.cshtml
@@ -13,6 +13,10 @@
     return;
 }
 
+<p class="govuk-body govuk-!-margin-bottom-0 chart-context">
+    This shows the previous year spend for @(Model.CurrentBfrYear - 2) to @(Model.CurrentBfrYear - 1).
+</p>
+
 <div id="@Model.Uuid" class="costs-chart-container" data-title="@Model.SubCategory.SubCategory">
     <div class="costs-chart-wrapper">
         <div class="govuk-!-margin-bottom-2 ssr-chart horizontal-bar-chart horizontal-bar-chart__no-hover">

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/Comparison/WhenViewingComparisonItSpend.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/Comparison/WhenViewingComparisonItSpend.cs
@@ -24,23 +24,23 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
     [Fact]
     public async Task CanDisplay()
     {
-        var (page, trust, userDefinedSet, spend) = await SetupNavigateInitPage();
+        var (page, trust, userDefinedSet, spend, currentBfrYear) = await SetupNavigateInitPage();
 
-        AssertPageLayout(page, trust, userDefinedSet, spend);
+        AssertPageLayout(page, trust, userDefinedSet, spend, currentBfrYear);
     }
 
     [Fact]
     public async Task CanDisplayChartWarningWhenChartApiFails()
     {
-        var (page, trust, userDefinedSet, spend) = await SetupNavigateInitPage(chartApiException: true);
+        var (page, trust, userDefinedSet, spend, currentBfrYear) = await SetupNavigateInitPage(chartApiException: true);
 
-        AssertPageLayout(page, trust, userDefinedSet, spend, chartError: true);
+        AssertPageLayout(page, trust, userDefinedSet, spend, currentBfrYear, chartError: true);
     }
 
     [Fact]
     public async Task CanStartCreateComparatorsJourneyWhenComparatorsMissing()
     {
-        var (page, trust, _, _) = await SetupNavigateInitPage(false);
+        var (page, trust, _, _, _) = await SetupNavigateInitPage(false);
 
         var redirectUri = WebUtility.UrlEncode(Paths.TrustComparisonItSpend(trust.CompanyNumber));
         DocumentAssert.AssertPageUrl(page, Paths.TrustComparatorsCreateBy(trust.CompanyNumber, redirectUri).ToAbsolute());
@@ -49,7 +49,7 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
     [Fact]
     public async Task CanDisplayTrustComparatorsWhenComparatorSetEmpty()
     {
-        var (page, trust, _, _) = await SetupNavigateInitPage(true, true);
+        var (page, trust, _, _, _) = await SetupNavigateInitPage(true, true);
 
         var redirectUri = WebUtility.UrlEncode(Paths.TrustComparisonItSpend(trust.CompanyNumber));
         DocumentAssert.AssertPageUrl(page, Paths.TrustComparatorsUserDefined(trust.CompanyNumber, null, redirectUri).ToAbsolute());
@@ -58,7 +58,7 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
     [Fact]
     public async Task CanNavigateToTrustComparators()
     {
-        var (page, trust, _, _) = await SetupNavigateInitPage();
+        var (page, trust, _, _, _) = await SetupNavigateInitPage();
 
         var anchor = page.QuerySelector("a[data-test-id='comparators-link']");
         Assert.NotNull(anchor);
@@ -95,7 +95,7 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
     [InlineData(1, "?viewAs=1&resultAs=1")]
     public async Task CanSubmitFilterOptionsForViewAs(int viewAs, string expectedQueryParams)
     {
-        var (page, trust, userDefinedSet, spend) = await SetupNavigateInitPage();
+        var (page, trust, userDefinedSet, spend, currentBfrYear) = await SetupNavigateInitPage();
 
         var action = page.QuerySelectorAll("button").FirstOrDefault(x => x.TextContent.Trim() == "Apply filters");
         Assert.NotNull(action);
@@ -113,6 +113,7 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
             trust,
             userDefinedSet,
             spend,
+            currentBfrYear,
             viewAs,
             expectedQueryParams: expectedQueryParams);
     }
@@ -121,7 +122,7 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
     [InlineData(1, "?viewAs=0&resultAs=1")]
     public async Task CanSubmitFilterOptionsForResultsAs(int resultAs, string expectedQueryParams)
     {
-        var (page, trust, userDefinedSet, spend) = await SetupNavigateInitPage();
+        var (page, trust, userDefinedSet, spend, currentBfrYear) = await SetupNavigateInitPage();
 
         var action = page.QuerySelectorAll("button").FirstOrDefault(x => x.TextContent.Trim() == "Apply filters");
         Assert.NotNull(action);
@@ -139,6 +140,7 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
             trust,
             userDefinedSet,
             spend,
+            currentBfrYear,
             resultAs: resultAs,
             expectedQueryParams: expectedQueryParams);
     }
@@ -153,7 +155,7 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
     [InlineData(6, "?viewAs=0&resultAs=1&selectedSubCategories=6")]
     public async Task CanSubmitFilterOptionsForSubCategories(int expectedSubCategoryId, string expectedQueryParams)
     {
-        var (page, trust, userDefinedSet, spend) = await SetupNavigateInitPage();
+        var (page, trust, userDefinedSet, spend, currentBfrYear) = await SetupNavigateInitPage();
 
         var action = page.QuerySelectorAll("button").FirstOrDefault(x => x.TextContent.Trim() == "Apply filters");
         Assert.NotNull(action);
@@ -171,6 +173,7 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
             trust,
             userDefinedSet,
             spend,
+            currentBfrYear,
             expectedSubCategories: BuildExpectedSubCategories(expectedSubCategoryId),
             expectedQueryParams: expectedQueryParams);
     }
@@ -178,7 +181,7 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
     [Fact]
     public async Task CanFollowChipsCorrectlyUpdatesPage()
     {
-        var (page, trust, userDefinedSet, spend) = await SetupNavigateInitPage(
+        var (page, trust, userDefinedSet, spend, currentBfrYear) = await SetupNavigateInitPage(
             queryParams: "?viewAs=0&resultAs=1&selectedSubCategories=0&selectedSubCategories=1");
 
         var target = page.QuerySelectorAll("a.app-filter__tag")
@@ -192,6 +195,7 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
             trust,
             userDefinedSet,
             spend,
+            currentBfrYear,
             expectedQueryParams: "?viewAs=0&resultAs=1&selectedSubCategories=0",
             expectedSubCategories: BuildExpectedSubCategories(0));
     }
@@ -199,7 +203,7 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
     [Fact]
     public async Task CanFollowClearCorrectlyUpdatesPage()
     {
-        var (page, trust, userDefinedSet, spend) = await SetupNavigateInitPage(
+        var (page, trust, userDefinedSet, spend, currentBfrYear) = await SetupNavigateInitPage(
             queryParams: "?viewAs=0&resultAs=1&selectedSubCategories=0&selectedSubCategories=1");
 
         var target = page.QuerySelectorAll("a").FirstOrDefault(x => x.TextContent.Trim() == "Clear");
@@ -212,10 +216,16 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
             trust,
             userDefinedSet,
             spend,
+            currentBfrYear,
             expectedQueryParams: "?viewAs=0&resultAs=1");
     }
 
-    private async Task<(IHtmlDocument page, Trust trust, UserDefinedSchoolComparatorSet userDefinedSet, TrustItSpend[] spend)> SetupNavigateInitPage(
+    private async Task<(
+        IHtmlDocument page,
+        Trust trust,
+        UserDefinedSchoolComparatorSet userDefinedSet,
+        TrustItSpend[] spend,
+        int currentBfrYear)> SetupNavigateInitPage(
         bool withComparatorSet = true,
         bool withEmptyComparatorSet = false,
         bool chartApiException = false,
@@ -247,6 +257,8 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
         var spend = Fixture.Build<TrustItSpend>().CreateMany().ToArray();
         spend.ElementAt(0).CompanyNumber = trust.CompanyNumber;
 
+        const int currentBfrYear = 2025;
+
         var horizontalBarChart = new ChartResponse
         {
             Html = "<svg />"
@@ -258,6 +270,7 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
             .SetupUserData(withComparatorSet ? comparatorSet : null)
             .SetupComparatorSet(trust, userDefinedSet)
             .SetupItSpend(trustSpend: spend)
+            .SetupBudgetForecast(trust, currentYear: currentBfrYear)
             .SetupChartRendering<TrustComparisonDatum>(horizontalBarChart);
 
         if (chartApiException)
@@ -266,7 +279,7 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
         }
 
         var page = await client.Navigate($"{Paths.TrustComparisonItSpend(trust.CompanyNumber)}{queryParams}");
-        return (page, trust, userDefinedSet, spend);
+        return (page, trust, userDefinedSet, spend, currentBfrYear);
     }
 
     private static void AssertPageLayout(
@@ -274,6 +287,7 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
         Trust trust,
         UserDefinedSchoolComparatorSet userDefinedSet,
         TrustItSpend[] spend,
+        int currentBfrYear,
         int viewAs = 0,
         int resultAs = 0,
         ExpectedSubCategory[]? expectedSubCategories = null,
@@ -302,7 +316,7 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
             var section = subCategorySections[i];
             var expected = expectedSubCategories[i];
 
-            AssertSpendingSection(section, expected, viewAs == 0, chartError);
+            AssertSpendingSection(section, expected, currentBfrYear, viewAs == 0, chartError);
         }
     }
 
@@ -381,6 +395,7 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
     private static void AssertSpendingSection(
         IElement section,
         ExpectedSubCategory expectedSubCategory,
+        int currentBfrYear,
         bool isChartView,
         bool chartError)
     {
@@ -390,28 +405,29 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
 
         if (isChartView)
         {
-            AssertChartSection(section, chartError);
+            AssertChartSection(section, currentBfrYear, chartError);
         }
     }
 
-    private static void AssertChartSection(IElement chartSection, bool chartError)
+    private static void AssertChartSection(IElement chartSection, int currentBfrYear, bool chartError)
     {
+        var chartContext = chartSection.QuerySelector(".chart-context");
         var chartSvg = chartSection.QuerySelector(".ssr-chart");
         var chartWarning = chartSection.QuerySelector(".ssr-chart-warning");
-        var chartContainer = chartSection.QuerySelector(".composed-container");
 
         if (chartError)
         {
             Assert.NotNull(chartWarning);
+            Assert.Null(chartContext);
             Assert.Null(chartSvg);
         }
         else
         {
+            Assert.NotNull(chartContext);
+            Assert.Contains($"This shows the previous year spend for {currentBfrYear - 2} to {currentBfrYear - 1}.", chartContext.TextContent);
             Assert.NotNull(chartSvg);
             Assert.Null(chartWarning);
         }
-
-        Assert.Null(chartContainer);
     }
 
     private static ExpectedSubCategory[] BuildExpectedSubCategories(params int[]? ids)

--- a/web/tests/Web.Tests/Domain/Charts/GivenASchoolComparisonItSpendHorizontalBarChartRequest.cs
+++ b/web/tests/Web.Tests/Domain/Charts/GivenASchoolComparisonItSpendHorizontalBarChartRequest.cs
@@ -31,6 +31,10 @@ public class GivenASchoolComparisonItSpendHorizontalBarChartRequest
         Assert.Equal("schoolName", actual.LabelField);
         Assert.Equal("%2$s", actual.LabelFormat);
         Assert.Equal("/%1$s", actual.LinkFormat);
+        Assert.Null(actual.MissingDataLabel);
+        Assert.Null(actual.MissingDataLabelWidth);
+        Assert.Null(actual.PaddingInner);
+        Assert.Null(actual.PaddingOuter);
         Assert.Equal("desc", actual.Sort);
         Assert.Equal(610, actual.Width);
         Assert.Equal("expenditure", actual.ValueField);

--- a/web/tests/Web.Tests/Domain/Charts/GivenATrustComparisonItSpendHorizontalBarChartRequest.cs
+++ b/web/tests/Web.Tests/Domain/Charts/GivenATrustComparisonItSpendHorizontalBarChartRequest.cs
@@ -1,0 +1,40 @@
+using AutoFixture;
+using Web.App.Domain.Charts;
+using Xunit;
+
+namespace Web.Tests.Domain.Charts;
+
+public class GivenATrustComparisonItSpendHorizontalBarChartRequest
+{
+    private readonly Fixture _fixture = new();
+
+    [Fact]
+    public void RequestShouldBeValid()
+    {
+        var uuid = _fixture.Create<Guid>().ToString();
+        var companyNumber = _fixture.Create<string>();
+        var data = _fixture.Build<TrustComparisonDatum>().CreateMany().ToArray();
+        const Dimensions.ResultAsOptions resultAs = Dimensions.ResultAsOptions.Actuals;
+
+        var actual = new TrustComparisonItSpendHorizontalBarChartRequest(uuid, companyNumber, data, f => $"/{f}", resultAs);
+
+        Assert.Equal(24, actual.BarHeight);
+        Assert.Equal(data, actual.Data);
+        Assert.Null(actual.GroupedKeys);
+        Assert.Equal(companyNumber, actual.HighlightKey);
+        Assert.Equal(uuid, actual.Id);
+        Assert.Equal("companyNumber", actual.KeyField);
+        Assert.Equal("trustName", actual.LabelField);
+        Assert.Equal("%2$s", actual.LabelFormat);
+        Assert.Equal("/%1$s", actual.LinkFormat);
+        Assert.Equal("No data submitted", actual.MissingDataLabel);
+        Assert.Equal(115, actual.MissingDataLabelWidth);
+        Assert.Equal(0.6m, actual.PaddingInner);
+        Assert.Equal(0.2m, actual.PaddingOuter);
+        Assert.Equal("desc", actual.Sort);
+        Assert.Equal(610, actual.Width);
+        Assert.Equal("expenditure", actual.ValueField);
+        Assert.Equal("currency", actual.ValueType);
+        Assert.Equal("actuals", actual.XAxisLabel);
+    }
+}

--- a/web/tests/Web.Tests/ViewModels/GivenATrustComparisonItSpendViewModel.cs
+++ b/web/tests/Web.Tests/ViewModels/GivenATrustComparisonItSpendViewModel.cs
@@ -1,4 +1,5 @@
 using AutoFixture;
+using Microsoft.Azure.Cosmos.Linq;
 using Web.App.Domain;
 using Web.App.Domain.Charts;
 using Web.App.ViewModels;
@@ -19,8 +20,9 @@ public class GivenATrustComparisonItSpendViewModel
         var userDefinedSet = _fixture.CreateMany<string>().ToArray();
         var expenditures = _fixture.Build<TrustItSpend>().CreateMany().ToArray();
         var subCategories = new TrustComparisonSubCategoriesViewModel(string.Empty, expenditures, []);
+        var currentBfrYear = _fixture.Create<int>();
 
-        var actual = new TrustComparisonItSpendViewModel(trust, comparatorGenerated, redirectUri, userDefinedSet, subCategories);
+        var actual = new TrustComparisonItSpendViewModel(trust, comparatorGenerated, redirectUri, userDefinedSet, subCategories, currentBfrYear);
 
         Assert.Equal(trust.CompanyNumber, actual.CompanyNumber);
         Assert.Equal(trust.TrustName, actual.Name);
@@ -28,6 +30,7 @@ public class GivenATrustComparisonItSpendViewModel
         Assert.Equal(redirectUri, actual.RedirectUri);
         Assert.Equal(userDefinedSet, actual.UserDefinedSet);
         Assert.Equal(subCategories.Items, actual.SubCategories);
+        Assert.Equal(currentBfrYear, actual.CurrentBfrYear);
         Assert.Equal(Views.ViewAsOptions.Chart, actual.ViewAs);
         Assert.Equal(Dimensions.ResultAsOptions.Actuals, actual.ResultAs);
         Assert.Empty(actual.SelectedSubCategories);


### PR DESCRIPTION
## 🧾 Summary

[AB#260041](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/260041) [AB#281180](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/281180)

- SSR chart `POST` and `SVG` rendering to Trust IT spend page (excluding sensitive charts)
- Unit and integration test coverage

<img width="987" height="1115" alt="image" src="https://github.com/user-attachments/assets/8959d3f8-1c6a-4ffd-aae5-c3721d3a3cc4" />

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Unit and integration tests updated _(if applicable)_.
- [x] All unit/integration tests are executed and passed.
- [x] Tested by running locally.

</details>
<details>
<summary>Documentation updates</summary>


- [ ] Code-level documentation (e.g., inline comments, docstrings) is updated.
- [ ] README.md or relevant module-level docs are updated.
- [ ] API changes are reflected in API documentation _(if applicable)_.
- [ ] Links to external references are included instead of duplicating content.
- [ ] No outdated or incorrect documentation remains.

</details>
<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [x] Screenshots or Demo _(if applicable)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] Design (UX and/or content) review _(if applicable)_.
- [ ] Documentation changes have been explicitly reviewed.
- [ ] CI/CD pipeline checks pass.

</details>

## 🧪 Testing notes

Wired up to relatively new Platform API that currently returns only stubbed data.
