### PR TITLE
feat: update and create new db views for high needs spending

### DIFF
--- a/core-infrastructure/src/db/Core.Database/Views/018-LocalAuthorityFinancial.sql
+++ b/core-infrastructure/src/db/Core.Database/Views/018-LocalAuthorityFinancial.sql
@@ -34,6 +34,12 @@ AS
         OutturnPlaceFundingSecondary,
         OutturnPlaceFundingSpecial,
         OutturnPlaceFundingAlternativeProvision,
+        OutturnSENTransportDSG,
+        OutturnHometoSchoolTransportPre16,
+        OutturnHometoSchoolTransport1618,
+        OutturnHometoSchoolTransport1925,
+        OutturnEdPsychologyService,
+        OutturnSENAdmin,
         BudgetTotalHighNeeds,
         BudgetTotalPlaceFunding,
         BudgetTotalTopUpFundingMaintained,
@@ -59,7 +65,13 @@ AS
         BudgetPlaceFundingPrimary,
         BudgetPlaceFundingSecondary,
         BudgetPlaceFundingSpecial,
-        BudgetPlaceFundingAlternativeProvision
+        BudgetPlaceFundingAlternativeProvision,
+        BudgetSENTransportDSG,
+        BudgetHometoSchoolTransportPre16,
+        BudgetHometoSchoolTransport1618,
+        BudgetHometoSchoolTransport1925,
+        BudgetEdPsychologyService,
+        BudgetSENAdmin
     FROM LocalAuthorityFinancial
 GO
 
@@ -99,6 +111,12 @@ AS
         IIF(Population2To18 > 0.0, OutturnPlaceFundingSecondary / Population2To18, NULL) AS OutturnPlaceFundingSecondary,
         IIF(Population2To18 > 0.0, OutturnPlaceFundingSpecial / Population2To18, NULL) AS OutturnPlaceFundingSpecial,
         IIF(Population2To18 > 0.0, OutturnPlaceFundingAlternativeProvision / Population2To18, NULL) AS OutturnPlaceFundingAlternativeProvision,
+        IIF(Population2To18 > 0.0, OutturnSENTransportDSG / Population2To18, NULL) AS OutturnSENTransportDSG,
+        IIF(Population2To18 > 0.0, OutturnHometoSchoolTransportPre16 / Population2To18, NULL) AS OutturnHometoSchoolTransportPre16,
+        IIF(Population2To18 > 0.0, OutturnHometoSchoolTransport1618 / Population2To18, NULL) AS OutturnHometoSchoolTransport1618,
+        IIF(Population2To18 > 0.0, OutturnHometoSchoolTransport1925 / Population2To18, NULL) AS OutturnHometoSchoolTransport1925,
+        IIF(Population2To18 > 0.0, OutturnEdPsychologyService / Population2To18, NULL) AS OutturnEdPsychologyService,
+        IIF(Population2To18 > 0.0, OutturnSENAdmin / Population2To18, NULL) AS OutturnSENAdmin,
         IIF(Population2To18 > 0.0, BudgetTotalHighNeeds / Population2To18, NULL) AS BudgetTotalHighNeeds,
         IIF(Population2To18 > 0.0, BudgetTotalPlaceFunding / Population2To18, NULL) AS BudgetTotalPlaceFunding,
         IIF(Population2To18 > 0.0, BudgetTotalTopUpFundingMaintained / Population2To18, NULL) AS BudgetTotalTopUpFundingMaintained,
@@ -124,7 +142,13 @@ AS
         IIF(Population2To18 > 0.0, BudgetPlaceFundingPrimary / Population2To18, NULL) AS BudgetPlaceFundingPrimary,
         IIF(Population2To18 > 0.0, BudgetPlaceFundingSecondary / Population2To18, NULL) AS BudgetPlaceFundingSecondary,
         IIF(Population2To18 > 0.0, BudgetPlaceFundingSpecial / Population2To18, NULL) AS BudgetPlaceFundingSpecial,
-        IIF(Population2To18 > 0.0, BudgetPlaceFundingAlternativeProvision / Population2To18, NULL) AS BudgetPlaceFundingAlternativeProvision
+        IIF(Population2To18 > 0.0, BudgetPlaceFundingAlternativeProvision / Population2To18, NULL) AS BudgetPlaceFundingAlternativeProvision,
+        IIF(Population2To18 > 0.0, BudgetSENTransportDSG / Population2To18, NULL) AS BudgetSENTransportDSG,
+        IIF(Population2To18 > 0.0, BudgetHometoSchoolTransportPre16 / Population2To18, NULL) AS BudgetHometoSchoolTransportPre16,
+        IIF(Population2To18 > 0.0, BudgetHometoSchoolTransport1618 / Population2To18, NULL) AS BudgetHometoSchoolTransport1618,
+        IIF(Population2To18 > 0.0, BudgetHometoSchoolTransport1925 / Population2To18, NULL) AS BudgetHometoSchoolTransport1925,
+        IIF(Population2To18 > 0.0, BudgetEdPsychologyService / Population2To18, NULL) AS BudgetEdPsychologyService,
+        IIF(Population2To18 > 0.0, BudgetSENAdmin / Population2To18, NULL) AS BudgetSENAdmin
     FROM LocalAuthorityFinancial
 GO
 
@@ -164,6 +188,12 @@ SELECT RunId,
        IIF(TotalPupils > 0.0, OutturnPlaceFundingSecondary / TotalPupils, NULL) AS OutturnPlaceFundingSecondary,
        IIF(TotalPupils > 0.0, OutturnPlaceFundingSpecial / TotalPupils, NULL) AS OutturnPlaceFundingSpecial,
        IIF(TotalPupils > 0.0, OutturnPlaceFundingAlternativeProvision / TotalPupils, NULL) AS OutturnPlaceFundingAlternativeProvision,
+       IIF(TotalPupils > 0.0, OutturnSENTransportDSG / TotalPupils, NULL) AS OutturnSENTransportDSG,
+       IIF(TotalPupils > 0.0, OutturnHometoSchoolTransportPre16 / TotalPupils, NULL) AS OutturnHometoSchoolTransportPre16,
+       IIF(TotalPupils > 0.0, OutturnHometoSchoolTransport1618 / TotalPupils, NULL) AS OutturnHometoSchoolTransport1618,
+       IIF(TotalPupils > 0.0, OutturnHometoSchoolTransport1925 / TotalPupils, NULL) AS OutturnHometoSchoolTransport1925,
+       IIF(TotalPupils > 0.0, OutturnEdPsychologyService / TotalPupils, NULL) AS OutturnEdPsychologyService,
+       IIF(TotalPupils > 0.0, OutturnSENAdmin / TotalPupils, NULL) AS OutturnSENAdmin,
        IIF(TotalPupils > 0.0, BudgetTotalHighNeeds / TotalPupils, NULL) AS BudgetTotalHighNeeds,
        IIF(TotalPupils > 0.0, BudgetTotalPlaceFunding / TotalPupils, NULL) AS BudgetTotalPlaceFunding,
        IIF(TotalPupils > 0.0, BudgetTotalTopUpFundingMaintained / TotalPupils, NULL) AS BudgetTotalTopUpFundingMaintained,
