### PR TITLE
feat: alter EHCP chart request to provide missing data label

### DIFF
--- a/web/src/Web.App/Domain/Charts/EducationHealthCarePlanHorizontalBarChartRequest.cs
+++ b/web/src/Web.App/Domain/Charts/EducationHealthCarePlanHorizontalBarChartRequest.cs
@@ -23,6 +23,7 @@ public record EducationHealthCarePlanHorizontalBarChartRequest : PostHorizontalB
         LinkFormat = linkFormatter == null
             ? string.Empty
             : linkFormatter.Invoke("%1$s");
+        MissingDataLabel = "No data submitted";
         Sort = "desc";
         Width = 610;
         ValueField = nameof(EducationHealthCarePlansComparisonDatum.Plans).ToLower();


### PR DESCRIPTION
## 🧾 Summary
> Briefly describe the changes and why they are needed.

Fixes [AB#299498](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/299498) [AB#310824](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/310824)

### ✨ Feature Details
> - **Functionality:** Ensures missing data values in EHCP charts display a "No data submitted" label instead of a zero.  This only appears when the user is viewing charts for an LA which has not submitted EHCP data.  When LAs with missing data are part of a comparator set for another LA they are simply omitted from the chart entirely (PR [#4082](https://github.com/DFE-Digital/education-benchmarking-and-insights/pull/4082)) 
> - **Implementation:** Very simple change to add the missing data label into the chart request

<img width="903" height="898" alt="Screenshot 2026-04-30 at 14 05 01" src="https://github.com/user-attachments/assets/814d636d-b169-43b4-8ad0-e60e3ae190f0" />

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [x] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes
> Add any additional context for reviewers, required dependencies, or specific testing instructions.
