### PR TITLE
feat: update page title and cta for LocalAuthorityHighNeedsStartBenchmarking page

### DIFF
--- a/web/src/Web.App/Constants/PageTitles.cs
+++ b/web/src/Web.App/Constants/PageTitles.cs
@@ -71,7 +71,7 @@ public static class PageTitles
     public const string LocalAuthorityHighNeedsBenchmarking = "Benchmark high needs";
     public const string LocalAuthorityEducationHealthCarePlans = "Benchmark education, health care plans";
     public const string LocalAuthorityHighNeedsSpending = "Benchmark high needs spending";
-    public const string LocalAuthorityHighNeedsStartBenchmarking = "Choose local authorities to compare high needs spending";
+    public const string LocalAuthorityHighNeedsStartBenchmarking = "Choose local authorities to compare";
     public const string LocalAuthorityHighNeedsHistoricData = "High needs historical spending";
     public const string TrustSpending = "Spending focus for this trust";
     public const string TrustComparatorsCreateBy = "How do you want to choose your own set of trusts?";

--- a/web/src/Web.App/Views/LocalAuthorityComparators/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityComparators/Index.cshtml
@@ -66,7 +66,7 @@
     <div class="govuk-button-group">
         <button type="submit" class="govuk-button" data-module="govuk-button" name="action"
                 value="@FormAction.Continue">
-            Benchmark high needs spending
+            Start benchmarking
         </button>
     </div>
 

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsStartBenchmarkingPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsStartBenchmarkingPage.cs
@@ -11,7 +11,7 @@ public class HighNeedsStartBenchmarkingPage(IPage page)
     private ILocator OthersComparatorsCards => page.Locator("#current-comparators-others");
     private ILocator SaveAndContinueButton => page.Locator(Selectors.Button, new PageLocatorOptions
     {
-        HasText = "Benchmark high needs spending"
+        HasText = "Start benchmarking"
     });
 
     public async Task IsDisplayed()

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsStartBenchmarking.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsStartBenchmarking.cs
@@ -401,7 +401,7 @@ public class WhenViewingHighNeedsStartBenchmarking(SchoolBenchmarkingWebAppClien
         DocumentAssert.Breadcrumbs(page, expectedBreadcrumbs);
 
         Assert.NotNull(authority.Name);
-        DocumentAssert.TitleAndH1(page, "Choose local authorities to compare high needs spending - Financial Benchmarking and Insights Tool - GOV.UK", "Choose local authorities to compare high needs spending");
+        DocumentAssert.TitleAndH1(page, "Choose local authorities to compare - Financial Benchmarking and Insights Tool - GOV.UK", "Choose local authorities to compare");
 
         var comparatorSelector = page.GetElementAndAssert("#LaInput", Assert.NotNull);
         var options = comparatorSelector.QuerySelectorAll("option").Select(q => q.TextContent).ToArray();


### PR DESCRIPTION
## 🧾 Summary

[AB#295179](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/295179) [AB#309281](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/309281)

### ✨ Feature Details

Minor change to update the page title, heading and CTA for the `LocalAuthorityHighNeedsStartBenchmarking` page. This page is where the comparator set is created for the high needs journey. Now this pages serves two pages the wording is required to be more generic.

<img width="1424" height="950" alt="image" src="https://github.com/user-attachments/assets/41e64040-574f-46a6-ae15-5c53d9859d22" />


## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [x] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
