### PR TITLE
Display 'sensitive' Trust IT Spend data from BFR if authorised to do so

### DIFF
--- a/platform/src/apis/Platform.Api.ChartRendering/src/functions/utils.ts
+++ b/platform/src/apis/Platform.Api.ChartRendering/src/functions/utils.ts
@@ -101,6 +101,11 @@ export function getDomain<T>(
   const dataMax = max(filteredData, (d) => d[valueField] as number) ?? 0;
   const maximum = !domainMax || domainMax < dataMax ? dataMax : domainMax;
 
+  if (minimum === 0 && maximum === 0) {
+    // 1000 is arbitrary for allowing zeroes to render correctly
+    return [0, 1000];
+  }
+
   return [minimum, maximum];
 }
 

--- a/platform/src/apis/Platform.Api.ChartRendering/tests/functions/utils.test.ts
+++ b/platform/src/apis/Platform.Api.ChartRendering/tests/functions/utils.test.ts
@@ -129,6 +129,12 @@ describe("getDomain", () => {
     { category: "G", value: 10 },
   ];
 
+  const sampleZeroData = [
+    { category: "A", value: 0 },
+    { category: "B", value: 0 },
+    { category: "C", value: 0 },
+  ];
+
   it("should return default domain if not supplied", () => {
     const result = getDomain(sampleData, "value");
     expect(result).toEqual([0, 100]);
@@ -142,6 +148,16 @@ describe("getDomain", () => {
   it("should return fallback domain if out of range", () => {
     const result = getDomain(sampleData, "value", 6, 99);
     expect(result).toEqual([5, 100]);
+  });
+
+  it("should return arbitrary default domain if all values are 0", () => {
+    const result = getDomain(sampleZeroData, "value");
+    expect(result).toEqual([0, 1000]);
+  });
+
+  it("should return arbitrary domain if range is 0, 0", () => {
+    const result = getDomain(sampleZeroData, "value", 0, 0);
+    expect(result).toEqual([0, 1000]);
   });
 });
 

--- a/web/src/Web.App/Attributes/TrustAuthorizationAttribute.cs
+++ b/web/src/Web.App/Attributes/TrustAuthorizationAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
-using Web.App.Identity;
+using Web.App.Extensions;
 
 namespace Web.App.Attributes;
 
@@ -11,15 +11,9 @@ public class TrustAuthorizationAttribute : AuthorizeAttribute, IAuthorizationFil
     public void OnAuthorization(AuthorizationFilterContext context)
     {
         var configuration = context.HttpContext.RequestServices.GetRequiredService<IConfiguration>();
-        if (configuration.GetValue<bool>(EnvironmentVariables.DisableOrganisationClaimCheck))
-        {
-            return;
-        }
-
         var companyNumber = context.RouteData.Values["companyNumber"]?.ToString();
 
-        var isValid = context.HttpContext.User.Claims.Any(c =>
-            companyNumber != null && c.Type == ClaimNames.Trusts && c.Value.Contains(companyNumber));
+        var isValid = context.HttpContext.User.HasTrustAuthorisation(companyNumber, configuration);
         if (!isValid)
         {
             context.Result = new ViewResult

--- a/web/src/Web.App/Controllers/TrustComparisonItSpendController.cs
+++ b/web/src/Web.App/Controllers/TrustComparisonItSpendController.cs
@@ -163,7 +163,11 @@ public class TrustComparisonItSpendController(
             .QueryTrusts(BuildApiQuery(resultAs, comparatorSet))
             .GetResultOrDefault<TrustItSpend[]>() ?? [];
 
-        var subCategories = new TrustComparisonSubCategoriesViewModel(trust.CompanyNumber!, expenditures, selectedSubCategories);
+        var forecasts = hasTrustAuthorisation
+            ? await itSpendApi.TrustForecast(trust.CompanyNumber).GetResultOrDefault<TrustItSpendForecastYear[]>()
+            : null;
+
+        var subCategories = new TrustComparisonSubCategoriesViewModel(trust.CompanyNumber!, expenditures, forecasts, selectedSubCategories);
         if (viewAs == Views.ViewAsOptions.Chart)
         {
             var charts = await BuildCharts(trust.CompanyNumber!, resultAs, subCategories);

--- a/web/src/Web.App/Controllers/TrustComparisonItSpendController.cs
+++ b/web/src/Web.App/Controllers/TrustComparisonItSpendController.cs
@@ -218,6 +218,7 @@ public class TrustComparisonItSpendController(
         return query;
     }
 
+    // todo: move both chart request building and API call methods to new service so that it may be unit tested outside the controller
     private async Task<ChartResponse[]> BuildCharts(string companyNumber, Dimensions.ResultAsOptions resultAs, TrustComparisonSubCategoriesViewModel subCategories)
     {
         var requests = subCategories.Items.Select(c => new TrustComparisonItSpendHorizontalBarChartRequest(
@@ -229,7 +230,13 @@ public class TrustComparisonItSpendController(
                 {
                     companyNumber = format
                 }) ?? string.Empty),
-            resultAs
+            resultAs,
+            c.ForecastData == null
+                ? null
+                : Math.Min(c.Data?.Min(d => d.Expenditure) ?? 0, c.ForecastData?.Min(d => d.Expenditure) ?? 0),
+            c.ForecastData == null
+                ? null
+                : Math.Max(c.Data?.Max(d => d.Expenditure) ?? 0, c.ForecastData?.Max(d => d.Expenditure) ?? 0)
         ));
 
         ChartResponse[] charts = [];
@@ -254,7 +261,9 @@ public class TrustComparisonItSpendController(
             .Select(c => new TrustForecastItSpendHorizontalBarChartRequest(
                 c.Uuid!,
                 c.ForecastData!,
-                resultAs
+                resultAs,
+                Math.Min(c.Data?.Min(d => d.Expenditure) ?? 0, c.ForecastData?.Min(d => d.Expenditure) ?? 0),
+                Math.Max(c.Data?.Max(d => d.Expenditure) ?? 0, c.ForecastData?.Max(d => d.Expenditure) ?? 0)
             ))
             .Where(r => r.Data != null && r.Data.Length != 0);
 

--- a/web/src/Web.App/Controllers/TrustComparisonItSpendController.cs
+++ b/web/src/Web.App/Controllers/TrustComparisonItSpendController.cs
@@ -8,6 +8,7 @@ using Web.App.Attributes;
 using Web.App.Attributes.RequestTelemetry;
 using Web.App.Domain;
 using Web.App.Domain.Charts;
+using Web.App.Extensions;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.Benchmark;
 using Web.App.Infrastructure.Apis.ChartRendering;
@@ -31,6 +32,7 @@ public class TrustComparisonItSpendController(
     IItSpendApi itSpendApi,
     IUserDataService userDataService,
     IBudgetForecastApi budgetForecastApi,
+    IConfiguration configuration,
     ILogger<TrustComparisonItSpendController> logger) : Controller
 {
     [HttpGet]
@@ -74,7 +76,8 @@ public class TrustComparisonItSpendController(
                     });
                 }
 
-                return await TrustComparisonItSpend(trust, userDefinedSet.Set, comparatorGenerated, redirectUri, selectedSubCategories, resultAs, viewAs);
+                var hasTrustAuthorisation = Request.HttpContext.User.HasTrustAuthorisation(trust.CompanyNumber, configuration);
+                return await TrustComparisonItSpend(trust, userDefinedSet.Set, comparatorGenerated, redirectUri, hasTrustAuthorisation, selectedSubCategories, resultAs, viewAs);
             }
             catch (Exception e)
             {
@@ -147,6 +150,7 @@ public class TrustComparisonItSpendController(
         string[] comparatorSet,
         bool? comparatorGenerated,
         string? redirectUri,
+        bool hasTrustAuthorisation,
         ItSpendingCategories.SubCategoryFilter[] selectedSubCategories,
         Dimensions.ResultAsOptions resultAs,
         Views.ViewAsOptions viewAs)

--- a/web/src/Web.App/Domain/Charts/GroupType.cs
+++ b/web/src/Web.App/Domain/Charts/GroupType.cs
@@ -2,5 +2,8 @@ namespace Web.App.Domain.Charts;
 
 public static class GroupType
 {
+    public const string Current = "current";
+    public const string Forecast = "forecast";
     public const string PartYear = "part-year";
+    public const string Previous = "previous";
 }

--- a/web/src/Web.App/Domain/Charts/TrustComparisonItSpendHorizontalBarChartRequest.cs
+++ b/web/src/Web.App/Domain/Charts/TrustComparisonItSpendHorizontalBarChartRequest.cs
@@ -11,10 +11,14 @@ public record TrustComparisonItSpendHorizontalBarChartRequest : PostHorizontalBa
         string companyNumber,
         TrustComparisonDatum[] filteredData,
         Func<string, string?> linkFormatter,
-        Dimensions.ResultAsOptions resultsAs)
+        Dimensions.ResultAsOptions resultsAs,
+        decimal? domainMin,
+        decimal? domainMax)
     {
         BarHeight = 24;
         Data = filteredData;
+        DomainMax = domainMax == 0 ? null : domainMax;
+        DomainMin = domainMin == 0 ? null : domainMin;
         HighlightKey = companyNumber;
         Id = uuid;
         KeyField = nameof(companyNumber);
@@ -38,10 +42,14 @@ public record TrustForecastItSpendHorizontalBarChartRequest : PostHorizontalBarC
     public TrustForecastItSpendHorizontalBarChartRequest(
         string uuid,
         TrustForecastDatum[] forecastData,
-        Dimensions.ResultAsOptions resultsAs)
+        Dimensions.ResultAsOptions resultsAs,
+        decimal? domainMin,
+        decimal? domainMax)
     {
         BarHeight = 24;
         Data = forecastData;
+        DomainMax = domainMax == 0 ? null : domainMax;
+        DomainMin = domainMin == 0 ? null : domainMin;
         Id = uuid;
         KeyField = "yearLabel";
         PaddingInner = 0.6m;

--- a/web/src/Web.App/Domain/Charts/TrustComparisonItSpendHorizontalBarChartRequest.cs
+++ b/web/src/Web.App/Domain/Charts/TrustComparisonItSpendHorizontalBarChartRequest.cs
@@ -40,10 +40,12 @@ public record TrustForecastItSpendHorizontalBarChartRequest : PostHorizontalBarC
         TrustForecastDatum[] forecastData,
         Dimensions.ResultAsOptions resultsAs)
     {
-        BarHeight = 20;
+        BarHeight = 24;
         Data = forecastData;
         Id = uuid;
         KeyField = "yearLabel";
+        PaddingInner = 0.6m;
+        PaddingOuter = 0.2m;
         Width = 610;
         ValueField = nameof(TrustForecastDatum.Expenditure).ToLower();
         ValueType = resultsAs.GetValueType();

--- a/web/src/Web.App/Domain/Charts/TrustComparisonItSpendHorizontalBarChartRequest.cs
+++ b/web/src/Web.App/Domain/Charts/TrustComparisonItSpendHorizontalBarChartRequest.cs
@@ -33,9 +33,50 @@ public record TrustComparisonItSpendHorizontalBarChartRequest : PostHorizontalBa
     }
 }
 
+public record TrustForecastItSpendHorizontalBarChartRequest : PostHorizontalBarChartRequest<TrustForecastDatum>
+{
+    public TrustForecastItSpendHorizontalBarChartRequest(
+        string uuid,
+        TrustForecastDatum[] forecastData,
+        Dimensions.ResultAsOptions resultsAs)
+    {
+        BarHeight = 20;
+        Data = forecastData;
+        Id = uuid;
+        KeyField = "yearLabel";
+        Width = 610;
+        ValueField = nameof(TrustForecastDatum.Expenditure).ToLower();
+        ValueType = resultsAs.GetValueType();
+        XAxisLabel = resultsAs.GetXAxisLabel();
+
+        var years = forecastData
+            .Where(f => f.Year != null)
+            .Select(f => f.YearLabel!)
+            .Distinct()
+            .OrderBy(y => y)
+            .ToArray();
+        if (years.Length == 3)
+        {
+            GroupedKeys = new ChartRequestGroupedKeys
+            {
+                [GroupType.Previous] = [years[0]],
+                [GroupType.Current] = [years[1]],
+                [GroupType.Forecast] = [years[2]]
+            };
+        }
+    }
+}
+
 public class TrustComparisonDatum
 {
     public string? CompanyNumber { get; init; }
     public string? TrustName { get; init; }
+    public decimal? Expenditure { get; init; }
+}
+
+public class TrustForecastDatum
+{
+    public int? Year { get; init; }
+    public string? YearLabel => Year == null ? null : $"{Year - 1} – {Year}";
     public decimal? Expenditure { get; init; }
 }

--- a/web/src/Web.App/Domain/Insight/ItSpend.cs
+++ b/web/src/Web.App/Domain/Insight/ItSpend.cs
@@ -83,3 +83,8 @@ public record TrustItSpend : ItSpend, IEqualityComparer<TrustItSpend>
 
     public int GetHashCode(TrustItSpend obj) => obj.CompanyNumber != null ? obj.CompanyNumber.GetHashCode() : 0;
 }
+
+public record TrustItSpendForecastYear : ItSpend
+{
+    public int? Year { get; set; }
+}

--- a/web/src/Web.App/Extensions/ClaimsPrincipalExtensions.cs
+++ b/web/src/Web.App/Extensions/ClaimsPrincipalExtensions.cs
@@ -150,4 +150,15 @@ public static class ClaimsPrincipalExtensions
 
         return principal;
     }
+
+    public static bool HasTrustAuthorisation(this ClaimsPrincipal principal, string? companyNumber, IConfiguration configuration)
+    {
+        if (configuration.GetValue<bool>(EnvironmentVariables.DisableOrganisationClaimCheck))
+        {
+            return true;
+        }
+
+        return principal.Claims.Any(c =>
+            companyNumber != null && c.Type == ClaimNames.Trusts && c.Value.Contains(companyNumber));
+    }
 }

--- a/web/src/Web.App/Infrastructure/Apis/ApiRequests/ChartRequest.cs
+++ b/web/src/Web.App/Infrastructure/Apis/ApiRequests/ChartRequest.cs
@@ -6,6 +6,8 @@ namespace Web.App.Infrastructure.Apis;
 public abstract record ChartRequest<T>
 {
     public T[]? Data { get; set; }
+    public decimal? DomainMax { get; set; }
+    public decimal? DomainMin { get; set; }
     public ChartRequestGroupedKeys? GroupedKeys { get; set; }
     public string? HighlightKey { get; set; }
     public string? Id { get; set; }

--- a/web/src/Web.App/Infrastructure/Apis/Insight/Api.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Insight/Api.cs
@@ -64,5 +64,6 @@ public static class Api
     {
         public static string Schools => "api/it-spend/schools";
         public static string Trusts => "api/it-spend/trusts";
+        public static string TrustForecast(string? companyNumber) => $"api/it-spend/trust/{companyNumber}/forecast";
     }
 }

--- a/web/src/Web.App/Infrastructure/Apis/Insight/ItSpendApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/Insight/ItSpendApi.cs
@@ -4,10 +4,12 @@ public interface IItSpendApi
 {
     Task<ApiResult> QuerySchools(ApiQuery? query = null, CancellationToken cancellationToken = default);
     Task<ApiResult> QueryTrusts(ApiQuery? query = null, CancellationToken cancellationToken = default);
+    Task<ApiResult> TrustForecast(string? companyNumber, CancellationToken cancellationToken = default);
 }
 
 public class ItSpendApi(HttpClient httpClient, string? key = default) : ApiBase(httpClient, key), IItSpendApi
 {
     public async Task<ApiResult> QuerySchools(ApiQuery? query = null, CancellationToken cancellationToken = default) => await GetAsync($"{Api.ItSpend.Schools}{query?.ToQueryString()}", cancellationToken);
     public async Task<ApiResult> QueryTrusts(ApiQuery? query = null, CancellationToken cancellationToken = default) => await GetAsync($"{Api.ItSpend.Trusts}{query?.ToQueryString()}", cancellationToken);
+    public async Task<ApiResult> TrustForecast(string? companyNumber, CancellationToken cancellationToken = default) => await GetAsync(Api.ItSpend.TrustForecast(companyNumber), cancellationToken);
 }

--- a/web/src/Web.App/Program.cs
+++ b/web/src/Web.App/Program.cs
@@ -49,6 +49,7 @@ builder.Services
     .AddScoped<ICommercialResourcesService, CommercialResourcesService>()
     .AddScoped<IBannerService, BannerService>()
     .AddScoped<ICostCodesService, CostCodesService>()
+    .AddScoped<ITrustItSpendChartService, TrustItSpendChartService>()
     .AddValidation()
     .AddActionResults();
 

--- a/web/src/Web.App/Services/TrustItSpendChartService.cs
+++ b/web/src/Web.App/Services/TrustItSpendChartService.cs
@@ -33,8 +33,12 @@ public class TrustItSpendChartService(
             c.Data!,
             buildUrl,
             resultAs,
-            c.ForecastData == null ? null : Math.Min(c.Data?.Min(d => d.Expenditure) ?? 0, c.ForecastData?.Min(d => d.Expenditure) ?? 0),
-            c.ForecastData == null ? null : Math.Max(c.Data?.Max(d => d.Expenditure) ?? 0, c.ForecastData?.Max(d => d.Expenditure) ?? 0)
+            c.ForecastData is not { Length: not 0 }
+                ? null
+                : Math.Min(c.Data?.Min(d => d.Expenditure) ?? 0, c.ForecastData?.Min(d => d.Expenditure) ?? 0),
+            c.ForecastData is not { Length: not 0 }
+                ? null
+                : Math.Max(c.Data?.Max(d => d.Expenditure) ?? 0, c.ForecastData?.Max(d => d.Expenditure) ?? 0)
         ));
 
         try

