### PR TITLE
feat: filter out null values when creating data arrays for EHCP charts

### DIFF
--- a/web/src/Web.App/Controllers/LocalAuthorityEducationHealthCarePlansController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityEducationHealthCarePlansController.cs
@@ -49,7 +49,7 @@ public class LocalAuthorityEducationHealthCarePlansController(
                     .QueryEhcpAsync(query)
                     .GetResultOrThrow<EducationHealthCarePlans[]>();
 
-                var subCategories = new EducationHealthCarePlansComparisonSubCategoriesViewModel(plans, selectedSubCategories);
+                var subCategories = new EducationHealthCarePlansComparisonSubCategoriesViewModel(plans, selectedSubCategories, code);
 
                 var charts = await BuildCharts(code, subCategories);
 

--- a/web/src/Web.App/ViewModels/EducationHealthCarePlansComparisonSubCategoriesViewModel.cs
+++ b/web/src/Web.App/ViewModels/EducationHealthCarePlansComparisonSubCategoriesViewModel.cs
@@ -8,17 +8,18 @@ public class EducationHealthCarePlansComparisonSubCategoriesViewModel
     public List<BenchmarkingViewModelCostSubCategory<EducationHealthCarePlansComparisonDatum>> Items { get; set; } = [];
 
     public EducationHealthCarePlansComparisonSubCategoriesViewModel(EducationHealthCarePlans[] plans,
-        EducationHealthCarePlansCategories.SubCategoryFilter[] filters)
+        EducationHealthCarePlansCategories.SubCategoryFilter[] filters,
+        string code)
     {
         filters = filters.Length > 0 ? filters : EducationHealthCarePlansCategories.All;
 
         foreach (var filter in filters)
         {
-            AddSubCategory(filter, plans);
+            AddSubCategory(filter, plans, code);
         }
     }
 
-    private void AddSubCategory(EducationHealthCarePlansCategories.SubCategoryFilter filter, EducationHealthCarePlans[] plans)
+    private void AddSubCategory(EducationHealthCarePlansCategories.SubCategoryFilter filter, EducationHealthCarePlans[] plans, string code)
     {
         var data = plans
             .Select(p => new EducationHealthCarePlansComparisonDatum
@@ -28,6 +29,7 @@ public class EducationHealthCarePlansComparisonSubCategoriesViewModel
                 Plans = filter.GetValue(p),
                 TotalPupils = p.TotalPupils
             })
+            .Where(x => x.Code == code || x.Plans != null)
             .OrderByDescending(x => x.Plans)
             .ToArray();
 


### PR DESCRIPTION
## 🧾 Summary
> Briefly describe the changes and why they are needed.

Fixes [AB#299498](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/299498) [AB#310741](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/310741)

### ✨ Feature Details
> - **Functionality:** Ensures that LAs with null values for ECHP data do not get displayed in charts (unless the LA with the null values is the LA being compared against comparators - in which case they will appear with 0 value still)
> - **Implementation:** Very simple filtering out of null values when constructing the array of viewmodels that gets used to construct chart rendering API requests

<img width="783" height="684" alt="Screenshot 2026-04-30 at 11 38 30" src="https://github.com/user-attachments/assets/0fe62b24-97e4-4b49-862f-5d2433272bb7" />

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [x] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes
> Add any additional context for reviewers, required dependencies, or specific testing instructions.
