### PR TITLE
feat: add download forecast data to trust it spend page

### DIFF
--- a/web/tests/Web.Integration.Tests/Pages/Trusts/Comparison/WhenRequestingComparisonItSpendDownload.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Trusts/Comparison/WhenRequestingComparisonItSpendDownload.cs
@@ -9,15 +9,17 @@ public class WhenRequestingTrustComparisonItSpendDownload : PageBase<SchoolBench
 {
     private readonly SchoolBenchmarkingWebAppClient _client;
     private readonly TrustItSpend[] _trustItSpend;
+    private readonly TrustItSpendForecastYear[] _trustForecast;
 
     public WhenRequestingTrustComparisonItSpendDownload(SchoolBenchmarkingWebAppClient client) : base(client)
     {
         _client = client;
-        _trustItSpend = Fixture.Build<TrustItSpend>().CreateMany().ToArray();
+        _trustItSpend = Fixture.Build<TrustItSpend>().CreateMany(5).ToArray();
+        _trustForecast = Fixture.Build<TrustItSpendForecastYear>().CreateMany(3).ToArray();
     }
 
     [Fact]
-    public async Task CanReturnOk()
+    public async Task CanReturnOkWithTrustClaim()
     {
         var trust = Fixture.Build<Trust>()
             .With(x => x.CompanyNumber, "87654321")
@@ -40,24 +42,96 @@ public class WhenRequestingTrustComparisonItSpendDownload : PageBase<SchoolBench
         var response = await _client
             .SetupUserData(comparatorSet)
             .SetupComparatorSet(trust, userDefinedSet)
-            .SetupItSpend(trustSpend: _trustItSpend)
+            .SetupItSpend(trustSpend: _trustItSpend, trustForecast: _trustForecast)
             .Get(Paths.TrustComparisonItSpendDownload(trust.CompanyNumber!));
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var expectedFileNames = new[]
         {
-            "benchmark-it-spending-previous-year-87654321.csv"
+            "benchmark-it-spending-previous-year-87654321.csv",
+            "benchmark-it-spending-forecast-87654321.csv"
         };
+
+        var files = new List<(string fileName, string content)>();
+        await foreach (var file in response.GetFilesFromZip())
+        {
+            Assert.Contains(file.fileName, expectedFileNames);
+
+            files.Add(file);
+        }
+
+        Assert.Equal(2, files.Count);
+
+        var previousYearFile = files.Single(f => f.fileName == "benchmark-it-spending-previous-year-87654321.csv");
+        var previousYearContent = previousYearFile.content;
+        Assert.NotNull(previousYearContent);
+        var previousYearLines = previousYearContent.Split(Environment.NewLine);
+        Assert.Equal(
+            "CompanyNumber,TrustName,Connectivity,OnsiteServers,ItLearningResources,AdministrationSoftwareAndSystems,LaptopsDesktopsAndTablets,OtherHardware,ItSupport",
+            previousYearLines.First());
+        Assert.Equal(_trustItSpend.Length, previousYearLines.Length - 1);
+
+        var forecastFile = files.Single(f => f.fileName == "benchmark-it-spending-forecast-87654321.csv");
+        var forecastContent = forecastFile.content;
+        Assert.NotNull(forecastContent);
+        var forecastLines = forecastContent.Split(Environment.NewLine);
+        Assert.Equal(
+            "Year,Connectivity,OnsiteServers,ItLearningResources,AdministrationSoftwareAndSystems,LaptopsDesktopsAndTablets,OtherHardware,ItSupport",
+            forecastLines.First());
+        Assert.Equal(_trustForecast.Length, forecastLines.Length - 1);
+    }
+
+    [Fact]
+    public async Task CanReturnOkWithNoTrustClaim()
+    {
+        var trust = Fixture.Build<Trust>()
+            .With(x => x.CompanyNumber, "12345678")
+            .Create();
+
+        var comparatorSet = new[]
+        {
+            new UserData
+            {
+                Type = "comparator-set",
+                Id = "456"
+            }
+        };
+
+        var userDefinedSet = new UserDefinedSchoolComparatorSet
+        {
+            Set = ["00000001", "00000002", "00000003"]
+        };
+
+        var response = await _client
+            .SetupUserData(comparatorSet)
+            .SetupComparatorSet(trust, userDefinedSet)
+            .SetupItSpend(trustSpend: _trustItSpend, trustForecast: _trustForecast)
+            .Get(Paths.TrustComparisonItSpendDownload(trust.CompanyNumber!));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var expectedFileNames = new[]
+        {
+            "benchmark-it-spending-previous-year-12345678.csv",
+        };
+
+        var files = new List<(string fileName, string content)>();
         await foreach (var tuple in response.GetFilesFromZip())
         {
             Assert.Contains(tuple.fileName, expectedFileNames);
 
-            var csvLines = tuple.content.Split(Environment.NewLine);
-            Assert.Equal(
-                "CompanyNumber,TrustName,Connectivity,OnsiteServers,ItLearningResources,AdministrationSoftwareAndSystems,LaptopsDesktopsAndTablets,OtherHardware,ItSupport",
-                csvLines.First());
-            Assert.Equal(_trustItSpend.Length, csvLines.Length - 1);
+            files.Add(tuple);
         }
+
+        Assert.Single(files);
+
+        var file = files.Single(f => f.fileName == "benchmark-it-spending-previous-year-12345678.csv");
+        var content = file.content;
+        Assert.NotNull(content);
+        var csvLines = content.Split(Environment.NewLine);
+        Assert.Equal(
+            "CompanyNumber,TrustName,Connectivity,OnsiteServers,ItLearningResources,AdministrationSoftwareAndSystems,LaptopsDesktopsAndTablets,OtherHardware,ItSupport",
+            csvLines.First());
+        Assert.Equal(_trustItSpend.Length, csvLines.Length - 1);
     }
 
     [Fact]


### PR DESCRIPTION
## 🧾 Summary

[AB#266041](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/266041) [AB#283847](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/283847)

Updates to allow download of forecast data only if user has valid claim for the selected trust.

Refactor to add new methods to remove duplicate code
- GetTrustUserContextAsync to obtain
  - user data
  - user defined comparator set
  - trust authorisation
- GetTrustItSpendAsync
  - bfr current year
  - it spend data for the comparator set (previous year)
  - it spend forecast data for the selected trust (conditional on trust authorisation)  

Also integration test coverage over this behaviour.

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Unit and integration tests updated _(if applicable)_.
- [x] All unit/integration tests are executed and passed.
- [x] Tested by running locally.

</details>

<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [ ] CI/CD pipeline checks pass.

</details>

## 🔍 Reviewer notes

E2E tests to follow on a future PR

## 🧪 Testing notes

Can verify running the web application locally toggling `DISABLE_ORG_CLAIM_CHECK` to simulate the user claim for the selected trust.
