### PR TITLE
feat: add update e2e tests 

### DIFF
--- a/web/tests/Web.E2ETests/Features/LocalAuthority/LocalAuthorityHome.feature
+++ b/web/tests/Web.E2ETests/Features/LocalAuthority/LocalAuthorityHome.feature
@@ -33,7 +33,7 @@
     @LocalAuthorityHomepageV2FlagDisabled
     Scenario: Schools accordion is displayed when feature is disabled
         Given I am on local authority homepage for local authority with code '204'
-        Then the Choose local authorties to compare page is displayed
+        Then the schools accordion should be displayed
 
     @LocalAuthorityHomepageV2FlagEnabled
     Scenario: Schools accordion is not displayed when feature is enabled

--- a/web/tests/Web.E2ETests/Features/LocalAuthority/LocalAuthorityHome.feature
+++ b/web/tests/Web.E2ETests/Features/LocalAuthority/LocalAuthorityHome.feature
@@ -76,3 +76,10 @@
         Then I should see the following table data in workforce tab
           | School name     | Pupils | Pupil:teacher ratio | EHC plan (%) | SEN support (%) |
           | Test school 237 | 225    | 1.89                | 1.8%         | 5.3%            |
+          
+    @HighNeedsBenchmarkingFlagEnabled
+    Scenario: Go to bechmark education, health and care plan page
+        Given I am on local authority homepage for local authority with code '202'
+        When I click on benchmark education health and care plans
+        Then the High needs benchmarking page is displayed    
+    

--- a/web/tests/Web.E2ETests/Features/LocalAuthority/LocalAuthorityHome.feature
+++ b/web/tests/Web.E2ETests/Features/LocalAuthority/LocalAuthorityHome.feature
@@ -17,7 +17,7 @@
     Scenario: Go to High needs benchmarking data page
         Given I am on local authority homepage for local authority with code '204'
         When I click on benchmark high needs
-        Then the High needs benchmarking page is displayed
+        Then the Choose local authorties to compare page is displayed
 
     Scenario: Go to High needs history page
         Given I am on local authority homepage for local authority with code '204'
@@ -33,7 +33,7 @@
     @LocalAuthorityHomepageV2FlagDisabled
     Scenario: Schools accordion is displayed when feature is disabled
         Given I am on local authority homepage for local authority with code '204'
-        Then the schools accordion should be displayed
+        Then the Choose local authorties to compare page is displayed
 
     @LocalAuthorityHomepageV2FlagEnabled
     Scenario: Schools accordion is not displayed when feature is enabled
@@ -81,5 +81,4 @@
     Scenario: Go to bechmark education, health and care plan page
         Given I am on local authority homepage for local authority with code '202'
         When I click on benchmark education health and care plans
-        Then the High needs benchmarking page is displayed    
-    
+        Then the Choose local authorties to compare page is displayed

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/ChooseLocalAuthoritiesToComparePage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/ChooseLocalAuthoritiesToComparePage.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace Web.E2ETests.Pages.LocalAuthority;
 
-public class HighNeedsStartBenchmarkingPage(IPage page)
+public class ChooseLocalAuthoritiesToComparePage(IPage page)
 {
     private ILocator PageH1Heading => page.Locator($"main {Selectors.H1}");
     private ILocator LaInputField => page.Locator("#LaInput");
@@ -11,7 +11,7 @@ public class HighNeedsStartBenchmarkingPage(IPage page)
     private ILocator OthersComparatorsCards => page.Locator("#current-comparators-others");
     private ILocator SaveAndContinueButton => page.Locator(Selectors.Button, new PageLocatorOptions
     {
-        HasText = "Start benchmarking"
+        HasText = "Start Benchmarking"
     });
 
     public async Task IsDisplayed()
@@ -42,10 +42,10 @@ public class HighNeedsStartBenchmarkingPage(IPage page)
         await page.Keyboard.PressAsync(Keyboard.TabKey);
     }
 
