### PR TITLE
fix: updates views for trust it spend

### DIFF
--- a/core-infrastructure/src/db/Core.Database/Views/028-ItSpendTrust.sql
+++ b/core-infrastructure/src/db/Core.Database/Views/028-ItSpendTrust.sql
@@ -40,14 +40,10 @@ SELECT
     v.OnsiteServers,
     v.OtherHardware
 FROM VW_ItSpendTrustDefaultActual v
-INNER JOIN Parameters p
-    ON p.Name = 'LatestBFRYear'
-WHERE v.RunId = p.Value
-AND v.Year IN (
-    CAST(p.Value AS INT) - 1,
-    CAST(p.Value AS INT),
-    CAST(p.Value AS INT) + 1
-);
+WHERE v.RunId = (SELECT Value FROM Parameters WHERE Name = 'CurrentYear')
+AND v.Year BETWEEN
+    (SELECT CAST(Value AS INT) FROM Parameters WHERE Name = 'LatestBFRYear') - 1
+    AND (SELECT CAST(Value AS INT) FROM Parameters WHERE Name = 'LatestBFRYear') + 1;
 GO
 
 DROP VIEW IF EXISTS VW_ItSpendTrustCurrentPreviousYearActual;
@@ -65,7 +61,5 @@ SELECT
     v.OnsiteServers,
     v.OtherHardware
 FROM VW_ItSpendTrustCurrentAllYearsActual v
-INNER JOIN Parameters p
-    ON p.Name = 'LatestBFRYear'
-WHERE v.Year = CAST(p.Value AS INT) - 1;
+WHERE v.Year = (SELECT CAST(Value AS INT) FROM Parameters WHERE Name = 'LatestBFRYear') - 1
 GO


### PR DESCRIPTION
## 🧾 Summary

[AB#266041](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/266041)

The existing implementation incorrectly created the "current" views based on the value of the `LatestBFRYear` row from the `Parameters` table this should be `CurrentYear` so it is always the latest `RunId`. Also updates those views to use sub queries for Parameters to match implementation elsewhere in the service.

## ✅ Checklist (expand sections as needed)
<details>
<summary>Code changes</summary>

- [x] Code follows project coding standards.
- [x] Code builds clean without any errors or warnings.
- [x] Branch has been rebased onto main.
- [x] Tested by running locally.

</details>

<details>
<summary>UX & metadata</summary>

- [x] Work items have been linked _[(use AB#)](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items)_.
- [x] Add relevant labels (e.g., `bug`, `enhancement`, `documentation`, `refactor`, etc.).

</details>
<details>
<summary>Review & approval</summary>

- [x] CI/CD pipeline checks pass.

</details>

## 🧪 Testing notes

Running the migration scripts against a local DB is successful and checking the values against the corresponding rows in the `BudgetForecast` table confirms the values are correct.