--- a/web/src/Web.App/Services/TrustItSpendChartService.cs
+++ b/web/src/Web.App/Services/TrustItSpendChartService.cs
@@ -1,0 +1,78 @@
+﻿using Web.App.Domain.Charts;
+using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Apis.ChartRendering;
+using Web.App.Infrastructure.Extensions;
+using Web.App.ViewModels;
+
+namespace Web.App.Services;
+
+public interface ITrustItSpendChartService
+{
+    Task<ChartResponse[]> BuildChartsAsync(
+        string companyNumber,
+        Dimensions.ResultAsOptions resultAs,
+        TrustComparisonSubCategoriesViewModel subCategories,
+        Func<string, string> buildUrl);
+
+    Task<ChartResponse[]> BuildForecastChartsAsync(Dimensions.ResultAsOptions resultAs, TrustComparisonSubCategoriesViewModel subCategories);
+}
+
+public class TrustItSpendChartService(
+    IChartRenderingApi chartRenderingApi,
+    ILogger<TrustItSpendChartService> logger) : ITrustItSpendChartService
+{
+    public async Task<ChartResponse[]> BuildChartsAsync(
+        string companyNumber,
+        Dimensions.ResultAsOptions resultAs,
+        TrustComparisonSubCategoriesViewModel subCategories,
+        Func<string, string> buildUrl)
+    {
+        var requests = subCategories.Items.Select(c => new TrustComparisonItSpendHorizontalBarChartRequest(
+            c.Uuid!,
+            companyNumber,
+            c.Data!,
+            buildUrl,
+            resultAs,
+            c.ForecastData == null ? null : Math.Min(c.Data?.Min(d => d.Expenditure) ?? 0, c.ForecastData?.Min(d => d.Expenditure) ?? 0),
+            c.ForecastData == null ? null : Math.Max(c.Data?.Max(d => d.Expenditure) ?? 0, c.ForecastData?.Max(d => d.Expenditure) ?? 0)
+        ));
+
+        try
+        {
+            return await chartRenderingApi
+                .PostHorizontalBarCharts(new PostHorizontalBarChartsRequest<TrustComparisonDatum>(requests))
+                .GetResultOrDefault<ChartResponse[]>() ?? [];
+        }
+        catch (Exception e)
+        {
+            logger.LogWarning(e, "Unable to load charts from API");
+            return [];
+        }
+    }
+
+    public async Task<ChartResponse[]> BuildForecastChartsAsync(Dimensions.ResultAsOptions resultAs, TrustComparisonSubCategoriesViewModel subCategories)
+    {
+        var requests = subCategories.Items
+            .Where(c => c.ForecastData != null)
+            .Select(c => new TrustForecastItSpendHorizontalBarChartRequest(
+                c.Uuid!,
+                c.ForecastData!,
+                resultAs,
+                Math.Min(c.Data?.Min(d => d.Expenditure) ?? 0, c.ForecastData?.Min(d => d.Expenditure) ?? 0),
+                Math.Max(c.Data?.Max(d => d.Expenditure) ?? 0, c.ForecastData?.Max(d => d.Expenditure) ?? 0)
+            ))
+            .Where(r => r.Data != null && r.Data.Length != 0);
+
+        try
+        {
+            return await chartRenderingApi
+                .PostHorizontalBarCharts(new PostHorizontalBarChartsRequest<TrustForecastDatum>(requests))
+                .GetResultOrDefault<ChartResponse[]>() ?? [];
+        }
+        catch (Exception e)
+        {
+            logger.LogWarning(e, "Unable to load forecast charts from API");
+            return [];
+        }
+    }
+}

