### PR TITLE
feat: make currently viewed entity name label bold when displaying text bar labels not links

### DIFF
--- a/platform/src/apis/Platform.Api.ChartRendering/src/functions/horizontalBarChart/template.ts
+++ b/platform/src/apis/Platform.Api.ChartRendering/src/functions/horizontalBarChart/template.ts
@@ -265,6 +265,25 @@ export default class HorizontalBarChartTemplate {
       return `${focusRect}${textLink}`;
     };
 
+    const templateTickText = (datum: string, index: number) => {
+      let label = formatTick(datum, index);
+
+      const classAttr = classnames("text-tick", {
+        "text-tick__highlight": datum === highlightKey,
+      });
+      
+      const labelParts = truncateLabel(
+        label,
+        isAllCaps(label) ? truncateLabelAt - 4 : truncateLabelAt
+      )
+        .split(" ")
+        .join(` </tspan><tspan>`);
+
+      return `<text x="-${tickSize + 3}" dy="0.32em" class="${classAttr}">
+    <tspan>${labelParts}</tspan>
+</text>`;
+    };
+
     function truncateLabel(label: string, maxLength: number) {
       if (label.length <= maxLength) {
         return label;
@@ -291,7 +310,7 @@ export default class HorizontalBarChartTemplate {
   ${
     linkFormat
       ? templateTickLink(d[keyField] as string, i)
-      : `<text x="-9" dy="0.32em">${escapeXml(value)}</text>`
+      : templateTickText(d[keyField] as string, i)
   }
 </g>`;
     });

--- a/platform/src/apis/Platform.Api.ChartRendering/src/functions/horizontalBarChart/template.ts
+++ b/platform/src/apis/Platform.Api.ChartRendering/src/functions/horizontalBarChart/template.ts
@@ -266,12 +266,12 @@ export default class HorizontalBarChartTemplate {
     };
 
     const templateTickText = (datum: string, index: number) => {
-      let label = formatTick(datum, index);
+      const label = formatTick(datum, index);
 
       const classAttr = classnames("text-tick", {
         "text-tick__highlight": datum === highlightKey,
       });
-      
+
       const labelParts = truncateLabel(
         label,
         isAllCaps(label) ? truncateLabelAt - 4 : truncateLabelAt
@@ -302,7 +302,6 @@ export default class HorizontalBarChartTemplate {
     }
 
     const yAxisChartTicks = normalisedData.map((d, i) => {
-      const value = formatTick(d[keyField] as string, i);
       const yAttr = y(d[keyField] as string)! + y.bandwidth() / 2;
 
       return `<g class="chart-tick" transform="translate(0,${yAttr})">

--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -937,6 +937,12 @@ table#current-comparators-la {
         .chart-tick {
           text-anchor: end;
 
+          .text-tick {
+            &.text-tick__highlight {
+              font-weight: bold;
+            }
+          }
+
           .link-tick {
             &.link-tick__highlight {
               font-weight: bold;


### PR DESCRIPTION

## 🧾 Summary
> Briefly describe the changes and why they are needed.

Fixes [AB#299498](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/299498) [AB#311034](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/311034)

### ✨ Feature Details
> - **Functionality:** Makes the bar label for the currently viewed school/LA bold when displaying bar labels as text rather than links. This can be seen on LA EHCP Benchmarking
> - **Implementation:** Followed the same pattern that is used for applying css classes to link labels to create formatting for text labels

<img width="771" height="881" alt="Screenshot 2026-04-30 at 13 45 48" src="https://github.com/user-attachments/assets/7a67d43c-a3b9-4812-9698-b945271be344" />

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [x] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes
> Add any additional context for reviewers, required dependencies, or specific testing instructions.
