### PR TITLE
feat: add download data to trust to trust it spend benchmarking page

### DIFF
--- a/web/src/Web.App/Views/TrustComparisonItSpend/_ItSpendFilter.cshtml
+++ b/web/src/Web.App/Views/TrustComparisonItSpend/_ItSpendFilter.cshtml
@@ -141,6 +141,17 @@
             <button type="submit" class="govuk-button govuk-!-margin-bottom-3" data-module="govuk-button">
                 Apply filters
             </button>
+            
+            <div class="govuk-button-group govuk-!-margin-bottom-0">
+                @if (Model.ViewAs == Views.ViewAsOptions.Chart)
+                {
+                    <div id="page-actions-button"></div>
+                }
+                <a href="@Url.Action("Download", "TrustComparisonItSpend", new { companyNumber = Model.CompanyNumber })" role="button"
+               class="govuk-button govuk-button--secondary" data-module="govuk-button">
+                Download page data
+            </a>
+            </div>
         }
     </div>
 </div>

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -788,6 +788,14 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         return this;
     }
 
+    public BenchmarkingWebAppClient SetupItSpendWithException()
+    {
+        ItSpendApi.Reset();
+        ItSpendApi.Setup(api => api.QuerySchools(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>())).Throws(new Exception());
+        ItSpendApi.Setup(api => api.QueryTrusts(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>())).Throws(new Exception());
+        return this;
+    }
+
     public BenchmarkingWebAppClient SetupHttpContextAccessor(ConcurrentDictionary<string, byte[]>? items = null)
     {
         HttpContextAccessor.Reset();

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/Comparison/WhenRequestingComparisonItSpendDownload.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/Comparison/WhenRequestingComparisonItSpendDownload.cs
@@ -1,0 +1,135 @@
+using System.Net;
+using AutoFixture;
+using Web.App.Domain;
+using Xunit;
+
+namespace Web.Integration.Tests.Pages.Trusts.Comparison;
+
+public class WhenRequestingTrustComparisonItSpendDownload : PageBase<SchoolBenchmarkingWebAppClient>
+{
+    private readonly SchoolBenchmarkingWebAppClient _client;
+    private readonly TrustItSpend[] _trustItSpend;
+
+    public WhenRequestingTrustComparisonItSpendDownload(SchoolBenchmarkingWebAppClient client) : base(client)
+    {
+        _client = client;
+        _trustItSpend = Fixture.Build<TrustItSpend>().CreateMany().ToArray();
+    }
+
+    [Fact]
+    public async Task CanReturnOk()
+    {
+        var trust = Fixture.Build<Trust>()
+            .With(x => x.CompanyNumber, "87654321")
+            .Create();
+
+        var comparatorSet = new[]
+        {
+            new UserData
+            {
+                Type = "comparator-set",
+                Id = "456"
+            }
+        };
+
+        var userDefinedSet = new UserDefinedSchoolComparatorSet
+        {
+            Set = ["00000001", "00000002", "00000003"]
+        };
+
+        var response = await _client
+            .SetupUserData(comparatorSet)
+            .SetupComparatorSet(trust, userDefinedSet)
+            .SetupItSpend(trustSpend: _trustItSpend)
+            .Get(Paths.TrustComparisonItSpendDownload(trust.CompanyNumber!));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var expectedFileNames = new[]
+        {
+            "benchmark-it-spending-previous-year-87654321.csv"
+        };
+        await foreach (var tuple in response.GetFilesFromZip())
+        {
+            Assert.Contains(tuple.fileName, expectedFileNames);
+
+            var csvLines = tuple.content.Split(Environment.NewLine);
+            Assert.Equal(
+                "CompanyNumber,TrustName,Connectivity,OnsiteServers,ItLearningResources,AdministrationSoftwareAndSystems,LaptopsDesktopsAndTablets,OtherHardware,ItSupport",
+                csvLines.First());
+            Assert.Equal(_trustItSpend.Length, csvLines.Length - 1);
+        }
+    }
+
+    [Fact]
+    public async Task CanReturnNotFoundWhenUserDataMissing()
+    {
+        var trust = Fixture.Build<Trust>()
+            .With(x => x.CompanyNumber, "87654321")
+            .Create();
+
+        var response = await _client
+            .SetupUserData()
+            .Get(Paths.TrustComparisonItSpendDownload(trust.CompanyNumber!));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CanReturnNotFoundWhenComparatorSetMissing()
+    {
+        var trust = Fixture.Build<Trust>()
+            .With(x => x.CompanyNumber, "87654321")
+            .Create();
+
+        var comparatorSet = new[]
+        {
+            new UserData
+            {
+                Type = "comparator-set",
+                Id = "456"
+            }
+        };
+
+        var userDefinedSet = new UserDefinedSchoolComparatorSet
+        {
+            Set = []
+        };
+
+        var response = await _client
+            .SetupUserData(comparatorSet)
+            .SetupComparatorSet(trust, userDefinedSet)
+            .Get(Paths.TrustComparisonItSpendDownload(trust.CompanyNumber!));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CanReturnInternalServerError()
+    {
+        var trust = Fixture.Build<Trust>()
+            .With(x => x.CompanyNumber, "87654321")
+            .Create();
+
+        var comparatorSet = new[]
+        {
+            new UserData
+            {
+                Type = "comparator-set",
+                Id = "456"
+            }
+        };
+
+        var userDefinedSet = new UserDefinedSchoolComparatorSet
+        {
+            Set = ["00000001", "00000002", "00000003"]
+        };
+
+        var response = await _client
+            .SetupUserData(comparatorSet)
+            .SetupComparatorSet(trust, userDefinedSet)
+            .SetupItSpendWithException()
+            .Get(Paths.TrustComparisonItSpendDownload(trust.CompanyNumber!));
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+}

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -31,6 +31,8 @@ public static class Paths
 
     public static string TrustComparisonItSpend(string? companyNumber) => $"/trust/{companyNumber}/benchmark-it-spending";
 
+    public static string TrustComparisonItSpendDownload(string? companyNumber) => $"/trust/{companyNumber}/benchmark-it-spending/download";
+
     public static string TrustCensus(string? companyNumber) => $"/trust/{companyNumber}/census";
 
     public static string TrustFinancialPlanning(string? companyNumber) => $"/trust/{companyNumber}/financial-planning";


### PR DESCRIPTION
## 🧾 Summary

[AB#266041](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/266041) - [AB#281182](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/281182)

Adds download data functionality to the trust benchmark it spending page. Currently only for previous year but this will be extended to conditionally include another csv for forecast when the user has valid claim in a future task on this story

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Unit and integration tests updated _(if applicable)_.
- [x] All unit/integration tests are executed and passed.
- [x] Tested by running locally.

</details>

<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] CI/CD pipeline checks pass.

</details>
