### PR TITLE
Added 'Save images' button to Trust IT Spend page when viewing as charts

### DIFF
--- a/web/src/Web.App/Views/TrustComparisonItSpend/Index.cshtml
+++ b/web/src/Web.App/Views/TrustComparisonItSpend/Index.cshtml
@@ -2,6 +2,7 @@
 @using Web.App.Domain.Charts
 @using Web.App.Extensions
 @using Web.App.ViewModels
+@using Web.App.ViewModels.Enhancements
 @model Web.App.ViewModels.TrustComparisonItSpendViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.ComparisonItSpend;
@@ -103,4 +104,14 @@
 
         initAll()
     </script>
+    
+    @await Html.PartialAsync("Enhancements/_PageActions", new PageActionsViewModel
+    {
+        All = true,
+        ElementId = "page-actions-button",
+        SaveClassName = "costs-chart-container",
+        SaveFileName = $"benchmark-it-spending-{Model.CompanyNumber}.zip",
+        SaveTitleAttr = "data-title",
+        StartImmediately = true
+    })
 }

--- a/web/tests/Web.Integration.Tests/Pages/Trusts/Comparison/WhenViewingComparisonItSpend.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/Comparison/WhenViewingComparisonItSpend.cs
@@ -228,6 +228,24 @@ public class WhenViewingComparisonItSpend(SchoolBenchmarkingWebAppClient client)
             expectedQueryParams: "?viewAs=0&resultAs=1");
     }
 
+    [Theory]
+    [InlineData(Views.ViewAsOptions.Chart, true)]
+    [InlineData(Views.ViewAsOptions.Table, false)]
+    public async Task CanSaveChartImages(Views.ViewAsOptions viewAs, bool expected)
+    {
+        var (page, _, _, _, _) = await SetupNavigateInitPage(true, queryParams: $"?viewAs={(int)viewAs}");
+
+        var button = page.QuerySelector("#page-actions-button");
+        if (expected)
+        {
+            Assert.NotNull(button);
+        }
+        else
+        {
+            Assert.Null(button);
+        }
+    }
+
     private async Task<(
         IHtmlDocument page,
         Trust trust,


### PR DESCRIPTION
## 🧾 Summary

[AB#266041](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/266041) [AB#281184](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/281184)

- Added enhancement to show 'save' button and trigger existing modal behaviour
- Integration test coverage over existence of button (action to be validated via future E2E tests)

<img width="792" height="940" alt="image" src="https://github.com/user-attachments/assets/a5332f70-dcd0-481d-921b-48d9eca7a5c1" />

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Unit and integration tests updated _(if applicable)_.
- [x] All unit/integration tests are executed and passed.
- [x] Tested by running locally.

</details>
<details>
<summary>Documentation updates</summary>


- [ ] Code-level documentation (e.g., inline comments, docstrings) is updated.
- [ ] README.md or relevant module-level docs are updated.
- [ ] API changes are reflected in API documentation _(if applicable)_.
- [ ] Links to external references are included instead of duplicating content.
- [ ] No outdated or incorrect documentation remains.

</details>
<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [x] Screenshots or Demo _(if applicable)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] Design (UX and/or content) review _(if applicable)_.
- [ ] Documentation changes have been explicitly reviewed.
- [ ] CI/CD pipeline checks pass.

</details>
