### PR TITLE
feat: adding charts to high needs spending benchmarking

### DIFF
--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsSpendingController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsSpendingController.cs
@@ -17,6 +17,7 @@ namespace Web.App.Controllers;
 public class LocalAuthorityHighNeedsSpendingController(
     ILogger<LocalAuthorityHighNeedsSpendingController> logger,
     ILocalAuthorityApi api,
+    IChartRenderingApi chartRenderingApi,
     ILocalAuthorityComparatorSetService comparatorSetService)
     : Controller
 {
@@ -46,14 +47,27 @@ public class LocalAuthorityHighNeedsSpendingController(
                 }.Concat(set).ToArray(),
                 resultAs,
                 type);
-
-
+                
                 var expenditures = await api
                     .QueryHighNeedsV2Async(query)
                     .GetResultOrThrow<HighNeedsSpending[]>();
 
                 var subCategories = new HighNeedsSpendingComparisonSubCategoriesViewModel(expenditures, selectedSubCategories, code);
 
+                var charts = await BuildCharts(code, subCategories, resultAs, type);
+
+                subCategories.Groups.ForEach(group =>
+                {
+                    group.Items.ForEach(item =>
+                    {
+                        var chart = charts.FirstOrDefault(c => c.Id != null && c.Id == item.Uuid);
+                        if (chart != null)
+                        {
+                            item.ChartSvg = chart.Html;
+                        }
+                    });
+                });
+                
                 var viewModel = new LocalAuthorityHighNeedsSpendingViewModel(la, set, subCategories)
                 {
                     SelectedSubCategories = selectedSubCategories,
@@ -99,4 +113,35 @@ public class LocalAuthorityHighNeedsSpendingController(
 
         return query;
     }
+    
+    private async Task<ChartResponse[]> BuildCharts(string code,
+        HighNeedsSpendingComparisonSubCategoriesViewModel subCategories,
+        HighNeedsDimensions.ResultAsOptions resultAs,
+        HighNeedsDimensions.SubmissionTypeOptions type)
+    {
+        var requests = subCategories
+            .Groups
+            .SelectMany(x => x.Items)
+            .Select(x => new HighNeedsSpendingHorizontalBarChartRequest(
+                x.Uuid!,
+                code,
+                x.Data!,
+                resultAs,
+                type));
+            
+        ChartResponse[] charts = [];
+        try
+        {
+            charts = await chartRenderingApi
+                .PostHorizontalBarCharts(new PostHorizontalBarChartsRequest<HighNeedsSpendingComparisonDatum>(requests))
+                .GetResultOrDefault<ChartResponse[]>() ?? [];
+        }
+        catch (Exception e)
+        {
+            logger.LogWarning(e, "Unable to load charts from API");
+        }
+
+        return charts;
+    }
+
 }

--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsSpendingController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsSpendingController.cs
@@ -47,7 +47,7 @@ public class LocalAuthorityHighNeedsSpendingController(
                 }.Concat(set).ToArray(),
                 resultAs,
                 type);
-                
+
                 var expenditures = await api
                     .QueryHighNeedsV2Async(query)
                     .GetResultOrThrow<HighNeedsSpending[]>();
@@ -67,7 +67,7 @@ public class LocalAuthorityHighNeedsSpendingController(
                         }
                     });
                 });