@@ -189,10 +219,255 @@ SELECT RunId,
        IIF(TotalPupils > 0.0, BudgetPlaceFundingPrimary / TotalPupils, NULL) AS BudgetPlaceFundingPrimary,
        IIF(TotalPupils > 0.0, BudgetPlaceFundingSecondary / TotalPupils, NULL) AS BudgetPlaceFundingSecondary,
        IIF(TotalPupils > 0.0, BudgetPlaceFundingSpecial / TotalPupils, NULL) AS BudgetPlaceFundingSpecial,
-       IIF(TotalPupils > 0.0, BudgetPlaceFundingAlternativeProvision / TotalPupils, NULL) AS BudgetPlaceFundingAlternativeProvision
+       IIF(TotalPupils > 0.0, BudgetPlaceFundingAlternativeProvision / TotalPupils, NULL) AS BudgetPlaceFundingAlternativeProvision,
+       IIF(TotalPupils > 0.0, BudgetSENTransportDSG / TotalPupils, NULL) AS BudgetSENTransportDSG,
+       IIF(TotalPupils > 0.0, BudgetHometoSchoolTransportPre16 / TotalPupils, NULL) AS BudgetHometoSchoolTransportPre16,
+       IIF(TotalPupils > 0.0, BudgetHometoSchoolTransport1618 / TotalPupils, NULL) AS BudgetHometoSchoolTransport1618,
+       IIF(TotalPupils > 0.0, BudgetHometoSchoolTransport1925 / TotalPupils, NULL) AS BudgetHometoSchoolTransport1925,
+       IIF(TotalPupils > 0.0, BudgetEdPsychologyService / TotalPupils, NULL) AS BudgetEdPsychologyService,
+       IIF(TotalPupils > 0.0, BudgetSENAdmin / TotalPupils, NULL) AS BudgetSENAdmin
     FROM LocalAuthorityFinancial
 GO
 