--- a/web/src/Web.App/ViewModels/TrustComparisonItSpendViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustComparisonItSpendViewModel.cs
@@ -22,7 +22,7 @@ public class TrustComparisonItSpendViewModel(
     public bool? ComparatorGenerated => comparatorGenerated;
     public string? RedirectUri => redirectUri;
     public string[]? UserDefinedSet => userDefinedSet;
-    public List<BenchmarkingViewModelCostSubCategory<TrustComparisonDatum>> SubCategories => subCategories.Items;
+    public List<TrustBenchmarkingViewModelCostSubCategory> SubCategories => subCategories.Items;
     public int CurrentBfrYear => currentBfrYear;
 
     public Views.ViewAsOptions ViewAs { get; init; } = Views.ViewAsOptions.Chart;

--- a/web/src/Web.App/ViewModels/TrustComparisonItSpendViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustComparisonItSpendViewModel.cs
@@ -33,21 +33,21 @@ public class TrustComparisonItSpendViewModel(
 public class TrustComparisonItSpendTableViewModel(
     string? companyNumber,
     Dimensions.ResultAsOptions resultAs,
-    BenchmarkingViewModelCostSubCategory<TrustComparisonDatum> subCategory,
+    TrustBenchmarkingViewModelCostSubCategory subCategory,
     int currentBfrYear)
 {
     public string? CompanyNumber => companyNumber;
     public Dimensions.ResultAsOptions ResultAs => resultAs;
-    public BenchmarkingViewModelCostSubCategory<TrustComparisonDatum> SubCategory => subCategory;
+    public TrustBenchmarkingViewModelCostSubCategory SubCategory => subCategory;
     public int CurrentBfrYear => currentBfrYear;
 }
 
 public class TrustComparisonItSpendChartViewModel(
     Guid uuid,
-    BenchmarkingViewModelCostSubCategory<TrustComparisonDatum> subCategory,
+    TrustBenchmarkingViewModelCostSubCategory subCategory,
     int currentBfrYear)
 {
     public Guid Uuid => uuid;
-    public BenchmarkingViewModelCostSubCategory<TrustComparisonDatum> SubCategory => subCategory;
+    public TrustBenchmarkingViewModelCostSubCategory SubCategory => subCategory;
     public int CurrentBfrYear => currentBfrYear;
 }

--- a/web/src/Web.App/ViewModels/TrustComparisonSubCategoriesViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustComparisonSubCategoriesViewModel.cs
@@ -39,15 +39,16 @@ public class TrustComparisonSubCategoriesViewModel
         var forecastData = forecasts?
             .Where(f => f.Year != null)
             .OrderBy(f => f.Year)
-            .Select(f => new KeyValuePair<int, decimal?>((int)f.Year!, filter.GetSelector()(f)))
-            .ToDictionary();
+            .Select(f => new TrustForecastDatum { Year = (int)f.Year!, Expenditure = filter.GetSelector()(f) })
+            .Where(d => d.Expenditure != null)
+            .ToArray();
 
         Items.Add(new TrustBenchmarkingViewModelCostSubCategory
         {
             Uuid = uuid,
             SubCategory = filter.GetHeadingForTrust(),
             Data = filteredData,
-            ForecastData = forecastData == null ? null : new TrustBenchmarkingViewModelCostSubCategoryForecast(forecastData)
+            ForecastData = forecastData
         });
     }
 }
@@ -55,11 +56,5 @@ public class TrustComparisonSubCategoriesViewModel
 public class TrustBenchmarkingViewModelCostSubCategory : BenchmarkingViewModelCostSubCategory<TrustComparisonDatum>
 {
     public string? ForecastChartSvg { get; set; }
-    public TrustBenchmarkingViewModelCostSubCategoryForecast? ForecastData { get; init; }
-}
-
-public class TrustBenchmarkingViewModelCostSubCategoryForecast(Dictionary<int, decimal?> forecastData)
-{
-    public int[] Years => forecastData.Keys.ToArray();
-    public decimal? this[int year] => forecastData[year];
+    public TrustForecastDatum[]? ForecastData { get; init; }
 }

--- a/web/src/Web.App/ViewModels/TrustComparisonSubCategoriesViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustComparisonSubCategoriesViewModel.cs
@@ -5,26 +5,29 @@ namespace Web.App.ViewModels;
 
 public class TrustComparisonSubCategoriesViewModel
 {
-    public List<BenchmarkingViewModelCostSubCategory<TrustComparisonDatum>> Items { get; set; } = [];
+    public List<TrustBenchmarkingViewModelCostSubCategory> Items { get; set; } = [];
 
-    public TrustComparisonSubCategoriesViewModel(string companyNumber, TrustItSpend[] expenditures,
+    public TrustComparisonSubCategoriesViewModel(
+        string companyNumber,
+        TrustItSpend[] expenditures,
+        TrustItSpendForecastYear[]? forecasts,
         ItSpendingCategories.SubCategoryFilter[] filters)
     {
         filters = filters.Length > 0 ? filters : ItSpendingCategories.All;
 
         foreach (var filter in filters)
         {
-            AddItSubCategory(companyNumber, filter, expenditures);
+            AddItSubCategory(companyNumber, filter, expenditures, forecasts);
         }
     }
 
-    private void AddItSubCategory(string companyNumber, ItSpendingCategories.SubCategoryFilter filter, TrustItSpend[] expenditures)
+    private void AddItSubCategory(string companyNumber, ItSpendingCategories.SubCategoryFilter filter, TrustItSpend[] expenditures, TrustItSpendForecastYear[]? forecasts)
     {
         var data = expenditures.GroupBy(e => e, (g, enumerable) => new TrustComparisonDatum
         {
             CompanyNumber = g.CompanyNumber,
             TrustName = g.TrustName,
-            Expenditure = enumerable.Select(filter.GetSelector()).FirstOrDefault(),
+            Expenditure = enumerable.Select(filter.GetSelector()).FirstOrDefault()
         }).ToArray();
 
         var uuid = Guid.NewGuid().ToString();
@@ -33,11 +36,30 @@ public class TrustComparisonSubCategoriesViewModel
             .OrderByDescending(x => x.Expenditure)
             .ToArray();
 
-        Items.Add(new BenchmarkingViewModelCostSubCategory<TrustComparisonDatum>
+        var forecastData = forecasts?
+            .Where(f => f.Year != null)
+            .OrderBy(f => f.Year)
+            .Select(f => new KeyValuePair<int, decimal?>((int)f.Year!, filter.GetSelector()(f)))
+            .ToDictionary();
+
+        Items.Add(new TrustBenchmarkingViewModelCostSubCategory
         {
             Uuid = uuid,
             SubCategory = filter.GetHeadingForTrust(),
-            Data = filteredData
+            Data = filteredData,
+            ForecastData = forecastData == null ? null : new TrustBenchmarkingViewModelCostSubCategoryForecast(forecastData)
         });
     }
+}
+
+public class TrustBenchmarkingViewModelCostSubCategory : BenchmarkingViewModelCostSubCategory<TrustComparisonDatum>
+{
+    public string? ForecastChartSvg { get; set; }
+    public TrustBenchmarkingViewModelCostSubCategoryForecast? ForecastData { get; init; }
+}
+
+public class TrustBenchmarkingViewModelCostSubCategoryForecast(Dictionary<int, decimal?> forecastData)
+{
+    public int[] Years => forecastData.Keys.ToArray();
+    public decimal? this[int year] => forecastData[year];
 }

--- a/web/src/Web.App/ViewModels/TrustComparisonSubCategoriesViewModel.cs
+++ b/web/src/Web.App/ViewModels/TrustComparisonSubCategoriesViewModel.cs
@@ -31,8 +31,7 @@ public class TrustComparisonSubCategoriesViewModel
         }).ToArray();
 
         var uuid = Guid.NewGuid().ToString();
