### PR TITLE
chore: add helper scripts for switching env config for platform api and api tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ Thumbs.db
 *.DotSettings.user
 
 # ==========================================
+# Scripts
+scripts/api-env.json
+scripts/api-tests-env.json
+
 # .NET / Visual Studio
 # ==========================================
 # Build & Output

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,116 @@
+# Development Scripts
+
+This directory contains PowerShell scripts to assist with local development and environment management.
+
+## Environment Switching
+
+These scripts allow you to quickly switch the configuration of the Platform APIs and the API Tests between local development and test environment dependencies.
+
+### Platform API Environment Switcher
+
+`switch-api-env.ps1` updates the `local.settings.json` files for all Platform API projects in `platform/src/apis`.
+
+**Usage:**
+
+```powershell
+.\switch-api-env.ps1 -Environment test
+```
+
+**Configuration:**
+Create a file named `api-env.json` in this directory. This file is ignored by Git to prevent secrets from leaking.
+
+**Example `api-env.json`:**
+
+```json
+{
+  "ApiTargets": [
+    "Platform.Api.Benchmark",
+    "Platform.Api.ChartRendering",
+    "Platform.Api.Content",
+    "Platform.Api.Establishment",
+    "Platform.Api.Insight",
+    "Platform.Api.LocalAuthority",
+    "Platform.Api.NonFinancial",
+    "Platform.Api.School",
+    "Platform.Api.Trust",
+    "Platform.MaintenanceTasks",
+    "Platform.Orchestrator"
+  ],
+  "Environments": {
+    "dev": {
+      "Sql__ConnectionString": "Server=localhost,1433;Database=data;User Id=SA;Password=mystrong!Pa55word;Encrypt=False;",
+      "Search__Name": "[INSERT_NAME]",
+      "Search__Key": "[INSERT_KEY]",
+      "Cache__Host": "localhost"
+    },
+    "test": {
+      "Sql__ConnectionString": "[INSERT_CONNECTION_STRING]",
+      "Search__Name": "[INSERT_NAME]",
+      "Search__Key": "[INSERT_KEY]",
+      "Cache__Host": "[INSERT_HOST]"
+    }
+  }
+}
+```
+
+### API Tests Environment Switcher
+
+`switch-api-tests-env.ps1` updates the `appsettings.local.json` file for the `Platform.ApiTests` project.
+
+**Usage:**
+
+```powershell
+.\switch-api-tests-env.ps1 -Environment local
+```
+
+**Configuration:**
+Create a file named `api-tests-env.json` in this directory. This file is ignored by Git.
+
+**Example `api-tests-env.json`:**
+
+```json
+{
+  "Environments": {
+    "local": {
+      "School:Host": "http://localhost:7302",
+      "School:Key": "[INSERT_KEY]",
+      "Trust:Host": "http://localhost:7303",
+      "Trust:Key": "[INSERT_KEY]",
+      "LocalAuthority:Host": "http://localhost:7301",
+      "LocalAuthority:Key": "[INSERT_KEY]",
+      "Insight:Host": "http://localhost:7071",
+      "Insight:Key": "[INSERT_KEY]",
+      "Benchmark:Host": "http://localhost:7072",
+      "Benchmark:Key": "[INSERT_KEY]",
+      "Establishment:Host": "http://localhost:7073",
+      "Establishment:Key": "[INSERT_KEY]",
+      "NonFinancial:Host": "http://localhost:7075",
+      "NonFinancial:Key": "[INSERT_KEY]",
+      "ChartRendering:Host": "http://localhost:7076",
+      "ChartRendering:Key": "[INSERT_KEY]",
+      "Content:Host": "http://localhost:7077",
+      "Content:Key": "[INSERT_KEY]"
+    },
+    "test": {
+      "School:Host": "[INSERT_URL]",
+      "School:Key": "[INSERT_KEY]",
+      "Trust:Host": "[INSERT_URL]",
+      "Trust:Key": "[INSERT_KEY]",
+      "LocalAuthority:Host": "[INSERT_URL]",
+      "LocalAuthority:Key": "[INSERT_KEY]",
+      "Insight:Host": "[INSERT_URL]",
+      "Insight:Key": "[INSERT_KEY]",
+      "Benchmark:Host": "[INSERT_URL]",
+      "Benchmark:Key": "[INSERT_KEY]",
+      "Establishment:Host": "[INSERT_URL]",
+      "Establishment:Key": "[INSERT_KEY]",
+      "NonFinancial:Host": "[INSERT_URL]",
+      "NonFinancial:Key": "[INSERT_KEY]",
+      "ChartRendering:Host": "[INSERT_URL]",
+      "ChartRendering:Key": "[INSERT_KEY]",
+      "Content:Host": "[INSERT_URL]",
+      "Content:Key": "[INSERT_KEY]"
+    }
+  }
+}
+```

