### PR TITLE
feat: add page scaffolding for the Local Authority Education, Health and Care Plans (EHCP) benchmarking 

### DIFF
--- a/web/src/Web.App/Constants/LocalAuthorityBenchmarkType.cs
+++ b/web/src/Web.App/Constants/LocalAuthorityBenchmarkType.cs
@@ -1,0 +1,7 @@
+﻿namespace Web.App;
+
+public enum LocalAuthorityBenchmarkType
+{
+    HighNeeds,
+    EducationHealthCarePlans
+}

--- a/web/src/Web.App/Constants/PageTitles.cs
+++ b/web/src/Web.App/Constants/PageTitles.cs
@@ -69,6 +69,7 @@ public static class PageTitles
     public const string LocalAuthorityCensus = "View pupil and workforce data";
     public const string LocalAuthorityHighNeeds = "High needs benchmarking overview";
     public const string LocalAuthorityHighNeedsBenchmarking = "Benchmark high needs";
+    public const string LocalAuthorityEducationHealthCarePlans = "Benchmark education, health care plans";
     public const string LocalAuthorityHighNeedsStartBenchmarking = "Choose local authorities to compare high needs spending";
     public const string LocalAuthorityHighNeedsHistoricData = "High needs historical spending";
     public const string TrustSpending = "Spending focus for this trust";

--- a/web/src/Web.App/Constants/Referrers.cs
+++ b/web/src/Web.App/Constants/Referrers.cs
@@ -7,4 +7,6 @@ public static class Referrers
     public const string SchoolSpending = "school-spending";
     public const string TeachingPeriodsManager = "teaching-periods-manager";
     public const string DeploymentPlan = "deployment-plan";
+    public const string BenchmarkHighNeeds = "benchmark-high-needs";
+    public const string BenchmarkEducationHealthCarePlans = "benchmark-education-health-care-plans";
 }

