### PR TITLE
feat: stitch EHCP charts into new page

### DIFF
--- a/web/src/Web.App/Controllers/LocalAuthorityEducationHealthCarePlansController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityEducationHealthCarePlansController.cs
@@ -17,6 +17,7 @@ namespace Web.App.Controllers;
 public class LocalAuthorityEducationHealthCarePlansController(
     ILogger<LocalAuthorityEducationHealthCarePlansController> logger,
     ILocalAuthorityApi api,
+    IChartRenderingApi chartRenderingApi,
     ILocalAuthorityComparatorSetService comparatorSetService)
     : Controller
 {
@@ -41,12 +42,16 @@ public class LocalAuthorityEducationHealthCarePlansController(
                 var query = BuildQuery(new[]
                 {
                     code
-                }.Concat(set).ToArray(), "Per1000Pupil");
+                }.Concat(set).ToArray(), EducationHealthCarePlanProperties.Dimension);
                 var plans = await api
                     .QueryEhcpAsync(query)
                     .GetResultOrThrow<EducationHealthCarePlans[]>();
 
                 var subCategories = new EducationHealthCarePlansComparisonSubCategoriesViewModel(plans, EducationHealthCarePlansCategories.All);
+
+                var charts = await BuildCharts(code, subCategories);
+
+                subCategories.Items.ForEach(i => i.ChartSvg = charts.FirstOrDefault(c => c.Id == i.Uuid)!.Html);
 
                 var viewModel = new LocalAuthorityEducationHealthCarePlansViewModel(la, set, subCategories)
                 {
@@ -80,5 +85,34 @@ public class LocalAuthorityEducationHealthCarePlansController(
 
         query.AddIfNotNull("dimension", dimension);
         return query;
+    }
+
+    private async Task<ChartResponse[]> BuildCharts(string urn,
+        EducationHealthCarePlansComparisonSubCategoriesViewModel subCategories)
+    {
+        var requests = subCategories.Items.Select(c => new EducationHealthCarePlanHorizontalBarChartRequest(
+            c.Uuid!,
+            urn,
+            c.Data!,
+            format => Uri.UnescapeDataString(
+                Url.Action("Index", "School", new
+                {
+                    urn = format
+                }) ?? string.Empty)
+        ));
+
+        ChartResponse[] charts = [];
+        try
+        {
+            charts = await chartRenderingApi
+                .PostHorizontalBarCharts(new PostHorizontalBarChartsRequest<EducationHealthCarePlansComparisonDatum>(requests))
+                .GetResultOrDefault<ChartResponse[]>() ?? [];
+        }
+        catch (Exception e)
+        {
+            logger.LogWarning(e, "Unable to load charts from API");
+        }
+
+        return charts;
     }
 }