--- a/scripts/switch-api-env.ps1
+++ b/scripts/switch-api-env.ps1
@@ -1,0 +1,48 @@
+param (
+    [Parameter(Mandatory=$true)]
+    [ValidateSet("local", "dev", "auto-test", "test")]
+    [string]$Environment
+)
+
+$scriptPath = Split-Path -Parent $MyInvocation.MyCommand.Path
+$configPath = Join-Path $scriptPath "api-env.json"
+
+if (-not (Test-Path $configPath)) {
+    Write-Error "Configuration file not found: $configPath. Please create it based on the examples in README.md."
+    exit 1
+}
+
+$config = Get-Content $configPath | ConvertFrom-Json
+$envValues = $config.Environments.$Environment
+
+if ($null -eq $envValues) {
+    Write-Error "Environment '$Environment' not defined in $configPath."
+    exit 1
+}
+
+$repoRoot = Split-Path -Parent $scriptPath
+$apiRoot = Join-Path $repoRoot "platform\src\apis"
+
+foreach ($target in $config.ApiTargets) {
+    $settingsPath = Join-Path $apiRoot "$target\local.settings.json"
+    
+    if (Test-Path $settingsPath) {
+        Write-Host "Updating $target..." -ForegroundColor Cyan
+        $settings = Get-Content $settingsPath | ConvertFrom-Json
+        
+        foreach ($property in $envValues.PSObject.Properties) {
+            $key = $property.Name
+            if ($settings.Values.PSObject.Properties.Match($key).Count -gt 0) {
+                $settings.Values.$key = $property.Value
+            }
+        }
+        
+        # Save JSON. We use standard ConvertTo-Json. 
+        # Note: PS 5.1 formatting is non-standard but safe.
+        $settings | ConvertTo-Json -Depth 10 | Set-Content $settingsPath -Encoding UTF8
+    } else {
+        Write-Warning "File not found: $settingsPath. Skipping."
+    }
+}
+
+Write-Host "Successfully switched Platform API to $Environment settings." -ForegroundColor Green

--- a/scripts/switch-api-tests-env.ps1
+++ b/scripts/switch-api-tests-env.ps1
@@ -1,0 +1,51 @@
+param (
+    [Parameter(Mandatory=$true)]
+    [ValidateSet("local", "dev", "auto-test", "test")]
+    [string]$Environment
+)
+
+$scriptPath = Split-Path -Parent $MyInvocation.MyCommand.Path
+$configPath = Join-Path $scriptPath "api-tests-env.json"
+
+if (-not (Test-Path $configPath)) {
+    Write-Error "Configuration file not found: $configPath. Please create it based on the examples in README.md."
+    exit 1
+}
+
+$config = Get-Content $configPath | ConvertFrom-Json
+$envValues = $config.Environments.$Environment
+
+if ($null -eq $envValues) {
+    Write-Error "Environment '$Environment' not defined in $configPath."
+    exit 1
+}
+
+$repoRoot = Split-Path -Parent $scriptPath
+$testsPath = Join-Path $repoRoot "platform\tests\Platform.ApiTests\appsettings.local.json"
+
+if (Test-Path $testsPath) {
+    Write-Host "Updating API Tests configuration..." -ForegroundColor Cyan
+    $settings = Get-Content $testsPath | ConvertFrom-Json
+    
+    foreach ($property in $envValues.PSObject.Properties) {
+        $key = $property.Name
+        # Split key by ':' (e.g. "School:Host")
+        $parts = $key.Split(':')
+        $section = $parts[0]
+        $propertyName = $parts[1]
+        
+        if ($null -eq $settings.$section) {
+            $settings | Add-Member -MemberType NoteProperty -Name $section -Value @{}
+        }
+        
+        $settings.$section.$propertyName = $property.Value
+    }
+    
+    # Save JSON. We use standard ConvertTo-Json. 
+    # Note: PS 5.1 formatting is non-standard but safe.
+    $settings | ConvertTo-Json -Depth 10 | Set-Content $testsPath -Encoding UTF8
+    Write-Host "Successfully switched API Tests to $Environment endpoints." -ForegroundColor Green
+} else {
+    Write-Error "File not found: $testsPath. Please create it first (you can copy appsettings.json as a template)."
+    exit 1
+}


### PR DESCRIPTION
## 🧾 Summary
Introduced environment switching scripts to streamline local development. These scripts allow developers to quickly toggle the configuration of Platform APIs and API Tests between local, dev, auto-test, and test environments without the overhead of maintaining duplicate template files.

### ✨ Feature Details
- Functionality: Provides a fast, configuration-driven way to update local settings for Platform APIs and their functional tests. This allows switching between local dependencies and various Azure-hosted environments (e.g., pointing local APIs to Test SQL/Search).
- Implementation: 
  - Created scripts/switch-api-env.ps1 to update local.settings.json across all Platform API projects.
  - Created scripts/switch-api-tests-env.ps1 to update appsettings.local.json for Platform.ApiTests.
  - Added a scripts/README.md with usage instructions and copy-paste configuration examples.
  - Updated .gitignore to ensure local configuration files (api-env.json, api-tests-env.json) are never committed, protecting secrets.
  - Implemented robust in-place JSON patching using PowerShell 5.1 compatible logic.

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [x] Tested by running locally.
- [x] Relevant documentation updated.

## 🔍 Notes
Developers should refer to the new scripts/README.md to set up their local api-env.json and api-tests-env.json files. Starter configuration files have been generated locally but are intentionally ignored by source control.