+DROP VIEW IF EXISTS VW_LocalAuthorityFinancialPerEHCP
+    GO
+
+CREATE VIEW VW_LocalAuthorityFinancialPerEHCP
+AS
+SELECT f.RunId,
+       f.RunType,
+       f.LaCode,
+       f.Population2To18,
+       f.TotalPupils,
+       IIF(n.EHCPTotal > 0.0, f.OutturnTotalHighNeeds / n.EHCPTotal, NULL) AS OutturnTotalHighNeeds,
+       IIF(n.EHCPTotal > 0.0, f.OutturnTotalPlaceFunding / n.EHCPTotal, NULL) AS OutturnTotalPlaceFunding,
+       IIF(n.EHCPTotal > 0.0, f.OutturnTotalTopUpFundingMaintained / n.EHCPTotal, NULL) AS OutturnTotalTopUpFundingMaintained,
+       IIF(n.EHCPTotal > 0.0, f.OutturnTotalTopUpFundingNonMaintained / n.EHCPTotal, NULL) AS OutturnTotalTopUpFundingNonMaintained,
+       IIF(n.EHCPTotal > 0.0, f.OutturnTotalSenServices / n.EHCPTotal, NULL) AS OutturnTotalSenServices,
+       IIF(n.EHCPTotal > 0.0, f.OutturnTotalAlternativeProvisionServices / n.EHCPTotal, NULL) AS OutturnTotalAlternativeProvisionServices,
+       IIF(n.EHCPTotal > 0.0, f.OutturnTotalHospitalServices / n.EHCPTotal, NULL) AS OutturnTotalHospitalServices,
+       IIF(n.EHCPTotal > 0.0, f.OutturnTotalOtherHealthServices / n.EHCPTotal, NULL) AS OutturnTotalOtherHealthServices,
+       IIF(n.EHCPTotal > 0.0, f.OutturnTopFundingMaintainedEarlyYears / n.EHCPTotal, NULL) AS OutturnTopFundingMaintainedEarlyYears,
+       IIF(n.EHCPTotal > 0.0, f.OutturnTopFundingMaintainedPrimary / n.EHCPTotal, NULL) AS OutturnTopFundingMaintainedPrimary,
+       IIF(n.EHCPTotal > 0.0, f.OutturnTopFundingMaintainedSecondary / n.EHCPTotal, NULL) AS OutturnTopFundingMaintainedSecondary,
+       IIF(n.EHCPTotal > 0.0, f.OutturnTopFundingMaintainedSpecial / n.EHCPTotal, NULL) AS OutturnTopFundingMaintainedSpecial,
+       IIF(n.EHCPTotal > 0.0, f.OutturnTopFundingMaintainedAlternativeProvision / n.EHCPTotal, NULL) AS OutturnTopFundingMaintainedAlternativeProvision,
+       IIF(n.EHCPTotal > 0.0, f.OutturnTopFundingMaintainedPostSchool / n.EHCPTotal, NULL) AS OutturnTopFundingMaintainedPostSchool,
+       IIF(n.EHCPTotal > 0.0, f.OutturnTopFundingMaintainedIncome / n.EHCPTotal, NULL) AS OutturnTopFundingMaintainedIncome,
+       IIF(n.EHCPTotal > 0.0, f.OutturnTopFundingNonMaintainedEarlyYears / n.EHCPTotal, NULL) AS OutturnTopFundingNonMaintainedEarlyYears,
+       IIF(n.EHCPTotal > 0.0, f.OutturnTopFundingNonMaintainedPrimary / n.EHCPTotal, NULL) AS OutturnTopFundingNonMaintainedPrimary,
+       IIF(n.EHCPTotal > 0.0, f.OutturnTopFundingNonMaintainedSecondary / n.EHCPTotal, NULL) AS OutturnTopFundingNonMaintainedSecondary,
+       IIF(n.EHCPTotal > 0.0, f.OutturnTopFundingNonMaintainedSpecial / n.EHCPTotal, NULL) AS OutturnTopFundingNonMaintainedSpecial,
+       IIF(n.EHCPTotal > 0.0, f.OutturnTopFundingNonMaintainedAlternativeProvision / n.EHCPTotal, NULL) AS OutturnTopFundingNonMaintainedAlternativeProvision,
+       IIF(n.EHCPTotal > 0.0, f.OutturnTopFundingNonMaintainedPostSchool / n.EHCPTotal, NULL) AS OutturnTopFundingNonMaintainedPostSchool,
+       IIF(n.EHCPTotal > 0.0, f.OutturnTopFundingNonMaintainedIncome / n.EHCPTotal, NULL) AS OutturnTopFundingNonMaintainedIncome,
+       IIF(n.EHCPTotal > 0.0, f.OutturnPlaceFundingPrimary / n.EHCPTotal, NULL) AS OutturnPlaceFundingPrimary,
+       IIF(n.EHCPTotal > 0.0, f.OutturnPlaceFundingSecondary / n.EHCPTotal, NULL) AS OutturnPlaceFundingSecondary,
+       IIF(n.EHCPTotal > 0.0, f.OutturnPlaceFundingSpecial / n.EHCPTotal, NULL) AS OutturnPlaceFundingSpecial,
+       IIF(n.EHCPTotal > 0.0, f.OutturnPlaceFundingAlternativeProvision / n.EHCPTotal, NULL) AS OutturnPlaceFundingAlternativeProvision,
+       IIF(n.EHCPTotal > 0.0, f.OutturnSENTransportDSG / n.EHCPTotal, NULL) AS OutturnSENTransportDSG,
+       IIF(n.EHCPTotal > 0.0, f.OutturnHometoSchoolTransportPre16 / n.EHCPTotal, NULL) AS OutturnHometoSchoolTransportPre16,
+       IIF(n.EHCPTotal > 0.0, f.OutturnHometoSchoolTransport1618 / n.EHCPTotal, NULL) AS OutturnHometoSchoolTransport1618,
+       IIF(n.EHCPTotal > 0.0, f.OutturnHometoSchoolTransport1925 / n.EHCPTotal, NULL) AS OutturnHometoSchoolTransport1925,
+       IIF(n.EHCPTotal > 0.0, f.OutturnEdPsychologyService / n.EHCPTotal, NULL) AS OutturnEdPsychologyService,
+       IIF(n.EHCPTotal > 0.0, f.OutturnSENAdmin / n.EHCPTotal, NULL) AS OutturnSENAdmin,
+       IIF(n.EHCPTotal > 0.0, f.BudgetTotalHighNeeds / n.EHCPTotal, NULL) AS BudgetTotalHighNeeds,
+       IIF(n.EHCPTotal > 0.0, f.BudgetTotalPlaceFunding / n.EHCPTotal, NULL) AS BudgetTotalPlaceFunding,
+       IIF(n.EHCPTotal > 0.0, f.BudgetTotalTopUpFundingMaintained / n.EHCPTotal, NULL) AS BudgetTotalTopUpFundingMaintained,
+       IIF(n.EHCPTotal > 0.0, f.BudgetTotalTopUpFundingNonMaintained / n.EHCPTotal, NULL) AS BudgetTotalTopUpFundingNonMaintained,
+       IIF(n.EHCPTotal > 0.0, f.BudgetTotalSenServices / n.EHCPTotal, NULL) AS BudgetTotalSenServices,
+       IIF(n.EHCPTotal > 0.0, f.BudgetTotalAlternativeProvisionServices / n.EHCPTotal, NULL) AS BudgetTotalAlternativeProvisionServices,
+       IIF(n.EHCPTotal > 0.0, f.BudgetTotalHospitalServices / n.EHCPTotal, NULL) AS BudgetTotalHospitalServices,
+       IIF(n.EHCPTotal > 0.0, f.BudgetTotalOtherHealthServices / n.EHCPTotal, NULL) AS BudgetTotalOtherHealthServices,
+       IIF(n.EHCPTotal > 0.0, f.BudgetTopFundingMaintainedEarlyYears / n.EHCPTotal, NULL) AS BudgetTopFundingMaintainedEarlyYears,
+       IIF(n.EHCPTotal > 0.0, f.BudgetTopFundingMaintainedPrimary / n.EHCPTotal, NULL) AS BudgetTopFundingMaintainedPrimary,
+       IIF(n.EHCPTotal > 0.0, f.BudgetTopFundingMaintainedSecondary / n.EHCPTotal, NULL) AS BudgetTopFundingMaintainedSecondary,
+       IIF(n.EHCPTotal > 0.0, f.BudgetTopFundingMaintainedSpecial / n.EHCPTotal, NULL) AS BudgetTopFundingMaintainedSpecial,
+       IIF(n.EHCPTotal > 0.0, f.BudgetTopFundingMaintainedAlternativeProvision / n.EHCPTotal, NULL) AS BudgetTopFundingMaintainedAlternativeProvision,
+       IIF(n.EHCPTotal > 0.0, f.BudgetTopFundingMaintainedPostSchool / n.EHCPTotal, NULL) AS BudgetTopFundingMaintainedPostSchool,
+       IIF(n.EHCPTotal > 0.0, f.BudgetTopFundingMaintainedIncome / n.EHCPTotal, NULL) AS BudgetTopFundingMaintainedIncome,
+       IIF(n.EHCPTotal > 0.0, f.BudgetTopFundingNonMaintainedEarlyYears / n.EHCPTotal, NULL) AS BudgetTopFundingNonMaintainedEarlyYears,
+       IIF(n.EHCPTotal > 0.0, f.BudgetTopFundingNonMaintainedPrimary / n.EHCPTotal, NULL) AS BudgetTopFundingNonMaintainedPrimary,
+       IIF(n.EHCPTotal > 0.0, f.BudgetTopFundingNonMaintainedSecondary / n.EHCPTotal, NULL) AS BudgetTopFundingNonMaintainedSecondary,
+       IIF(n.EHCPTotal > 0.0, f.BudgetTopFundingNonMaintainedSpecial / n.EHCPTotal, NULL) AS BudgetTopFundingNonMaintainedSpecial,
+       IIF(n.EHCPTotal > 0.0, f.BudgetTopFundingNonMaintainedAlternativeProvision / n.EHCPTotal, NULL) AS BudgetTopFundingNonMaintainedAlternativeProvision,
+       IIF(n.EHCPTotal > 0.0, f.BudgetTopFundingNonMaintainedPostSchool / n.EHCPTotal, NULL) AS BudgetTopFundingNonMaintainedPostSchool,
+       IIF(n.EHCPTotal > 0.0, f.BudgetTopFundingNonMaintainedIncome / n.EHCPTotal, NULL) AS BudgetTopFundingNonMaintainedIncome,
+       IIF(n.EHCPTotal > 0.0, f.BudgetPlaceFundingPrimary / n.EHCPTotal, NULL) AS BudgetPlaceFundingPrimary,
+       IIF(n.EHCPTotal > 0.0, f.BudgetPlaceFundingSecondary / n.EHCPTotal, NULL) AS BudgetPlaceFundingSecondary,
+       IIF(n.EHCPTotal > 0.0, f.BudgetPlaceFundingSpecial / n.EHCPTotal, NULL) AS BudgetPlaceFundingSpecial,
+       IIF(n.EHCPTotal > 0.0, f.BudgetPlaceFundingAlternativeProvision / n.EHCPTotal, NULL) AS BudgetPlaceFundingAlternativeProvision,
+       IIF(n.EHCPTotal > 0.0, f.BudgetSENTransportDSG / n.EHCPTotal, NULL) AS BudgetSENTransportDSG,
+       IIF(n.EHCPTotal > 0.0, f.BudgetHometoSchoolTransportPre16 / n.EHCPTotal, NULL) AS BudgetHometoSchoolTransportPre16,
+       IIF(n.EHCPTotal > 0.0, f.BudgetHometoSchoolTransport1618 / n.EHCPTotal, NULL) AS BudgetHometoSchoolTransport1618,
+       IIF(n.EHCPTotal > 0.0, f.BudgetHometoSchoolTransport1925 / n.EHCPTotal, NULL) AS BudgetHometoSchoolTransport1925,
+       IIF(n.EHCPTotal > 0.0, f.BudgetEdPsychologyService / n.EHCPTotal, NULL) AS BudgetEdPsychologyService,
+       IIF(n.EHCPTotal > 0.0, f.BudgetSENAdmin / n.EHCPTotal, NULL) AS BudgetSENAdmin
+FROM LocalAuthorityFinancial f
+    LEFT JOIN LocalAuthorityNonFinancial n ON n.LaCode = f.LaCode
+GO
+
+DROP VIEW IF EXISTS VW_LocalAuthorityFinancialPerSENSupport
+    GO
+
+CREATE VIEW VW_LocalAuthorityFinancialPerSENSupport
+AS
+SELECT f.RunId,
+       f.RunType,
+       f.LaCode,
+       f.Population2To18,
+       f.TotalPupils,
+       IIF(n.SENSupport > 0.0, f.OutturnTotalHighNeeds / n.SENSupport, NULL) AS OutturnTotalHighNeeds,
+       IIF(n.SENSupport > 0.0, f.OutturnTotalPlaceFunding / n.SENSupport, NULL) AS OutturnTotalPlaceFunding,
+       IIF(n.SENSupport > 0.0, f.OutturnTotalTopUpFundingMaintained / n.SENSupport, NULL) AS OutturnTotalTopUpFundingMaintained,
+       IIF(n.SENSupport > 0.0, f.OutturnTotalTopUpFundingNonMaintained / n.SENSupport, NULL) AS OutturnTotalTopUpFundingNonMaintained,
+       IIF(n.SENSupport > 0.0, f.OutturnTotalSenServices / n.SENSupport, NULL) AS OutturnTotalSenServices,
+       IIF(n.SENSupport > 0.0, f.OutturnTotalAlternativeProvisionServices / n.SENSupport, NULL) AS OutturnTotalAlternativeProvisionServices,
+       IIF(n.SENSupport > 0.0, f.OutturnTotalHospitalServices / n.SENSupport, NULL) AS OutturnTotalHospitalServices,
+       IIF(n.SENSupport > 0.0, f.OutturnTotalOtherHealthServices / n.SENSupport, NULL) AS OutturnTotalOtherHealthServices,
+       IIF(n.SENSupport > 0.0, f.OutturnTopFundingMaintainedEarlyYears / n.SENSupport, NULL) AS OutturnTopFundingMaintainedEarlyYears,
+       IIF(n.SENSupport > 0.0, f.OutturnTopFundingMaintainedPrimary / n.SENSupport, NULL) AS OutturnTopFundingMaintainedPrimary,
+       IIF(n.SENSupport > 0.0, f.OutturnTopFundingMaintainedSecondary / n.SENSupport, NULL) AS OutturnTopFundingMaintainedSecondary,
+       IIF(n.SENSupport > 0.0, f.OutturnTopFundingMaintainedSpecial / n.SENSupport, NULL) AS OutturnTopFundingMaintainedSpecial,
+       IIF(n.SENSupport > 0.0, f.OutturnTopFundingMaintainedAlternativeProvision / n.SENSupport, NULL) AS OutturnTopFundingMaintainedAlternativeProvision,
+       IIF(n.SENSupport > 0.0, f.OutturnTopFundingMaintainedPostSchool / n.SENSupport, NULL) AS OutturnTopFundingMaintainedPostSchool,
+       IIF(n.SENSupport > 0.0, f.OutturnTopFundingMaintainedIncome / n.SENSupport, NULL) AS OutturnTopFundingMaintainedIncome,
+       IIF(n.SENSupport > 0.0, f.OutturnTopFundingNonMaintainedEarlyYears / n.SENSupport, NULL) AS OutturnTopFundingNonMaintainedEarlyYears,
+       IIF(n.SENSupport > 0.0, f.OutturnTopFundingNonMaintainedPrimary / n.SENSupport, NULL) AS OutturnTopFundingNonMaintainedPrimary,
+       IIF(n.SENSupport > 0.0, f.OutturnTopFundingNonMaintainedSecondary / n.SENSupport, NULL) AS OutturnTopFundingNonMaintainedSecondary,
+       IIF(n.SENSupport > 0.0, f.OutturnTopFundingNonMaintainedSpecial / n.SENSupport, NULL) AS OutturnTopFundingNonMaintainedSpecial,
+       IIF(n.SENSupport > 0.0, f.OutturnTopFundingNonMaintainedAlternativeProvision / n.SENSupport, NULL) AS OutturnTopFundingNonMaintainedAlternativeProvision,
+       IIF(n.SENSupport > 0.0, f.OutturnTopFundingNonMaintainedPostSchool / n.SENSupport, NULL) AS OutturnTopFundingNonMaintainedPostSchool,
+       IIF(n.SENSupport > 0.0, f.OutturnTopFundingNonMaintainedIncome / n.SENSupport, NULL) AS OutturnTopFundingNonMaintainedIncome,
+       IIF(n.SENSupport > 0.0, f.OutturnPlaceFundingPrimary / n.SENSupport, NULL) AS OutturnPlaceFundingPrimary,
+       IIF(n.SENSupport > 0.0, f.OutturnPlaceFundingSecondary / n.SENSupport, NULL) AS OutturnPlaceFundingSecondary,
+       IIF(n.SENSupport > 0.0, f.OutturnPlaceFundingSpecial / n.SENSupport, NULL) AS OutturnPlaceFundingSpecial,
+       IIF(n.SENSupport > 0.0, f.OutturnPlaceFundingAlternativeProvision / n.SENSupport, NULL) AS OutturnPlaceFundingAlternativeProvision,
+       IIF(n.SENSupport > 0.0, f.OutturnSENTransportDSG / n.SENSupport, NULL) AS OutturnSENTransportDSG,
+       IIF(n.SENSupport > 0.0, f.OutturnHometoSchoolTransportPre16 / n.SENSupport, NULL) AS OutturnHometoSchoolTransportPre16,
+       IIF(n.SENSupport > 0.0, f.OutturnHometoSchoolTransport1618 / n.SENSupport, NULL) AS OutturnHometoSchoolTransport1618,
+       IIF(n.SENSupport > 0.0, f.OutturnHometoSchoolTransport1925 / n.SENSupport, NULL) AS OutturnHometoSchoolTransport1925,
+       IIF(n.SENSupport > 0.0, f.OutturnEdPsychologyService / n.SENSupport, NULL) AS OutturnEdPsychologyService,
+       IIF(n.SENSupport > 0.0, f.OutturnSENAdmin / n.SENSupport, NULL) AS OutturnSENAdmin,
+       IIF(n.SENSupport > 0.0, f.BudgetTotalHighNeeds / n.SENSupport, NULL) AS BudgetTotalHighNeeds,
+       IIF(n.SENSupport > 0.0, f.BudgetTotalPlaceFunding / n.SENSupport, NULL) AS BudgetTotalPlaceFunding,
+       IIF(n.SENSupport > 0.0, f.BudgetTotalTopUpFundingMaintained / n.SENSupport, NULL) AS BudgetTotalTopUpFundingMaintained,
+       IIF(n.SENSupport > 0.0, f.BudgetTotalTopUpFundingNonMaintained / n.SENSupport, NULL) AS BudgetTotalTopUpFundingNonMaintained,
+       IIF(n.SENSupport > 0.0, f.BudgetTotalSenServices / n.SENSupport, NULL) AS BudgetTotalSenServices,
+       IIF(n.SENSupport > 0.0, f.BudgetTotalAlternativeProvisionServices / n.SENSupport, NULL) AS BudgetTotalAlternativeProvisionServices,
+       IIF(n.SENSupport > 0.0, f.BudgetTotalHospitalServices / n.SENSupport, NULL) AS BudgetTotalHospitalServices,
+       IIF(n.SENSupport > 0.0, f.BudgetTotalOtherHealthServices / n.SENSupport, NULL) AS BudgetTotalOtherHealthServices,
+       IIF(n.SENSupport > 0.0, f.BudgetTopFundingMaintainedEarlyYears / n.SENSupport, NULL) AS BudgetTopFundingMaintainedEarlyYears,
+       IIF(n.SENSupport > 0.0, f.BudgetTopFundingMaintainedPrimary / n.SENSupport, NULL) AS BudgetTopFundingMaintainedPrimary,
+       IIF(n.SENSupport > 0.0, f.BudgetTopFundingMaintainedSecondary / n.SENSupport, NULL) AS BudgetTopFundingMaintainedSecondary,
+       IIF(n.SENSupport > 0.0, f.BudgetTopFundingMaintainedSpecial / n.SENSupport, NULL) AS BudgetTopFundingMaintainedSpecial,
+       IIF(n.SENSupport > 0.0, f.BudgetTopFundingMaintainedAlternativeProvision / n.SENSupport, NULL) AS BudgetTopFundingMaintainedAlternativeProvision,
+       IIF(n.SENSupport > 0.0, f.BudgetTopFundingMaintainedPostSchool / n.SENSupport, NULL) AS BudgetTopFundingMaintainedPostSchool,
+       IIF(n.SENSupport > 0.0, f.BudgetTopFundingMaintainedIncome / n.SENSupport, NULL) AS BudgetTopFundingMaintainedIncome,
+       IIF(n.SENSupport > 0.0, f.BudgetTopFundingNonMaintainedEarlyYears / n.SENSupport, NULL) AS BudgetTopFundingNonMaintainedEarlyYears,
+       IIF(n.SENSupport > 0.0, f.BudgetTopFundingNonMaintainedPrimary / n.SENSupport, NULL) AS BudgetTopFundingNonMaintainedPrimary,
+       IIF(n.SENSupport > 0.0, f.BudgetTopFundingNonMaintainedSecondary / n.SENSupport, NULL) AS BudgetTopFundingNonMaintainedSecondary,
+       IIF(n.SENSupport > 0.0, f.BudgetTopFundingNonMaintainedSpecial / n.SENSupport, NULL) AS BudgetTopFundingNonMaintainedSpecial,
+       IIF(n.SENSupport > 0.0, f.BudgetTopFundingNonMaintainedAlternativeProvision / n.SENSupport, NULL) AS BudgetTopFundingNonMaintainedAlternativeProvision,
+       IIF(n.SENSupport > 0.0, f.BudgetTopFundingNonMaintainedPostSchool / n.SENSupport, NULL) AS BudgetTopFundingNonMaintainedPostSchool,
+       IIF(n.SENSupport > 0.0, f.BudgetTopFundingNonMaintainedIncome / n.SENSupport, NULL) AS BudgetTopFundingNonMaintainedIncome,
+       IIF(n.SENSupport > 0.0, f.BudgetPlaceFundingPrimary / n.SENSupport, NULL) AS BudgetPlaceFundingPrimary,
+       IIF(n.SENSupport > 0.0, f.BudgetPlaceFundingSecondary / n.SENSupport, NULL) AS BudgetPlaceFundingSecondary,
+       IIF(n.SENSupport > 0.0, f.BudgetPlaceFundingSpecial / n.SENSupport, NULL) AS BudgetPlaceFundingSpecial,
+       IIF(n.SENSupport > 0.0, f.BudgetPlaceFundingAlternativeProvision / n.SENSupport, NULL) AS BudgetPlaceFundingAlternativeProvision,
+       IIF(n.SENSupport > 0.0, f.BudgetSENTransportDSG / n.SENSupport, NULL) AS BudgetSENTransportDSG,
+       IIF(n.SENSupport > 0.0, f.BudgetHometoSchoolTransportPre16 / n.SENSupport, NULL) AS BudgetHometoSchoolTransportPre16,
+       IIF(n.SENSupport > 0.0, f.BudgetHometoSchoolTransport1618 / n.SENSupport, NULL) AS BudgetHometoSchoolTransport1618,
+       IIF(n.SENSupport > 0.0, f.BudgetHometoSchoolTransport1925 / n.SENSupport, NULL) AS BudgetHometoSchoolTransport1925,
+       IIF(n.SENSupport > 0.0, f.BudgetEdPsychologyService / n.SENSupport, NULL) AS BudgetEdPsychologyService,
+       IIF(n.SENSupport > 0.0, f.BudgetSENAdmin / n.SENSupport, NULL) AS BudgetSENAdmin
+FROM LocalAuthorityFinancial f
+     LEFT JOIN LocalAuthorityNonFinancial n ON n.LaCode = f.LaCode
+GO
+
+DROP VIEW IF EXISTS VW_LocalAuthorityFinancialPerSENSupportAndEHCP
+    GO
+GO
+
+CREATE VIEW VW_LocalAuthorityFinancialPerSENSupportAndEHCP
+AS
+SELECT f.RunId,
+       f.RunType,
+       f.LaCode,
+       f.Population2To18,
+       f.TotalPupils,
+       IIF(x.TotalSupport > 0.0, f.OutturnTotalHighNeeds / x.TotalSupport, NULL) AS OutturnTotalHighNeeds,
+       IIF(x.TotalSupport > 0.0, f.OutturnTotalPlaceFunding / x.TotalSupport, NULL) AS OutturnTotalPlaceFunding,
+       IIF(x.TotalSupport > 0.0, f.OutturnTotalTopUpFundingMaintained / x.TotalSupport, NULL) AS OutturnTotalTopUpFundingMaintained,
+       IIF(x.TotalSupport > 0.0, f.OutturnTotalTopUpFundingNonMaintained / x.TotalSupport, NULL) AS OutturnTotalTopUpFundingNonMaintained,
+       IIF(x.TotalSupport > 0.0, f.OutturnTotalSenServices / x.TotalSupport, NULL) AS OutturnTotalSenServices,
+       IIF(x.TotalSupport > 0.0, f.OutturnTotalAlternativeProvisionServices / x.TotalSupport, NULL) AS OutturnTotalAlternativeProvisionServices,
+       IIF(x.TotalSupport > 0.0, f.OutturnTotalHospitalServices / x.TotalSupport, NULL) AS OutturnTotalHospitalServices,
+       IIF(x.TotalSupport > 0.0, f.OutturnTotalOtherHealthServices / x.TotalSupport, NULL) AS OutturnTotalOtherHealthServices,
+       IIF(x.TotalSupport > 0.0, f.OutturnTopFundingMaintainedEarlyYears / x.TotalSupport, NULL) AS OutturnTopFundingMaintainedEarlyYears,
+       IIF(x.TotalSupport > 0.0, f.OutturnTopFundingMaintainedPrimary / x.TotalSupport, NULL) AS OutturnTopFundingMaintainedPrimary,
+       IIF(x.TotalSupport > 0.0, f.OutturnTopFundingMaintainedSecondary / x.TotalSupport, NULL) AS OutturnTopFundingMaintainedSecondary,
+       IIF(x.TotalSupport > 0.0, f.OutturnTopFundingMaintainedSpecial / x.TotalSupport, NULL) AS OutturnTopFundingMaintainedSpecial,
+       IIF(x.TotalSupport > 0.0, f.OutturnTopFundingMaintainedAlternativeProvision / x.TotalSupport, NULL) AS OutturnTopFundingMaintainedAlternativeProvision,
+       IIF(x.TotalSupport > 0.0, f.OutturnTopFundingMaintainedPostSchool / x.TotalSupport, NULL) AS OutturnTopFundingMaintainedPostSchool,
+       IIF(x.TotalSupport > 0.0, f.OutturnTopFundingMaintainedIncome / x.TotalSupport, NULL) AS OutturnTopFundingMaintainedIncome,
+       IIF(x.TotalSupport > 0.0, f.OutturnTopFundingNonMaintainedEarlyYears / x.TotalSupport, NULL) AS OutturnTopFundingNonMaintainedEarlyYears,
+       IIF(x.TotalSupport > 0.0, f.OutturnTopFundingNonMaintainedPrimary / x.TotalSupport, NULL) AS OutturnTopFundingNonMaintainedPrimary,
+       IIF(x.TotalSupport > 0.0, f.OutturnTopFundingNonMaintainedSecondary / x.TotalSupport, NULL) AS OutturnTopFundingNonMaintainedSecondary,
+       IIF(x.TotalSupport > 0.0, f.OutturnTopFundingNonMaintainedSpecial / x.TotalSupport, NULL) AS OutturnTopFundingNonMaintainedSpecial,
+       IIF(x.TotalSupport > 0.0, f.OutturnTopFundingNonMaintainedAlternativeProvision / x.TotalSupport, NULL) AS OutturnTopFundingNonMaintainedAlternativeProvision,
+       IIF(x.TotalSupport > 0.0, f.OutturnTopFundingNonMaintainedPostSchool / x.TotalSupport, NULL) AS OutturnTopFundingNonMaintainedPostSchool,
+       IIF(x.TotalSupport > 0.0, f.OutturnTopFundingNonMaintainedIncome / x.TotalSupport, NULL) AS OutturnTopFundingNonMaintainedIncome,
+       IIF(x.TotalSupport > 0.0, f.OutturnPlaceFundingPrimary / x.TotalSupport, NULL) AS OutturnPlaceFundingPrimary,
+       IIF(x.TotalSupport > 0.0, f.OutturnPlaceFundingSecondary / x.TotalSupport, NULL) AS OutturnPlaceFundingSecondary,
+       IIF(x.TotalSupport > 0.0, f.OutturnPlaceFundingSpecial / x.TotalSupport, NULL) AS OutturnPlaceFundingSpecial,
+       IIF(x.TotalSupport > 0.0, f.OutturnPlaceFundingAlternativeProvision / x.TotalSupport, NULL) AS OutturnPlaceFundingAlternativeProvision,
+       IIF(x.TotalSupport > 0.0, f.OutturnSENTransportDSG / x.TotalSupport, NULL) AS OutturnSENTransportDSG,
+       IIF(x.TotalSupport > 0.0, f.OutturnHometoSchoolTransportPre16 / x.TotalSupport, NULL) AS OutturnHometoSchoolTransportPre16,
+       IIF(x.TotalSupport > 0.0, f.OutturnHometoSchoolTransport1618 / x.TotalSupport, NULL) AS OutturnHometoSchoolTransport1618,
+       IIF(x.TotalSupport > 0.0, f.OutturnHometoSchoolTransport1925 / x.TotalSupport, NULL) AS OutturnHometoSchoolTransport1925,
+       IIF(x.TotalSupport > 0.0, f.OutturnEdPsychologyService / x.TotalSupport, NULL) AS OutturnEdPsychologyService,
+       IIF(x.TotalSupport > 0.0, f.OutturnSENAdmin / x.TotalSupport, NULL) AS OutturnSENAdmin,
+       IIF(x.TotalSupport > 0.0, f.BudgetTotalHighNeeds / x.TotalSupport, NULL) AS BudgetTotalHighNeeds,
+       IIF(x.TotalSupport > 0.0, f.BudgetTotalPlaceFunding / x.TotalSupport, NULL) AS BudgetTotalPlaceFunding,
+       IIF(x.TotalSupport > 0.0, f.BudgetTotalTopUpFundingMaintained / x.TotalSupport, NULL) AS BudgetTotalTopUpFundingMaintained,
+       IIF(x.TotalSupport > 0.0, f.BudgetTotalTopUpFundingNonMaintained / x.TotalSupport, NULL) AS BudgetTotalTopUpFundingNonMaintained,
+       IIF(x.TotalSupport > 0.0, f.BudgetTotalSenServices / x.TotalSupport, NULL) AS BudgetTotalSenServices,
+       IIF(x.TotalSupport > 0.0, f.BudgetTotalAlternativeProvisionServices / x.TotalSupport, NULL) AS BudgetTotalAlternativeProvisionServices,
+       IIF(x.TotalSupport > 0.0, f.BudgetTotalHospitalServices / x.TotalSupport, NULL) AS BudgetTotalHospitalServices,
+       IIF(x.TotalSupport > 0.0, f.BudgetTotalOtherHealthServices / x.TotalSupport, NULL) AS BudgetTotalOtherHealthServices,
+       IIF(x.TotalSupport > 0.0, f.BudgetTopFundingMaintainedEarlyYears / x.TotalSupport, NULL) AS BudgetTopFundingMaintainedEarlyYears,
+       IIF(x.TotalSupport > 0.0, f.BudgetTopFundingMaintainedPrimary / x.TotalSupport, NULL) AS BudgetTopFundingMaintainedPrimary,
+       IIF(x.TotalSupport > 0.0, f.BudgetTopFundingMaintainedSecondary / x.TotalSupport, NULL) AS BudgetTopFundingMaintainedSecondary,
+       IIF(x.TotalSupport > 0.0, f.BudgetTopFundingMaintainedSpecial / x.TotalSupport, NULL) AS BudgetTopFundingMaintainedSpecial,
+       IIF(x.TotalSupport > 0.0, f.BudgetTopFundingMaintainedAlternativeProvision / x.TotalSupport, NULL) AS BudgetTopFundingMaintainedAlternativeProvision,
+       IIF(x.TotalSupport > 0.0, f.BudgetTopFundingMaintainedPostSchool / x.TotalSupport, NULL) AS BudgetTopFundingMaintainedPostSchool,
+       IIF(x.TotalSupport > 0.0, f.BudgetTopFundingMaintainedIncome / x.TotalSupport, NULL) AS BudgetTopFundingMaintainedIncome,
+       IIF(x.TotalSupport > 0.0, f.BudgetTopFundingNonMaintainedEarlyYears / x.TotalSupport, NULL) AS BudgetTopFundingNonMaintainedEarlyYears,
+       IIF(x.TotalSupport > 0.0, f.BudgetTopFundingNonMaintainedPrimary / x.TotalSupport, NULL) AS BudgetTopFundingNonMaintainedPrimary,
+       IIF(x.TotalSupport > 0.0, f.BudgetTopFundingNonMaintainedSecondary / x.TotalSupport, NULL) AS BudgetTopFundingNonMaintainedSecondary,
+       IIF(x.TotalSupport > 0.0, f.BudgetTopFundingNonMaintainedSpecial / x.TotalSupport, NULL) AS BudgetTopFundingNonMaintainedSpecial,
+       IIF(x.TotalSupport > 0.0, f.BudgetTopFundingNonMaintainedAlternativeProvision / x.TotalSupport, NULL) AS BudgetTopFundingNonMaintainedAlternativeProvision,
+       IIF(x.TotalSupport > 0.0, f.BudgetTopFundingNonMaintainedPostSchool / x.TotalSupport, NULL) AS BudgetTopFundingNonMaintainedPostSchool,
+       IIF(x.TotalSupport > 0.0, f.BudgetTopFundingNonMaintainedIncome / x.TotalSupport, NULL) AS BudgetTopFundingNonMaintainedIncome,
+       IIF(x.TotalSupport > 0.0, f.BudgetPlaceFundingPrimary / x.TotalSupport, NULL) AS BudgetPlaceFundingPrimary,
+       IIF(x.TotalSupport > 0.0, f.BudgetPlaceFundingSecondary / x.TotalSupport, NULL) AS BudgetPlaceFundingSecondary,
+       IIF(x.TotalSupport > 0.0, f.BudgetPlaceFundingSpecial / x.TotalSupport, NULL) AS BudgetPlaceFundingSpecial,
+       IIF(x.TotalSupport > 0.0, f.BudgetPlaceFundingAlternativeProvision / x.TotalSupport, NULL) AS BudgetPlaceFundingAlternativeProvision,
+       IIF(x.TotalSupport > 0.0, f.BudgetSENTransportDSG / x.TotalSupport, NULL) AS BudgetSENTransportDSG,
+       IIF(x.TotalSupport > 0.0, f.BudgetHometoSchoolTransportPre16 / x.TotalSupport, NULL) AS BudgetHometoSchoolTransportPre16,
+       IIF(x.TotalSupport > 0.0, f.BudgetHometoSchoolTransport1618 / x.TotalSupport, NULL) AS BudgetHometoSchoolTransport1618,
+       IIF(x.TotalSupport > 0.0, f.BudgetHometoSchoolTransport1925 / x.TotalSupport, NULL) AS BudgetHometoSchoolTransport1925,
+       IIF(x.TotalSupport > 0.0, f.BudgetEdPsychologyService / x.TotalSupport, NULL) AS BudgetEdPsychologyService,
+       IIF(x.TotalSupport > 0.0, f.BudgetSENAdmin / x.TotalSupport, NULL) AS BudgetSENAdmin
+FROM LocalAuthorityFinancial f
+    LEFT JOIN LocalAuthorityNonFinancial n ON n.LaCode = f.LaCode
+    CROSS APPLY (
+        SELECT n.EHCPTotal + n.SENSupport AS TotalSupport
+) x
+GO
+    
+    
 DROP VIEW IF EXISTS VW_LocalAuthorityFinancialDefaultActual
 GO
 