-    public async Task<HighNeedsStartBenchmarkingPage> PressEnterKey()
+    public async Task<ChooseLocalAuthoritiesToComparePage> PressEnterKey()
     {
         await page.Keyboard.PressAsync(Keyboard.EnterKey);
-        return new HighNeedsStartBenchmarkingPage(page);
+        return new ChooseLocalAuthoritiesToComparePage(page);
     }
 
     public async Task ComparatorsContains(string name)

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsBenchmarkingPage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/HighNeedsBenchmarkingPage.cs
@@ -28,10 +28,10 @@ public class HighNeedsBenchmarkingPage(IPage page)
         await ViewAsChartRadio.Click();
     }
 
-    public async Task<HighNeedsStartBenchmarkingPage> ClickChangeComparatorsLink()
+    public async Task<ChooseLocalAuthoritiesToComparePage> ClickChangeComparatorsLink()
     {
         await ChangeComparatorsLink.ClickAsync();
-        return new HighNeedsStartBenchmarkingPage(page);
+        return new ChooseLocalAuthoritiesToComparePage(page);
     }
 
     public async Task AreChartsDisplayed(int count)

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/HomePage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/HomePage.cs
@@ -22,6 +22,11 @@ public class HomePage(IPage page)
     {
         HasText = "Benchmark high needs"
     });
