### PR TITLE
feat: add data tables and toggle between chart/table views to ehcp page

### DIFF
--- a/web/src/Web.App/Controllers/LocalAuthorityEducationHealthCarePlansController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityEducationHealthCarePlansController.cs
@@ -1,11 +1,13 @@
 ﻿using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Web.App.Attributes;
-using Web.App.Domain;
+using Web.App.Domain.Charts;
+using Web.App.Domain.LocalAuthorities;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Extensions;
 using Web.App.Services;
 using Web.App.ViewModels;
+using LocalAuthority = Web.App.Domain.LocalAuthority;
 
 namespace Web.App.Controllers;
 
@@ -19,7 +21,9 @@ public class LocalAuthorityEducationHealthCarePlansController(
     : Controller
 {
     [HttpGet]
-    public async Task<IActionResult> Index(string code)
+    public async Task<IActionResult> Index(
+        string code,
+        Views.ViewAsOptions viewAs = Views.ViewAsOptions.Chart)
     {
         using (logger.BeginScope(new { code }))
         {
@@ -34,7 +38,22 @@ public class LocalAuthorityEducationHealthCarePlansController(
                     return RedirectToAction("Index", "LocalAuthorityComparators", new { code, type = LocalAuthorityBenchmarkType.EducationHealthCarePlans });
                 }
 
-                return View(new LocalAuthorityEducationHealthCarePlansViewModel(la, set));
+                var query = BuildQuery(new[]
+                {
+                    code
+                }.Concat(set).ToArray(), "Per1000Pupil");
+                var plans = await api
+                    .QueryEhcpAsync(query)
+                    .GetResultOrThrow<EducationHealthCarePlans[]>();
+
+                var subCategories = new EducationHealthCarePlansComparisonSubCategoriesViewModel(plans, EducationHealthCarePlansCategories.All);
+
+                var viewModel = new LocalAuthorityEducationHealthCarePlansViewModel(la, set, subCategories)
+                {
+                    ViewAs = viewAs,
+                };
+
+                return View(viewModel);
             }
             catch (Exception e)
             {
@@ -42,5 +61,24 @@ public class LocalAuthorityEducationHealthCarePlansController(
                 return e is StatusCodeException s ? StatusCode((int)s.Status) : StatusCode(500);
             }
         }
+    }
+
+    [HttpPost]
+    public IActionResult Index(string code, int viewAs, int resultAs) => RedirectToAction("Index", new
+    {
+        code,
+        viewAs
+    });
+
+    private static ApiQuery BuildQuery(string[] codes, string dimension)
+    {
+        var query = new ApiQuery();
+        foreach (var c in codes)
+        {
+            query.AddIfNotNull("code", c);
+        }
+
+        query.AddIfNotNull("dimension", dimension);
+        return query;
     }
 }

--- a/web/src/Web.App/Domain/LocalAuthorities/EducationHealthCarePlans.cs
+++ b/web/src/Web.App/Domain/LocalAuthorities/EducationHealthCarePlans.cs
@@ -1,0 +1,15 @@
+namespace Web.App.Domain.LocalAuthorities;
+
+public record EducationHealthCarePlans
+{
+    public string? Name { get; set; }
+    public decimal? TotalPupils { get; set; }
+    public decimal? Total { get; set; }
+    public decimal? Mainstream { get; set; }
+    public decimal? Resourced { get; set; }
+    public decimal? Special { get; set; }
+    public decimal? Independent { get; set; }
+    public decimal? Hospital { get; set; }
+    public decimal? Post16 { get; set; }
+    public decimal? Other { get; set; }
+}

--- a/web/src/Web.App/Domain/LocalAuthorities/EducationHealthCarePlansCategories.cs
+++ b/web/src/Web.App/Domain/LocalAuthorities/EducationHealthCarePlansCategories.cs
@@ -1,0 +1,70 @@
+namespace Web.App.Domain.LocalAuthorities;
+
+public static class EducationHealthCarePlansCategories
+{
+    public enum SubCategoryFilter
+    {
+        Total = 0,
+        Mainstream = 1,
+        Resourced = 2,
+        Special = 3,
+        Independent = 4,
+        Hospital = 5,
+        Post16 = 6,
+        Other = 7
+    }
+
+    public static readonly SubCategoryFilter[] All =
+    [
+        SubCategoryFilter.Total,
+        SubCategoryFilter.Mainstream,
+        SubCategoryFilter.Resourced,
+        SubCategoryFilter.Special,
+        SubCategoryFilter.Independent,
+        SubCategoryFilter.Hospital,
+        SubCategoryFilter.Post16,
+        SubCategoryFilter.Other
+    ];
+
+    public static string GetHeading(this SubCategoryFilter filter) => filter switch
+    {
+        SubCategoryFilter.Total => "Total pupils with EHC plans",
+        SubCategoryFilter.Mainstream => "Placement of pupils with EHC plans in mainstream schools or academies",
+        SubCategoryFilter.Resourced => "Placement of pupils with EHC plans resourced provision or SEN units",
+        SubCategoryFilter.Special => "Placement of pupils with EHC plans maintained special school or special academies",
+        SubCategoryFilter.Independent => "Placement of pupils with EHC plans NMSS or independent schools",
+        SubCategoryFilter.Hospital => "Placement of pupils with EHC plans in hospital schools or alternative provisions",
+        SubCategoryFilter.Post16 => "Placement of pupils with EHC plans in post 16",
+        SubCategoryFilter.Other => "Placement of pupils with EHC plans in other types of provisions",
+        _ => ""
+    };
+
+    public static string GetTableHeading(this SubCategoryFilter filter) => filter switch
+    {
+        SubCategoryFilter.Total => "Total pupils with EHC plans (per 1000 pupils)",
+        SubCategoryFilter.Mainstream => "EHC plans in Mainstream schools or academies (per 1000 pupils)",
+        SubCategoryFilter.Resourced => "EHC plans in Resourced provision or SEN units (per 1000 pupils)",
+        SubCategoryFilter.Special => "EHC plans in Maintained special school or special academies (per 1000 pupils)",
+        SubCategoryFilter.Independent => "EHC plans in NMSS or independent schools (per 1000 pupils)",
+        SubCategoryFilter.Hospital => "EHC plans in Hospital schools or alternative provisions (per 1000 pupils)",
+        SubCategoryFilter.Post16 => "EHC plans in Post 16 (per 1000 pupils)",
+        SubCategoryFilter.Other => "EHC plans in other types of provisions (per 1000 pupils)",
+        _ => ""
+    };
+
+    public static decimal? GetValue(this SubCategoryFilter filter, EducationHealthCarePlans p) =>
+        filter switch
+        {
+            SubCategoryFilter.Total => p.Total,
+            SubCategoryFilter.Mainstream => p.Mainstream,
+            SubCategoryFilter.Resourced => p.Resourced,
+            SubCategoryFilter.Special => p.Special,
+            SubCategoryFilter.Independent => p.Independent,
+            SubCategoryFilter.Hospital => p.Hospital,
+            SubCategoryFilter.Post16 => p.Post16,
+            SubCategoryFilter.Other => p.Other,
+            _ => null
+        };
+
+
+}

--- a/web/src/Web.App/ViewModels/BenchmarkingViewModelCostSubCategory.cs
+++ b/web/src/Web.App/ViewModels/BenchmarkingViewModelCostSubCategory.cs
@@ -4,6 +4,7 @@ public class BenchmarkingViewModelCostSubCategory<T>
 {
     public string? Uuid { get; init; }
     public string? SubCategory { get; init; }
+    public string? TableHeading { get; init; }
     public string? ChartSvg { get; set; }
     public T[]? Data { get; init; }
 }

--- a/web/src/Web.App/ViewModels/EducationHealthCarePlansComparisonSubCategoriesViewModel.cs
+++ b/web/src/Web.App/ViewModels/EducationHealthCarePlansComparisonSubCategoriesViewModel.cs
@@ -1,0 +1,50 @@
+using Web.App.Domain.LocalAuthorities;
+
+namespace Web.App.ViewModels;
+
+public class EducationHealthCarePlansComparisonSubCategoriesViewModel
+{
+    public List<BenchmarkingViewModelCostSubCategory<EducationHealthCarePlansComparisonDatum>> Items { get; set; } = [];
+
+    public EducationHealthCarePlansComparisonSubCategoriesViewModel(EducationHealthCarePlans[] plans,
+        EducationHealthCarePlansCategories.SubCategoryFilter[] filters)
+    {
+        filters = filters.Length > 0 ? filters : EducationHealthCarePlansCategories.All;
+
+        foreach (var filter in filters)
+        {
+            AddSubCategory(filter, plans);
+        }
+    }
+
+    private void AddSubCategory(EducationHealthCarePlansCategories.SubCategoryFilter filter, EducationHealthCarePlans[] plans)
+    {
+        var data = plans
+            .Select(p => new EducationHealthCarePlansComparisonDatum
+            {
+                Name = p.Name,
+                Plans = filter.GetValue(p),
+                TotalPupils = p.TotalPupils
+            })
+            .OrderByDescending(x => x.Plans)
+            .ToArray();
+
+        var uuid = Guid.NewGuid().ToString();
+
+        Items.Add(new BenchmarkingViewModelCostSubCategory<EducationHealthCarePlansComparisonDatum>
+        {
+            Uuid = uuid,
+            SubCategory = filter.GetHeading(),
+            TableHeading = filter.GetTableHeading(),
+            Data = data
+        });
+    }
+}
+
+// TODO: as part of chart wiring up move to Domain/Charts
+public class EducationHealthCarePlansComparisonDatum
+{
+    public string? Name { get; set; }
+    public decimal? Plans { get; set; }
+    public decimal? TotalPupils { get; set; }
+}

--- a/web/src/Web.App/ViewModels/LocalAuthorityEducationHealthCarePlansViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityEducationHealthCarePlansViewModel.cs
@@ -1,8 +1,12 @@
 using Web.App.Domain;
+using Web.App.Domain.Charts;
 
 namespace Web.App.ViewModels;
 
-public class LocalAuthorityEducationHealthCarePlansViewModel(LocalAuthority localAuthority, string[] comparators)
+public class LocalAuthorityEducationHealthCarePlansViewModel(
+    LocalAuthority localAuthority,
+    string[] comparators,
+    EducationHealthCarePlansComparisonSubCategoriesViewModel subCategories)
 {
     public string? Code => localAuthority.Code;
     public string? Name => localAuthority.Name;
@@ -11,4 +15,12 @@ public class LocalAuthorityEducationHealthCarePlansViewModel(LocalAuthority loca
         .Where(c => c != Code)
         .Distinct()
         .ToArray();
+    public List<BenchmarkingViewModelCostSubCategory<EducationHealthCarePlansComparisonDatum>> SubCategories => subCategories.Items;
+    public Views.ViewAsOptions ViewAs { get; set; } = Views.ViewAsOptions.Chart;
+}
+
+public class LocalAuthorityEducationHealthCarePlansTableViewModel(
+    BenchmarkingViewModelCostSubCategory<EducationHealthCarePlansComparisonDatum> subCategory)
+{
+    public BenchmarkingViewModelCostSubCategory<EducationHealthCarePlansComparisonDatum> SubCategory => subCategory;
 }

--- a/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/Index.cshtml
@@ -1,3 +1,6 @@
+@using Web.App.Domain.Charts
+@using Web.App.Extensions
+@using Web.App.ViewModels
 @model Web.App.ViewModels.LocalAuthorityEducationHealthCarePlansViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.LocalAuthorityEducationHealthCarePlans;
@@ -33,3 +36,66 @@
 
 @await Html.PartialAsync("_UnderstandTheDataWeUse")
 @await Html.PartialAsync("_HowDataIsPresented")
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        @using (Html.BeginForm(FormMethod.Post, true, new
+                {
+                    @class = "actions-form",
+                    novalidate = "novalidate",
+                    role = "search"
+                }))
+        {
+            <div class="govuk-form-group">
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-label">
+                        View as
+                    </legend>
+                    <div class="govuk-radios govuk-radios--inline govuk-radios--small" data-module="govuk-radios"
+                         id="@nameof(LocalAuthorityEducationHealthCarePlansViewModel.ViewAs)">
+                        @foreach (var view in Views.All)
+                        {
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input"
+                                       id="view-@view"
+                                       name="@nameof(LocalAuthorityEducationHealthCarePlansViewModel.ViewAs)" type="radio"
+                                       value="@((int)view)"
+                                       @(Model.ViewAs == view ? "checked" : "")>
+                                <label class="govuk-label govuk-radios__label"
+                                       for="view-@view">
+                                    @view.GetDescription()
+                                </label>
+                            </div>
+                        }
+                    </div>
+                </fieldset>
+            </div>
+
+            <div class="actions-form__button">
+                <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+                    Apply
+                </button>
+            </div>
+        }
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+        <h2 class="govuk-heading-m">EHC Plans</h2>
+        @for (var i = 0; i < Model.SubCategories.Count; i++)
+        {
+            var subCategory = Model.SubCategories.ElementAt(i);
+
+            <section id="cost-sub-category-@subCategory.SubCategory?.ToSlug()">
+                <h3 class="govuk-heading-s">@subCategory.SubCategory</h3>
+
+                @if (Model.ViewAs == Views.ViewAsOptions.Chart)
+                {
+                    <p class="govuk-body">chart under construction</p>
+                }
+                else
+                {
+                    @await Html.PartialAsync("_EhcPlanTable", new LocalAuthorityEducationHealthCarePlansTableViewModel(subCategory))
+                }
+            </section>
+        }
+    </div>
+</div>

--- a/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/_EhcPlanTable.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/_EhcPlanTable.cshtml
@@ -1,0 +1,37 @@
+@using Web.App.Extensions
+@model Web.App.ViewModels.LocalAuthorityEducationHealthCarePlansTableViewModel
+
+@if (Model.SubCategory.Data is null)
+{
+    <div
+        class="govuk-warning-text govuk-!-margin-top-2 govuk-!-margin-bottom-2 ssr-chart-warning">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+            <span class="govuk-visually-hidden">Warning</span>
+            Unable to display data
+        </strong>
+    </div>
+    return;
+}
+<div>
+
+    <table class="govuk-table">
+        <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Local Authority</th>
+            <th scope="col" class="govuk-table__header">@Model.SubCategory.TableHeading</th>
+            <th scope="col" class="govuk-table__header">Pupils</th>
+        </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        @foreach (var row in Model.SubCategory.Data)
+        {
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell">@row.Name</td>
+                <td class="govuk-table__cell">@row.Plans.ToSimpleDisplay()</td>
+                <td class="govuk-table__cell govuk-table__cell--numeric">@(row.TotalPupils?.ToString("N0"))</td>
+            </tr>
+        }
+        </tbody>
+    </table>
+</div>

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -22,6 +22,7 @@ using Web.App.Infrastructure.WebAssets;
 using Web.App.Services;
 using Xunit.Abstractions;
 using File = Web.App.Domain.Content.File;
+using LocalAuthority = Web.App.Domain.LocalAuthority;
 using UriBuilder = Web.App.Builders.UriBuilder;
 
 // ReSharper disable MemberCanBePrivate.Global
@@ -919,6 +920,30 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     {
         SchoolApi.Reset();
         SchoolApi.Setup(api => api.SingleAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Throws(new Exception());
+        return this;
+    }
+
+    public BenchmarkingWebAppClient SetupLocalAuthorityEndpoints(
+        Web.App.Domain.LocalAuthorities.LocalAuthority localAuthority,
+        EducationHealthCarePlans[]? educationHealthCarePlans = null)
+    {
+        LocalAuthorityApi.Reset();
+        LocalAuthorityApi.Setup(api => api.SingleAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(localAuthority));
+        LocalAuthorityApi.Setup(api => api.QueryEhcpAsync(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(educationHealthCarePlans ?? []));
+        return this;
+    }
+
+    public BenchmarkingWebAppClient SetupLocalAuthorityEndpointsWithNotFound()
+    {
+        LocalAuthorityApi.Reset();
+        LocalAuthorityApi.Setup(api => api.SingleAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.NotFound);
+        return this;
+    }
+
+    public BenchmarkingWebAppClient SetupLocalAuthorityEndpointsWithException()
+    {
+        LocalAuthorityApi.Reset();
+        LocalAuthorityApi.Setup(api => api.SingleAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Throws(new Exception());
         return this;
     }
 

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingEducationHealthCarePlans.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingEducationHealthCarePlans.cs
@@ -1,0 +1,188 @@
+using System.Net;
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using AutoFixture;
+using Web.App.Domain.Charts;
+using Web.App.Domain.LocalAuthorities;
+using Xunit;
+
+namespace Web.Integration.Tests.Pages.LocalAuthorities;
+
+public class WhenViewingEducationHealthCarePlans(SchoolBenchmarkingWebAppClient client) : PageBase<SchoolBenchmarkingWebAppClient>(client)
+{
+    [Fact]
+    public async Task CanDisplay()
+    {
+        var (page, authority, plans) = await SetupNavigateInitPage();
+
+        AssertPageLayout(page, authority, plans);
+    }
+
+    [Fact]
+    public async Task CanDisplayProblemWithService()
+    {
+        const string code = "123";
+        var page = await Client.SetupLocalAuthorityEndpointsWithException()
+            .Navigate(Paths.LocalAuthorityEducationHealthCarePlans(code));
+
+        PageAssert.IsProblemPage(page);
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityEducationHealthCarePlans(code).ToAbsolute(), HttpStatusCode.InternalServerError);
+    }
+
+    [Fact]
+    public async Task CanDisplayNotFoundForEstablishment()
+    {
+        const string code = "123";
+        var page = await Client.SetupLocalAuthorityEndpointsWithNotFound()
+            .Navigate(Paths.LocalAuthorityEducationHealthCarePlans(code));
+
+        PageAssert.IsNotFoundPage(page);
+        DocumentAssert.AssertPageUrl(page, Paths.LocalAuthorityEducationHealthCarePlans(code).ToAbsolute(), HttpStatusCode.NotFound);
+    }
+
+    [Theory]
+    [InlineData(0, "?viewAs=0")]
+    [InlineData(1, "?viewAs=1")]
+    public async Task CanSubmitOptionsForViewAs(int viewAs, string expectedQueryParams)
+    {
+        var (page, authority, plans) = await SetupNavigateInitPage(expectedQueryParams);
+
+        var action = page.QuerySelectorAll("button").FirstOrDefault(x => x.TextContent.Trim() == "Apply");
+        Assert.NotNull(action);
+        var form = action.Closest("form");
+        Assert.NotNull(form);
+        page = await Client.SubmitForm(form, action, f =>
+        {
+            f.SetFormValues(new Dictionary<string, string>
+            {
+                { "ViewAs", viewAs.ToString() }
+            });
+        });
+
+        AssertPageLayout(
+            page,
+            authority,
+            plans,
+            viewAs: viewAs,
+            expectedQueryParams: expectedQueryParams);
+    }
+
+    private async Task<(
+        IHtmlDocument page,
+        Web.App.Domain.LocalAuthorities.LocalAuthority authority,
+        EducationHealthCarePlans[] plans)> SetupNavigateInitPage(
+        string queryParams = "")
+    {
+        var authority = Fixture.Build<Web.App.Domain.LocalAuthorities.LocalAuthority>()
+            .With(a => a.Code, "123")
+            .Create();
+
+        var plans = Fixture.Build<EducationHealthCarePlans>()
+            .CreateMany(3).ToArray();
+
+        Assert.NotNull(authority.Code);
+
+        var client = Client.SetupInsights()
+            .SetupLocalAuthorityEndpoints(authority, plans)
+            .SetupLocalAuthoritiesComparators(authority.Code, ["123", "124"]);
+
+        var page = await client.Navigate($"{Paths.LocalAuthorityEducationHealthCarePlans(authority.Code)}{queryParams}");
+
+        return (page, authority, plans);
+    }
+
+    private static void AssertPageLayout(
+        IHtmlDocument page,
+        Web.App.Domain.LocalAuthorities.LocalAuthority authority,
+        EducationHealthCarePlans[] plans,
+        int viewAs = 0,
+        string expectedQueryParams = "")
+    {
+        DocumentAssert.AssertPageUrl(page, $"{Paths.LocalAuthorityEducationHealthCarePlans(authority.Code)}{expectedQueryParams}".ToAbsolute());
+
+        Assert.NotNull(authority.Name);
+        DocumentAssert.TitleAndH1(page, "Benchmark education, health care plans - Financial Benchmarking and Insights Tool - GOV.UK", "Benchmark education, health care plans");
+
+        var form = page.QuerySelector(".actions-form");
+        Assert.NotNull(form);
+
+        AssertFormOptions(form, viewAs);
+
+        if (viewAs == 0)
+        {
+            //TODO: asserts chart once implemented
+            Assert.True(true);
+        }
+        else
+        {
+            AssertTableSection(page, plans);
+        }
+    }
+
+    private static void AssertFormOptions(
+        IElement form,
+        int viewAs = 0)
+    {
+        var viewAsContainer = form.QuerySelector("#ViewAs");
+        Assert.NotNull(viewAsContainer);
+
+        var radioInputs = viewAsContainer.QuerySelectorAll("input[type='radio']");
+        Assert.Equal(Views.All.Length, radioInputs.Length);
+
+        foreach (var view in Views.All)
+        {
+            var value = ((int)view).ToString();
+
+            var input = radioInputs.FirstOrDefault(x => x.GetAttribute("value") == value);
+            Assert.NotNull(input);
+
+            var shouldBeChecked = viewAs == (int)view;
+            var isChecked = input.HasAttribute("checked");
+
+            Assert.Equal(shouldBeChecked, isChecked);
+        }
+    }
+
+    private static void AssertTableSection(IHtmlDocument page, EducationHealthCarePlans[] plans)
+    {
+        var tables = page.QuerySelectorAll(".govuk-table");
+        Assert.NotNull(tables);
+
+        foreach (var table in tables)
+        {
+            var heading = table.QuerySelector("thead th:nth-child(2)")!.TextContent.Trim();
+
+            // get required prop from table heading to later extract expected value from plan
+            Assert.True(HeadingToValue.TryGetValue(heading, out var extractor),
+                $"Unknown heading: {heading}");
+
+            var rows = table.QuerySelectorAll("tbody tr");
+            Assert.Equal(plans.Length, rows.Length);
+
+            foreach (var row in rows)
+            {
+                var cells = row.TableCells();
+
+                var expected = plans.FirstOrDefault(g => g.Name == cells[0]);
+                Assert.NotNull(expected);
+
+                Assert.Equal(cells[0], expected.Name);
+                Assert.Equal(cells[1], extractor(expected).ToString());
+                Assert.Equal(cells[2], expected.TotalPupils.ToString());
+            }
+        }
+    }
+
+    private static readonly Dictionary<string, Func<EducationHealthCarePlans, decimal?>> HeadingToValue =
+        new()
+        {
+            ["Total pupils with EHC plans (per 1000 pupils)"] = p => p.Total,
+            ["EHC plans in Mainstream schools or academies (per 1000 pupils)"] = p => p.Mainstream,
+            ["EHC plans in Resourced provision or SEN units (per 1000 pupils)"] = p => p.Resourced,
+            ["EHC plans in Maintained special school or special academies (per 1000 pupils)"] = p => p.Special,
+            ["EHC plans in NMSS or independent schools (per 1000 pupils)"] = p => p.Independent,
+            ["EHC plans in Hospital schools or alternative provisions (per 1000 pupils)"] = p => p.Hospital,
+            ["EHC plans in Post 16 (per 1000 pupils)"] = p => p.Post16,
+            ["EHC plans in other types of provisions (per 1000 pupils)"] = p => p.Other
+        };
+}

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -292,7 +292,7 @@ public static class Paths
     public static string LocalAuthorityResources(string? code) => $"/local-authority/{code}/find-ways-to-spend-less";
 
     public static string LocalAuthorityHighNeedsBenchmarking(string? code) => $"/local-authority/{code}/high-needs/benchmarking";
-
+    public static string LocalAuthorityEducationHealthCarePlans(string? code) => $"/local-authority/{code}/education-health-care-plans";
     public static string LocalAuthorityHighNeedsStartBenchmarking(string? code, LocalAuthorityBenchmarkType type, string? referrer = null) => string.IsNullOrWhiteSpace(referrer)
             ? $"/local-authority/{code}/comparators?type={type}"
             : $"/local-authority/{code}/comparators?type={type}&referrer={referrer}";


### PR DESCRIPTION
## 🧾 Summary

[AB#299498](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/299498) [AB#308381](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/308381)

### ✨ Feature Details

#### Functionality:

- Adds data tables to the new EHCP page.
- Introduces a chart/table toggle (charts currently placeholder text until SSR bar charts are implemented).
- No filtering yet, all categories are shown by default.

#### Implementation:

**Domain**

`EducationHealthCarePlans`

A new domain model representing the API response.
This duplicates `LocalAuthorityNumberOfPlans`, but the existing types aren’t ideal and there is already duplication across LA domain models (`Web.App.Domain.LocalAuthorities` vs `Web.App.Domain.LocalAuthority`).

Proposal: address the duplication across Local Authority in a separate ticket. I’ll raise one after review if agreed.

`EducationHealthCarePlansCategories`

Mirrors the IT Spend pattern.

- Represents category filters
-  Provides `GetTableHeading()` to supply the correct column heading for each category.

**Controllers**

LocalAuthorityEducationHealthCarePlansController now:

- Calls `LocalAuthorityApi.QueryEhcpAsync` to fetch comparator‑set plans.
- Redirects with a `viewAs` query parameter to control chart/table mode.

**View Models**

- `LocalAuthorityEducationHealthCarePlansViewModel` now includes SubCategories and ViewAs.
- `EducationHealthCarePlansComparisonSubCategoriesViewModel` responsible for transforming the raw `EducationHealthCarePlans[]` returned from the API into a set of sub‑category comparison groups suitable for rendering as tables (and later charts). Mirrors the pattern used in IT Spend
- `EducationHealthCarePlansComparisonDatum` created to represent a single row of comparison data (usable for both tables and charts) will be moved to `Domain/Charts` once work to implement the charts is underway.
- `LocalAuthorityEducationHealthCarePlansTableViewModel` added to represent each sub‑category table.
- `BenchmarkingViewModelCostSubCategory<T>` updated with a `TableHeading` property.

**Views**

- New partial for rendering each EHCP table, with a fallback warning if data is null.
- Added a form to toggle between chart and table view.
- Conditional rendering: tables for each selected sub‑category or placeholder chart text.

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [x] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.

## 🔍 Notes

Table headings have been agreed with Design; they were not all originally specified in the Figma. Some alignment adjustments will be needed for the column headers, but it makes more sense to revisit this once the page is closer to its final state.

This is a slightly larger PR than ideal sorry but a chunk of these lines are within the integration tests. Happy to split if the reviewer feels that would be helpful
