### PR TITLE
feat: add save chart images and download data to high needs spending

### DIFF
--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsSpendingController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsSpendingController.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
+using Web.App.ActionResults;
 using Web.App.Attributes;
 using Web.App.Domain.Charts;
 using Web.App.Domain.LocalAuthorities;
+using Web.App.Extensions;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Extensions;
 using Web.App.Services;
@@ -95,6 +97,53 @@ public class LocalAuthorityHighNeedsSpendingController(
         resultAs,
         type
     });
+
+    [HttpGet]
+    [Produces("application/zip")]
+    [ProducesResponseType<byte[]>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [Route("download")]
+    public async Task<IActionResult> Download(
+        string code,
+        HighNeedsDimensions.ResultAsOptions resultAs = HighNeedsDimensions.ResultAsOptions.PerPupil,
+        HighNeedsDimensions.SubmissionTypeOptions type = HighNeedsDimensions.SubmissionTypeOptions.Outturn)
+    {
+        using (logger.BeginScope(new
+        {
+            code
+        }))
+        {
+            try
+            {
+                var set = comparatorSetService.ReadUserDefinedComparatorSetFromSession(code).Set;
+                if (set.Length == 0)
+                {
+                    return RedirectToAction("Index", "LocalAuthorityComparators", new { code, type = LocalAuthorityBenchmarkType.EducationHealthCarePlans });
+                }
+
+                var query = BuildQuery(new[]
+                    {
+                        code
+                    }.Concat(set).ToArray(),
+                    resultAs,
+                    type);
+
+                var expenditures = await api
+                    .QueryHighNeedsV2Async(query)
+                    .GetResultOrThrow<HighNeedsSpending[]>();
+
+                var typeLabel = type.GetSubmissionTypeDescription().ToSlug();
+                var resultAsLabel = resultAs.GetResultAsDescription().TrimStart('£').ToSlug();
+
+                return new CsvResults([new CsvResult(expenditures, $"benchmark-high-needs-spending-{typeLabel}-{resultAsLabel}-{code}.csv")], $"benchmark-high-needs-spending-{typeLabel}-{resultAsLabel}-{code}.zip");
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "An error downloading high needs spending data: {DisplayUrl}", Request.GetDisplayUrl());
+                return StatusCode(500);
+            }
+        }
+    }
 
     private static ApiQuery BuildQuery(
         string[] codes,

--- a/web/src/Web.App/Domain/Charts/HighNeedsDimensions.cs
+++ b/web/src/Web.App/Domain/Charts/HighNeedsDimensions.cs
@@ -56,6 +56,13 @@ public static class HighNeedsDimensions
         _ => throw new ArgumentOutOfRangeException(nameof(option))
     };
 
+    public static string GetSubmissionTypeFileName(this SubmissionTypeOptions option) => option switch
+    {
+        SubmissionTypeOptions.Budget => "planned-expenditure",
+        SubmissionTypeOptions.Outturn => "outturn",
+        _ => throw new ArgumentOutOfRangeException(nameof(option))
+    };
+
     public static string GetResultAsDescription(this ResultAsOptions option) => option switch
     {
         ResultAsOptions.PerPupil => "£ per pupil",

--- a/web/src/Web.App/Domain/LocalAuthorities/HighNeedsSpending.cs
+++ b/web/src/Web.App/Domain/LocalAuthorities/HighNeedsSpending.cs
@@ -1,3 +1,4 @@
+// ReSharper disable ClassNeverInstantiated.Global
 namespace Web.App.Domain.LocalAuthorities;
 
 public record HighNeedsSpending
@@ -5,7 +6,6 @@ public record HighNeedsSpending
     public string? Code { get; set; }
     public string? Name { get; set; }
     public decimal? TotalPupils { get; set; }
-    public decimal? TotalHighNeeds { get; set; }
     public decimal? TotalPlaceFunding { get; set; }
     public decimal? TotalTopUpFundingMaintained { get; set; }
     public decimal? TotalTopUpFundingNonMaintained { get; set; }

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
@@ -49,7 +49,15 @@
                 {
                     <div id="page-actions-button"></div>
                 }
-                @*TODO: download data*@
+                <a href="@Url.Action("Download", "LocalAuthorityHighNeedsSpending", new
+                         {
+                             code = Model.Code,
+                             resultAs = Model.ResultAs,
+                             type = Model.Type
+                         })" role="button"
+                   class="govuk-button govuk-button--secondary" data-module="govuk-button">
+                    Download page data
+                </a>
             </div>
         </div>
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
@@ -1,6 +1,7 @@
 @using Web.App.Domain.Charts
 @using Web.App.Extensions
 @using Web.App.ViewModels