+    
+    private ILocator BenchmarkEhcpLink => page.Locator(Selectors.GovLink, new PageLocatorOptions
+    {
+        HasText = "Benchmark education, health and care plans"
+    });
 
     private ILocator HighNeedsHistoryLink => page.Locator(Selectors.GovLink, new PageLocatorOptions
     {
@@ -222,6 +227,12 @@ public class HomePage(IPage page)
     {
         await WorkforceApplyFilters.ShouldBeVisible();
         await WorkforceApplyFilters.Click();
+    }
+    
+    public async Task<HighNeedsStartBenchmarkingPage> ClickBenchmarkEhcp()
+    {
+        await BenchmarkEhcpLink.Click();
+        return new HighNeedsStartBenchmarkingPage(page);
     }
 
     private async Task ExpandAccordionIfNotExpanded(ILocator accordionButton)

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/HomePage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/HomePage.cs
@@ -22,7 +22,7 @@ public class HomePage(IPage page)
     {
         HasText = "Benchmark high needs"
     });
-    
+
     private ILocator BenchmarkEhcpLink => page.Locator(Selectors.GovLink, new PageLocatorOptions
     {
         HasText = "Benchmark education, health and care plans"
@@ -228,7 +228,7 @@ public class HomePage(IPage page)
         await WorkforceApplyFilters.ShouldBeVisible();
         await WorkforceApplyFilters.Click();
     }
-    
+
     public async Task<ChooseLocalAuthoritiesToComparePage> ClickBenchmarkEhcp()
     {
         await BenchmarkEhcpLink.Click();

--- a/web/tests/Web.E2ETests/Pages/LocalAuthority/HomePage.cs
+++ b/web/tests/Web.E2ETests/Pages/LocalAuthority/HomePage.cs
@@ -77,10 +77,10 @@ public class HomePage(IPage page)
         return new BenchmarkCensusPage(page);
     }
 
-    public async Task<HighNeedsStartBenchmarkingPage> ClickBenchmarkHighNeeds()
+    public async Task<ChooseLocalAuthoritiesToComparePage> ClickBenchmarkHighNeeds()
     {
         await HighNeedsBenchmarkingLink.Click();
-        return new HighNeedsStartBenchmarkingPage(page);
+        return new ChooseLocalAuthoritiesToComparePage(page);
     }
 
     public async Task<HighNeedsHistoricDataPage> ClickHighNeedsHistory()
@@ -229,10 +229,10 @@ public class HomePage(IPage page)
         await WorkforceApplyFilters.Click();
     }
     
-    public async Task<HighNeedsStartBenchmarkingPage> ClickBenchmarkEhcp()
+    public async Task<ChooseLocalAuthoritiesToComparePage> ClickBenchmarkEhcp()
     {
         await BenchmarkEhcpLink.Click();
-        return new HighNeedsStartBenchmarkingPage(page);
+        return new ChooseLocalAuthoritiesToComparePage(page);
     }
 
     private async Task ExpandAccordionIfNotExpanded(ILocator accordionButton)

--- a/web/tests/Web.E2ETests/Steps/LocalAuthority/HighNeedsBenchmarkingSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/LocalAuthority/HighNeedsBenchmarkingSteps.cs
@@ -9,7 +9,7 @@ namespace Web.E2ETests.Steps.LocalAuthority;
 public class HighNeedsBenchmarkingSteps(PageDriver driver)
 {
     private HighNeedsBenchmarkingPage? _highNeedsBenchmarkingPage;
-    private HighNeedsStartBenchmarkingPage? _highNeedsStartBenchmarkingPage;
+    private ChooseLocalAuthoritiesToComparePage? _highNeedsStartBenchmarkingPage;
 
     [Given("I am on local authority high needs start benchmarking for local authority with code '(.*)'")]
     public async Task GivenIAmOnLocalAuthorityHighNeedsStartBenchmarkingForLocalAuthorityWithCode(string laCode)
@@ -18,7 +18,7 @@ public class HighNeedsBenchmarkingSteps(PageDriver driver)
         var page = await driver.Current;
         await page.GotoAndWaitForLoadAsync(url);
 
-        _highNeedsStartBenchmarkingPage = new HighNeedsStartBenchmarkingPage(page);
+        _highNeedsStartBenchmarkingPage = new ChooseLocalAuthoritiesToComparePage(page);
         await _highNeedsStartBenchmarkingPage.IsDisplayed();
     }
 

--- a/web/tests/Web.E2ETests/Steps/LocalAuthority/HighNeedsStartBenchmarkingSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/LocalAuthority/HighNeedsStartBenchmarkingSteps.cs
@@ -9,7 +9,7 @@ namespace Web.E2ETests.Steps.LocalAuthority;
 public class HighNeedsStartBenchmarkingSteps(PageDriver driver, PageDriverWithJavaScriptDisabled driverNoJs)
 {
     private HighNeedsBenchmarkingPage? _highNeedsBenchmarkingPage;
-    private HighNeedsStartBenchmarkingPage? _highNeedsStartBenchmarkingPage;
+    private ChooseLocalAuthoritiesToComparePage? _highNeedsStartBenchmarkingPage;
     private bool _javascriptDisabled;
 
     [Given("JavaScript is '(.*)'")]
@@ -89,7 +89,7 @@ public class HighNeedsStartBenchmarkingSteps(PageDriver driver, PageDriverWithJa
         var page = await (_javascriptDisabled ? driverNoJs : driver).Current;
         await page.GotoAndWaitForLoadAsync(url);
 
-        _highNeedsStartBenchmarkingPage = new HighNeedsStartBenchmarkingPage(page);
+        _highNeedsStartBenchmarkingPage = new ChooseLocalAuthoritiesToComparePage(page);
         await _highNeedsStartBenchmarkingPage.IsDisplayed();
     }
 

--- a/web/tests/Web.E2ETests/Steps/LocalAuthority/HomeSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/LocalAuthority/HomeSteps.cs
@@ -11,7 +11,7 @@ public class HomeSteps(PageDriver driver)
     private BenchmarkCensusPage? _benchmarkCensusPage;
     private CompareYourCostsPage? _compareYourCostsPage;
     private HomePage? _localAuthorityHomePage;
-    private HighNeedsStartBenchmarkingPage? _benchmarkHighNeedsPage;
+    private ChooseLocalAuthoritiesToComparePage? _chooseLocalAuthoritiesPage;
     private HighNeedsHistoricDataPage? _highNeedsHistoryPage;
 
     [Given("I am on local authority homepage for local authority with code '(.*)'")]
@@ -50,7 +50,7 @@ public class HomeSteps(PageDriver driver)
     public async Task WhenIClickOnBenchmarkHighNeeds()
     {
         Assert.NotNull(_localAuthorityHomePage);
-        _benchmarkHighNeedsPage = await _localAuthorityHomePage.ClickBenchmarkHighNeeds();
+        _chooseLocalAuthoritiesPage = await _localAuthorityHomePage.ClickBenchmarkHighNeeds();
     }
 
     [When("I click on high needs historic data")]
@@ -74,11 +74,11 @@ public class HomeSteps(PageDriver driver)
         await _localAuthorityHomePage.HasBanner(title, heading, body);
     }
 
-    [Then("the High needs benchmarking page is displayed")]
+    [Then("the Choose local authorties to compare page is displayed")]
     public async Task ThenTheHighNeedsBenchmarkingPageIsDisplayed()
     {
-        Assert.NotNull(_benchmarkHighNeedsPage);
-        await _benchmarkHighNeedsPage.IsDisplayed();
+        Assert.NotNull(_chooseLocalAuthoritiesPage);
+        await _chooseLocalAuthoritiesPage.IsDisplayed();
     }
 
     [Then("the High needs historic data page is displayed")]
@@ -187,7 +187,7 @@ public class HomeSteps(PageDriver driver)
     public async Task WhenIClickOnBenchamarkEducationHealthAndCarePlans()
     {
         Assert.NotNull(_localAuthorityHomePage);
-        _benchmarkHighNeedsPage = await _localAuthorityHomePage.ClickBenchmarkEhcp();
+        _chooseLocalAuthoritiesPage = await _localAuthorityHomePage.ClickBenchmarkEhcp();
     }
 
     private static string LocalAuthorityHomeUrl(string laCode) => $"{TestConfiguration.ServiceUrl}/local-authority/{laCode}";

--- a/web/tests/Web.E2ETests/Steps/LocalAuthority/HomeSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/LocalAuthority/HomeSteps.cs
@@ -182,7 +182,7 @@ public class HomeSteps(PageDriver driver)
         Assert.NotNull(_localAuthorityHomePage);
         await _localAuthorityHomePage.ClickWorkforceApplyFilters();
     }