@@ -220,6 +495,27 @@ CREATE VIEW VW_LocalAuthorityFinancialDefaultPerPupil
 AS
     SELECT *
     FROM VW_LocalAuthorityFinancialPerPupil
+    WHERE RunType = 'default'
+GO
+
+CREATE VIEW VW_LocalAuthorityFinancialDefaultPerEHCP
+AS
+    SELECT *
+    FROM VW_LocalAuthorityFinancialPerEHCP
+    WHERE RunType = 'default'
+GO
+
+CREATE VIEW VW_LocalAuthorityFinancialDefaultPerSENSupport
+AS
+    SELECT *
+    FROM VW_LocalAuthorityFinancialPerSENSupport
+    WHERE RunType = 'default'
+GO
+
+CREATE VIEW VW_LocalAuthorityFinancialDefaultPerSENSupportAndEHCP
+AS
+    SELECT *
+    FROM VW_LocalAuthorityFinancialPerSENSupportAndEHCP
     WHERE RunType = 'default'
 GO
 
@@ -260,6 +556,39 @@ AS
         l.Name
     FROM LocalAuthority l
         LEFT JOIN VW_LocalAuthorityFinancialDefaultPerPupil c ON c.LaCode = l.Code
+    WHERE c.RunId = (SELECT Value
+    FROM Parameters
+    WHERE Name = 'CurrentYear')
+GO
+
+CREATE VIEW VW_LocalAuthorityFinancialDefaultCurrentPerEHCP
+AS
+    SELECT c.*,
+        l.Name
+    FROM LocalAuthority l
+        LEFT JOIN VW_LocalAuthorityFinancialDefaultPerEHCP c ON c.LaCode = l.Code
+    WHERE c.RunId = (SELECT Value
+    FROM Parameters
+    WHERE Name = 'CurrentYear')
+GO
+
+CREATE VIEW VW_LocalAuthorityFinancialDefaultCurrentPerSENSupport
+AS
+    SELECT c.*,
+        l.Name
+    FROM LocalAuthority l
+        LEFT JOIN VW_LocalAuthorityFinancialDefaultPerSENSupport c ON c.LaCode = l.Code
+    WHERE c.RunId = (SELECT Value
+    FROM Parameters
+    WHERE Name = 'CurrentYear')
+GO
+
+CREATE VIEW VW_LocalAuthorityFinancialDefaultCurrentPerSENSupportAndEHCP
+AS
+    SELECT c.*,
+        l.Name
+    FROM LocalAuthority l
+        LEFT JOIN VW_LocalAuthorityFinancialDefaultPerSENSupportAndEHCP c ON c.LaCode = l.Code
     WHERE c.RunId = (SELECT Value
     FROM Parameters
     WHERE Name = 'CurrentYear')

