### PR TITLE
feat: remove links from LA names in EHCP charts

### DIFF
--- a/web/src/Web.App/Controllers/LocalAuthorityEducationHealthCarePlansController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityEducationHealthCarePlansController.cs
@@ -136,18 +136,13 @@ public class LocalAuthorityEducationHealthCarePlansController(
         return query;
     }
 
-    private async Task<ChartResponse[]> BuildCharts(string urn,
+    private async Task<ChartResponse[]> BuildCharts(string code,
         EducationHealthCarePlansComparisonSubCategoriesViewModel subCategories)
     {
         var requests = subCategories.Items.Select(c => new EducationHealthCarePlanHorizontalBarChartRequest(
             c.Uuid!,
-            urn,
-            c.Data!,
-            format => Uri.UnescapeDataString(
-                Url.Action("Index", "School", new
-                {
-                    urn = format
-                }) ?? string.Empty)
+            code,
+            c.Data!
         ));
 
         ChartResponse[] charts = [];

--- a/web/src/Web.App/Domain/Charts/EducationHealthCarePlanHorizontalBarChartRequest.cs
+++ b/web/src/Web.App/Domain/Charts/EducationHealthCarePlanHorizontalBarChartRequest.cs
@@ -1,3 +1,4 @@
+using Microsoft.Azure.Cosmos.Linq;
 using Web.App.Infrastructure.Apis;
 
 // ReSharper disable ClassNeverInstantiated.Global
@@ -10,7 +11,7 @@ public record EducationHealthCarePlanHorizontalBarChartRequest : PostHorizontalB
         string uuid,
         string code,
         EducationHealthCarePlansComparisonDatum[] filteredData,
-        Func<string, string?> linkFormatter)
+        Func<string, string?>? linkFormatter = null)
     {
         BarHeight = 22;
         Data = filteredData;
@@ -19,7 +20,9 @@ public record EducationHealthCarePlanHorizontalBarChartRequest : PostHorizontalB
         KeyField = nameof(EducationHealthCarePlansComparisonDatum.Code).ToLower();
         LabelField = "name";
         LabelFormat = "%2$s";
-        LinkFormat = linkFormatter("%1$s");
+        LinkFormat = linkFormatter == null
+            ? string.Empty
+            : linkFormatter.Invoke("%1$s");
         Sort = "desc";
         Width = 610;
         ValueField = nameof(EducationHealthCarePlansComparisonDatum.Plans).ToLower();


### PR DESCRIPTION
## 🧾 Summary
> Briefly describe the changes and why they are needed.

Fixes [AB#299498](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/299498) [AB#310739](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/310739)

### ✨ Feature Details
> - **Functionality:** remove hyperlink markup from LA names in charts on the LA EHCP benchmarking page
> - **Implementation:** Made `linkFormat` property optionally null on the class which encapsulates an EHCP chart request. A null value then passes an empty string in the request, which the chart rendering API interprets as an instruction to not make labels into links

<img width="492" height="786" alt="Screenshot 2026-04-28 at 10 52 59" src="https://github.com/user-attachments/assets/44a7e8f4-1c3b-4b14-9f16-4d19f362f4c2" />

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [x] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes
> Add any additional context for reviewers, required dependencies, or specific testing instructions.