--- a/web/src/Web.App/Controllers/LocalAuthorityEducationHealthCarePlansController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityEducationHealthCarePlansController.cs
@@ -51,7 +51,14 @@ public class LocalAuthorityEducationHealthCarePlansController(
 
                 var charts = await BuildCharts(code, subCategories);
 
-                subCategories.Items.ForEach(i => i.ChartSvg = charts.FirstOrDefault(c => c.Id == i.Uuid)!.Html);
+                subCategories.Items!.ForEach(i =>
+                {
+                    var chart = charts.FirstOrDefault(c => c.Id != null && c.Id == i.Uuid);
+                    if (chart != null)
+                    {
+                        i.ChartSvg = chart.Html;
+                    }
+                });
 
                 var viewModel = new LocalAuthorityEducationHealthCarePlansViewModel(la, set, subCategories)
                 {

--- a/web/src/Web.App/Domain/Charts/EducationHealthCarePlanHorizontalBarChartRequest.cs
+++ b/web/src/Web.App/Domain/Charts/EducationHealthCarePlanHorizontalBarChartRequest.cs
@@ -1,0 +1,37 @@
+using Web.App.Infrastructure.Apis;
+
+// ReSharper disable ClassNeverInstantiated.Global
+
+namespace Web.App.Domain.Charts;
+
+public record EducationHealthCarePlanHorizontalBarChartRequest : PostHorizontalBarChartRequest<EducationHealthCarePlansComparisonDatum>
+{
+    public EducationHealthCarePlanHorizontalBarChartRequest(
+        string uuid,
+        string code,
+        EducationHealthCarePlansComparisonDatum[] filteredData,
+        Func<string, string?> linkFormatter)
+    {
+        BarHeight = 22;
+        Data = filteredData;
+        HighlightKey = code;
+        Id = uuid;
+        KeyField = nameof(EducationHealthCarePlansComparisonDatum.Code).ToLower();
+        LabelField = "name";
+        LabelFormat = "%2$s";
+        LinkFormat = linkFormatter("%1$s");
+        Sort = "desc";
+        Width = 610;
+        ValueField = nameof(EducationHealthCarePlansComparisonDatum.Plans).ToLower();
+        ValueType = Web.App.Domain.Charts.ValueType.Numeric;
+        XAxisLabel = EducationHealthCarePlanProperties.XAxisLabel;
+    }
+}
+
+public class EducationHealthCarePlansComparisonDatum
+{
+    public string? Code { get; set; }
+    public string? Name { get; set; }
+    public decimal? Plans { get; set; }
+    public decimal? TotalPupils { get; set; }
+}

--- a/web/src/Web.App/Domain/Charts/EducationHealthCarePlanProperties.cs
+++ b/web/src/Web.App/Domain/Charts/EducationHealthCarePlanProperties.cs
@@ -1,0 +1,7 @@
+namespace Web.App.Domain.Charts;
+
+public static class EducationHealthCarePlanProperties
+{
+    public static readonly string Dimension = "Per1000Pupil";
+    public static readonly string XAxisLabel = "EHC plans per 1,000 pupils";
+}

--- a/web/src/Web.App/Domain/LocalAuthorities/EducationHealthCarePlans.cs
+++ b/web/src/Web.App/Domain/LocalAuthorities/EducationHealthCarePlans.cs
@@ -2,6 +2,7 @@ namespace Web.App.Domain.LocalAuthorities;
 
 public record EducationHealthCarePlans
 {
+    public string? Code { get; set; }
     public string? Name { get; set; }
     public decimal? TotalPupils { get; set; }
     public decimal? Total { get; set; }

--- a/web/src/Web.App/ViewModels/EducationHealthCarePlansComparisonSubCategoriesViewModel.cs
+++ b/web/src/Web.App/ViewModels/EducationHealthCarePlansComparisonSubCategoriesViewModel.cs
@@ -1,3 +1,4 @@
+using Web.App.Domain.Charts;
 using Web.App.Domain.LocalAuthorities;
 
 namespace Web.App.ViewModels;
@@ -22,6 +23,7 @@ public class EducationHealthCarePlansComparisonSubCategoriesViewModel
         var data = plans
             .Select(p => new EducationHealthCarePlansComparisonDatum
             {
+                Code = p.Code,
                 Name = p.Name,
                 Plans = filter.GetValue(p),
                 TotalPupils = p.TotalPupils
@@ -39,12 +41,4 @@ public class EducationHealthCarePlansComparisonSubCategoriesViewModel
             Data = data
         });
     }
-}
-
-// TODO: as part of chart wiring up move to Domain/Charts
-public class EducationHealthCarePlansComparisonDatum
-{
-    public string? Name { get; set; }
-    public decimal? Plans { get; set; }
-    public decimal? TotalPupils { get; set; }
 }

--- a/web/src/Web.App/ViewModels/LocalAuthorityEducationHealthCarePlansViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityEducationHealthCarePlansViewModel.cs
@@ -24,3 +24,9 @@ public class LocalAuthorityEducationHealthCarePlansTableViewModel(
 {
     public BenchmarkingViewModelCostSubCategory<EducationHealthCarePlansComparisonDatum> SubCategory => subCategory;
 }
+
+public class LocalAuthorityEducationHealthCarePlansChartViewModel(
+    BenchmarkingViewModelCostSubCategory<EducationHealthCarePlansComparisonDatum> subCategory)
+{
+    public BenchmarkingViewModelCostSubCategory<EducationHealthCarePlansComparisonDatum> SubCategory => subCategory;
+}

--- a/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/Index.cshtml
@@ -89,7 +89,7 @@
 
                 @if (Model.ViewAs == Views.ViewAsOptions.Chart)
                 {
-                    <p class="govuk-body">chart under construction</p>
+                    @await Html.PartialAsync("_EhcPlanChart", new LocalAuthorityEducationHealthCarePlansChartViewModel(subCategory))
                 }
                 else
                 {

--- a/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/_EhcPlanChart.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/_EhcPlanChart.cshtml
@@ -1,0 +1,22 @@
+@model Web.App.ViewModels.LocalAuthorityEducationHealthCarePlansChartViewModel
+
+@if (string.IsNullOrWhiteSpace(Model.SubCategory.ChartSvg))
+{
+    <div
+        class="govuk-warning-text govuk-!-margin-top-2 govuk-!-margin-bottom-2 ssr-chart-warning">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+            <span class="govuk-visually-hidden">Warning</span>
+            Unable to display chart
+        </strong>
+    </div>
+    return;
+}
+
+<div id="@Model.SubCategory.Uuid" data-title="@Model.SubCategory.SubCategory">
+    <div class="costs-chart-wrapper">
+        <div class="govuk-!-margin-bottom-2 ssr-chart horizontal-bar-chart">
+            @Html.Raw(Model.SubCategory.ChartSvg)
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## 🧾 Summary
> Briefly describe the changes and why they are needed.

Fixes [AB#308379](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/308379) (Task within [AB#299498](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/299498))

### ✨ Feature Details
> - **Functionality:** Adds unfiltered EHCP charts to the EHCP benchmarking page
> - **Implementation:** 
>   - New private method within `LocalAuthorityEducationHealthCarePlansController.cs` to make request for 
>   charts to `ChartRenderingAPI`
>   - associated chart request class to encapsulate the request details
>   - updates to the ehcp benchmarking view and new chart partial to handle display

<img width="685" height="919" alt="Screenshot 2026-04-21 at 14 59 02" src="https://github.com/user-attachments/assets/4530bd9e-b51b-4b65-bc92-9e72306fedfb" />


## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [x] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes
> Add any additional context for reviewers, required dependencies, or specific testing instructions.

I've created a new view model for the charts partial (`LocalAuthorityEducationHealthCarePlansChartViewModel`)
which is actually identical to the existing table partial (`LocalAuthorityEducationHealthCarePlansTableViewModel`)
and I wasn't 100% sure that was the correct approach. Perhaps we could instead use the same class for both
purposes?

ALso, I've deliberately deferred any test writing for this.  I think any tests written now will be so badly affected once filtering is introduced that spending time on it now will be a bit of a waste.