--- a/core-infrastructure/src/db/Core.Database/Views/018-LocalAuthorityFinancial.sql
+++ b/core-infrastructure/src/db/Core.Database/Views/018-LocalAuthorityFinancial.sql
@@ -304,7 +304,7 @@ SELECT f.RunId,
        IIF(n.EHCPTotal > 0.0, f.BudgetEdPsychologyService / n.EHCPTotal, NULL) AS BudgetEdPsychologyService,
        IIF(n.EHCPTotal > 0.0, f.BudgetSENAdmin / n.EHCPTotal, NULL) AS BudgetSENAdmin
 FROM LocalAuthorityFinancial f
-    LEFT JOIN LocalAuthorityNonFinancial n ON n.LaCode = f.LaCode
+    LEFT JOIN LocalAuthorityNonFinancial n ON n.LaCode = f.LaCode AND f.RunId = n.RunId
 GO
 
 DROP VIEW IF EXISTS VW_LocalAuthorityFinancialPerSENSupport
@@ -382,7 +382,7 @@ SELECT f.RunId,
        IIF(n.SENSupport > 0.0, f.BudgetEdPsychologyService / n.SENSupport, NULL) AS BudgetEdPsychologyService,
        IIF(n.SENSupport > 0.0, f.BudgetSENAdmin / n.SENSupport, NULL) AS BudgetSENAdmin
 FROM LocalAuthorityFinancial f