+@using Web.App.ViewModels.Enhancements
 @model Web.App.ViewModels.LocalAuthorityHighNeedsSpendingViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.LocalAuthorityHighNeedsSpending;
@@ -42,7 +43,15 @@
         @await Html.PartialAsync("_Filter", Model)
     </div>
     <div class="govuk-grid-column-two-thirds">
-        <p class="govuk-body">page actions under construction</p>
+        <div class="page-actions-wrapper-horizontal">
+            <div class="page-actions">
+                @if (Model.ViewAs == Views.ViewAsOptions.Chart)
+                {
+                    <div id="page-actions-button"></div>
+                }
+                @*TODO: download data*@
+            </div>
+        </div>
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
         @using (Html.BeginForm(FormMethod.Post, true, new
@@ -131,3 +140,17 @@
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
 @await Component.InvokeAsync("LocalAuthorityHighNeedsHelp")
+
+@section scripts
+{
+
+    @await Html.PartialAsync("Enhancements/_PageActions", new PageActionsViewModel
+    {
+        All = true,
+        ElementId = "page-actions-button",
+        SaveClassName = "costs-chart-container",
+        SaveFileName = $"benchmark-high-needs-spending-{Model.Code}.zip",
+        SaveTitleAttr = "data-title",
+        StartImmediately = true
+    })
+}

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -925,11 +925,13 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
 
     public BenchmarkingWebAppClient SetupLocalAuthorityEndpoints(
         Web.App.Domain.LocalAuthorities.LocalAuthority localAuthority,
-        EducationHealthCarePlans[]? educationHealthCarePlans = null)
+        EducationHealthCarePlans[]? educationHealthCarePlans = null,
+        HighNeedsSpending[]? highNeedsSpendings = null)
     {
         LocalAuthorityApi.Reset();
         LocalAuthorityApi.Setup(api => api.SingleAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(localAuthority));
         LocalAuthorityApi.Setup(api => api.QueryEhcpAsync(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(educationHealthCarePlans ?? []));
+        LocalAuthorityApi.Setup(api => api.QueryHighNeedsV2Async(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>())).ReturnsAsync(ApiResult.Ok(highNeedsSpendings ?? []));
         return this;
     }
 

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenRequestingHighNeedsSpendingDownload.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenRequestingHighNeedsSpendingDownload.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using AutoFixture;
+using Web.App.Domain;
+using Web.App.Domain.LocalAuthorities;
+using Xunit;
+
+namespace Web.Integration.Tests.Pages.LocalAuthorities;
+
+public class WhenRequestingHighNeedsSpendingDownload : PageBase<SchoolBenchmarkingWebAppClient>
+{
+    private readonly SchoolBenchmarkingWebAppClient _client;
+    private readonly HighNeedsSpending[] _expenditures;
+
+    public WhenRequestingHighNeedsSpendingDownload(SchoolBenchmarkingWebAppClient client) : base(client)
+    {
+        _client = client;
+        _expenditures = Fixture.Build<HighNeedsSpending>().CreateMany().ToArray();
+    }
+
+    [Fact]
+    public async Task CanReturnOk()
+    {
+        var authority = Fixture.Build<Web.App.Domain.LocalAuthorities.LocalAuthority>()
+            .With(x => x.Code, "123")
+            .Create();
+
+        var comparatorSet = Fixture.Build<SchoolComparatorSet>()
+            .With(c => c.Pupil, Fixture.CreateMany<string>().ToArray())
+            .Without(c => c.Building)
+            .Create();
+
+        Assert.NotNull(authority.Code);
+        var response = await _client
+                .SetupLocalAuthorityEndpoints(authority, highNeedsSpendings: _expenditures)
+                .SetupLocalAuthoritiesComparators(authority.Code, ["123", "124"])
+                .Get(Paths.LocalAuthorityHighNeedsSpendingDownload(authority.Code));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var expectedFileNames = new[]
+        {
+            "benchmark-high-needs-spending-outturn-per-pupil-123.csv"
+        };
+        await foreach (var tuple in response.GetFilesFromZip())
+        {
+            Assert.Contains(tuple.fileName, expectedFileNames);
+
+            var csvLines = tuple.content.Split(Environment.NewLine);
+            Assert.Equal(
+                "Code,Name,TotalPupils,TotalPlaceFunding,TotalTopUpFundingMaintained,TotalTopUpFundingNonMaintained,TotalSenServices,TotalAlternativeProvisionServices,TotalHospitalServices,TotalOtherHealthServices,TopFundingMaintainedEarlyYears,TopFundingMaintainedPrimary,TopFundingMaintainedSecondary,TopFundingMaintainedSpecial,TopFundingMaintainedAlternativeProvision,TopFundingMaintainedPostSchool,TopFundingMaintainedIncome,TopFundingNonMaintainedEarlyYears,TopFundingNonMaintainedPrimary,TopFundingNonMaintainedSecondary,TopFundingNonMaintainedSpecial,TopFundingNonMaintainedAlternativeProvision,TopFundingNonMaintainedPostSchool,TopFundingNonMaintainedIncome,PlaceFundingPrimary,PlaceFundingSecondary,PlaceFundingSpecial,PlaceFundingAlternativeProvision,SenTransportDsg,HometoSchoolTransportPre16,HometoSchoolTransport1618,HometoSchoolTransport1925,EdPsychologyService,SenAdmin",
+                csvLines.First());
+            Assert.Equal(_expenditures.Length, csvLines.Length - 1);
+        }
+    }
+
+    [Fact]
+    public async Task CanReturnInternalServerError()
+    {
+        const string code = "123";
+        var response = await _client
+            .SetupEstablishmentWithException()
+            .Get(Paths.LocalAuthorityHighNeedsSpendingDownload(code));
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+}

--- a/web/tests/Web.Integration.Tests/Paths.cs
+++ b/web/tests/Web.Integration.Tests/Paths.cs
@@ -294,6 +294,7 @@ public static class Paths
     public static string LocalAuthorityHighNeedsBenchmarking(string? code) => $"/local-authority/{code}/high-needs/benchmarking";
     public static string LocalAuthorityEducationHealthCarePlans(string? code) => $"/local-authority/{code}/education-health-care-plans";
     public static string LocalAuthorityEducationHealthCarePlansDownload(string? code) => $"/local-authority/{code}/education-health-care-plans/download";
+    public static string LocalAuthorityHighNeedsSpendingDownload(string? code) => $"/local-authority/{code}/high-needs-spending/download";
     public static string LocalAuthorityHighNeedsStartBenchmarking(string? code, LocalAuthorityBenchmarkType type, string? referrer = null) => string.IsNullOrWhiteSpace(referrer)
             ? $"/local-authority/{code}/comparators?type={type}"
             : $"/local-authority/{code}/comparators?type={type}&referrer={referrer}";


### PR DESCRIPTION
## 🧾 Summary

[AB#295179](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/295179) [AB#308388](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/308388)

### ✨ Feature Details
**Functionality:**

This PR updates the high needs spending page to allow users to download charts as images and download the page data based on the current selection for submission type (budget or outturn) and compare by options.

**Implementation:**

Following the patterns for ehcp save images functionality is added to the page as a progressive enhancement when javascript is available. 

Because this page has no sensible default (e.g., “actuals”), the download functionality now bases its export on the current selection for submission type and compare by options. This keeps the downloaded data aligned with what the user is actually looking at.

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [x] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.

## 🔍 Notes

The approach for download data has been discussed and agree with design as detailed in the parent work item