--- a/web/src/Web.App/Controllers/LocalAuthorityComparatorsController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityComparatorsController.cs
@@ -22,13 +22,9 @@ public class LocalAuthorityComparatorsController(
 {
     [HttpGet]
 
-    public async Task<IActionResult> Index(string code, [FromQuery] string? referrer = null)
+    public async Task<IActionResult> Index(string code, [FromQuery] LocalAuthorityBenchmarkType type, [FromQuery] string? referrer = null)
     {
-        using (logger.BeginScope(new
-        {
-            code,
-            referrer
-        }))
+        using (logger.BeginScope(new { code, type, referrer }))
         {
             try
             {
@@ -38,6 +34,7 @@ public class LocalAuthorityComparatorsController(
                 var viewModel = new LocalAuthorityComparatorsViewModel(
                     localAuthority,
                     GetComparators(localAuthority.StatisticalNeighbours, code),
+                    type,
                     referrer);
                 return View(viewModel);
             }
@@ -50,7 +47,7 @@ public class LocalAuthorityComparatorsController(
     }
 
     [HttpPost]
-    public async Task<IActionResult> Index([FromRoute] string code, [FromForm] LocalAuthorityComparatorSelectionViewModel viewModel)
+    public async Task<IActionResult> Index([FromRoute] string code, [FromQuery] LocalAuthorityBenchmarkType type, [FromForm] LocalAuthorityComparatorSelectionViewModel viewModel)
     {
         using (logger.BeginScope(new
         {
@@ -99,10 +96,10 @@ public class LocalAuthorityComparatorsController(
                 {
                     localAuthorityComparatorSetService.SetUserDefinedComparatorSetInSession(code, new UserDefinedLocalAuthorityComparatorSet { Set = comparators.ToArray() });
 
-                    return RedirectToAction("Index", "LocalAuthorityHighNeedsBenchmarking", new { code });
+                    return ContinueActionResult(code, type);
                 }
 
-                return View(nameof(Index), new LocalAuthorityComparatorsViewModel(localAuthority, comparators.ToArray(), viewModel.Referrer));
+                return View(nameof(Index), new LocalAuthorityComparatorsViewModel(localAuthority, comparators.ToArray(), type, viewModel.Referrer));
             }
             catch (Exception e)
             {
@@ -110,6 +107,19 @@ public class LocalAuthorityComparatorsController(
                 return StatusCode(StatusCodes.Status400BadRequest);
             }
         }
+    }
+
+    private RedirectToActionResult ContinueActionResult(string code, LocalAuthorityBenchmarkType type)
+    {
+        switch (type)
+        {
+            case LocalAuthorityBenchmarkType.EducationHealthCarePlans:
+                return RedirectToAction("Index", "LocalAuthorityEducationHealthCarePlans", new { code });
+            case LocalAuthorityBenchmarkType.HighNeeds:
+            default:
+                return RedirectToAction("Index", "LocalAuthorityHighNeedsBenchmarking", new { code });
+        }
+
     }
 
     private string[] GetComparators(IEnumerable<LocalAuthorityStatisticalNeighbour>? neighbours, string code)

--- a/web/src/Web.App/Controllers/LocalAuthorityEducationHealthCarePlansController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityEducationHealthCarePlansController.cs
@@ -1,17 +1,46 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
 using Web.App.Attributes;
+using Web.App.Domain;
+using Web.App.Infrastructure.Apis;
+using Web.App.Infrastructure.Extensions;
+using Web.App.Services;
+using Web.App.ViewModels;
 
 namespace Web.App.Controllers;
 
 [Controller]
 [Route("local-authority/{code}/education-health-care-plans")]
 [ValidateLaCode]
-public class LocalAuthorityEducationHealthCarePlansController
+public class LocalAuthorityEducationHealthCarePlansController(
+    ILogger<LocalAuthorityEducationHealthCarePlansController> logger,
+    ILocalAuthorityApi api,
+    ILocalAuthorityComparatorSetService comparatorSetService)
     : Controller
 {
     [HttpGet]
-    public IActionResult Index(string code)
+    public async Task<IActionResult> Index(string code)
     {
-        return new ContentResult();
+        using (logger.BeginScope(new { code }))
+        {
+            try
+            {
+
+                var la = await api.SingleAsync(code).GetResultOrThrow<LocalAuthority>();
+
+                var set = comparatorSetService.ReadUserDefinedComparatorSetFromSession(code).Set;
+                if (set.Length == 0)
+                {
+                    return RedirectToAction("Index", "LocalAuthorityComparators", new { code, type = LocalAuthorityBenchmarkType.EducationHealthCarePlans });
+                }
+
+                return View(new LocalAuthorityEducationHealthCarePlansViewModel(la, set));
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "An error displaying local authority education, health care plans: {DisplayUrl}", Request.GetDisplayUrl());
+                return e is StatusCodeException s ? StatusCode((int)s.Status) : StatusCode(500);
+            }
+        }
     }
 }

--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsBenchmarkingController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsBenchmarkingController.cs
@@ -47,7 +47,7 @@ public class LocalAuthorityHighNeedsBenchmarkingController(
                 var set = localAuthorityComparatorSetService.ReadUserDefinedComparatorSetFromSession(code).Set;
                 if (set.Length == 0)
                 {
-                    return RedirectToAction("Index", "LocalAuthorityComparators", new { code });
+                    return RedirectToAction("Index", "LocalAuthorityComparators", new { code, type = LocalAuthorityBenchmarkType.HighNeeds });
                 }
 
                 var years = await financeService.GetYears();

--- a/web/src/Web.App/ViewModels/LocalAuthorityComparatorsViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityComparatorsViewModel.cs
@@ -2,10 +2,11 @@ using Web.App.Domain;
 
 namespace Web.App.ViewModels;
 
-public class LocalAuthorityComparatorsViewModel(LocalAuthorityStatisticalNeighbours localAuthority, string[] comparators, string? referrer)
+public class LocalAuthorityComparatorsViewModel(LocalAuthorityStatisticalNeighbours localAuthority, string[] comparators, LocalAuthorityBenchmarkType type, string? referrer)
 {
     public string? Code => localAuthority.Code;
     public string? Name => localAuthority.Name;
+    public LocalAuthorityBenchmarkType Type => type;
     public string? Referrer => referrer;
 
     public string[] StatisticalNeighbours => localAuthority.StatisticalNeighbours?

--- a/web/src/Web.App/ViewModels/LocalAuthorityEducationHealthCarePlansViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityEducationHealthCarePlansViewModel.cs
@@ -1,0 +1,14 @@
+using Web.App.Domain;
+
+namespace Web.App.ViewModels;
+
+public class LocalAuthorityEducationHealthCarePlansViewModel(LocalAuthority localAuthority, string[] comparators)
+{
+    public string? Code => localAuthority.Code;
+    public string? Name => localAuthority.Name;
+
+    public string[] Comparators => comparators
+        .Where(c => c != Code)
+        .Distinct()
+        .ToArray();
+}

--- a/web/src/Web.App/Views/LocalAuthority/_HighNeeds.cshtml
+++ b/web/src/Web.App/Views/LocalAuthority/_HighNeeds.cshtml
@@ -15,10 +15,12 @@
             </summary>
             <div class="govuk-details__text">
                 <p class="govuk-body">
-                This data covers the period @(Model.HeadlineStatistics.S251Year - 1)-@Model.HeadlineStatistics.S251Year for section 251 data (s251).
+                    This data covers the period @(Model.HeadlineStatistics.S251Year - 1)-@Model.HeadlineStatistics.S251Year for section 251 data (s251).
                 </p>
                 <p class="govuk-body">
-                The outturn includes place funding for pupils with special educational needs taught in academies. You can read about how we calculate this in the <a href="@Url.Action("HighNeedsGlossary", "StaticContent")" class="govuk-link govuk-link--no-visited-state">glossary</a>.
+                    The outturn includes place funding for pupils with special educational needs taught in academies. You can read about how we calculate this in the <a
+                        href="@Url.Action("HighNeedsGlossary", "StaticContent")"
+                        class="govuk-link govuk-link--no-visited-state">glossary</a>.
                 </p>
             </div>
         </details>
@@ -37,7 +39,8 @@
                     <h3 class="govuk-heading-s">
                         <a href="@Url.Action("Index", "LocalAuthorityComparators", new
                                  {
-                                     code = Model.Code
+                                     code = Model.Code,
+                                     type = LocalAuthorityBenchmarkType.HighNeeds
                                  })" class="govuk-link govuk-link--no-visited-state">
                             Benchmark high needs
                         </a>
@@ -50,7 +53,10 @@
             <feature name="@FeatureFlags.HighNeedsBenchmarking">
                 <li>
                     <h3 class="govuk-heading-s">
-                        <a href="@Url.Action("Index", "LocalAuthorityHighNeedsSpending", new { code = Model.Code })" class="govuk-link govuk-link--no-visited-state">
+                        <a href="@Url.Action("Index", "LocalAuthorityHighNeedsSpending", new
+                                 {
+                                     code = Model.Code,
+                                 })" class="govuk-link govuk-link--no-visited-state">
                             Benchmark high needs spending
                         </a>
                     </h3>
@@ -60,7 +66,11 @@
                 </li>
                 <li>
                     <h3 class="govuk-heading-s">
-                        <a href="@Url.Action("Index", "LocalAuthorityEducationHealthCarePlans", new { code = Model.Code })" class="govuk-link govuk-link--no-visited-state">
+                        <a href="@Url.Action("Index", "LocalAuthorityComparators", new
+                                 {
+                                     code = Model.Code,
+                                     type = LocalAuthorityBenchmarkType.EducationHealthCarePlans
+                                 })" class="govuk-link govuk-link--no-visited-state">
                             Benchmark education, health and care plans
                         </a>
                     </h3>

--- a/web/src/Web.App/Views/LocalAuthorityComparators/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityComparators/Index.cshtml
@@ -3,16 +3,16 @@
 @model Web.App.ViewModels.LocalAuthorityComparatorsViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.LocalAuthorityHighNeedsStartBenchmarking;
-    var referrer = Url.Action(
-        "Index",
-        Model.Referrer == "benchmarking" ? "LocalAuthorityHighNeedsBenchmarking" : "LocalAuthority",
-        new { Model.Code });
+    var referrerController = Model.Referrer switch  
+    {
+        Referrers.BenchmarkHighNeeds => "LocalAuthorityHighNeedsBenchmarking",
+        Referrers.BenchmarkEducationHealthCarePlans => "LocalAuthorityEducationHealthCarePlans",
+        _ => "LocalAuthority"
+    };
 }
 
 @section Backlink {
-    <div class="govuk-width-container">
-        <a class="govuk-back-link" href="@referrer">Back</a>
-    </div>
+    <a class="govuk-back-link" href="@Url.Action("Index", referrerController, new { Model.Code })">Back</a>
 }
 
 @await Component.InvokeAsync("EstablishmentHeading", new
@@ -60,7 +60,7 @@
     </div>
 }
 
-<form action="@Url.Action("Index","LocalAuthorityComparators", new { Model.Code })" method="post">
+<form action="@Url.Action("Index","LocalAuthorityComparators", new { code = Model.Code, type = Model.Type })" method="post">
 
     <div class="govuk-button-group">
         <button type="submit" class="govuk-button" data-module="govuk-button" name="action"
@@ -79,8 +79,7 @@
 
     @if (!string.IsNullOrWhiteSpace(Model.Referrer))
     {
-        <input name="@nameof(LocalAuthorityComparatorsViewModel.Referrer)" value="@Model.Referrer"
-               type="hidden"/>
+        <input name="@nameof(LocalAuthorityComparatorsViewModel.Referrer)" value="@Model.Referrer" type="hidden"/>
     }
     
     @await Component.InvokeAsync("LocalAuthorityComparators", new

--- a/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/Index.cshtml
@@ -1,0 +1,26 @@
+@model Web.App.ViewModels.LocalAuthorityEducationHealthCarePlansViewModel
+@{
+    ViewData[ViewDataKeys.Title] = PageTitles.LocalAuthorityEducationHealthCarePlans;
+}
+
+@await Component.InvokeAsync("EstablishmentHeading", new
+{
+    title = ViewData[ViewDataKeys.Title],
+    name = Model.Name,
+    id = Model.Code,
+    kind = OrganisationTypes.LocalAuthority
+})
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <p class="govuk-body">
+            <a href="@Url.Action("Index", "LocalAuthorityComparators", new
+                     {
+                         code = Model.Code,
+                         type = LocalAuthorityBenchmarkType.EducationHealthCarePlans,
+                         referrer = Referrers.BenchmarkEducationHealthCarePlans
+                     })" class="govuk-link govuk-link--no-visited-state">Change local authorities to benchmark against</a>
+        </p>
+    </div>
+</div>
+

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsBenchmarking/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsBenchmarking/Index.cshtml
@@ -19,7 +19,8 @@
             <a href="@Url.Action("Index", "LocalAuthorityComparators", new
                      {
                          code = Model.Code,
-                         referrer = "benchmarking"
+                         type = LocalAuthorityBenchmarkType.HighNeeds,
+                         referrer = Referrers.BenchmarkHighNeeds
                      })" class="govuk-link govuk-link--no-visited-state">Change local authorities to benchmark against</a>
         </p>
     </div>

--- a/web/src/Web.App/Views/Shared/_Layout.cshtml
+++ b/web/src/Web.App/Views/Shared/_Layout.cshtml
@@ -94,10 +94,11 @@
     <div class="govuk-width-container">
         @await Component.InvokeAsync("PhaseBanner")
         <navigation></navigation>
+        @await RenderSectionAsync("Backlink", required: false)
     </div>
 </nav>
 
-@RenderSection("Backlink", required: false)
+
 
 <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-width-container">

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsBenchmarking.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsBenchmarking.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using AngleSharp.Html.Dom;
 using AutoFixture;
+using Web.App;
 using Web.App.Domain;
 using Xunit;
 
@@ -43,7 +44,7 @@ public class WhenViewingHighNeedsBenchmarking(SchoolBenchmarkingWebAppClient cli
     {
         var (page, authority, _) = await SetupNavigateInitPage([]);
 
-        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeedsStartBenchmarking(authority.Code).ToAbsolute());
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeedsStartBenchmarking(authority.Code, LocalAuthorityBenchmarkType.HighNeeds).ToAbsolute());
     }
 
     private async Task<(IHtmlDocument page, Web.App.Domain.LocalAuthorities.LocalAuthority authority, string[] set)> SetupNavigateInitPage(string[]? comparatorSet = null)

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsStartBenchmarking.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsStartBenchmarking.cs
@@ -2,6 +2,7 @@
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using AutoFixture;
+using Web.App;
 using Web.App.Domain;
 using Xunit;
 
@@ -244,7 +245,7 @@ public class WhenViewingHighNeedsStartBenchmarking(SchoolBenchmarkingWebAppClien
     {
         var (page, authority, neighbourAuthorities, _) = await SetupNavigateInitPage();
 
-        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeedsStartBenchmarking(authority.Code).ToAbsolute());
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeedsStartBenchmarking(authority.Code, LocalAuthorityBenchmarkType.HighNeeds).ToAbsolute());
 
         var selectedNeighbours = page.GetElementAndAssert("#current-comparators-neighbours", Assert.NotNull);
         var cards = selectedNeighbours.QuerySelectorAll(".app-removable-card");
@@ -260,7 +261,7 @@ public class WhenViewingHighNeedsStartBenchmarking(SchoolBenchmarkingWebAppClien
 
     [Theory]
     [InlineData(null)]
-    [InlineData("benchmarking")]
+    [InlineData("benchmark-high-needs")]
     public async Task CanNavigateBack(string? referrer)
     {
         var (page, authority, _, _) = await SetupNavigateInitPage(["code1"], referrer);
@@ -296,7 +297,7 @@ public class WhenViewingHighNeedsStartBenchmarking(SchoolBenchmarkingWebAppClien
 
         page = await Client.SubmitForm(page.Forms[0], removeAllButton);
 
-        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeedsStartBenchmarking(authority.Code).ToAbsolute());
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeedsStartBenchmarking(authority.Code, LocalAuthorityBenchmarkType.HighNeeds).ToAbsolute());
 
         page.GetElementAndAssert("button[name='action'][value='clear']", Assert.Null);
         page.GetElementAndAssert("#current-comparators-neighbours", Assert.Null);
@@ -323,7 +324,7 @@ public class WhenViewingHighNeedsStartBenchmarking(SchoolBenchmarkingWebAppClien
 
         page = await Client.SubmitForm(page.Forms[0], resetButton);
 
-        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeedsStartBenchmarking(authority.Code).ToAbsolute());
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeedsStartBenchmarking(authority.Code, LocalAuthorityBenchmarkType.HighNeeds).ToAbsolute());
 
         var neighboursSelected = page.GetElementAndAssert("#current-comparators-neighbours", Assert.NotNull);
         var cards = neighboursSelected.QuerySelectorAll(".app-removable-card");
@@ -384,14 +385,14 @@ public class WhenViewingHighNeedsStartBenchmarking(SchoolBenchmarkingWebAppClien
         var page = await Client.SetupEstablishment(authority, authorities)
             .SetupInsights()
             .SetupLocalAuthoritiesComparators(authority.Code!, comparators ?? [])
-            .Navigate(Paths.LocalAuthorityHighNeedsStartBenchmarking(authority.Code, referrer));
+            .Navigate(Paths.LocalAuthorityHighNeedsStartBenchmarking(authority.Code, LocalAuthorityBenchmarkType.HighNeeds, referrer));
 
         return (page, authority, neighbourAuthorities, otherAuthorities);
     }
 
     private static void AssertPageLayout(IHtmlDocument page, LocalAuthorityStatisticalNeighbours authority, Web.App.Domain.LocalAuthorities.LocalAuthority[] authorities)
     {
-        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeedsStartBenchmarking(authority.Code).ToAbsolute());
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeedsStartBenchmarking(authority.Code, LocalAuthorityBenchmarkType.HighNeeds).ToAbsolute());
 
         var expectedBreadcrumbs = new[]
         {

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHome.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHome.cs
@@ -99,7 +99,7 @@ public class WhenViewingHome(SchoolBenchmarkingWebAppClient client) : PageBase<S
         Assert.NotNull(anchor);
 
         page = await Client.Follow(anchor);
-        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeedsStartBenchmarking(authority.Code).ToAbsolute());
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityHighNeedsStartBenchmarking(authority.Code, LocalAuthorityBenchmarkType.HighNeeds).ToAbsolute());
     }
 
     [Fact]

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -1,3 +1,5 @@
+using Web.App;
+
 namespace Web.Integration.Tests;
 
 public static class Paths