-     LEFT JOIN LocalAuthorityNonFinancial n ON n.LaCode = f.LaCode
+     LEFT JOIN LocalAuthorityNonFinancial n ON n.LaCode = f.LaCode AND f.RunId = n.RunId
 GO
 
 DROP VIEW IF EXISTS VW_LocalAuthorityFinancialPerSENSupportAndEHCP
@@ -461,7 +461,7 @@ SELECT f.RunId,
        IIF(x.TotalSupport > 0.0, f.BudgetEdPsychologyService / x.TotalSupport, NULL) AS BudgetEdPsychologyService,
        IIF(x.TotalSupport > 0.0, f.BudgetSENAdmin / x.TotalSupport, NULL) AS BudgetSENAdmin
 FROM LocalAuthorityFinancial f
-    LEFT JOIN LocalAuthorityNonFinancial n ON n.LaCode = f.LaCode
+    LEFT JOIN LocalAuthorityNonFinancial n ON n.LaCode = f.LaCode AND f.RunId = n.RunId
     CROSS APPLY (
         SELECT n.EHCPTotal + n.SENSupport AS TotalSupport
 ) x
@@ -498,6 +498,9 @@ AS
     WHERE RunType = 'default'
 GO
 
+DROP VIEW IF EXISTS VW_LocalAuthorityFinancialDefaultPerEHCP
+GO
+
 CREATE VIEW VW_LocalAuthorityFinancialDefaultPerEHCP
 AS
     SELECT *
