### PR TITLE
chore: update e2e tests pipeline config to ignore the tagged tests

### DIFF
--- a/pipelines/web/steps/run-e2e-tests.yaml
+++ b/pipelines/web/steps/run-e2e-tests.yaml
@@ -31,7 +31,7 @@ steps:
     inputs:
       command: test
       projects: '${{ parameters.workspaceDir }}/e2e-tests-files/Web.E2ETests/Web.E2ETests.dll'
-      arguments: --filter "Category!=LocalAuthorityHomepageV2FlagDisabled&Category!=DSISignIn"
+      arguments: --filter "Category!=LocalAuthorityHomepageV2FlagDisabled&Category!=DSISignIn&Category!=HighNeedsBenchmarkingFlagEnabled"
 
   - publish: ${{ parameters.workspaceDir }}/e2e-tests-files/Web.E2ETests/screenshots
     artifact: e2e-test-outputs-$(System.JobAttempt)


### PR DESCRIPTION
## 🧾 Summary
The PR updates the e2e pipeline configs to ignore the tests which are tagged. The feature is behind featureflag so the tests would be ignored until we enable the feature. This will allow us to make updates to the tests without breaking the pipeline. 

Fixes [AB#309194](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/309194) [AB#299439](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/299439)

### ⛓️ Tech Debt & Refactor Details
> - **Major Changes:**updated the e2e tests pipeline config
> - **Benefits:** This will allow us to make changes to the tests and push until the feature is enabled without blocking the pipeline
> - **Trade-offs:** The tests won't add any benefit until they are enabled but they will be updated/run locally as of when the changes are made in the area.

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [ ] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes
> this review of this should be done after the review of [PR](https://github.com/DFE-Digital/education-benchmarking-and-insights/pull/4050) 
the tests have been added in the other PR which will fail in the pipeline and this PR will ignore those tests in the pipeline. 