@@ -291,9 +293,9 @@ public static class Paths
 
     public static string LocalAuthorityHighNeedsBenchmarking(string? code) => $"/local-authority/{code}/high-needs/benchmarking";
 
-    public static string LocalAuthorityHighNeedsStartBenchmarking(string? code, string? referrer = null) => string.IsNullOrWhiteSpace(referrer)
-            ? $"/local-authority/{code}/comparators"
-            : $"/local-authority/{code}/comparators?referrer={referrer}";
+    public static string LocalAuthorityHighNeedsStartBenchmarking(string? code, LocalAuthorityBenchmarkType type, string? referrer = null) => string.IsNullOrWhiteSpace(referrer)
+            ? $"/local-authority/{code}/comparators?type={type}"
+            : $"/local-authority/{code}/comparators?type={type}&referrer={referrer}";
 
     public static string LocalAuthorityHighNeedsHistoricData(string? code) => $"/local-authority/{code}/high-needs/history";
     public static string LocalAuthoritySchoolsFinanceDownload(string? code) => $"/local-authority/{code}/download/schools/finance";


### PR DESCRIPTION
## 🧻 Summary
Adds the initial page scaffolding for the Local Authority Education, Health and Care Plans (EHCP) benchmarking section. This builds on the recent refactor of the local authority comparators controller by extending it to support the new EHCP benchmarking flow alongside High Needs.