@@ -505,11 +508,17 @@ AS
     WHERE RunType = 'default'
 GO
 
+DROP VIEW IF EXISTS VW_LocalAuthorityFinancialDefaultPerSENSupport
+GO
+
 CREATE VIEW VW_LocalAuthorityFinancialDefaultPerSENSupport
 AS
     SELECT *
     FROM VW_LocalAuthorityFinancialPerSENSupport
     WHERE RunType = 'default'
+GO
+
+DROP VIEW IF EXISTS VW_LocalAuthorityFinancialDefaultPerSENSupportAndEHCP
 GO
 
 CREATE VIEW VW_LocalAuthorityFinancialDefaultPerSENSupportAndEHCP
@@ -561,6 +570,9 @@ AS
     WHERE Name = 'CurrentYear')
 GO
 
+DROP VIEW IF EXISTS VW_LocalAuthorityFinancialDefaultCurrentPerEHCP
+GO
+
 CREATE VIEW VW_LocalAuthorityFinancialDefaultCurrentPerEHCP
 AS
     SELECT c.*,
@@ -572,6 +584,9 @@ AS
     WHERE Name = 'CurrentYear')
 GO
 
+DROP VIEW IF EXISTS VW_LocalAuthorityFinancialDefaultCurrentPerSENSupport
+GO
+
 CREATE VIEW VW_LocalAuthorityFinancialDefaultCurrentPerSENSupport
 AS
     SELECT c.*,
