### PR TITLE
feat: add table partial for high needs spending data

### DIFF
--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsSpendingController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsSpendingController.cs
@@ -40,8 +40,8 @@ public class LocalAuthorityHighNeedsSpendingController(
                 {
                     code
                 }.Concat(set).ToArray(),
-                    HighNeedsDimensions.ResultAsOptions.PerEhcp.GetResultAsQueryParam(),
-                    HighNeedsDimensions.SubmissionTypeOptions.Budget.GetSubmissionTypeQueryParam());
+                    HighNeedsDimensions.ResultAsOptions.PerPupil.GetResultAsQueryParam(),
+                    HighNeedsDimensions.SubmissionTypeOptions.Outturn.GetSubmissionTypeQueryParam());
 
 
                 var expenditures = await api

--- a/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsSpendingViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsSpendingViewModel.cs
@@ -21,7 +21,7 @@ public class LocalAuthorityHighNeedsSpendingViewModel(
 
     public HighNeedsSpendingCategories.SubCategoryFilter[] SelectedSubCategories { get; set; } = [];
 
-    public Views.ViewAsOptions ViewAs { get; set; } = Views.ViewAsOptions.Table;
+    public Views.ViewAsOptions ViewAs { get; set; } = Views.ViewAsOptions.Chart;
 
     public HighNeedsDimensions.ResultAsOptions ResultAs { get; set; } = HighNeedsDimensions.ResultAsOptions.PerPupil;
 

--- a/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsSpendingViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsSpendingViewModel.cs
@@ -21,7 +21,7 @@ public class LocalAuthorityHighNeedsSpendingViewModel(
 
     public HighNeedsSpendingCategories.SubCategoryFilter[] SelectedSubCategories { get; set; } = [];
 
-    public Views.ViewAsOptions ViewAs { get; set; } = Views.ViewAsOptions.Chart;
+    public Views.ViewAsOptions ViewAs { get; set; } = Views.ViewAsOptions.Table;
 
     public HighNeedsDimensions.ResultAsOptions ResultAs { get; set; } = HighNeedsDimensions.ResultAsOptions.PerPupil;
 

--- a/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsSpendingViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsSpendingViewModel.cs
@@ -25,7 +25,7 @@ public class LocalAuthorityHighNeedsSpendingViewModel(
 
     public HighNeedsDimensions.ResultAsOptions ResultAs { get; set; } = HighNeedsDimensions.ResultAsOptions.PerPupil;
 
-    public HighNeedsDimensions.SubmissionTypeOptions Type { get; set; } = HighNeedsDimensions.SubmissionTypeOptions.Budget;
+    public HighNeedsDimensions.SubmissionTypeOptions Type { get; set; } = HighNeedsDimensions.SubmissionTypeOptions.Outturn;
 }
 
 public class LocalAuthorityHighNeedsSpendingDataViewModel(

--- a/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsSpendingViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsSpendingViewModel.cs
@@ -29,7 +29,13 @@ public class LocalAuthorityHighNeedsSpendingViewModel(
 }
 
 public class LocalAuthorityHighNeedsSpendingDataViewModel(
-    BenchmarkingViewModelCostSubCategory<HighNeedsSpendingComparisonDatum> subCategory)
+    BenchmarkingViewModelCostSubCategory<HighNeedsSpendingComparisonDatum> subCategory,
+    HighNeedsDimensions.ResultAsOptions resultAs,
+    HighNeedsDimensions.SubmissionTypeOptions type,
+    string code)
 {
     public BenchmarkingViewModelCostSubCategory<HighNeedsSpendingComparisonDatum> SubCategory => subCategory;
+    public HighNeedsDimensions.ResultAsOptions ResultAs => resultAs;
+    public HighNeedsDimensions.SubmissionTypeOptions Type => type;
+    public string? Code => code;
 }

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
@@ -66,7 +66,7 @@
                         }
                         else
                         {
-                            <p class="govuk-body">table partial under construction</p>
+                            @await Html.PartialAsync("_HighNeedsSpendingTable", new LocalAuthorityHighNeedsSpendingDataViewModel(subCategory, Model.ResultAs, Model.Type, Model.Code!))
                         }
                     </section>
                 }

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_HighNeedsSpendingTable.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_HighNeedsSpendingTable.cshtml
@@ -1,0 +1,37 @@
+@using Web.App.Domain.Charts
+@using Web.App.Extensions
+@model Web.App.ViewModels.LocalAuthorityHighNeedsSpendingDataViewModel
+
+@if (Model.SubCategory.Data is null)
+{
+    <div
+        class="govuk-warning-text govuk-!-margin-top-2 govuk-!-margin-bottom-2 ssr-chart-warning">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+            <span class="govuk-visually-hidden">Warning</span>
+            Unable to display data
+        </strong>
+    </div>
+    return;
+}
+<div>
+    <table class="govuk-table">
+        <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Local Authority</th>
+            <th scope="col" class="govuk-table__header govuk-table__header--numeric">Number of pupils</th>
+            <th scope="col" class="govuk-table__header govuk-table__header--numeric">@Model.Type.GetSubmissionTypeDescription() (@Model.ResultAs.GetResultAsDescription())</th>
+        </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        @foreach (var row in Model.SubCategory.Data)
+        {
+            <tr class="govuk-table__row @(row.Code == Model.Code ? "govuk-!-font-weight-bold" : "")">
+                <td class="govuk-table__cell">@row.Name</td>
+                <td class="govuk-table__cell govuk-table__header--numeric">@(row.TotalPupils?.ToString("N0"))</td>
+                <td class="govuk-table__cell govuk-table__cell--numeric">@(row.Expenditure?.ToCurrency())</td>
+            </tr>
+        }
+        </tbody>
+    </table>
+</div>


### PR DESCRIPTION
## 🧾 Summary

dependent on #4135 

[AB#295179](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/295179) [AB#311301](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/311301)

### ✨ Feature Details

**Functionality:**
Adds tables to high needs spending page. Table row for selected establishment highlighted as bold

**Implementation:**
Adds new partial to render data as table, updates view model with required values

<img width="1134" height="1108" alt="image" src="https://github.com/user-attachments/assets/831b253e-02ad-4169-801f-266697886c8d" />

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [x] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes

To validate locally reapply the reverted commit 7495a34 to set the default view as option in the VM and observe tables.

Integration tests will be added at a later date once the work for this page is finalised.
