### PR TITLE
feat: update tables for ehcp page to align with latest designs

### DIFF
--- a/web/src/Web.App/Domain/LocalAuthorities/EducationHealthCarePlansCategories.cs
+++ b/web/src/Web.App/Domain/LocalAuthorities/EducationHealthCarePlansCategories.cs
@@ -41,27 +41,14 @@ public static class EducationHealthCarePlansCategories
 
     public static string GetHeading(this SubCategoryFilter filter) => filter switch
     {
-        SubCategoryFilter.Total => "Total pupils with EHC plans",
-        SubCategoryFilter.Mainstream => "Placement of pupils with EHC plans in mainstream schools or academies",
-        SubCategoryFilter.Resourced => "Placement of pupils with EHC plans resourced provision or SEN units",
-        SubCategoryFilter.Special => "Placement of pupils with EHC plans maintained special school or special academies",
-        SubCategoryFilter.Independent => "Placement of pupils with EHC plans NMSS or independent schools",
-        SubCategoryFilter.Hospital => "Placement of pupils with EHC plans in hospital schools or alternative provisions",
-        SubCategoryFilter.Post16 => "Placement of pupils with EHC plans in post 16",
-        SubCategoryFilter.Other => "Placement of pupils with EHC plans in other types of provisions",
-        _ => ""
-    };
-
-    public static string GetTableHeading(this SubCategoryFilter filter) => filter switch
-    {
-        SubCategoryFilter.Total => "Total pupils with EHC plans (per 1000 pupils)",
-        SubCategoryFilter.Mainstream => "EHC plans in Mainstream schools or academies (per 1000 pupils)",
-        SubCategoryFilter.Resourced => "EHC plans in Resourced provision or SEN units (per 1000 pupils)",
-        SubCategoryFilter.Special => "EHC plans in Maintained special school or special academies (per 1000 pupils)",
-        SubCategoryFilter.Independent => "EHC plans in NMSS or independent schools (per 1000 pupils)",
-        SubCategoryFilter.Hospital => "EHC plans in Hospital schools or alternative provisions (per 1000 pupils)",
-        SubCategoryFilter.Post16 => "EHC plans in Post 16 (per 1000 pupils)",
-        SubCategoryFilter.Other => "EHC plans in other types of provisions (per 1000 pupils)",
+        SubCategoryFilter.Total => "Total EHC plans",
+        SubCategoryFilter.Mainstream => "EHC plans supported in mainstream schools or academies",
+        SubCategoryFilter.Resourced => "EHC plans supported in resourced provision or SEN units",
+        SubCategoryFilter.Special => "EHC plans supported in maintained special schools or special academies",
+        SubCategoryFilter.Independent => "EHC plans supported in NMSS or independent schools",
+        SubCategoryFilter.Hospital => "EHC plans supported in hospital schools or alternative provisions",
+        SubCategoryFilter.Post16 => "EHC plans supported in post 16",
+        SubCategoryFilter.Other => "EHC plans supported in other settings",
         _ => ""
     };
 

--- a/web/src/Web.App/ViewModels/BenchmarkingViewModelCostSubCategory.cs
+++ b/web/src/Web.App/ViewModels/BenchmarkingViewModelCostSubCategory.cs
@@ -5,7 +5,6 @@ public class BenchmarkingViewModelCostSubCategory<T>
     public string? Uuid { get; init; }
     public string? SubCategory { get; init; }
     public int? SubCategoryId { get; init; }
-    public string? TableHeading { get; init; }
     public string? ChartSvg { get; set; }
     public T[]? Data { get; init; }
 }

--- a/web/src/Web.App/ViewModels/EducationHealthCarePlansComparisonSubCategoriesViewModel.cs
+++ b/web/src/Web.App/ViewModels/EducationHealthCarePlansComparisonSubCategoriesViewModel.cs
@@ -39,7 +39,6 @@ public class EducationHealthCarePlansComparisonSubCategoriesViewModel
         {
             Uuid = uuid,
             SubCategory = filter.GetHeading(),
-            TableHeading = filter.GetTableHeading(),
             Data = data
         });
     }