@@ -581,6 +596,9 @@ AS
     WHERE c.RunId = (SELECT Value
     FROM Parameters
     WHERE Name = 'CurrentYear')
+GO
+
+DROP VIEW IF EXISTS VW_LocalAuthorityFinancialDefaultCurrentPerSENSupportAndEHCP
 GO
 
 CREATE VIEW VW_LocalAuthorityFinancialDefaultCurrentPerSENSupportAndEHCP


### PR DESCRIPTION
## 🧾 Summary

[AB#295178](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/295178) [AB#309842](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/309842)
[AB#286015](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/286015) [AB#310264](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/310264)

### ✨ Feature Details
**Functionality:**

Updates existing high needs spending DB views to include the new SEN transport and central SEN services columns. Adds new views to support "support-based" dimensions for high needs spending as required in the stories for the current high needs work.

**Implementation:**

Updates to existing high needs spending views.
Current consumers are explicit about the columns that are selected from these views so no impact is expected from this change to current usage. Therefore for completeness `VW_LocalAuthorityFinancialPerPopulation` has been updated also.

New views.
Following existing patterns the following new views have been added.
`VW_LocalAuthorityFinancialPerEHCP` spending values per `EHCPTotal` from `LocalAuthorityNonFinancial`
`VW_LocalAuthorityFinancialPerSENSupport` spending values per `SENSupport` from `LocalAuthorityNonFinancial`
`VW_LocalAuthorityFinancialPerSENSupportAndEHCP` spending values per `SENSupport + EHCPTotal` from `LocalAuthorityNonFinancial`
Derived `Default` and `DefaultCurrent` views from each of the above.


## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [x] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
