### PR TITLE
feat: add basic page details for EHCP benchmarking

### DIFF
--- a/web/src/Web.App/Constants/DataSourceTypes.cs
+++ b/web/src/Web.App/Constants/DataSourceTypes.cs
@@ -5,4 +5,5 @@ public static class DataSourceTypes
     public const string Spending = "spending";
     public const string Census = "census";
     public const string HighNeeds = "high-needs";
+    public const string LocalAuthorityEducationHealthCarePlans = "local-authority-education-health-care-plans";
 }

--- a/web/src/Web.App/ViewComponents/DataSourceViewComponent.cs
+++ b/web/src/Web.App/ViewComponents/DataSourceViewComponent.cs
@@ -26,6 +26,7 @@ public class DataSourceViewComponent(IFinanceService financeService) : ViewCompo
                 "Pupil data is taken from the school census data set in January."
             ],
             DataSourceTypes.HighNeeds => await GetHighNeedsDataSource(pageTitle),
+            DataSourceTypes.LocalAuthorityEducationHealthCarePlans => await LocalAuthorityEducationHealthCarePlansNarrative(),
             _ => throw new ArgumentOutOfRangeException(nameof(sourceType))
         };
 
@@ -77,5 +78,11 @@ public class DataSourceViewComponent(IFinanceService financeService) : ViewCompo
                 $"This data includes Section 251 data (s251) for period {years.S251 - 1}-{years.S251} and special educational needs (SEN) data for January {years.S251}."],
             _ => throw new ArgumentOutOfRangeException(nameof(pageTitle))
         };
+    }
+
+    private async Task<string[]> LocalAuthorityEducationHealthCarePlansNarrative()
+    {
+        var years = await financeService.GetYears();
+        return [$"This data includes special educational needs (SEN) data and is based on the SEN2 data collection as at January {years.S251 - 1}. This covers education, health and care (EHC) plans."];
     }
 }

--- a/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/Index.cshtml
@@ -24,3 +24,12 @@
     </div>
 </div>
 
+@await Component.InvokeAsync("DataSource", new
+{
+    organisationType = OrganisationTypes.LocalAuthority,
+    sourceType = DataSourceTypes.LocalAuthorityEducationHealthCarePlans,
+    className = "govuk-grid-column-two-thirds"
+})
+
+@await Html.PartialAsync("_UnderstandTheDataWeUse")
+@await Html.PartialAsync("_HowDataIsPresented")

--- a/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/_HowDataIsPresented.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/_HowDataIsPresented.cshtml
@@ -1,0 +1,8 @@
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m">How data is presented</h2>
+        <p class="govuk-body">
+            To make the data easier to read, we only show local authorities we have data for.
+        </p>
+    </div>
+</div>

--- a/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/_UnderstandTheDataWeUse.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/_UnderstandTheDataWeUse.cshtml
@@ -1,0 +1,19 @@
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <details class="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                    Understand the data we use on this page
+                </span>
+            </summary>
+            <div class="govuk-details__text">
+                <p class="govuk-body">
+                    SEN2 is a statutory annual data collection of special educational needs.
+                </p>
+                <p class="govuk-body">
+                    Pupil numbers are taken from the school census return. These are summed up from schools already present in FBIT data for each local authority.
+                </p>
+            </div>
+        </details>
+    </div>
+</div>


### PR DESCRIPTION
## 🧾 Summary
This PR adds the basic details for the Local Authority Education, Health and Care Plans (EHCP) benchmarking features. 

[AB#299498](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/299498) [AB#308383](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/308383)

### ✨ Feature Details
- Functionality: 
  - Provides basic page structures for  EHCP benchmarking.
  - Updated DataSourceViewComponent and DataSourceTypes to support EHCP-specific narratives. Created partial views (_UnderstandTheDataWeUse, _HowDataIsPresented) to provide context on the data.

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [x] Tested by running locally (or docs render correctly locally).

 ## 🔍 Notes
This is primarily a scaffolding PR to establish the page structures. Further work will be required to populate the page with the actual benchmarking charts and data visualizations.
