### PR TITLE
feat: add basic page details for High Need Spending benchmarking

### DIFF
--- a/web/src/Web.App/Constants/DataSourceTypes.cs
+++ b/web/src/Web.App/Constants/DataSourceTypes.cs
@@ -6,4 +6,5 @@ public static class DataSourceTypes
     public const string Census = "census";
     public const string HighNeeds = "high-needs";
     public const string LocalAuthorityEducationHealthCarePlans = "local-authority-education-health-care-plans";
+    public const string LocalAuthorityHighNeedsSpending = "local-authority-high-needs-spending";
 }

--- a/web/src/Web.App/Controllers/LocalAuthorityComparatorsController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityComparatorsController.cs
@@ -114,6 +114,8 @@ public class LocalAuthorityComparatorsController(
     {
         switch (type)
         {
+            case LocalAuthorityBenchmarkType.HighNeedsSpending:
+                return RedirectToAction("Index", "LocalAuthorityHighNeedsSpending", new { code });
             case LocalAuthorityBenchmarkType.EducationHealthCarePlans:
                 return RedirectToAction("Index", "LocalAuthorityEducationHealthCarePlans", new { code });
             case LocalAuthorityBenchmarkType.HighNeeds:

--- a/web/src/Web.App/ViewComponents/DataSourceViewComponent.cs
+++ b/web/src/Web.App/ViewComponents/DataSourceViewComponent.cs
@@ -27,6 +27,7 @@ public class DataSourceViewComponent(IFinanceService financeService) : ViewCompo
             ],
             DataSourceTypes.HighNeeds => await GetHighNeedsDataSource(pageTitle),
             DataSourceTypes.LocalAuthorityEducationHealthCarePlans => await LocalAuthorityEducationHealthCarePlansNarrative(),
+            DataSourceTypes.LocalAuthorityHighNeedsSpending => await LocalAuthorityHighNeedsSpendingNarrative(),
             _ => throw new ArgumentOutOfRangeException(nameof(sourceType))
         };
 
@@ -84,5 +85,14 @@ public class DataSourceViewComponent(IFinanceService financeService) : ViewCompo
     {
         var years = await financeService.GetYears();
         return [$"This data includes special educational needs (SEN) data and is based on the SEN2 data collection as at January {years.S251 - 1}. This covers education, health and care (EHC) plans."];
+    }
+
+    private async Task<string[]> LocalAuthorityHighNeedsSpendingNarrative()
+    {
+        var years = await financeService.GetYears();
+        return [
+            $"This data includes section 251 data (s251) for period {years.S251 - 1}-{years.S251}. It includes planned expenditure and outturn spend, using aggregated s251 categories.",
+            "The outturn does not include place funding for pupils with special educational needs taught in academies."
+        ];
     }
 }

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
@@ -24,3 +24,12 @@
     </div>
 </div>
 
+@await Component.InvokeAsync("DataSource", new
+{
+    organisationType = OrganisationTypes.LocalAuthority,
+    sourceType = DataSourceTypes.LocalAuthorityHighNeedsSpending,
+    className = "govuk-grid-column-two-thirds"
+})
+
+@await Html.PartialAsync("_UnderstandTheDataWeUse")
+@await Html.PartialAsync("_HowDataIsPresented")

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_HowDataIsPresented.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_HowDataIsPresented.cshtml
@@ -1,0 +1,8 @@
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m">How data is presented</h2>
+        <p class="govuk-body">
+            To make the data easier to read, we only show local authorities we have data for.
+        </p>
+    </div>
+</div>

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_UnderstandTheDataWeUse.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_UnderstandTheDataWeUse.cshtml
@@ -1,0 +1,22 @@
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <details class="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                    Understand the data we use on this page
+                </span>
+            </summary>
+            <div class="govuk-details__text">
+                <p class="govuk-body">
+                    Section 251 is the regulatory requirement to prepare and submit annual, education and children and young people’s services, budget and outturn statements for each financial year.
+                </p>
+                <p class="govuk-body">
+                    The outturn is the actual amount spent on high needs by local authorities in each financial year. This is taken from the s251 outturn statement.
+                </p>
+                <p class="govuk-body">
+                    The ‘£ per pupil’ view option uses pupil numbers taken from the school census return. These are summed up from schools already present in FBIT data for each local authority.
+                </p>
+            </div>
+        </details>
+    </div>
+</div>


### PR DESCRIPTION
## 🧾 Summary
This PR adds the basic details for the Local Authority High Need Spending benchmarking features. 

[AB#295179](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/295179) [AB#308391](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/308391)

### ✨ Feature Details
- Functionality: 
  - Provides basic page structures for  High Needs Spending benchmarking.
  - Updated DataSourceViewComponent and DataSourceTypes to support High Need spending-specific narratives. Created partial views (_UnderstandTheDataWeUse, _HowDataIsPresented) to provide context on the data.

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [x] Tested by running locally (or docs render correctly locally).

 ## 🔍 Notes
This is primarily a scaffolding PR to establish the page structures. Further work will be required to populate the page with the actual benchmarking charts and data visualizations.
