### PR TITLE
feat: add save chart images and download page data to ehcp page

### DIFF
--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -502,6 +502,24 @@ hr.govuk-section-break--print {
   }
 }
 
+.page-actions-wrapper-horizontal {
+
+  .page-actions {
+    display: flex;
+    flex-flow: row;
+    gap: 20px;
+    margin-bottom: 20px;
+
+    button {
+      margin: 0;
+    }
+
+    @include govuk-media-query($until: tablet) {
+      flex-direction: column;
+    }
+  }
+}
+
 .composed-container {
   min-height: 335px;
 }

--- a/web/src/Web.App/Controllers/LocalAuthorityEducationHealthCarePlansController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityEducationHealthCarePlansController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
+using Web.App.ActionResults;
 using Web.App.Attributes;
 using Web.App.Domain.Charts;
 using Web.App.Domain.LocalAuthorities;
@@ -84,6 +85,44 @@ public class LocalAuthorityEducationHealthCarePlansController(
         selectedSubCategories,
         viewAs
     });
+
+    [HttpGet]
+    [Produces("application/zip")]
+    [ProducesResponseType<byte[]>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [Route("download")]
+    public async Task<IActionResult> Download(string code)
+    {
+        using (logger.BeginScope(new
+        {
+            code
+        }))
+        {
+            try
+            {
+                var set = comparatorSetService.ReadUserDefinedComparatorSetFromSession(code).Set;
+                if (set.Length == 0)
+                {
+                    return RedirectToAction("Index", "LocalAuthorityComparators", new { code, type = LocalAuthorityBenchmarkType.EducationHealthCarePlans });
+                }
+
+                var query = BuildQuery(new[]
+                {
+                    code
+                }.Concat(set).ToArray(), EducationHealthCarePlanProperties.Dimension);
+                var plans = await api
+                    .QueryEhcpAsync(query)
+                    .GetResultOrThrow<EducationHealthCarePlans[]>();
+
+                return new CsvResults([new CsvResult(plans, $"benchmark-education-health-care-plans-{code}.csv")], $"benchmark-education-health-care-plans-{code}.zip");
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "An error downloading education health care plans data: {DisplayUrl}", Request.GetDisplayUrl());
+                return StatusCode(500);
+            }
+        }
+    }
 
     private static ApiQuery BuildQuery(string[] codes, string dimension)
     {

--- a/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/Index.cshtml
@@ -1,6 +1,7 @@
 @using Web.App.Domain.Charts
 @using Web.App.Extensions
 @using Web.App.ViewModels
+@using Web.App.ViewModels.Enhancements
 @model Web.App.ViewModels.LocalAuthorityEducationHealthCarePlansViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.LocalAuthorityEducationHealthCarePlans;
@@ -42,6 +43,23 @@
         @await Html.PartialAsync("_PlansFilter", Model)
     </div>
     <div class="govuk-grid-column-two-thirds">
+        <div class="page-actions-wrapper-horizontal">
+            <div class="page-actions">
+                @if (Model.ViewAs == Views.ViewAsOptions.Chart)
+                {
+                    <div id="page-actions-button"></div>
+                }
+                <a href="@Url.Action("Download", "LocalAuthorityEducationHealthCarePlans", new
+                         {
+                             code = Model.Code
+                         })" role="button"
+                   class="govuk-button govuk-button--secondary" data-module="govuk-button">
+                    Download page data
+                </a>
+            </div>
+        </div>
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
         @using (Html.BeginForm(FormMethod.Post, true, new
                 {
                     @class = "actions-form",
@@ -102,3 +120,17 @@
         }
     </div>
 </div>
+
+@section scripts
+{
+
+    @await Html.PartialAsync("Enhancements/_PageActions", new PageActionsViewModel
+    {
+        All = true,
+        ElementId = "page-actions-button",
+        SaveClassName = "costs-chart-container",
+        SaveFileName = $"benchmark-education-health-care-plans-{Model.Code}.zip",
+        SaveTitleAttr = "data-title",
+        StartImmediately = true
+    })
+}

--- a/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/_EhcPlanChart.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/_EhcPlanChart.cshtml
@@ -13,7 +13,7 @@
     return;
 }
 
-<div id="@Model.SubCategory.Uuid" data-title="@Model.SubCategory.SubCategory">
+<div id="@Model.SubCategory.Uuid" class="costs-chart-container" data-title="@Model.SubCategory.SubCategory">
     <div class="costs-chart-wrapper">
         <div class="govuk-!-margin-bottom-2 ssr-chart horizontal-bar-chart">
             @Html.Raw(Model.SubCategory.ChartSvg)

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenRequestingEducationHealthCarePlansDownload.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenRequestingEducationHealthCarePlansDownload.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using AutoFixture;
+using Web.App.Domain;
+using Web.App.Domain.LocalAuthorities;
+using Xunit;
+
+namespace Web.Integration.Tests.Pages.LocalAuthorities;
+
+public class WhenRequestingEducationHealthCarePlansDownload : PageBase<SchoolBenchmarkingWebAppClient>
+{
+    private readonly SchoolBenchmarkingWebAppClient _client;
+    private readonly EducationHealthCarePlans[] _plans;
+
+    public WhenRequestingEducationHealthCarePlansDownload(SchoolBenchmarkingWebAppClient client) : base(client)
+    {
+        _client = client;
+        _plans = Fixture.Build<EducationHealthCarePlans>().CreateMany().ToArray();
+    }
+
+    [Fact]
+    public async Task CanReturnOk()
+    {
+        var authority = Fixture.Build<Web.App.Domain.LocalAuthorities.LocalAuthority>()
+            .With(x => x.Code, "123")
+            .Create();
+
+        var comparatorSet = Fixture.Build<SchoolComparatorSet>()
+            .With(c => c.Pupil, Fixture.CreateMany<string>().ToArray())
+            .Without(c => c.Building)
+            .Create();
+
+        Assert.NotNull(authority.Code);
+        var response = await _client
+                .SetupLocalAuthorityEndpoints(authority, _plans)
+                .SetupLocalAuthoritiesComparators(authority.Code, ["123", "124"])
+                .Get(Paths.LocalAuthorityEducationHealthCarePlansDownload(authority.Code));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var expectedFileNames = new[]
+        {
+            "benchmark-education-health-care-plans-123.csv"
+        };
+        await foreach (var tuple in response.GetFilesFromZip())
+        {
+            Assert.Contains(tuple.fileName, expectedFileNames);
+
+            var csvLines = tuple.content.Split(Environment.NewLine);
+            Assert.Equal(
+                "Code,Name,TotalPupils,Total,Mainstream,Resourced,Special,Independent,Hospital,Post16,Other",
+                csvLines.First());
+            Assert.Equal(_plans.Length, csvLines.Length - 1);
+        }
+    }
+
+    [Fact]
+    public async Task CanReturnInternalServerError()
+    {
+        const string code = "123";
+        var response = await _client
+            .SetupEstablishmentWithException()
+            .Get(Paths.LocalAuthorityEducationHealthCarePlansDownload(code));
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+}

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingEducationHealthCarePlans.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingEducationHealthCarePlans.cs
@@ -67,13 +67,27 @@ public class WhenViewingEducationHealthCarePlans(SchoolBenchmarkingWebAppClient 
             expectedQueryParams: expectedQueryParams);
     }
 
+    [Fact]
+    public async Task CanDownloadPageData()
+    {
+        var (page, authority, _) = await SetupNavigateInitPage();
+
+        var anchor = page.QuerySelectorAll("a.govuk-button")
+            .FirstOrDefault(x => x.TextContent.Trim() == "Download page data");
+        Assert.NotNull(anchor);
+
+        var newPage = await Client.Follow(anchor);
+
+        DocumentAssert.AssertPageUrl(newPage, Paths.LocalAuthorityEducationHealthCarePlansDownload(authority.Code).ToAbsolute());
+    }
+
     private async Task<(
         IHtmlDocument page,
-        Web.App.Domain.LocalAuthorities.LocalAuthority authority,
+        LocalAuthority authority,
         EducationHealthCarePlans[] plans)> SetupNavigateInitPage(
         string queryParams = "")
     {
-        var authority = Fixture.Build<Web.App.Domain.LocalAuthorities.LocalAuthority>()
+        var authority = Fixture.Build<LocalAuthority>()
             .With(a => a.Code, "123")
             .Create();
 
@@ -93,7 +107,7 @@ public class WhenViewingEducationHealthCarePlans(SchoolBenchmarkingWebAppClient 
 
     private static void AssertPageLayout(
         IHtmlDocument page,
-        Web.App.Domain.LocalAuthorities.LocalAuthority authority,
+        LocalAuthority authority,
         EducationHealthCarePlans[] plans,
         int viewAs = 0,
         string expectedQueryParams = "")

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -293,6 +293,7 @@ public static class Paths
 
     public static string LocalAuthorityHighNeedsBenchmarking(string? code) => $"/local-authority/{code}/high-needs/benchmarking";
     public static string LocalAuthorityEducationHealthCarePlans(string? code) => $"/local-authority/{code}/education-health-care-plans";
+    public static string LocalAuthorityEducationHealthCarePlansDownload(string? code) => $"/local-authority/{code}/education-health-care-plans/download";
     public static string LocalAuthorityHighNeedsStartBenchmarking(string? code, LocalAuthorityBenchmarkType type, string? referrer = null) => string.IsNullOrWhiteSpace(referrer)
             ? $"/local-authority/{code}/comparators?type={type}"
             : $"/local-authority/{code}/comparators?type={type}&referrer={referrer}";


### PR DESCRIPTION
## 🧾 Summary

[AB#308380](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/308380) [AB#308380](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/308380)

### ✨ Feature Details
**Functionality:**

This PR updates the ehcp page by adding "page‑action" buttons for saving chart images and downloading the underlying data. It also introduces a new controller action that generates a CSV and bundles it into a ZIP file for download.

 **Implementation:**

Added a new .page-actions-wrapper-horizontal class to align page‑action buttons horizontally on larger screens and stack them vertically on smaller breakpoints.

Updated the view to render the Download page data button within the new layout wrapper and only render the Save chart images button when the page is in Chart view.

Integrated the existing PageActions enhancement component, including the required partial in the scripts section, to expose the correct element IDs, filenames, etc for chart export.

<img width="1641" height="970" alt="image" src="https://github.com/user-attachments/assets/e1b8e37e-56d2-49f7-9a92-886e65bde0da" />


## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [x] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [x] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes

Possible further work will be required to ensure the styling correctly matches the designs but this PR is intended to cover all functionality and the basic styling for these buttons
