### PR TITLE
feat: add controls for filtering and chart options to high needs spending

### DIFF
--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -1201,6 +1201,35 @@ table#current-comparators-la {
   }
 }
 
+.options-form {
+  display: flex;
+  align-items: flex-start;
+  gap: govuk-spacing(3);
+
+  @include govuk-media-query($until: tablet) {
+    flex-direction: column;
+    gap: govuk-spacing(1);
+  }
+}
+
+.options-form__view-as {
+  margin-right: govuk-spacing(4);
+}
+
+.options-form__compare-by {
+  margin-right: govuk-spacing(6);
+}
+
+.options-form__apply {
+  margin-top: govuk-spacing(6);
+
+  @include govuk-media-query($until: tablet) {
+    margin-top: govuk-spacing(1);
+    width: 100%;
+  }
+}
+
+
 .actions-form
 {
   display: flex;

--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsSpendingController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsSpendingController.cs
@@ -44,8 +44,8 @@ public class LocalAuthorityHighNeedsSpendingController(
                 {
                     code
                 }.Concat(set).ToArray(),
-                resultAs.GetResultAsQueryParam(),
-                type.GetSubmissionTypeQueryParam());
+                resultAs,
+                type);
 
 
                 var expenditures = await api
@@ -82,7 +82,10 @@ public class LocalAuthorityHighNeedsSpendingController(
         type
     });
 
-    private static ApiQuery BuildQuery(string[] codes, string dimension, string submissionType)
+    private static ApiQuery BuildQuery(
+        string[] codes,
+        HighNeedsDimensions.ResultAsOptions dimension,
+        HighNeedsDimensions.SubmissionTypeOptions submissionType)
     {
         var query = new ApiQuery();
         foreach (var c in codes)
@@ -90,9 +93,9 @@ public class LocalAuthorityHighNeedsSpendingController(
             query.AddIfNotNull("code", c);
         }
 
-        query.AddIfNotNull("dimension", dimension);
+        query.AddIfNotNull("dimension", dimension.GetResultAsQueryParam());
 
-        query.AddIfNotNull("type", submissionType);
+        query.AddIfNotNull("type", submissionType.GetSubmissionTypeQueryParam());
 
         return query;
     }

--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsSpendingController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsSpendingController.cs
@@ -22,8 +22,10 @@ public class LocalAuthorityHighNeedsSpendingController(
 {
     [HttpGet]
     public async Task<IActionResult> Index(string code,
+        HighNeedsSpendingCategories.SubCategoryFilter[] selectedSubCategories,
         Views.ViewAsOptions viewAs = Views.ViewAsOptions.Chart,
-        HighNeedsDimensions.ResultAsOptions resultAs = HighNeedsDimensions.ResultAsOptions.PerPupil)
+        HighNeedsDimensions.ResultAsOptions resultAs = HighNeedsDimensions.ResultAsOptions.PerPupil,
+        HighNeedsDimensions.SubmissionTypeOptions type = HighNeedsDimensions.SubmissionTypeOptions.Outturn)
     {
         using (logger.BeginScope(new { code }))
         {
@@ -42,21 +44,22 @@ public class LocalAuthorityHighNeedsSpendingController(
                 {
                     code
                 }.Concat(set).ToArray(),
-                    HighNeedsDimensions.ResultAsOptions.PerPupil.GetResultAsQueryParam(),
-                    HighNeedsDimensions.SubmissionTypeOptions.Outturn.GetSubmissionTypeQueryParam());
+                resultAs.GetResultAsQueryParam(),
+                type.GetSubmissionTypeQueryParam());
 
 
                 var expenditures = await api
                     .QueryHighNeedsV2Async(query)
                     .GetResultOrThrow<HighNeedsSpending[]>();
 
-                var subCategories = new HighNeedsSpendingComparisonSubCategoriesViewModel(expenditures, HighNeedsSpendingCategories.All, code);
+                var subCategories = new HighNeedsSpendingComparisonSubCategoriesViewModel(expenditures, selectedSubCategories, code);
 
                 var viewModel = new LocalAuthorityHighNeedsSpendingViewModel(la, set, subCategories)
                 {
-                    SelectedSubCategories = HighNeedsSpendingCategories.All,
+                    SelectedSubCategories = selectedSubCategories,
                     ViewAs = viewAs,
-                    ResultAs = resultAs
+                    ResultAs = resultAs,
+                    Type = type
                 };
 
                 return View(viewModel);
@@ -68,13 +71,15 @@ public class LocalAuthorityHighNeedsSpendingController(
             }
         }
     }
