### PR TITLE
feat: Persist KS4 banding to db

### DIFF
--- a/core-infrastructure/src/db/Core.Database/Scripts/124-AlterNonFinancialTable.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/124-AlterNonFinancialTable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE NonFinancial ADD KS4ProgressBanding nvarchar(50) NULL;

--- a/data-pipeline/src/pipeline/utils/database.py
+++ b/data-pipeline/src/pipeline/utils/database.py
@@ -409,6 +409,7 @@ def insert_non_financial_data(
         "Percentage without EHC": "PercentWithoutEducationalHealthCarePlan",
         "Ks2Progress": "KS2Progress",
         "Progress8Measure": "KS4Progress",
+        "Progress8Banding": "KS4ProgressBanding",
         "Percentage Primary Need VI": "PercentWithVI",
         "Percentage Primary Need SPLD": "PercentWithSPLD",
         "Percentage Primary Need SLD": "PercentWithSLD",


### PR DESCRIPTION
## 🧾 Summary
[AB#283987](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/283987)
* We already read both KS4 progress indicators and banding (eg Average, Below Average) from the data source, however the banding isn't persisted to the db
* Persists it to the db so we can do the progress indicators work.