-    
+
     [When("I click on benchmark education health and care plans")]
     public async Task WhenIClickOnBenchamarkEducationHealthAndCarePlans()
     {

--- a/web/tests/Web.E2ETests/Steps/LocalAuthority/HomeSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/LocalAuthority/HomeSteps.cs
@@ -182,6 +182,13 @@ public class HomeSteps(PageDriver driver)
         Assert.NotNull(_localAuthorityHomePage);
         await _localAuthorityHomePage.ClickWorkforceApplyFilters();
     }
+    
+    [When("I click on benchmark education health and care plans")]
+    public async Task WhenIClickOnBenchamarkEducationHealthAndCarePlans()
+    {
+        Assert.NotNull(_localAuthorityHomePage);
+        _benchmarkHighNeedsPage = await _localAuthorityHomePage.ClickBenchmarkEhcp();
+    }
 
     private static string LocalAuthorityHomeUrl(string laCode) => $"{TestConfiguration.ServiceUrl}/local-authority/{laCode}";
 


### PR DESCRIPTION
## 🧾 Summary
updated and added new tests

Fixes [AB#308205](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/308205) [AB#299498](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/299498)

### ✨ Feature Details
> - Added tests to assert the new link is available on the LA homepage. Also added a tag on the tests which will be used to enable/disable the test in pipeline as per the feature flag
> - Also updated the files which were using old page name from 'choose local authorities to compare high needs spending' to 'choose local authorities to compare' and the button text accordingly too. 


## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes
> The tests will initially fail but will start passing after [PR](https://github.com/DFE-Digital/education-benchmarking-and-insights/pull/4045) will go in and [AB#309281](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/309281) is merged 
