### PR TITLE
feat: add new links to LA homepage, conditional based on feature flag

### DIFF
--- a/platform/src/apis/Platform.Api.Content/Properties/launchSettings.json
+++ b/platform/src/apis/Platform.Api.Content/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Platform.Api.Content": {
       "commandName": "Project",
-      "commandLineArgs": "--port 7029",
+      "commandLineArgs": "--port 7077",
       "launchBrowser": false
     }
   }

--- a/web/src/Web.App/Controllers/LocalAuthorityEducationHealthCarePlansController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityEducationHealthCarePlansController.cs
@@ -6,7 +6,7 @@ namespace Web.App.Controllers;
 [Controller]
 [Route("local-authority/{code}/education-health-care-plans")]
 [ValidateLaCode]
-public class LocalAuthorityEducationHealthCarePlansController 
+public class LocalAuthorityEducationHealthCarePlansController
     : Controller
 {
     [HttpGet]

--- a/web/src/Web.App/Controllers/LocalAuthorityEducationHealthCarePlansController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityEducationHealthCarePlansController.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Web.App.Attributes;
+
+namespace Web.App.Controllers;
+
+[Controller]
+[Route("local-authority/{code}/education-health-care-plans")]
+[ValidateLaCode]
+public class LocalAuthorityEducationHealthCarePlansController 
+    : Controller
+{
+    [HttpGet]
+    public IActionResult Index(string code)
+    {
+        return new ContentResult();
+    }
+}

--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsSpendingController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsSpendingController.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Web.App.Attributes;
+
+namespace Web.App.Controllers;
+
+[Controller]
+[Route("local-authority/{code}/high-needs-spending")]
+[ValidateLaCode]
+public class LocalAuthorityHighNeedsSpendingController 
+    : Controller
+{
+    [HttpGet]
+    public IActionResult Index(string code)
+    {
+        return new ContentResult();
+    }
+}

--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsSpendingController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsSpendingController.cs
@@ -6,7 +6,7 @@ namespace Web.App.Controllers;
 [Controller]
 [Route("local-authority/{code}/high-needs-spending")]
 [ValidateLaCode]
-public class LocalAuthorityHighNeedsSpendingController 
+public class LocalAuthorityHighNeedsSpendingController
     : Controller
 {
     [HttpGet]

--- a/web/src/Web.App/Views/LocalAuthority/_HighNeeds.cshtml
+++ b/web/src/Web.App/Views/LocalAuthority/_HighNeeds.cshtml
@@ -32,19 +32,43 @@
 <div class="govuk-grid-row" id="high-needs-links">
     <div class="govuk-grid-column-full">
         <ul class="app-links">
-            <li>
-                <h3 class="govuk-heading-s">
-                    <a href="@Url.Action("Comparators", "LocalAuthorityHighNeedsBenchmarking", new
-                             {
-                                 code = Model.Code
-                             })" class="govuk-link govuk-link--no-visited-state">
-                        Benchmark high needs
-                    </a>
-                </h3>
-                <p class="govuk-body">
-                    Benchmark spending against statistical neighbours or other local authorities of your choice.
-                </p>
-            </li>
+            <feature negate="true" name="@FeatureFlags.HighNeedsBenchmarking">
+                <li>
+                    <h3 class="govuk-heading-s">
+                        <a href="@Url.Action("Comparators", "LocalAuthorityHighNeedsBenchmarking", new
+                                 {
+                                     code = Model.Code
+                                 })" class="govuk-link govuk-link--no-visited-state">
+                            Benchmark high needs
+                        </a>
+                    </h3>
+                    <p class="govuk-body">
+                        Benchmark spending against statistical neighbours or other local authorities of your choice.
+                    </p>
+                </li>
+            </feature>
+            <feature name="@FeatureFlags.HighNeedsBenchmarking">
+                <li>
+                    <h3 class="govuk-heading-s">
+                        <a href="@Url.Action("Index", "LocalAuthorityHighNeedsSpending", new { code = Model.Code })" class="govuk-link govuk-link--no-visited-state">
+                            Benchmark high needs spending
+                        </a>
+                    </h3>
+                    <p class="govuk-body">
+                        Benchmark outturn and planned expenditure on high needs with other local authorities.
+                    </p>
+                </li>
+                <li>
+                    <h3 class="govuk-heading-s">
+                        <a href="@Url.Action("Index", "LocalAuthorityEducationHealthCarePlans", new { code = Model.Code })" class="govuk-link govuk-link--no-visited-state">
+                            Benchmark education, health and care plans
+                        </a>
+                    </h3>
+                    <p class="govuk-body">
+                        Compare placement of pupils with EHC plans with other local authorities.
+                    </p>
+                </li>
+            </feature>
             <li>
                 <h3 class="govuk-heading-s">
                     <a href="@Url.Action("Index", "LocalAuthorityHighNeedsHistoricData", new


### PR DESCRIPTION
## 🧾 Summary
Add new benchmarking links to the Local Authority (LA) homepage under the "High Needs" section. These links are conditionally displayed based on the HighNeedsBenchmarking feature flag.

Fixes [AB#299439](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/299439) [AB#308377](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/308377)

### ✨ Feature Details
- Functionality: Provides Local Authorities with direct access to new benchmarking tools for "High Needs Spending" and "Education, Health and Care Plans (EHCP)" directly from their dashboard when the feature flag is enabled.
- Implementation: 
  - Created LocalAuthorityHighNeedsSpendingController and LocalAuthorityEducationHealthCarePlansController as entry points for the new benchmarking sections.
  - Updated web/src/Web.App/Views/LocalAuthority/_HighNeeds.cshtml to conditionally render the new links ("Benchmark high needs spending" and "Benchmark education, health and care plans") using the HighNeedsBenchmarking feature flag.
  - Updated the existing "Benchmark high needs" link to only show when the new benchmarking feature is disabled.
  - Adjusted the local launch port for Platform.Api.Content to 7077.

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [x] Tested by running locally (or docs render correctly locally).

## 🔍 Notes
The new controllers currently return a ContentResult as placeholders for the upcoming benchmarking features.