-                
+
                 var viewModel = new LocalAuthorityHighNeedsSpendingViewModel(la, set, subCategories)
                 {
                     SelectedSubCategories = selectedSubCategories,
@@ -113,7 +113,7 @@ public class LocalAuthorityHighNeedsSpendingController(
 
         return query;
     }
-    
+
     private async Task<ChartResponse[]> BuildCharts(string code,
         HighNeedsSpendingComparisonSubCategoriesViewModel subCategories,
         HighNeedsDimensions.ResultAsOptions resultAs,
@@ -128,7 +128,7 @@ public class LocalAuthorityHighNeedsSpendingController(
                 x.Data!,
                 resultAs,
                 type));
-            
+
         ChartResponse[] charts = [];
         try
         {

--- a/web/src/Web.App/Domain/Charts/HighNeedsSpendingHorizontalBarChartRequest.cs
+++ b/web/src/Web.App/Domain/Charts/HighNeedsSpendingHorizontalBarChartRequest.cs
@@ -1,0 +1,43 @@
+using Microsoft.Azure.Cosmos.Linq;
+using Web.App.Infrastructure.Apis;
+
+// ReSharper disable ClassNeverInstantiated.Global
+
+namespace Web.App.Domain.Charts;
+
+public record HighNeedsSpendingHorizontalBarChartRequest : PostHorizontalBarChartRequest<HighNeedsSpendingComparisonDatum>
+{
+    public HighNeedsSpendingHorizontalBarChartRequest(
+        string uuid,
+        string code,
+        HighNeedsSpendingComparisonDatum[] filteredData,
+        HighNeedsDimensions.ResultAsOptions resultAs,
+        HighNeedsDimensions.SubmissionTypeOptions type,
+        Func<string, string?>? linkFormatter = null)
+    {
+        BarHeight = 22;
+        Data = filteredData;
+        HighlightKey = code;
+        Id = uuid;
+        KeyField = nameof(HighNeedsSpendingComparisonDatum.Code).ToLower();
+        LabelField = "name";
+        LabelFormat = "%2$s";
+        LinkFormat = linkFormatter == null
+            ? string.Empty
+            : linkFormatter.Invoke("%1$s");
+        MissingDataLabel = "No data submitted";
+        Sort = "desc";
+        Width = 610;
+        ValueField = nameof(HighNeedsSpendingComparisonDatum.Expenditure).ToLower();
+        ValueType = Web.App.Domain.Charts.ValueType.Currency;
+        XAxisLabel = $"{type.GetSubmissionTypeDescription()} ({resultAs.GetResultAsDescription()})";
+    }
+}
+
+public class HighNeedsSpendingComparisonDatum
+{
+    public string? Code { get; init; }
+    public string? Name { get; init; }
+    public decimal? Expenditure { get; init; }
+    public decimal? TotalPupils { get; init; }
+}

--- a/web/src/Web.App/ViewModels/HighNeedsSpendingComparisonSubCategoriesViewModel.cs
+++ b/web/src/Web.App/ViewModels/HighNeedsSpendingComparisonSubCategoriesViewModel.cs
@@ -1,3 +1,4 @@
+using Web.App.Domain.Charts;
 using Web.App.Domain.LocalAuthorities;
 
 namespace Web.App.ViewModels;
@@ -70,12 +71,4 @@ public class HighNeedsSpendingComparisonGroup
         Items.Count(i => i.SubCategoryId.HasValue && selectedIds.Contains(i.SubCategoryId.Value));
     public IEnumerable<BenchmarkingViewModelCostSubCategory<HighNeedsSpendingComparisonDatum>> SelectedItems(HashSet<int> selectedIds) =>
         Items.Where(i => i.SubCategoryId.HasValue && selectedIds.Contains(i.SubCategoryId.Value));
-}
-
-public class HighNeedsSpendingComparisonDatum
-{
-    public string? Code { get; init; }
-    public string? Name { get; init; }
-    public decimal? Expenditure { get; init; }
-    public decimal? TotalPupils { get; init; }
 }

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
@@ -115,7 +115,7 @@
 
                         @if (Model.ViewAs == Views.ViewAsOptions.Chart)
                         {
-                            <p class="govuk-body">chart partial under construction</p>
+                            @await Html.PartialAsync("_HighNeedsSpendingChart", new LocalAuthorityHighNeedsSpendingDataViewModel(subCategory, Model.ResultAs, Model.Type, Model.Code!))
                         }
                         else
                         {

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_HighNeedsSpendingChart.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_HighNeedsSpendingChart.cshtml
@@ -1,0 +1,22 @@
+@model Web.App.ViewModels.LocalAuthorityHighNeedsSpendingDataViewModel
+
+@if (string.IsNullOrWhiteSpace(Model.SubCategory.ChartSvg))
+{
+    <div
+        class="govuk-warning-text govuk-!-margin-top-2 govuk-!-margin-bottom-2 ssr-chart-warning">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+            <span class="govuk-visually-hidden">Warning</span>
+            Unable to display chart
+        </strong>
+    </div>
+    return;
+}
+
+<div id="@Model.SubCategory.Uuid" class="costs-chart-container" data-title="@Model.SubCategory.SubCategory">
+    <div class="costs-chart-wrapper">
+        <div class="govuk-!-margin-bottom-2 ssr-chart horizontal-bar-chart">
+            @Html.Raw(Model.SubCategory.ChartSvg)
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## 🧾 Summary
> Briefly describe the changes and why they are needed.

Fixes [AB#295179](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/295179) [AB#308387](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/308387)

### ✨ Feature Details
> - **Functionality:** Adds charts to the High Needs Spending Benchmarking page, respecting the filters and page options selected
> - **Implementation:** Follows the pattern established for School IT Spending and LA EHCP charts. A collection of chart request object is built, one request for each chart selected inthe user filters, and a single API call made with the collection of requests.  Once obtained the controller stitches each chart into the corresponding subcategory in the main viewmodel.

<img width="768" height="754" alt="Screenshot 2026-05-07 at 12 05 24" src="https://github.com/user-attachments/assets/c6ca462b-b9b7-4801-b0cb-f13e6fd19ae7" />

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [x] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes
> Add any additional context for reviewers, required dependencies, or specific testing instructions.