-        var filteredData = data
-            .Where(x => x.CompanyNumber == companyNumber || x.Expenditure > 0)
+        var sortedData = data
             .OrderByDescending(x => x.Expenditure)
             .ToArray();
 
@@ -47,7 +46,7 @@ public class TrustComparisonSubCategoriesViewModel
         {
             Uuid = uuid,
             SubCategory = filter.GetHeadingForTrust(),
-            Data = filteredData,
+            Data = sortedData,
             ForecastData = forecastData
         });
     }

--- a/web/src/Web.App/Views/TrustComparisonItSpend/_ItSpendChart.cshtml
+++ b/web/src/Web.App/Views/TrustComparisonItSpend/_ItSpendChart.cshtml
@@ -24,3 +24,18 @@
         </div>
     </div>
 </div>
+
+@if (!string.IsNullOrWhiteSpace(Model.SubCategory.ForecastChartSvg))
+{
+    <p class="govuk-body govuk-!-margin-bottom-0">
+        This shows your trust's current and forecast spend. This is only visible to you.
+    </p>
+
+    <div id="@Model.Uuid-forecast" class="costs-chart-container" data-title="@Model.SubCategory.SubCategory (forecast)">
+        <div class="costs-chart-wrapper">
+            <div class="govuk-!-margin-bottom-2 ssr-chart horizontal-bar-chart horizontal-bar-chart__no-hover">
+                @Html.Raw(Model.SubCategory.ForecastChartSvg)
+            </div>
+        </div>
+    </div>
+}

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -696,13 +696,10 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         return this;
     }
 