[AB#299498](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/299498) [AB#308378](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/308378) 

### ✨ Feature Details
- **Functionality:** Introduces a new page for benchmarking education, health and care plans for local authorities. Users are now directed through the comparator selection process specifically for EHCP before viewing the new benchmarking page.
- **Implementation:** 
  - Added the `LocalAuthorityBenchmarkType.EducationHealthCarePlans` enum value.
  - Updated `LocalAuthorityComparatorsController` to accept and route based on `LocalAuthorityBenchmarkType` (`HighNeeds` or `EducationHealthCarePlans`).
  - Created `LocalAuthorityEducationHealthCarePlansController`, its corresponding view model, and the `Index.cshtml` view to act as the scaffold.
  - Updated existing Local Authority views (`_HighNeeds.cshtml` and `HighNeedsBenchmarking/Index.cshtml`) to pass the new `LocalAuthorityBenchmarkType` parameter when choosing comparators.
  - Updated integration tests and path generation methods to account for the new route parameters.

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [x] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.

## 🔍 Notes
The new EHCP benchmarking page currently serves as a scaffold with the correct routing and comparator selection loop in place. Subsequent PRs will build out the data visualization and remaining functionality for this page.


A11y & e2e tests are expected to fail as a result of these changes. Tasks 308205 & 308207 to update & add additional tests.