--- a/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/_EhcPlanTable.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityEducationHealthCarePlans/_EhcPlanTable.cshtml
@@ -18,18 +18,18 @@
     <table class="govuk-table">
         <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">Local Authority</th>
-            <th scope="col" class="govuk-table__header">@Model.SubCategory.TableHeading</th>
-            <th scope="col" class="govuk-table__header">Pupils</th>
+            <th scope="col" class="govuk-table__header">Local authority</th>
+            <th scope="col" class="govuk-table__header govuk-table__header--numeric">Number of pupils</th>
+            <th scope="col" class="govuk-table__header govuk-table__header--numeric">EHC plans per 1,000 pupils</th>
         </tr>
         </thead>
         <tbody class="govuk-table__body">
         @foreach (var row in Model.SubCategory.Data)
         {
-            <tr class="govuk-table__row@(row.Code == Model.Code ? " govuk-table__header" : "")">
+            <tr class="govuk-table__row@(row.Code == Model.Code ? " govuk-!-font-weight-bold" : "")">
                 <td class="govuk-table__cell">@row.Name</td>
-                <td class="govuk-table__cell">@(row.Plans == null ? "No data submitted" : row.Plans.ToSimpleDisplay())</td>
                 <td class="govuk-table__cell govuk-table__cell--numeric">@(row.TotalPupils?.ToString("N0"))</td>
+                <td class="govuk-table__cell govuk-table__cell--numeric">@(row.Plans == null ? "No data submitted" : row.Plans.ToSimpleDisplay())</td>
             </tr>
         }
         </tbody>

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_HighNeedsSpendingTable.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_HighNeedsSpendingTable.cshtml
@@ -26,9 +26,9 @@
         <tbody class="govuk-table__body">
         @foreach (var row in Model.SubCategory.Data)
         {
-            <tr class="govuk-table__row @(row.Code == Model.Code ? "govuk-!-font-weight-bold" : "")">
+            <tr class="govuk-table__row @(row.Code == Model.Code ? " govuk-!-font-weight-bold" : "")">
                 <td class="govuk-table__cell">@row.Name</td>
-                <td class="govuk-table__cell govuk-table__header--numeric">@(row.TotalPupils?.ToString("N0"))</td>
+                <td class="govuk-table__cell govuk-table__cell--numeric">@(row.TotalPupils?.ToString("N0"))</td>
                 <td class="govuk-table__cell govuk-table__cell--numeric">@(row.Expenditure?.ToCurrency())</td>
             </tr>
         }

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingEducationHealthCarePlans.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingEducationHealthCarePlans.cs
@@ -279,30 +279,26 @@ public class WhenViewingEducationHealthCarePlans(SchoolBenchmarkingWebAppClient 
 
     private static void AssertTableSection(IHtmlDocument page, EducationHealthCarePlans[] plans)
     {
-        var tables = page.QuerySelectorAll(".govuk-table");
-        Assert.NotNull(tables);
+        var sections = page.QuerySelectorAll("[id*=\"cost-sub-category-\"]");
+        Assert.NotEmpty(sections);
 
-        foreach (var table in tables)
+        foreach (var section in sections)
         {
-            var heading = table.QuerySelector("thead th:nth-child(2)")!.TextContent.Trim();
-
-            // get required prop from table heading to later extract expected value from plan
-            Assert.True(HeadingToValue.TryGetValue(heading, out var extractor),
-                $"Unknown heading: {heading}");
-
-            var rows = table.QuerySelectorAll("tbody tr");
+            Assert.NotNull(section.Id);
+            var match = Sections.Single(s => section.Id.Contains(s.Id));
+            
+            var rows = section.QuerySelectorAll("tbody tr");
             Assert.Equal(plans.Length, rows.Length);
 
             foreach (var row in rows)
             {
                 var cells = row.TableCells();
-
-                var expected = plans.FirstOrDefault(g => g.Name == cells[0]);
-                Assert.NotNull(expected);
+                var expected = plans.Single(p => p.Name == cells[0]);
 
                 Assert.Equal(cells[0], expected.Name);
-                Assert.Equal(cells[1], extractor(expected).ToString());
-                Assert.Equal(cells[2], expected.TotalPupils.ToString());
+                Assert.Equal(cells[1], expected.TotalPupils.ToString());
+                var value = match.Select(expected);
+                Assert.Equal(cells[2], value?.ToString());
             }
         }
     }
@@ -353,19 +349,18 @@ public class WhenViewingEducationHealthCarePlans(SchoolBenchmarkingWebAppClient 
 
         return ids.Select(id => AllSubCategories.First(c => c.Id == id)).ToArray();
     }
-
-    private static readonly Dictionary<string, Func<EducationHealthCarePlans, decimal?>> HeadingToValue =
-        new()
-        {
-            ["Total pupils with EHC plans (per 1000 pupils)"] = p => p.Total,
-            ["EHC plans in Mainstream schools or academies (per 1000 pupils)"] = p => p.Mainstream,
-            ["EHC plans in Resourced provision or SEN units (per 1000 pupils)"] = p => p.Resourced,
-            ["EHC plans in Maintained special school or special academies (per 1000 pupils)"] = p => p.Special,
-            ["EHC plans in NMSS or independent schools (per 1000 pupils)"] = p => p.Independent,
-            ["EHC plans in Hospital schools or alternative provisions (per 1000 pupils)"] = p => p.Hospital,
-            ["EHC plans in Post 16 (per 1000 pupils)"] = p => p.Post16,
-            ["EHC plans in other types of provisions (per 1000 pupils)"] = p => p.Other
-        };
+    
+    private static readonly (string Id, Func<EducationHealthCarePlans, decimal?> Select)[] Sections =
+    [
+        ("cost-sub-category-total-ehc-plans", p => p.Total),
+        ("cost-sub-category-ehc-plans-supported-in-mainstream-schools-or-academies", p => p.Mainstream),
+        ("cost-sub-category-ehc-plans-supported-in-resourced-provision-or-sen-units", p => p.Resourced),
+        ("cost-sub-category-ehc-plans-supported-in-maintained-special-schools-or-special-academies", p => p.Special),
+        ("cost-sub-category-ehc-plans-supported-in-nmss-or-independent-schools", p => p.Independent),
+        ("cost-sub-category-ehc-plans-supported-in-hospital-schools-or-alternative-provisions", p => p.Hospital),
+        ("cost-sub-category-ehc-plans-supported-in-post-16", p => p.Post16),
+        ("cost-sub-category-ehc-plans-supported-in-other-settings", p => p.Other)
+    ];
 
     #endregion
 }

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingEducationHealthCarePlans.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingEducationHealthCarePlans.cs
@@ -286,7 +286,7 @@ public class WhenViewingEducationHealthCarePlans(SchoolBenchmarkingWebAppClient 
         {
             Assert.NotNull(section.Id);
             var match = Sections.Single(s => section.Id.Contains(s.Id));
-            
+
             var rows = section.QuerySelectorAll("tbody tr");
             Assert.Equal(plans.Length, rows.Length);
 
@@ -349,7 +349,7 @@ public class WhenViewingEducationHealthCarePlans(SchoolBenchmarkingWebAppClient 
 
         return ids.Select(id => AllSubCategories.First(c => c.Id == id)).ToArray();
     }
-    
+
     private static readonly (string Id, Func<EducationHealthCarePlans, decimal?> Select)[] Sections =
     [
         ("cost-sub-category-total-ehc-plans", p => p.Total),


### PR DESCRIPTION
## 🧾 Summary

[AB#299498](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/299498) [AB#311505](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/311505)

### ✨ Feature Details
**Functionality:**

Updates the heading and tables for the EHCP page to align with latest designs

<img width="899" height="1174" alt="image" src="https://github.com/user-attachments/assets/de164831-8c36-4d22-b00b-93259445aa58" />

**Implementation:**

Updates domain class `EducationHealthCarePlansCategories` to remove `GetTableHeading()` now table headings are generic and update the values for `GetHeading()` to match the latest version of the prototype. Within the partial view the table columns have been reordered as required and the table headings have been updated.

In addition the classes have been updated to align for both high needs spending and ehcp

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [x] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [x] Relevant documentation updated _(if applicable)_.
- [x] Screenshots or Demo included _(for UI/frontend changes)_.