-    public BenchmarkingWebAppClient SetupChartRendering<T>(ChartResponse chartResponse, bool reset = true)
+    public BenchmarkingWebAppClient SetupChartRendering<T>(ChartResponse chartResponse)
     {
         ChartResponse[] chartResponses = [];
-        if (reset)
-        {
-            ChartRenderingApi.Reset();
-        }
+        ChartRenderingApi.Reset();
         ChartRenderingApi
             .Setup(api => api.PostHorizontalBarCharts(It.IsAny<PostHorizontalBarChartsRequest<T>>(), It.IsAny<CancellationToken>()))
             .Callback<PostHorizontalBarChartsRequest<T>, CancellationToken>((request, _) =>

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -696,10 +696,13 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         return this;
     }
 
-    public BenchmarkingWebAppClient SetupChartRendering<T>(ChartResponse chartResponse)
+    public BenchmarkingWebAppClient SetupChartRendering<T>(ChartResponse chartResponse, bool reset = true)
     {
         ChartResponse[] chartResponses = [];
-        ChartRenderingApi.Reset();
+        if (reset)
+        {
+            ChartRenderingApi.Reset();
+        }
         ChartRenderingApi
             .Setup(api => api.PostHorizontalBarCharts(It.IsAny<PostHorizontalBarChartsRequest<T>>(), It.IsAny<CancellationToken>()))
             .Callback<PostHorizontalBarChartsRequest<T>, CancellationToken>((request, _) =>
@@ -780,11 +783,12 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         return this;
     }
 
-    public BenchmarkingWebAppClient SetupItSpend(SchoolItSpend[]? schoolSpend = null, TrustItSpend[]? trustSpend = null)
+    public BenchmarkingWebAppClient SetupItSpend(SchoolItSpend[]? schoolSpend = null, TrustItSpend[]? trustSpend = null, TrustItSpendForecastYear[]? trustForecast = null)
     {
         ItSpendApi.Reset();
         ItSpendApi.Setup(api => api.QuerySchools(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(schoolSpend ?? []));
         ItSpendApi.Setup(api => api.QueryTrusts(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(trustSpend ?? []));
+        ItSpendApi.Setup(api => api.TrustForecast(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(trustForecast ?? []));
         return this;
     }
 

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/Comparison/WhenViewingComparisonItSpend.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/Comparison/WhenViewingComparisonItSpend.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace Web.Integration.Tests.Pages.Trusts.Comparison;
 
+// todo: integration test coverage over forecast data and chart rendering
 public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client) : PageBase<SchoolBenchmarkingWebAppClient>(client)
 {
     private static readonly ExpectedSubCategory[] AllSubCategories =
@@ -264,6 +265,7 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
             Html = "<svg />"
         };
 
+        // todo: stub forecast API and forecast chart building (if provided in optional params)
         var client = Client
             .SetupEstablishment(trust)
             .SetupInsights()

--- a/web/tests/Web.Tests/Attributes/GivenATrustAuthorizationAttribute.cs
+++ b/web/tests/Web.Tests/Attributes/GivenATrustAuthorizationAttribute.cs
@@ -34,26 +34,15 @@ public class GivenATrustAuthorizationAttribute
     }
 
     [Theory]
-    [InlineData("12345678", new string[]
-        { }, true, false)]
-    [InlineData("12345678", new[]
-    {
-        "12345678"
-    }, true, false)]
-    [InlineData("123456", new[]
-    {
-        "12345678"
-    }, true, false)]
-    [InlineData("12345678", new[]
-    {
-        "87654321"
-    }, false, true)]
-    [InlineData("12345687", new string[]
-        { }, false, true)]
-    [InlineData("12345678", new string[]
-        { }, null, true)]
-    [InlineData(null, new string[]
-        { }, false, true)]
+    [InlineData("12345678", new string[] { }, true, false)]
+    [InlineData("12345678", new[] { "12345678" }, true, false)]
+    [InlineData("123456", new[] { "12345678" }, true, false)]
+    [InlineData("123456", new[] { "12345678" }, false, false)]
+    [InlineData("12345678", new[] { "12345678" }, false, false)]
+    [InlineData("12345678", new[] { "87654321" }, false, true)]
+    [InlineData("12345687", new string[] { }, false, true)]
+    [InlineData("12345678", new string[] { }, null, true)]
+    [InlineData(null, new string[] { }, false, true)]
     public async Task ShouldReturnForbiddenIfInvalidClaims(string? companyNumber, string[] trustClaims, bool? disableOrganisationClaimCheck, bool forbidden)
     {
         var routeData = new RouteData(new RouteValueDictionary

--- a/web/tests/Web.Tests/Domain/Charts/GivenATrustComparisonItSpendHorizontalBarChartRequest.cs
+++ b/web/tests/Web.Tests/Domain/Charts/GivenATrustComparisonItSpendHorizontalBarChartRequest.cs
@@ -15,11 +15,15 @@ public class GivenATrustComparisonItSpendHorizontalBarChartRequest
         var companyNumber = _fixture.Create<string>();
         var data = _fixture.Build<TrustComparisonDatum>().CreateMany().ToArray();
         const Dimensions.ResultAsOptions resultAs = Dimensions.ResultAsOptions.Actuals;
+        var domainMin = _fixture.Create<decimal>();
+        var domainMax = _fixture.Create<decimal>();
 
-        var actual = new TrustComparisonItSpendHorizontalBarChartRequest(uuid, companyNumber, data, f => $"/{f}", resultAs);
+        var actual = new TrustComparisonItSpendHorizontalBarChartRequest(uuid, companyNumber, data, f => $"/{f}", resultAs, domainMin, domainMax);
 
         Assert.Equal(24, actual.BarHeight);
         Assert.Equal(data, actual.Data);
+        Assert.Equal(domainMin, actual.DomainMin);
+        Assert.Equal(domainMax, actual.DomainMax);
         Assert.Null(actual.GroupedKeys);
         Assert.Equal(companyNumber, actual.HighlightKey);
         Assert.Equal(uuid, actual.Id);

--- a/web/tests/Web.Tests/Domain/Charts/GivenATrustForecastItSpendHorizontalBarChartRequest.cs
+++ b/web/tests/Web.Tests/Domain/Charts/GivenATrustForecastItSpendHorizontalBarChartRequest.cs
@@ -1,0 +1,64 @@
+using AutoFixture;
+using Web.App.Domain.Charts;
+using Web.App.Infrastructure.Apis;
+using Xunit;
+
+namespace Web.Tests.Domain.Charts;
+
+public class GivenATrustForecastItSpendHorizontalBarChartRequest
+{
+    private readonly Fixture _fixture = new();
+
+    [Fact]
+    public void RequestShouldBeValid()
+    {
+        var uuid = _fixture.Create<Guid>().ToString();
+        TrustForecastDatum[] data =
+        [
+            new()
+            {
+                Year = 2022,
+                Expenditure = 123
+            },
+            new()
+            {
+                Year = 2024,
+                Expenditure = 456
+            },
+            new()
+            {
+                Year = 2023,
+                Expenditure = 789
+            }
+        ];
+        const Dimensions.ResultAsOptions resultAs = Dimensions.ResultAsOptions.Actuals;
+
+        var actual = new TrustForecastItSpendHorizontalBarChartRequest(uuid, data, resultAs);
+
+        Assert.Equal(20, actual.BarHeight);
+        Assert.Equal(data, actual.Data);
+        Assert.Null(actual.HighlightKey);
+        Assert.Equal(uuid, actual.Id);
+        Assert.Equal("yearLabel", actual.KeyField);
+        Assert.Null(actual.LabelField);
+        Assert.Null(actual.LabelFormat);
+        Assert.Null(actual.LinkFormat);
+        Assert.Null(actual.MissingDataLabel);
+        Assert.Null(actual.MissingDataLabelWidth);
+        Assert.Null(actual.PaddingInner);
+        Assert.Null(actual.PaddingOuter);
+        Assert.Null(actual.Sort);
+        Assert.Equal(610, actual.Width);
+        Assert.Equal("expenditure", actual.ValueField);
+        Assert.Equal("currency", actual.ValueType);
+        Assert.Equal("actuals", actual.XAxisLabel);
+
+        var expectedGroups = new ChartRequestGroupedKeys
+        {
+            { "previous", ["2021 – 2022"] },
+            { "current", ["2022 – 2023"] },
+            { "forecast", ["2023 – 2024"] }
+        };
+        Assert.Equal(expectedGroups, actual.GroupedKeys);
+    }
+}

--- a/web/tests/Web.Tests/Domain/Charts/GivenATrustForecastItSpendHorizontalBarChartRequest.cs
+++ b/web/tests/Web.Tests/Domain/Charts/GivenATrustForecastItSpendHorizontalBarChartRequest.cs
@@ -32,11 +32,15 @@ public class GivenATrustForecastItSpendHorizontalBarChartRequest
             }
         ];
         const Dimensions.ResultAsOptions resultAs = Dimensions.ResultAsOptions.Actuals;
+        var domainMin = _fixture.Create<decimal>();
+        var domainMax = _fixture.Create<decimal>();
 
-        var actual = new TrustForecastItSpendHorizontalBarChartRequest(uuid, data, resultAs);
+        var actual = new TrustForecastItSpendHorizontalBarChartRequest(uuid, data, resultAs, domainMin, domainMax);
 
         Assert.Equal(24, actual.BarHeight);
         Assert.Equal(data, actual.Data);
+        Assert.Equal(domainMin, actual.DomainMin);
+        Assert.Equal(domainMax, actual.DomainMax);
         Assert.Null(actual.HighlightKey);
         Assert.Equal(uuid, actual.Id);
         Assert.Equal("yearLabel", actual.KeyField);

--- a/web/tests/Web.Tests/Domain/Charts/GivenATrustForecastItSpendHorizontalBarChartRequest.cs
+++ b/web/tests/Web.Tests/Domain/Charts/GivenATrustForecastItSpendHorizontalBarChartRequest.cs
@@ -35,7 +35,7 @@ public class GivenATrustForecastItSpendHorizontalBarChartRequest
 
         var actual = new TrustForecastItSpendHorizontalBarChartRequest(uuid, data, resultAs);
 
-        Assert.Equal(20, actual.BarHeight);
+        Assert.Equal(24, actual.BarHeight);
         Assert.Equal(data, actual.Data);
         Assert.Null(actual.HighlightKey);
         Assert.Equal(uuid, actual.Id);
@@ -45,8 +45,8 @@ public class GivenATrustForecastItSpendHorizontalBarChartRequest
         Assert.Null(actual.LinkFormat);
         Assert.Null(actual.MissingDataLabel);
         Assert.Null(actual.MissingDataLabelWidth);
-        Assert.Null(actual.PaddingInner);
-        Assert.Null(actual.PaddingOuter);
+        Assert.Equal(0.6m, actual.PaddingInner);
+        Assert.Equal(0.2m, actual.PaddingOuter);
         Assert.Null(actual.Sort);
         Assert.Equal(610, actual.Width);
         Assert.Equal("expenditure", actual.ValueField);

--- a/web/tests/Web.Tests/Extensions/GivenAClaimsPrincipal.cs
+++ b/web/tests/Web.Tests/Extensions/GivenAClaimsPrincipal.cs
@@ -1,0 +1,38 @@
+using System.Security.Claims;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using Web.App;
+using Web.App.Extensions;
+using Web.App.Identity;
+using Xunit;
+
+namespace Web.Tests.Extensions;
+
+public class GivenAClaimsPrincipal
+{
+    private readonly Mock<IConfiguration> _configuration = new();
+
+    [Theory]
+    [InlineData("12345678", new string[] { }, true, true)]
+    [InlineData("12345678", new[] { "12345678" }, true, true)]
+    [InlineData("123456", new[] { "12345678" }, true, true)]
+    [InlineData("123456", new[] { "12345678" }, false, true)]
+    [InlineData("12345678", new[] { "12345678" }, false, true)]
+    [InlineData("12345678", new[] { "87654321" }, false, false)]
+    [InlineData("12345687", new string[] { }, false, false)]
+    [InlineData("12345678", new string[] { }, null, false)]
+    [InlineData(null, new string[] { }, false, false)]
+    public void ReturnsExpectedTrustAuthorisation(string? companyNumber, string[] trustClaims, bool? disableOrganisationClaimCheck, bool authorised)
+    {
+        var section = Mock.Of<IConfigurationSection>();
+        section.Value = disableOrganisationClaimCheck?.ToString();
+        _configuration
+            .Setup(c => c.GetSection(EnvironmentVariables.DisableOrganisationClaimCheck))
+            .Returns(section);
+        var user = new ClaimsPrincipal(new ClaimsIdentity(trustClaims.Select(c => new Claim(ClaimNames.Trusts, c)), "mock"));
+
+        var result = user.HasTrustAuthorisation(companyNumber, _configuration.Object);
+
+        Assert.Equal(authorised, result);
+    }
+}

--- a/web/tests/Web.Tests/Infrastructure/GivenAnItSpendApi.cs
+++ b/web/tests/Web.Tests/Infrastructure/GivenAnItSpendApi.cs
@@ -41,4 +41,16 @@ public class GivenAnItSpendApi(ITestOutputHelper testOutputHelper) : ApiClientTe
 
         VerifyCall(HttpMethod.Get, "api/it-spend/trusts?companyNumber=12345678&companyNumber=87654321");
     }
+
+    [Fact]
+    public async Task TrustForecastShouldCallCorrectUrl()
+    {
+        var api = new ItSpendApi(HttpClient);
+
+        const string companyNumber = "12345678";
+
+        await api.TrustForecast(companyNumber);
+
+        VerifyCall(HttpMethod.Get, "api/it-spend/trust/12345678/forecast");
+    }
 }

--- a/web/tests/Web.Tests/Services/WhenTrustItSpendChartServiceIsCalled.cs
+++ b/web/tests/Web.Tests/Services/WhenTrustItSpendChartServiceIsCalled.cs
@@ -1,0 +1,113 @@
+﻿using AutoFixture;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Web.App.Domain;
+using Web.App.Domain.Charts;
+using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Apis.ChartRendering;
+using Web.App.Services;
+using Web.App.ViewModels;
+using Xunit;
+
+namespace Web.Tests.Services;
+
+public class WhenTrustItSpendChartServiceIsCalled
+{
+    private readonly Mock<IChartRenderingApi> _chartRenderingApiMock = new();
+    private readonly Mock<ILogger<TrustItSpendChartService>> _loggerMock = new();
+    private readonly Fixture _fixture = new();
+
+    [Fact]
+    public async Task BuildChartsAsyncReturnsChartResponseWhenApiSucceeds()
+    {
+        // Arrange
+        var expectedResponse = new[] { new ChartResponse() };
+        _chartRenderingApiMock
+            .Setup(api => api.PostHorizontalBarCharts(It.IsAny<PostHorizontalBarChartsRequest<TrustComparisonDatum>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ApiResult.Ok(expectedResponse));
+
+        var expenditures = _fixture.Build<TrustItSpend>().CreateMany(10).ToArray();
+
+        var forecasts = _fixture.Build<TrustItSpendForecastYear>().CreateMany(3).ToArray();
+
+        var filters = new[]
+        {
+            ItSpendingCategories.SubCategoryFilter.AdministrationSoftwareSystems,
+            ItSpendingCategories.SubCategoryFilter.Connectivity
+        };
+
+        var subCategories = new TrustComparisonSubCategoriesViewModel("123", expenditures, forecasts, filters);
+
+        var service = new TrustItSpendChartService(_chartRenderingApiMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await service.BuildChartsAsync("123", Dimensions.ResultAsOptions.Actuals, subCategories, _ => "url/");
+
+        // Assert
+        Assert.Equivalent(expectedResponse, result);
+    }
+
+    [Fact]
+    public async Task BuildChartsAsyncReturnsEmptyWhenApiFails()
+    {
+        // Arrange
+        _chartRenderingApiMock
+            .Setup(api => api.PostHorizontalBarCharts(It.IsAny<PostHorizontalBarChartsRequest<TrustComparisonDatum>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("API error"));
+
+        var expenditures = _fixture.Build<TrustItSpend>().CreateMany(10).ToArray();
+        var forecasts = _fixture.Build<TrustItSpendForecastYear>().CreateMany(3).ToArray();
+        var filters = new[] { ItSpendingCategories.SubCategoryFilter.AdministrationSoftwareSystems };
+
+        var subCategories = new TrustComparisonSubCategoriesViewModel("123", expenditures, forecasts, filters);
+        var service = new TrustItSpendChartService(_chartRenderingApiMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await service.BuildChartsAsync("123", Dimensions.ResultAsOptions.Actuals, subCategories, s => $"url/{s}");
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task BuildForecastChartsAsyncReturnsChartResponseWhenApiSucceeds()
+    {
+        // Arrange
+        var expectedResponse = new[] { new ChartResponse() };
+        _chartRenderingApiMock
+            .Setup(api => api.PostHorizontalBarCharts(It.IsAny<PostHorizontalBarChartsRequest<TrustForecastDatum>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ApiResult.Ok(expectedResponse));
+
+        var expenditures = _fixture.Build<TrustItSpend>().CreateMany(10).ToArray();
+        var forecasts = _fixture.Build<TrustItSpendForecastYear>().CreateMany(3).ToArray();
+        var filters = new[] { ItSpendingCategories.SubCategoryFilter.AdministrationSoftwareSystems };
+
+        var subCategories = new TrustComparisonSubCategoriesViewModel("123", expenditures, forecasts, filters);
+
+        var service = new TrustItSpendChartService(_chartRenderingApiMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await service.BuildForecastChartsAsync(Dimensions.ResultAsOptions.Actuals, subCategories);
+
+        // Assert
+        Assert.Equivalent(expectedResponse, result);
+    }
+
+    [Fact]
+    public async Task BuildForecastChartsAsyncReturnsEmptyWhenNoForecastData()
+    {
+        // Arrange
+        var expenditures = _fixture.Build<TrustItSpend>().CreateMany(5).ToArray();
+        var filters = new[] { ItSpendingCategories.SubCategoryFilter.Connectivity };
+
+        var subCategories = new TrustComparisonSubCategoriesViewModel("123", expenditures, null, filters);
+
+        var service = new TrustItSpendChartService(_chartRenderingApiMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await service.BuildForecastChartsAsync(Dimensions.ResultAsOptions.Actuals, subCategories);
+
+        // Assert
+        Assert.Empty(result);
+    }
+}

--- a/web/tests/Web.Tests/Services/WhenTrustItSpendChartServiceIsCalled.cs
+++ b/web/tests/Web.Tests/Services/WhenTrustItSpendChartServiceIsCalled.cs
@@ -17,6 +17,293 @@ public class WhenTrustItSpendChartServiceIsCalled
     private readonly Mock<ILogger<TrustItSpendChartService>> _loggerMock = new();
     private readonly Fixture _fixture = new();
 
+    public static TheoryData<TrustItSpend[], TrustItSpendForecastYear[]?, decimal?[], decimal?[]> BuildChartsDomainTestData = new()
+    {
+        {
+            [
+                new TrustItSpend
+                {
+                    CompanyNumber = "12345678",
+                    AdministrationSoftwareAndSystems = 0
+                },
+                new TrustItSpend
+                {
+                    CompanyNumber = "23456789",
+                    AdministrationSoftwareAndSystems = 1000
+                }
+            ],
+            null, [
+                null // no forecast data
+            ],
+            [
+                null // no forecast data
+            ]
+        },
+        {
+            [
+                new TrustItSpend
+                {
+                    CompanyNumber = "12345678",
+                    AdministrationSoftwareAndSystems = 0
+                },
+                new TrustItSpend
+                {
+                    CompanyNumber = "23456789",
+                    AdministrationSoftwareAndSystems = 1000
+                }
+            ],
+            [
+                new TrustItSpendForecastYear
+                {
+                    Year = 2022,
+                    Connectivity = 100
+                },
+                new TrustItSpendForecastYear
+                {
+                    Year = 2023,
+                    Connectivity = 200
+                },
+                new TrustItSpendForecastYear
+                {
+                    Year = 2024,
+                    Connectivity = 300
+                }
+            ],
+            [
+                null // no matching forecast data
+            ],
+            [
+                null // no matching forecast data
+            ]
+        },
+        {
+            [
+                new TrustItSpend
+                {
+                    CompanyNumber = "12345678",
+                    AdministrationSoftwareAndSystems = 0
+                },
+                new TrustItSpend
+                {
+                    CompanyNumber = "23456789",
+                    AdministrationSoftwareAndSystems = 1000
+                }
+            ],
+            [
+                new TrustItSpendForecastYear
+                {
+                    Year = 2022,
+                    AdministrationSoftwareAndSystems = 100
+                },
+                new TrustItSpendForecastYear
+                {
+                    Year = 2023,
+                    AdministrationSoftwareAndSystems = 200
+                },
+                new TrustItSpendForecastYear
+                {
+                    Year = 2024,
+                    AdministrationSoftwareAndSystems = 300
+                }
+            ],
+            [
+                null // 0 resolves to null
+            ],
+            [
+                1000 // maximum value from spend data
+            ]
+        },
+        {
+            [
+                new TrustItSpend
+                {
+                    CompanyNumber = "12345678",
+                    AdministrationSoftwareAndSystems = 50
+                },
+                new TrustItSpend
+                {
+                    CompanyNumber = "23456789",
+                    AdministrationSoftwareAndSystems = 1000
+                }
+            ],
+            [
+                new TrustItSpendForecastYear
+                {
+                    Year = 2022,
+                    AdministrationSoftwareAndSystems = 100
+                },
+                new TrustItSpendForecastYear
+                {
+                    Year = 2023,
+                    AdministrationSoftwareAndSystems = 200
+                },
+                new TrustItSpendForecastYear
+                {
+                    Year = 2024,
+                    AdministrationSoftwareAndSystems = 3000
+                }
+            ],
+            [
+                50 // minimum value from spend data
+            ],
+            [
+                3000 // maximum value from forecast data
+            ]
+        },
+        {
+            [
+                new TrustItSpend
+                {
+                    CompanyNumber = "12345678",
+                    AdministrationSoftwareAndSystems = 100
+                },
+                new TrustItSpend
+                {
+                    CompanyNumber = "23456789",
+                    AdministrationSoftwareAndSystems = 3000
+                }
+            ],
+            [
+                new TrustItSpendForecastYear
+                {
+                    Year = 2022,
+                    AdministrationSoftwareAndSystems = 50
+                },
+                new TrustItSpendForecastYear
+                {
+                    Year = 2023,
+                    AdministrationSoftwareAndSystems = 200
+                },
+                new TrustItSpendForecastYear
+                {
+                    Year = 2024,
+                    AdministrationSoftwareAndSystems = 1000
+                }
+            ],
+            [
+                50 // minimum value from forecast data
+            ],
+            [
+                3000 // maximum value from spend data
+            ]
+        }
+    };
+
+    public static TheoryData<TrustItSpend[], TrustItSpendForecastYear[]?, decimal?[], decimal?[]> BuildForecastChartsDomainTestData = new()
+    {
+        {
+            [
+                new TrustItSpend
+                {
+                    CompanyNumber = "12345678",
+                    AdministrationSoftwareAndSystems = 0
+                },
+                new TrustItSpend
+                {
+                    CompanyNumber = "23456789",
+                    AdministrationSoftwareAndSystems = 1000
+                }
+            ],
+            [
+                new TrustItSpendForecastYear
+                {
+                    Year = 2022,
+                    AdministrationSoftwareAndSystems = 100
+                },
+                new TrustItSpendForecastYear
+                {
+                    Year = 2023,
+                    AdministrationSoftwareAndSystems = 200
+                },
+                new TrustItSpendForecastYear
+                {
+                    Year = 2024,
+                    AdministrationSoftwareAndSystems = 300
+                }
+            ],
+            [
+                null // 0 resolves to null
+            ],
+            [
+                1000 // maximum value from spend data
+            ]
+        },
+        {
+            [
+                new TrustItSpend
+                {
+                    CompanyNumber = "12345678",
+                    AdministrationSoftwareAndSystems = 50
+                },
+                new TrustItSpend
+                {
+                    CompanyNumber = "23456789",
+                    AdministrationSoftwareAndSystems = 1000
+                }
+            ],
+            [
+                new TrustItSpendForecastYear
+                {
+                    Year = 2022,
+                    AdministrationSoftwareAndSystems = 100
+                },
+                new TrustItSpendForecastYear
+                {
+                    Year = 2023,
+                    AdministrationSoftwareAndSystems = 200
+                },
+                new TrustItSpendForecastYear
+                {
+                    Year = 2024,
+                    AdministrationSoftwareAndSystems = 3000
+                }
+            ],
+            [
+                50 // minimum value from spend data
+            ],
+            [
+                3000 // maximum value from forecast data
+            ]
+        },
+        {
+            [
+                new TrustItSpend
+                {
+                    CompanyNumber = "12345678",
+                    AdministrationSoftwareAndSystems = 100
+                },
+                new TrustItSpend
+                {
+                    CompanyNumber = "23456789",
+                    AdministrationSoftwareAndSystems = 3000
+                }
+            ],
+            [
+                new TrustItSpendForecastYear
+                {
+                    Year = 2022,
+                    AdministrationSoftwareAndSystems = 50
+                },
+                new TrustItSpendForecastYear
+                {
+                    Year = 2023,
+                    AdministrationSoftwareAndSystems = 200
+                },
+                new TrustItSpendForecastYear
+                {
+                    Year = 2024,
+                    AdministrationSoftwareAndSystems = 1000
+                }
+            ],
+            [
+                50 // minimum value from forecast data
+            ],
+            [
+                3000 // maximum value from spend data
+            ]
+        }
+    };
+
     [Fact]
     public async Task BuildChartsAsyncReturnsChartResponseWhenApiSucceeds()
     {
@@ -70,6 +357,81 @@ public class WhenTrustItSpendChartServiceIsCalled
     }
 
     [Fact]
+    public async Task BuildChartsAsyncBuildsExpectedRequest()
+    {
+        PostHorizontalBarChartsRequest<TrustComparisonDatum>? actualRequest = null;
+        _chartRenderingApiMock
+            .Setup(api => api.PostHorizontalBarCharts(It.IsAny<PostHorizontalBarChartsRequest<TrustComparisonDatum>>(), It.IsAny<CancellationToken>()))
+            .Callback<PostHorizontalBarChartsRequest<TrustComparisonDatum>, CancellationToken>((request, _) =>
+            {
+                actualRequest = request;
+            });
+
+        var expenditures = _fixture.Build<TrustItSpend>().CreateMany(10).ToArray();
+
+        var forecasts = _fixture.Build<TrustItSpendForecastYear>().CreateMany(3).ToArray();
+
+        var filters = new[]
+        {
+            ItSpendingCategories.SubCategoryFilter.AdministrationSoftwareSystems,
+            ItSpendingCategories.SubCategoryFilter.Connectivity
+        };
+
+        const string companyNumber = "123";
+        var subCategories = new TrustComparisonSubCategoriesViewModel(companyNumber, expenditures, forecasts, filters);
+
+        var service = new TrustItSpendChartService(_chartRenderingApiMock.Object, _loggerMock.Object);
+
+        // Act
+        await service.BuildChartsAsync(companyNumber, Dimensions.ResultAsOptions.Actuals, subCategories, u => $"url/{u}");
+
+        // Assert
+        Assert.Equal(subCategories.Items.Count, actualRequest?.Count);
+        for (var i = 0; i < subCategories.Items.Count; i++)
+        {
+            var item = actualRequest?.ElementAtOrDefault(i);
+            var viewModel = subCategories.Items.ElementAtOrDefault(i);
+            Assert.Equal(viewModel?.Uuid, item?.Id);
+            Assert.Equal(companyNumber, item?.HighlightKey);
+            Assert.Equal(viewModel?.Data, item?.Data);
+            Assert.Equal("url/%1$s", item?.LinkFormat);
+            Assert.Equal("currency", item?.ValueType);
+            Assert.Equal("actuals", item?.XAxisLabel);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(BuildChartsDomainTestData))]
+    public async Task BuildChartsAsyncReturnsExpectedRequestDomain(TrustItSpend[] expenditures, TrustItSpendForecastYear[]? forecasts, decimal?[] expectedDomainsMin, decimal?[] expectedDomainsMax)
+    {
+        // Arrange
+        PostHorizontalBarChartsRequest<TrustComparisonDatum>? actualRequest = null;
+        _chartRenderingApiMock
+            .Setup(api => api.PostHorizontalBarCharts(It.IsAny<PostHorizontalBarChartsRequest<TrustComparisonDatum>>(), It.IsAny<CancellationToken>()))
+            .Callback<PostHorizontalBarChartsRequest<TrustComparisonDatum>, CancellationToken>((request, _) =>
+            {
+                actualRequest = request;
+            });
+
+        var filters = new[] { ItSpendingCategories.SubCategoryFilter.AdministrationSoftwareSystems };
+
+        var subCategories = new TrustComparisonSubCategoriesViewModel("123", expenditures, forecasts, filters);
+        var service = new TrustItSpendChartService(_chartRenderingApiMock.Object, _loggerMock.Object);
+
+        // Act
+        await service.BuildChartsAsync("123", Dimensions.ResultAsOptions.Actuals, subCategories, s => $"url/{s}");
+
+        // Assert
+        Assert.Equal(subCategories.Items.Count, actualRequest?.Count);
+        for (var i = 0; i < subCategories.Items.Count; i++)
+        {
+            var item = actualRequest?.ElementAtOrDefault(i);
+            Assert.Equal(expectedDomainsMin.ElementAtOrDefault(i), item?.DomainMin);
+            Assert.Equal(expectedDomainsMax.ElementAtOrDefault(i), item?.DomainMax);
+        }
+    }
+
+    [Fact]
     public async Task BuildForecastChartsAsyncReturnsChartResponseWhenApiSucceeds()
     {
         // Arrange
@@ -109,5 +471,80 @@ public class WhenTrustItSpendChartServiceIsCalled
 
         // Assert
         Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task BuildForecastChartsAsyncBuildsExpectedRequest()
+    {
+        PostHorizontalBarChartsRequest<TrustForecastDatum>? actualRequest = null;
+        _chartRenderingApiMock
+            .Setup(api => api.PostHorizontalBarCharts(It.IsAny<PostHorizontalBarChartsRequest<TrustForecastDatum>>(), It.IsAny<CancellationToken>()))
+            .Callback<PostHorizontalBarChartsRequest<TrustForecastDatum>, CancellationToken>((request, _) =>
+            {
+                actualRequest = request;
+            });
+
+        var expenditures = _fixture.Build<TrustItSpend>().CreateMany(10).ToArray();
+
+        var forecasts = _fixture.Build<TrustItSpendForecastYear>().CreateMany(3).ToArray();
+
+        var filters = new[]
+        {
+            ItSpendingCategories.SubCategoryFilter.AdministrationSoftwareSystems,
+            ItSpendingCategories.SubCategoryFilter.Connectivity
+        };
+
+        const string companyNumber = "123";
+        var subCategories = new TrustComparisonSubCategoriesViewModel(companyNumber, expenditures, forecasts, filters);
+
+        var service = new TrustItSpendChartService(_chartRenderingApiMock.Object, _loggerMock.Object);
+
+        // Act
+        await service.BuildForecastChartsAsync(Dimensions.ResultAsOptions.Actuals, subCategories);
+
+        // Assert
+        Assert.Equal(subCategories.Items.Count, actualRequest?.Count);
+        for (var i = 0; i < subCategories.Items.Count; i++)
+        {
+            var item = actualRequest?.ElementAtOrDefault(i);
+            var viewModel = subCategories.Items.ElementAtOrDefault(i);
+            Assert.Equal(viewModel?.Uuid, item?.Id);
+            Assert.Null(item?.HighlightKey);
+            Assert.Equal(viewModel?.ForecastData, item?.Data);
+            Assert.Null(item?.LinkFormat);
+            Assert.Equal("currency", item?.ValueType);
+            Assert.Equal("actuals", item?.XAxisLabel);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(BuildForecastChartsDomainTestData))]
+    public async Task BuildForecastChartsAsyncReturnsExpectedRequestDomain(TrustItSpend[] expenditures, TrustItSpendForecastYear[]? forecasts, decimal?[] expectedDomainsMin, decimal?[] expectedDomainsMax)
+    {
+        // Arrange
+        PostHorizontalBarChartsRequest<TrustForecastDatum>? actualRequest = null;
+        _chartRenderingApiMock
+            .Setup(api => api.PostHorizontalBarCharts(It.IsAny<PostHorizontalBarChartsRequest<TrustForecastDatum>>(), It.IsAny<CancellationToken>()))
+            .Callback<PostHorizontalBarChartsRequest<TrustForecastDatum>, CancellationToken>((request, _) =>
+            {
+                actualRequest = request;
+            });
+
+        var filters = new[] { ItSpendingCategories.SubCategoryFilter.AdministrationSoftwareSystems };
+
+        var subCategories = new TrustComparisonSubCategoriesViewModel("123", expenditures, forecasts, filters);
+        var service = new TrustItSpendChartService(_chartRenderingApiMock.Object, _loggerMock.Object);
+
+        // Act
+        await service.BuildForecastChartsAsync(Dimensions.ResultAsOptions.Actuals, subCategories);
+
+        // Assert
+        Assert.Equal(subCategories.Items.Count, actualRequest?.Count);
+        for (var i = 0; i < subCategories.Items.Count; i++)
+        {
+            var item = actualRequest?.ElementAtOrDefault(i);
+            Assert.Equal(expectedDomainsMin.ElementAtOrDefault(i), item?.DomainMin);
+            Assert.Equal(expectedDomainsMax.ElementAtOrDefault(i), item?.DomainMax);
+        }
     }
 }

--- a/web/tests/Web.Tests/ViewModels/GivenATrustComparisonItSpendViewModel.cs
+++ b/web/tests/Web.Tests/ViewModels/GivenATrustComparisonItSpendViewModel.cs
@@ -19,7 +19,7 @@ public class GivenATrustComparisonItSpendViewModel
         const string redirectUri = nameof(redirectUri);
         var userDefinedSet = _fixture.CreateMany<string>().ToArray();
         var expenditures = _fixture.Build<TrustItSpend>().CreateMany().ToArray();
-        var subCategories = new TrustComparisonSubCategoriesViewModel(string.Empty, expenditures, []);
+        var subCategories = new TrustComparisonSubCategoriesViewModel(string.Empty, expenditures, null, []);
         var currentBfrYear = _fixture.Create<int>();
 
         var actual = new TrustComparisonItSpendViewModel(trust, comparatorGenerated, redirectUri, userDefinedSet, subCategories, currentBfrYear);

--- a/web/tests/Web.Tests/ViewModels/GivenATrustComparisonSubCategoriesViewModel.cs
+++ b/web/tests/Web.Tests/ViewModels/GivenATrustComparisonSubCategoriesViewModel.cs
@@ -1,0 +1,89 @@
+using AutoFixture;
+using Web.App.Domain;
+using Web.App.Domain.Charts;
+using Web.App.ViewModels;
+using Xunit;
+
+namespace Web.Tests.ViewModels;
+
+public class GivenATrustComparisonSubCategoriesViewModel
+{
+    private readonly Fixture _fixture = new();
+
+    [Fact]
+    public void ShouldFlattenAllSubCategoriesForTrustItSpendWithoutForecast()
+    {
+        const string companyNumber = nameof(companyNumber);
+        var expenditures = _fixture.Build<TrustItSpend>().CreateMany().ToArray();
+
+        var actual = new TrustComparisonSubCategoriesViewModel(companyNumber, expenditures, null, ItSpendingCategories.All);
+
+        Assert.Equal(7, actual.Items.Count);
+        AssertSubCategory(actual.Items.ElementAt(0), "ICT costs: Administration software and systems", companyNumber, s => s.AdministrationSoftwareAndSystems, expenditures);
+        AssertSubCategory(actual.Items.ElementAt(1), "ICT costs: Connectivity", companyNumber, s => s.Connectivity, expenditures);
+        AssertSubCategory(actual.Items.ElementAt(2), "ICT costs: IT learning resources", companyNumber, s => s.ItLearningResources, expenditures);
+        AssertSubCategory(actual.Items.ElementAt(3), "ICT costs: IT support", companyNumber, s => s.ItSupport, expenditures);
+        AssertSubCategory(actual.Items.ElementAt(4), "ICT costs: Laptops, desktops and tablets", companyNumber, s => s.LaptopsDesktopsAndTablets, expenditures);
+        AssertSubCategory(actual.Items.ElementAt(5), "ICT costs: Onsite servers", companyNumber, s => s.OnsiteServers, expenditures);
+        AssertSubCategory(actual.Items.ElementAt(6), "ICT costs: Other hardware", companyNumber, s => s.OtherHardware, expenditures);
+    }
+
+    [Fact]
+    public void ShouldFlattenAllSubCategoriesForTrustItSpendWithForecast()
+    {
+        const string companyNumber = nameof(companyNumber);
+        var expenditures = _fixture.Build<TrustItSpend>().CreateMany().ToArray();
+        var forecasts = _fixture.Build<TrustItSpendForecastYear>().CreateMany().ToArray();
+
+        var actual = new TrustComparisonSubCategoriesViewModel(companyNumber, expenditures, forecasts, ItSpendingCategories.All);
+
+        Assert.Equal(7, actual.Items.Count);
+        AssertSubCategory(actual.Items.ElementAt(0), "ICT costs: Administration software and systems", companyNumber, s => s.AdministrationSoftwareAndSystems, expenditures, forecasts);
+        AssertSubCategory(actual.Items.ElementAt(1), "ICT costs: Connectivity", companyNumber, s => s.Connectivity, expenditures, forecasts);
+        AssertSubCategory(actual.Items.ElementAt(2), "ICT costs: IT learning resources", companyNumber, s => s.ItLearningResources, expenditures, forecasts);
+        AssertSubCategory(actual.Items.ElementAt(3), "ICT costs: IT support", companyNumber, s => s.ItSupport, expenditures, forecasts);
+        AssertSubCategory(actual.Items.ElementAt(4), "ICT costs: Laptops, desktops and tablets", companyNumber, s => s.LaptopsDesktopsAndTablets, expenditures, forecasts);
+        AssertSubCategory(actual.Items.ElementAt(5), "ICT costs: Onsite servers", companyNumber, s => s.OnsiteServers, expenditures, forecasts);
+        AssertSubCategory(actual.Items.ElementAt(6), "ICT costs: Other hardware", companyNumber, s => s.OtherHardware, expenditures, forecasts);
+    }
+
+    private static void AssertSubCategory(
+        TrustBenchmarkingViewModelCostSubCategory actual,
+        string name,
+        string companyNumber,
+        Func<ItSpend, decimal?> selector,
+        TrustItSpend[] expenditures,
+        TrustItSpendForecastYear[]? forecasts = null)
+    {
+        Assert.Null(actual.ChartSvg);
+        Assert.Equal(name, actual.SubCategory);
+        Assert.NotNull(actual.Uuid);
+
+        var expected = expenditures
+            .Select(e => new TrustComparisonDatum
+            {
+                CompanyNumber = e.CompanyNumber,
+                TrustName = e.TrustName,
+                Expenditure = selector(e)
+            })
+            .Where(x => x.CompanyNumber == companyNumber || x.Expenditure > 0);
+
+        Assert.Equivalent(expected, actual.Data);
+
+        if (forecasts == null)
+        {
+            Assert.Null(actual.ForecastData);
+            return;
+        }
+
+        var expectedForecast = forecasts
+            .OrderBy(f => f.Year)
+            .Select(f => new KeyValuePair<int, decimal?>((int)f.Year!, selector(f)))
+            .ToDictionary();
+        Assert.Equal(expectedForecast.Keys, actual.ForecastData?.Years);
+        foreach (var (year, value) in expectedForecast)
+        {
+            Assert.Equal(value, actual.ForecastData?[year]);
+        }
+    }
+}

--- a/web/tests/Web.Tests/ViewModels/GivenATrustComparisonSubCategoriesViewModel.cs
+++ b/web/tests/Web.Tests/ViewModels/GivenATrustComparisonSubCategoriesViewModel.cs
@@ -78,12 +78,8 @@ public class GivenATrustComparisonSubCategoriesViewModel
 
         var expectedForecast = forecasts
             .OrderBy(f => f.Year)
-            .Select(f => new KeyValuePair<int, decimal?>((int)f.Year!, selector(f)))
-            .ToDictionary();
-        Assert.Equal(expectedForecast.Keys, actual.ForecastData?.Years);
-        foreach (var (year, value) in expectedForecast)
-        {
-            Assert.Equal(value, actual.ForecastData?[year]);
-        }
+            .Select(f => new TrustForecastDatum { Year = (int)f.Year!, Expenditure = selector(f) })
+            .ToArray();
+        Assert.Equivalent(expectedForecast, actual.ForecastData);
     }
 }


### PR DESCRIPTION
## 🧾 Summary

[AB#266041](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/266041) [AB#283432](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/283432)

- Refactored 'Trust authorisation' logic and evaluated on Trust IT spending page
- Build subcategories with result from Trust IT Forecast API call if authorised to do so
- Send additional API request for SSR charts for Trust IT Forecast if data available
- Modify SSR chart requests for Trust IT spend to include custom domain that matches extremes of forecast data, or spending data, based on the min/max across both data sets
- Prevent filtering out of negative or zero values from Trust IT spend data
- Fixed min/max domains in SSR charts when both evaluate to `0`
- Refactor SSR chart request/response logic into service
- Integration and unit test coverage

<img width="676" height="871" alt="image" src="https://github.com/user-attachments/assets/872e33f8-55fd-4f9b-9cd6-a52af742e2fd" />

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Unit and integration tests updated _(if applicable)_.
- [x] All unit/integration tests are executed and passed.
- [x] Tested by running locally.

</details>
<details>
<summary>Documentation updates</summary>


- [ ] Code-level documentation (e.g., inline comments, docstrings) is updated.
- [ ] README.md or relevant module-level docs are updated.
- [ ] API changes are reflected in API documentation _(if applicable)_.
- [ ] Links to external references are included instead of duplicating content.
- [ ] No outdated or incorrect documentation remains.

</details>
<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [x] Screenshots or Demo _(if applicable)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] Design (UX and/or content) review _(if applicable)_.
- [ ] Documentation changes have been explicitly reviewed.
- [ ] CI/CD pipeline checks pass.

</details>

## 🧪 Testing notes

Connect to an environment with BFR IT spend data for best results. Also ensure 'disable org check' flag is set to enable sensitive data to be viewable.