-    
+
     [HttpPost]
-    public IActionResult Index(string code, int viewAs, int resultAs) => RedirectToAction("Index", new
+    public IActionResult Index(string code, int[]? selectedSubCategories, int viewAs, int resultAs, int type) => RedirectToAction("Index", new
     {
         code,
+        selectedSubCategories,
         viewAs,
-        resultAs
+        resultAs,
+        type
     });
 
     private static ApiQuery BuildQuery(string[] codes, string dimension, string submissionType)

--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsSpendingController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsSpendingController.cs
@@ -21,7 +21,9 @@ public class LocalAuthorityHighNeedsSpendingController(
     : Controller
 {
     [HttpGet]
-    public async Task<IActionResult> Index(string code)
+    public async Task<IActionResult> Index(string code,
+        Views.ViewAsOptions viewAs = Views.ViewAsOptions.Chart,
+        HighNeedsDimensions.ResultAsOptions resultAs = HighNeedsDimensions.ResultAsOptions.PerPupil)
     {
         using (logger.BeginScope(new { code }))
         {
@@ -53,6 +55,8 @@ public class LocalAuthorityHighNeedsSpendingController(
                 var viewModel = new LocalAuthorityHighNeedsSpendingViewModel(la, set, subCategories)
                 {
                     SelectedSubCategories = HighNeedsSpendingCategories.All,
+                    ViewAs = viewAs,
+                    ResultAs = resultAs
                 };
 
                 return View(viewModel);
@@ -64,6 +68,14 @@ public class LocalAuthorityHighNeedsSpendingController(
             }
         }
     }
+    
+    [HttpPost]
+    public IActionResult Index(string code, int viewAs, int resultAs) => RedirectToAction("Index", new
+    {
+        code,
+        viewAs,
+        resultAs
+    });
 
     private static ApiQuery BuildQuery(string[] codes, string dimension, string submissionType)
     {

--- a/web/src/Web.App/Domain/Charts/HighNeedsDimensions.cs
+++ b/web/src/Web.App/Domain/Charts/HighNeedsDimensions.cs
@@ -12,7 +12,7 @@ public static class HighNeedsDimensions
         PerSenSupport = 2,
         PerTotalSupport = 3
     }
-    
+
     public static readonly ResultAsOptions[] AllResultsAsOptions =
     [
         ResultAsOptions.PerPupil,
@@ -23,14 +23,14 @@ public static class HighNeedsDimensions
 
     public enum SubmissionTypeOptions
     {
-        Budget = 0,
-        Outturn = 1
+        Outturn = 0,
+        Budget = 1
     }
-    
+
     public static readonly SubmissionTypeOptions[] AllSubmissionTypeOptions =
     [
-        SubmissionTypeOptions.Budget,
-        SubmissionTypeOptions.Outturn
+        SubmissionTypeOptions.Outturn,
+        SubmissionTypeOptions.Budget
     ];
 
     public static string GetSubmissionTypeQueryParam(this SubmissionTypeOptions option) => option switch

--- a/web/src/Web.App/Domain/Charts/HighNeedsDimensions.cs
+++ b/web/src/Web.App/Domain/Charts/HighNeedsDimensions.cs
@@ -12,12 +12,26 @@ public static class HighNeedsDimensions
         PerSenSupport = 2,
         PerTotalSupport = 3
     }
+    
+    public static readonly ResultAsOptions[] AllResultsAsOptions =
+    [
+        ResultAsOptions.PerPupil,
+        ResultAsOptions.PerEhcp,
+        ResultAsOptions.PerSenSupport,
+        ResultAsOptions.PerTotalSupport,
+    ];
 
     public enum SubmissionTypeOptions
     {
         Budget = 0,
         Outturn = 1
     }
+    
+    public static readonly SubmissionTypeOptions[] AllSubmissionTypeOptions =
+    [
+        SubmissionTypeOptions.Budget,
+        SubmissionTypeOptions.Outturn
+    ];
 
     public static string GetSubmissionTypeQueryParam(this SubmissionTypeOptions option) => option switch
     {

--- a/web/src/Web.App/ViewModels/BenchmarkingViewModelCostSubCategory.cs
+++ b/web/src/Web.App/ViewModels/BenchmarkingViewModelCostSubCategory.cs
@@ -4,6 +4,7 @@ public class BenchmarkingViewModelCostSubCategory<T>
 {
     public string? Uuid { get; init; }
     public string? SubCategory { get; init; }
+    public int? SubCategoryId { get; init; }
     public string? TableHeading { get; init; }
     public string? ChartSvg { get; set; }
     public T[]? Data { get; init; }

--- a/web/src/Web.App/ViewModels/HighNeedsSpendingComparisonSubCategoriesViewModel.cs
+++ b/web/src/Web.App/ViewModels/HighNeedsSpendingComparisonSubCategoriesViewModel.cs
@@ -56,6 +56,7 @@ public class HighNeedsSpendingComparisonSubCategoriesViewModel
         {
             Uuid = Guid.NewGuid().ToString(),
             SubCategory = filter.GetHeading(),
+            SubCategoryId = (int)filter,
             Data = data
         };
     }

--- a/web/src/Web.App/ViewModels/HighNeedsSpendingComparisonSubCategoriesViewModel.cs
+++ b/web/src/Web.App/ViewModels/HighNeedsSpendingComparisonSubCategoriesViewModel.cs
@@ -64,14 +64,18 @@ public class HighNeedsSpendingComparisonSubCategoriesViewModel
 
 public class HighNeedsSpendingComparisonGroup
 {
-    public string Group { get; set; } = "";
-    public List<BenchmarkingViewModelCostSubCategory<HighNeedsSpendingComparisonDatum>> Items { get; set; } = [];
+    public string Group { get; init; } = "";
+    public List<BenchmarkingViewModelCostSubCategory<HighNeedsSpendingComparisonDatum>> Items { get; init; } = [];
+    public int SelectedCount(HashSet<int> selectedIds) =>
+        Items.Count(i => i.SubCategoryId.HasValue && selectedIds.Contains(i.SubCategoryId.Value));
+    public IEnumerable<BenchmarkingViewModelCostSubCategory<HighNeedsSpendingComparisonDatum>> SelectedItems(HashSet<int> selectedIds) =>
+        Items.Where(i => i.SubCategoryId.HasValue && selectedIds.Contains(i.SubCategoryId.Value));
 }
 
 public class HighNeedsSpendingComparisonDatum
 {
-    public string? Code { get; set; }
-    public string? Name { get; set; }
-    public decimal? Expenditure { get; set; }
-    public decimal? TotalPupils { get; set; }
+    public string? Code { get; init; }
+    public string? Name { get; init; }
+    public decimal? Expenditure { get; init; }
+    public decimal? TotalPupils { get; init; }
 }

--- a/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsSpendingViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsSpendingViewModel.cs
@@ -17,15 +17,23 @@ public class LocalAuthorityHighNeedsSpendingViewModel(
         .Distinct()
         .ToArray();
 
+    public KeyValuePair<HighNeedsSpendingCategories.CategoryGroup, HighNeedsSpendingCategories.SubCategoryFilter[]>[] AllGroups =>
+        HighNeedsSpendingCategories.Groups.ToArray();
     public List<HighNeedsSpendingComparisonGroup> Groups => subCategories.Groups;
+    public HighNeedsSpendingCategories.SubCategoryFilter[] SelectedSubCategories { get; init; } = [];
+    public HashSet<int> SelectedIds =>
+        SelectedSubCategories
+            .Select(x => (int)x)
+            .ToHashSet();
 
-    public HighNeedsSpendingCategories.SubCategoryFilter[] SelectedSubCategories { get; set; } = [];
+    public IEnumerable<HighNeedsSpendingComparisonGroup> SelectedGroups =>
+        Groups.Where(g => g.SelectedCount(SelectedIds) > 0);
 
-    public Views.ViewAsOptions ViewAs { get; set; } = Views.ViewAsOptions.Chart;
+    public Views.ViewAsOptions ViewAs { get; init; } = Views.ViewAsOptions.Chart;
 
-    public HighNeedsDimensions.ResultAsOptions ResultAs { get; set; } = HighNeedsDimensions.ResultAsOptions.PerPupil;
+    public HighNeedsDimensions.ResultAsOptions ResultAs { get; init; } = HighNeedsDimensions.ResultAsOptions.PerPupil;
 
-    public HighNeedsDimensions.SubmissionTypeOptions Type { get; set; } = HighNeedsDimensions.SubmissionTypeOptions.Outturn;
+    public HighNeedsDimensions.SubmissionTypeOptions Type { get; init; } = HighNeedsDimensions.SubmissionTypeOptions.Outturn;
 }
 
 public class LocalAuthorityHighNeedsSpendingDataViewModel(
@@ -37,5 +45,5 @@ public class LocalAuthorityHighNeedsSpendingDataViewModel(
     public BenchmarkingViewModelCostSubCategory<HighNeedsSpendingComparisonDatum> SubCategory => subCategory;
     public HighNeedsDimensions.ResultAsOptions ResultAs => resultAs;
     public HighNeedsDimensions.SubmissionTypeOptions Type => type;
-    public string? Code => code;
+    public string Code => code;
 }

--- a/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/Index.cshtml
@@ -69,7 +69,7 @@
         {
             <div class="govuk-form-group">
                 <fieldset class="govuk-fieldset">
-                    <legend class="govuk-label">
+                    <legend class="govuk-label govuk-!-font-weight-bold">
                         View as
                     </legend>
                     <div class="govuk-radios govuk-radios--inline govuk-radios--small" data-module="govuk-radios"

--- a/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/Index.cshtml
@@ -62,17 +62,17 @@
 
         @using (Html.BeginForm(FormMethod.Post, true, new
                 {
-                    @class = "actions-form",
+                    @class = "options-form",
                     novalidate = "novalidate",
                     role = "search"
                 }))
         {
-            <div class="govuk-form-group">
+            <div class="options-form__view-as">
                 <fieldset class="govuk-fieldset">
                     <legend class="govuk-label govuk-!-font-weight-bold">
                         View as
                     </legend>
-                    <div class="govuk-radios govuk-radios--inline govuk-radios--small" data-module="govuk-radios"
+                    <div class="govuk-radios govuk-radios--small" data-module="govuk-radios"
                          id="@nameof(LocalAuthorityEducationHealthCarePlansViewModel.ViewAs)">
                         @foreach (var view in Views.All)
                         {
@@ -92,7 +92,7 @@
                 </fieldset>
             </div>
 
-            <div class="actions-form__button">
+            <div class="options-form__apply">
                 <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button">
                     Apply
                 </button>

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
@@ -39,7 +39,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">
-        <p class="govuk-body">filters under construction</p>
+        @await Html.PartialAsync("_Filter", Model)
     </div>
     <div class="govuk-grid-column-two-thirds">
         <p class="govuk-body">page actions under construction</p>

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
@@ -47,17 +47,17 @@
 
         @using (Html.BeginForm(FormMethod.Post, true, new
             {
-                @class = "actions-form",
+                @class = "options-form",
                 novalidate = "novalidate",
                 role = "search"
             }))
         {
-            <div class="govuk-form-group">
+            <div class="options-form__view-as">
                 <fieldset class="govuk-fieldset">
                     <legend class="govuk-label govuk-!-font-weight-bold">
                         View as
                     </legend>
-                    <div class="govuk-radios govuk-radios--inline govuk-radios--small" data-module="govuk-radios"
+                    <div class="govuk-radios govuk-radios--small" data-module="govuk-radios"
                          id="@nameof(LocalAuthorityHighNeedsSpendingViewModel.ViewAs)">
                         @foreach (var view in Views.All)
                         {
@@ -77,7 +77,7 @@
                 </fieldset>
             </div>
 
-            <div class="govuk-form-group">
+            <div class="options-form__compare-by">
                 <label class="govuk-label govuk-!-font-weight-bold" for="@nameof(LocalAuthorityHighNeedsSpendingViewModel.ResultAs)">
                     Compare by
                 </label>
@@ -93,7 +93,7 @@
                 </select>
             </div>
 
-            <div class="actions-form__button">
+            <div class="options-form__apply">
                 <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button">
                     Apply
                 </button>

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
@@ -45,7 +45,60 @@
         <p class="govuk-body">page actions under construction</p>
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-        <p class="govuk-body">form actions under construction</p>
+        @using (Html.BeginForm(FormMethod.Post, true, new
+            {
+                @class = "actions-form",
+                novalidate = "novalidate",
+                role = "search"
+            }))
+        {
+            <div class="govuk-form-group">
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-label">
+                        View as
+                    </legend>
+                    <div class="govuk-radios govuk-radios--inline govuk-radios--small" data-module="govuk-radios"
+                         id="@nameof(LocalAuthorityHighNeedsSpendingViewModel.ViewAs)">
+                        @foreach (var view in Views.All)
+                        {
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input"
+                                       id="view-@view"
+                                       name="@nameof(LocalAuthorityHighNeedsSpendingViewModel.ViewAs)" type="radio"
+                                       value="@((int)view)"
+                                       @(Model.ViewAs == view ? "checked" : "")>
+                                <label class="govuk-label govuk-radios__label"
+                                       for="view-@view">
+                                    @view.GetDescription()
+                                </label>
+                            </div>
+                        }
+                    </div>
+                </fieldset>
+            </div>
+
+            <div class="govuk-form-group">
+                <label class="govuk-label" for="@nameof(LocalAuthorityHighNeedsSpendingViewModel.ResultAs)">
+                    Compare by
+                </label>
+                <select class="govuk-select" id="@nameof(LocalAuthorityHighNeedsSpendingViewModel.ResultAs)" name="@nameof(LocalAuthorityHighNeedsSpendingViewModel.ResultAs)">
+                    @foreach (var option in HighNeedsDimensions.AllResultsAsOptions)
+                    {
+                        <option
+                            value="@((int)option)"
+                            selected="@(Model.ResultAs == option ? "selected" : null)">
+                            @option.GetResultAsDescription()
+                        </option>
+                    }
+                </select>
+            </div>
+
+            <div class="actions-form__button">
+                <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+                    Apply
+                </button>
+            </div>
+        }
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
         @foreach (var group in Model.Groups.Where(group => group.Items.Any()))

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
@@ -54,7 +54,7 @@
         {
             <div class="govuk-form-group">
                 <fieldset class="govuk-fieldset">
-                    <legend class="govuk-label">
+                    <legend class="govuk-label govuk-!-font-weight-bold">
                         View as
                     </legend>
                     <div class="govuk-radios govuk-radios--inline govuk-radios--small" data-module="govuk-radios"
@@ -78,7 +78,7 @@
             </div>
 
             <div class="govuk-form-group">
-                <label class="govuk-label" for="@nameof(LocalAuthorityHighNeedsSpendingViewModel.ResultAs)">
+                <label class="govuk-label govuk-!-font-weight-bold" for="@nameof(LocalAuthorityHighNeedsSpendingViewModel.ResultAs)">
                     Compare by
                 </label>
                 <select class="govuk-select" id="@nameof(LocalAuthorityHighNeedsSpendingViewModel.ResultAs)" name="@nameof(LocalAuthorityHighNeedsSpendingViewModel.ResultAs)">

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_Filter.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_Filter.cshtml
@@ -3,14 +3,6 @@
 @using Web.App.ViewModels
 @model Web.App.ViewModels.LocalAuthorityHighNeedsSpendingViewModel
 
-@{
-    var selectedIds = Model.SelectedSubCategories
-        .Select(x => (int)x)
-        .ToHashSet();
-
-    var index = 1;
-}
-
 <div class="app-filter">
     <div class="app-filter__header">
         <h2 class="govuk-heading-m govuk-!-margin-0">
@@ -28,16 +20,12 @@
                 <a href="@Url.Action("Index", "LocalAuthorityHighNeedsSpending", new { Model.Code, viewAs = (int)Model.ViewAs, resultAs = (int)Model.ResultAs }))"
                    class="govuk-link govuk-link--no-visited-state">Clear</a>
             </div>
-            @foreach (var group in Model.Groups.Where(g =>
-                          g.Items.Any(i => i.SubCategoryId.HasValue && selectedIds.Contains(i.SubCategoryId.Value))
-                      ))
+            @foreach (var group in Model.SelectedGroups)
             {
                 <h3 class="govuk-heading-s">@group.Group</h3>
 
                 <ul class="govuk-list">
-                    @foreach (var item in group.Items.Where(i =>
-                                  i.SubCategoryId.HasValue && selectedIds.Contains(i.SubCategoryId.Value)
-                              ))
+                    @foreach (var item in group.SelectedItems(Model.SelectedIds))
                     {
                         <li>
                             <a href="@Url.Action("Index", new {
@@ -64,12 +52,13 @@
                    value="@Model.SelectedSubCategories"/>
 
             <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
-                @foreach (var group in HighNeedsSpendingCategories.Groups)
+                @for (var i = 0; i < Model.AllGroups.Length; i++)
                 {
-                    var headingId = $"accordion-default-heading-{index}";
-                    var contentId = $"accordion-default-content-{index}";
+                    var group = Model.AllGroups[i];
+                    var headingId = $"accordion-default-heading-{i + 1}";
+                    var contentId = $"accordion-default-content-{i + 1}";
 
-                    var groupSelectedCount = group.Value.Count(x => selectedIds.Contains((int)x));
+                    var groupSelectedCount = group.Value.Count(x => Model.SelectedIds.Contains((int)x));
                     
                     <div class="govuk-accordion__section">
                         <div class="govuk-accordion__section-header">
@@ -97,7 +86,7 @@
                                         @foreach (var sub in group.Value)
                                         {
                                             var id = (int)sub;
-                                            var isChecked = selectedIds.Contains(id);
+                                            var isChecked = Model.SelectedIds.Contains(id);
 
                                             <div class="govuk-checkboxes__item">
                                                 <input class="govuk-checkboxes__input"
@@ -119,8 +108,6 @@
                             </div>
                         </div>
                     </div>
-
-                    index++;
                 }
             </div>
             <div class="govuk-form-group">

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_Filter.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_Filter.cshtml
@@ -29,12 +29,14 @@
                     {
                         <li>
                             <a href="@Url.Action("Index", new {
-                                         Model.Code,
-                                         viewAs = (int)Model.ViewAs,
-                                selectedSubCategories = Model.SelectedSubCategories
-                                    .Where(x => (int)x != item.SubCategoryId)
-                                    .Select(x => (int)x)
-                                     })"
+                                        Model.Code,
+                                        viewAs = (int)Model.ViewAs,
+                                        resultAs = (int)Model.ResultAs,
+                                        type = (int)Model.Type,
+                                        selectedSubCategories = Model.SelectedSubCategories
+                                            .Where(x => (int)x != item.SubCategoryId)
+                                            .Select(x => (int)x)
+                                             })"
                            class="app-filter__tag">
                             @item.SubCategory
                         </a>

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_Filter.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_Filter.cshtml
@@ -1,0 +1,156 @@
+@using Web.App.Domain.Charts
+@using Web.App.Domain.LocalAuthorities
+@using Web.App.ViewModels
+@model Web.App.ViewModels.LocalAuthorityHighNeedsSpendingViewModel
+
+@{
+    var selectedIds = Model.SelectedSubCategories
+        .Select(x => (int)x)
+        .ToHashSet();
+
+    var index = 1;
+}
+
+<div class="app-filter">
+    <div class="app-filter__header">
+        <h2 class="govuk-heading-m govuk-!-margin-0">
+            Filters
+        </h2>
+    </div>
+
+    @if (Model.SelectedSubCategories.Length > 0)
+    {
+        <div class="app-filter__selected">
+            <div class="app-filter__selected-header">
+                <h2 class="govuk-heading-m">
+                    Selected filters
+                </h2>
+                <a href="@Url.Action("Index", "LocalAuthorityHighNeedsSpending", new { Model.Code, viewAs = (int)Model.ViewAs, resultAs = (int)Model.ResultAs }))"
+                   class="govuk-link govuk-link--no-visited-state">Clear</a>
+            </div>
+            @foreach (var group in Model.Groups.Where(g =>
+                          g.Items.Any(i => i.SubCategoryId.HasValue && selectedIds.Contains(i.SubCategoryId.Value))
+                      ))
+            {
+                <h3 class="govuk-heading-s">@group.Group</h3>
+
+                <ul class="govuk-list">
+                    @foreach (var item in group.Items.Where(i =>
+                                  i.SubCategoryId.HasValue && selectedIds.Contains(i.SubCategoryId.Value)
+                              ))
+                    {
+                        <li>
+                            <a href="@Url.Action("Index", new {
+                                         Model.Code,
+                                         viewAs = (int)Model.ViewAs,
+                                selectedSubCategories = Model.SelectedSubCategories
+                                    .Where(x => (int)x != item.SubCategoryId)
+                                    .Select(x => (int)x)
+                                     })"
+                           class="app-filter__tag">
+                            @item.SubCategory
+                        </a>
+                        </li>
+                    }
+                </ul>
+            }
+        </div>
+    }
+    <div class="app-filter__body">
+        @using (Html.BeginForm(FormMethod.Post, true, new { novalidate = "novalidate", role = "search" }))
+        {
+            <input type="hidden"
+                   name="@nameof(LocalAuthorityHighNeedsSpendingViewModel.SelectedSubCategories)"
+                   value="@Model.SelectedSubCategories"/>
+
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+                @foreach (var group in HighNeedsSpendingCategories.Groups)
+                {
+                    var headingId = $"accordion-default-heading-{index}";
+                    var contentId = $"accordion-default-content-{index}";
+
+                    var groupSelectedCount = group.Value.Count(x => selectedIds.Contains((int)x));
+                    
+                    <div class="govuk-accordion__section">
+                        <div class="govuk-accordion__section-header">
+                            <h2 class="govuk-accordion__section-heading">
+                                <span class="govuk-accordion__section-button"
+                                      id="@headingId">
+                                    @group.Key.GetCategoryGroupDescription()
+                                    
+                                    @if (groupSelectedCount > 0)
+                                    {
+                                        <span class="govuk-hint app-filter__selected-hint">
+                                            @($"{groupSelectedCount} selected")
+                                        </span>
+                                    }
+                                    
+                                </span>
+                            </h2>
+                        </div>
+
+                        <div id="@contentId" class="govuk-accordion__section-content">
+                            <div class="govuk-form-group">
+                                <fieldset class="govuk-fieldset">
+                                    <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+
+                                        @foreach (var sub in group.Value)
+                                        {
+                                            var id = (int)sub;
+                                            var isChecked = selectedIds.Contains(id);
+
+                                            <div class="govuk-checkboxes__item">
+                                                <input class="govuk-checkboxes__input"
+                                                       id="subcategory-@id"
+                                                       name="@nameof(Model.SelectedSubCategories)"
+                                                       value="@id"
+                                                       type="checkbox"
+                                                       @(isChecked ? "checked" : "") />
+
+                                                <label class="govuk-label govuk-checkboxes__label"
+                                                       for="subcategory-@id">
+                                                    @sub.GetSubCategoryFilterDescription()
+                                                </label>
+                                            </div>
+                                        }
+
+                                    </div>
+                                </fieldset>
+                            </div>
+                        </div>
+                    </div>
+
+                    index++;
+                }
+            </div>
+            <div class="govuk-form-group">
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                        Show
+                    </legend>
+                    <div class="govuk-radios govuk-radios--small" data-module="govuk-radios"
+                         id="@nameof(LocalAuthorityHighNeedsSpendingViewModel.Type)">
+                        @foreach (var type in HighNeedsDimensions.AllSubmissionTypeOptions)
+                        {
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input"
+                                       id="type-@type"
+                                       name="@nameof(LocalAuthorityHighNeedsSpendingViewModel.Type)" type="radio"
+                                       value="@((int)type)"
+                                       @(Model.Type == type ? "checked" : "")>
+                                <label class="govuk-label govuk-radios__label"
+                                       for="type-@type">
+                                    @type.GetSubmissionTypeDescription()
+                                </label>
+                            </div>
+                        }
+                    </div>
+                </fieldset>
+            </div>
+            <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+            <button type="submit" class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-1" data-module="govuk-button">
+                Apply filters
+            </button>
+        }
+    </div>
+</div>

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingEducationHealthCarePlans.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingEducationHealthCarePlans.cs
@@ -202,7 +202,7 @@ public class WhenViewingEducationHealthCarePlans(SchoolBenchmarkingWebAppClient 
         Assert.NotNull(authority.Name);
         DocumentAssert.TitleAndH1(page, "Benchmark education, health care plans - Financial Benchmarking and Insights Tool - GOV.UK", "Benchmark education, health care plans");
 
-        var form = page.QuerySelector(".actions-form");
+        var form = page.QuerySelector(".options-form");
         Assert.NotNull(form);
 
         AssertFormOptions(form, viewAs);
@@ -214,7 +214,6 @@ public class WhenViewingEducationHealthCarePlans(SchoolBenchmarkingWebAppClient 
 
         if (viewAs == 0)
         {
-            //TODO: asserts chart once implemented
             AssertChartSection(page, plans, chartApiError);
         }
         else


### PR DESCRIPTION
## 🧾 Summary

[AB#295179](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/295179)
[AB#308389](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/308389)
[AB#308390](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/308390)

<img width="661" height="983" alt="image" src="https://github.com/user-attachments/assets/d873ede8-d7df-4895-a22e-a6fbe1268f18" />

### ✨ Feature Details
**Functionality:**

This PR introduces filtering and chart options to the benchmark high needs page.
Users can now:
- Select one or more sub categories via grouped accordion filter
- View selected filters as removeable tags
- Choose whether to view planned expenditure or outturn data
- Switch between chart and table views
- Choose how to compare spending (e.g., £ per pupil, £ per EHCP, etc.)

It also standardises the styling and layout of the options bar across EHCP and High Needs Spending to align with the latest designs.

<img width="1283" height="488" alt="image" src="https://github.com/user-attachments/assets/e1ec67f5-4371-4153-bae9-ab5765206f01" />

<img width="1248" height="318" alt="image" src="https://github.com/user-attachments/assets/c3e7c0bf-e561-43e8-991a-f187f96b391d" />


**Implementation:**

- Follows the established pattern used in Benchmark IT Spending / EHCP / Senior Leadership, but uses the domain‑owned HighNeedsSpendingCategories.Groups for filter structure
- Updated view models with new properties (`SelectedIds`, `SelectedGroups`) and helper methods
- Introduced the `.options-form` layout for the View As / Compare By controls
- Removed `govuk-radios--inline` from the “View as” radios on EHCP and High Needs Spending pages to match updated designs

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [x] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [x] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes

Tests to follow once all work on this page is finalised
