### PR TITLE
feat: add data sources to high needs spending benchmarking

### DIFF
--- a/web/src/Web.App/Controllers/LocalAuthorityHighNeedsSpendingController.cs
+++ b/web/src/Web.App/Controllers/LocalAuthorityHighNeedsSpendingController.cs
@@ -20,7 +20,8 @@ public class LocalAuthorityHighNeedsSpendingController(
     ILogger<LocalAuthorityHighNeedsSpendingController> logger,
     ILocalAuthorityApi api,
     IChartRenderingApi chartRenderingApi,
-    ILocalAuthorityComparatorSetService comparatorSetService)
+    ILocalAuthorityComparatorSetService comparatorSetService,
+    IFinanceService financeService)
     : Controller
 {
     [HttpGet]
@@ -58,6 +59,8 @@ public class LocalAuthorityHighNeedsSpendingController(
 
                 var charts = await BuildCharts(code, subCategories, resultAs, type);
 
+                var years = await financeService.GetYears();
+
                 subCategories.Groups.ForEach(group =>
                 {
                     group.Items.ForEach(item =>
@@ -75,7 +78,8 @@ public class LocalAuthorityHighNeedsSpendingController(
                     SelectedSubCategories = selectedSubCategories,
                     ViewAs = viewAs,
                     ResultAs = resultAs,
-                    Type = type
+                    Type = type,
+                    Year = years.S251
                 };
 
                 return View(viewModel);

--- a/web/src/Web.App/Domain/LocalAuthorities/HighNeedsSpendingCategories.cs
+++ b/web/src/Web.App/Domain/LocalAuthorities/HighNeedsSpendingCategories.cs
@@ -255,4 +255,58 @@ public static class HighNeedsSpendingCategories
             SubCategoryFilter.SenAdmin => s.SenAdmin,
             _ => null
         };
+
+    public static string[] GetLineCodes(this SubCategoryFilter filter) => filter switch
+    {
+        SubCategoryFilter.TotalPlaceFunding => ["1.0.2"],
+        SubCategoryFilter.TotalTopUpFundingMaintained => ["1.2.1", "1.2.2", "1.2.4", "1.2.11"],
+        SubCategoryFilter.TotalTopUpFundingNonMaintained => ["1.2.3"],
+        SubCategoryFilter.TotalSenServices => ["1.2.5", "1.2.8", "1.2.9"],
+        SubCategoryFilter.TotalAlternativeProvisionServices => ["1.2.7"],
+        SubCategoryFilter.TotalHospitalServices => ["1.2.6"],
+        SubCategoryFilter.TotalOtherHealthServices => ["1.2.13"],
+        SubCategoryFilter.PlaceFundingPrimary => ["1.0.2"],
+        SubCategoryFilter.PlaceFundingSecondary => ["1.0.2"],
+        SubCategoryFilter.PlaceFundingSpecial => ["1.0.2"],
+        SubCategoryFilter.PlaceFundingAlternativeProvision => ["1.0.2"],
+        SubCategoryFilter.TopFundingMaintainedEarlyYears => ["1.2.1", "1.2.2", "1.2.4", "1.2.11"],
+        SubCategoryFilter.TopFundingMaintainedPrimary => ["1.2.1", "1.2.2", "1.2.4", "1.2.11"],
+        SubCategoryFilter.TopFundingMaintainedSecondary => ["1.2.1", "1.2.2", "1.2.4", "1.2.11"],
+        SubCategoryFilter.TopFundingMaintainedSpecial => ["1.2.1", "1.2.2", "1.2.4", "1.2.11"],
+        SubCategoryFilter.TopFundingMaintainedAlternativeProvision => ["1.2.1", "1.2.2", "1.2.4", "1.2.11"],
+        SubCategoryFilter.TopFundingMaintainedPostSchool => ["1.2.1", "1.2.2", "1.2.4", "1.2.11"],
+        SubCategoryFilter.TopFundingMaintainedIncome => ["1.2.1", "1.2.2", "1.2.4", "1.2.11"],
+        SubCategoryFilter.TopFundingNonMaintainedEarlyYears => ["1.2.3"],
+        SubCategoryFilter.TopFundingNonMaintainedPrimary => ["1.2.3"],
+        SubCategoryFilter.TopFundingNonMaintainedSecondary => ["1.2.3"],
+        SubCategoryFilter.TopFundingNonMaintainedSpecial => ["1.2.3"],
+        SubCategoryFilter.TopFundingNonMaintainedAlternativeProvision => ["1.2.3"],
+        SubCategoryFilter.TopFundingNonMaintainedPostSchool => ["1.2.3"],
+        SubCategoryFilter.TopFundingNonMaintainedIncome => ["1.2.3"],
+        SubCategoryFilter.HometoSchoolTransportPre16 => ["2.1.4"],
+        SubCategoryFilter.HometoSchoolTransport1618 => ["2.1.6"],
+        SubCategoryFilter.HometoSchoolTransport1925 => ["2.1.7"],
+        SubCategoryFilter.SenTransportDsg => ["1.4.11"],
+        SubCategoryFilter.EdPsychologyService => ["2.1.1"],
+        SubCategoryFilter.SenAdmin => ["2.1.2"],
+        _ => []
+    };
+
+    public static HighNeedsSpendingDataSourceInfoType GetAdditionalInfo(this SubCategoryFilter filter) => filter switch
+    {
+        SubCategoryFilter.TotalPlaceFunding => HighNeedsSpendingDataSourceInfoType.Glossary,
+        SubCategoryFilter.TotalHospitalServices => HighNeedsSpendingDataSourceInfoType.Hospital,
+        SubCategoryFilter.PlaceFundingPrimary => HighNeedsSpendingDataSourceInfoType.Glossary,
+        SubCategoryFilter.PlaceFundingSecondary => HighNeedsSpendingDataSourceInfoType.Glossary,
+        SubCategoryFilter.PlaceFundingSpecial => HighNeedsSpendingDataSourceInfoType.Glossary,
+        SubCategoryFilter.PlaceFundingAlternativeProvision => HighNeedsSpendingDataSourceInfoType.Glossary,
+        _ => HighNeedsSpendingDataSourceInfoType.None
+    };
+
+    public enum HighNeedsSpendingDataSourceInfoType
+    {
+        Glossary,
+        Hospital,
+        None
+    }
 }

--- a/web/src/Web.App/ViewModels/BenchmarkingViewModelCostSubCategory.cs
+++ b/web/src/Web.App/ViewModels/BenchmarkingViewModelCostSubCategory.cs
@@ -1,3 +1,5 @@
+using Web.App.Domain.LocalAuthorities;
+
 namespace Web.App.ViewModels;
 
 public class BenchmarkingViewModelCostSubCategory<T>
@@ -6,5 +8,7 @@ public class BenchmarkingViewModelCostSubCategory<T>
     public string? SubCategory { get; init; }
     public int? SubCategoryId { get; init; }
     public string? ChartSvg { get; set; }
+    public string[]? LineCodes { get; init; }
+    public HighNeedsSpendingCategories.HighNeedsSpendingDataSourceInfoType AdditionalInfo { get; init; }
     public T[]? Data { get; init; }
 }

--- a/web/src/Web.App/ViewModels/HighNeedsSpendingComparisonSubCategoriesViewModel.cs
+++ b/web/src/Web.App/ViewModels/HighNeedsSpendingComparisonSubCategoriesViewModel.cs
@@ -58,6 +58,8 @@ public class HighNeedsSpendingComparisonSubCategoriesViewModel
             Uuid = Guid.NewGuid().ToString(),
             SubCategory = filter.GetHeading(),
             SubCategoryId = (int)filter,
+            LineCodes = filter.GetLineCodes(),
+            AdditionalInfo = filter.GetAdditionalInfo(),
             Data = data
         };
     }

--- a/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsSpendingViewModel.cs
+++ b/web/src/Web.App/ViewModels/LocalAuthorityHighNeedsSpendingViewModel.cs
@@ -34,16 +34,19 @@ public class LocalAuthorityHighNeedsSpendingViewModel(
     public HighNeedsDimensions.ResultAsOptions ResultAs { get; init; } = HighNeedsDimensions.ResultAsOptions.PerPupil;
 
     public HighNeedsDimensions.SubmissionTypeOptions Type { get; init; } = HighNeedsDimensions.SubmissionTypeOptions.Outturn;
+    public int? Year { get; init; }
 }
 
 public class LocalAuthorityHighNeedsSpendingDataViewModel(
     BenchmarkingViewModelCostSubCategory<HighNeedsSpendingComparisonDatum> subCategory,
     HighNeedsDimensions.ResultAsOptions resultAs,
     HighNeedsDimensions.SubmissionTypeOptions type,
-    string code)
+    string code,
+    int? year = null)
 {
     public BenchmarkingViewModelCostSubCategory<HighNeedsSpendingComparisonDatum> SubCategory => subCategory;
     public HighNeedsDimensions.ResultAsOptions ResultAs => resultAs;
     public HighNeedsDimensions.SubmissionTypeOptions Type => type;
     public string Code => code;
+    public int? Year => year;
 }

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
@@ -138,6 +138,8 @@
                         {
                             @await Html.PartialAsync("_HighNeedsSpendingTable", new LocalAuthorityHighNeedsSpendingDataViewModel(subCategory, Model.ResultAs, Model.Type, Model.Code!))
                         }
+                        
+                        @await Html.PartialAsync("_HighNeedsSpendingDataSources", new LocalAuthorityHighNeedsSpendingDataViewModel(subCategory, Model.ResultAs, Model.Type, Model.Code!, Model.Year))
                     </section>
                 }
             </section>

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
@@ -132,7 +132,7 @@
 
                         @if (Model.ViewAs == Views.ViewAsOptions.Chart)
                         {
-                            @await Html.PartialAsync("_HighNeedsSpendingChart", new LocalAuthorityHighNeedsSpendingDataViewModel(subCategory, Model.ResultAs, Model.Type, Model.Code!))
+                            @await Html.PartialAsync("_HighNeedsSpendingChart", new LocalAuthorityHighNeedsSpendingDataViewModel(subCategory, Model.ResultAs, Model.Type, Model.Code!, Model.Year))
                         }
                         else
                         {

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
@@ -136,10 +136,8 @@
                         }
                         else
                         {
-                            @await Html.PartialAsync("_HighNeedsSpendingTable", new LocalAuthorityHighNeedsSpendingDataViewModel(subCategory, Model.ResultAs, Model.Type, Model.Code!))
+                            @await Html.PartialAsync("_HighNeedsSpendingTable", new LocalAuthorityHighNeedsSpendingDataViewModel(subCategory, Model.ResultAs, Model.Type, Model.Code!, Model.Year))
                         }
-                        
-                        @await Html.PartialAsync("_HighNeedsSpendingDataSources", new LocalAuthorityHighNeedsSpendingDataViewModel(subCategory, Model.ResultAs, Model.Type, Model.Code!, Model.Year))
                     </section>
                 }
             </section>

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_HighNeedsSpendingChart.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_HighNeedsSpendingChart.cshtml
@@ -1,3 +1,5 @@
+@using Web.App.Domain.LocalAuthorities
+
 @model Web.App.ViewModels.LocalAuthorityHighNeedsSpendingDataViewModel
 
 @if (string.IsNullOrWhiteSpace(Model.SubCategory.ChartSvg))
@@ -19,4 +21,37 @@
             @Html.Raw(Model.SubCategory.ChartSvg)
         </div>
     </div>
+</div>
+
+<div class="govuk-!-margin-bottom-7 app-source-info">
+    @if (Model.SubCategory.AdditionalInfo == HighNeedsSpendingCategories.HighNeedsSpendingDataSourceInfoType.None)
+    {
+        <p class="govuk-body-s govuk-!-margin-bottom-1">
+            Source: @await Html.PartialAsync("_HighNeedsSpendingLineCodes", Model) 
+        </p>
+    }
+    else
+    {
+        <p class="govuk-body-s govuk-!-margin-bottom-1">Sources:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li class="govuk-body-s">
+                @await Html.PartialAsync("_HighNeedsSpendingLineCodes", Model)
+            </li>
+            <li class="govuk-body-s">
+                @if (Model.SubCategory.AdditionalInfo == HighNeedsSpendingCategories.HighNeedsSpendingDataSourceInfoType.Glossary)
+                {
+                    <text>
+                        Place funding for academies. You can read about how we calculate this in the
+                        <a href="/guidance/high-needs-glossary" class="govuk-link govuk-link--no-visited-state">
+                            glossary
+                        </a>
+                    </text>
+                }
+                else if (Model.SubCategory.AdditionalInfo == HighNeedsSpendingCategories.HighNeedsSpendingDataSourceInfoType.Hospital)
+                {
+                    <text>Dedicated Schools Grant (@(Model.Year - 1)/@(Model.Year)): total hospital education deductions</text>
+                }
+            </li>
+        </ul>
+    }
 </div>

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_HighNeedsSpendingChart.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_HighNeedsSpendingChart.cshtml
@@ -22,36 +22,3 @@
         </div>
     </div>
 </div>
-
-<div class="govuk-!-margin-bottom-7 app-source-info">
-    @if (Model.SubCategory.AdditionalInfo == HighNeedsSpendingCategories.HighNeedsSpendingDataSourceInfoType.None)
-    {
-        <p class="govuk-body-s govuk-!-margin-bottom-1">
-            Source: @await Html.PartialAsync("_HighNeedsSpendingLineCodes", Model) 
-        </p>
-    }
-    else
-    {
-        <p class="govuk-body-s govuk-!-margin-bottom-1">Sources:</p>
-        <ul class="govuk-list govuk-list--bullet">
-            <li class="govuk-body-s">
-                @await Html.PartialAsync("_HighNeedsSpendingLineCodes", Model)
-            </li>
-            <li class="govuk-body-s">
-                @if (Model.SubCategory.AdditionalInfo == HighNeedsSpendingCategories.HighNeedsSpendingDataSourceInfoType.Glossary)
-                {
-                    <text>
-                        Place funding for academies. You can read about how we calculate this in the
-                        <a href="/guidance/high-needs-glossary" class="govuk-link govuk-link--no-visited-state">
-                            glossary
-                        </a>
-                    </text>
-                }
-                else if (Model.SubCategory.AdditionalInfo == HighNeedsSpendingCategories.HighNeedsSpendingDataSourceInfoType.Hospital)
-                {
-                    <text>Dedicated Schools Grant (@(Model.Year - 1)/@(Model.Year)): total hospital education deductions</text>
-                }
-            </li>
-        </ul>
-    }
-</div>

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_HighNeedsSpendingChart.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_HighNeedsSpendingChart.cshtml
@@ -21,4 +21,6 @@
             @Html.Raw(Model.SubCategory.ChartSvg)
         </div>
     </div>
+    
+    @await Html.PartialAsync("_HighNeedsSpendingDataSources", Model)
 </div>

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_HighNeedsSpendingDataSources.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_HighNeedsSpendingDataSources.cshtml
@@ -1,0 +1,36 @@
+@using Web.App.Domain.LocalAuthorities
+
+@model Web.App.ViewModels.LocalAuthorityHighNeedsSpendingDataViewModel
+
+<div class="govuk-!-margin-bottom-7 app-source-info">
+    @if (Model.SubCategory.AdditionalInfo == HighNeedsSpendingCategories.HighNeedsSpendingDataSourceInfoType.None)
+    {
+    <p class="govuk-body-s govuk-!-margin-bottom-1">
+        Source: @await Html.PartialAsync("_HighNeedsSpendingLineCodes", Model)
+    </p>
+    }
+    else
+    {
+    <p class="govuk-body-s govuk-!-margin-bottom-1">Sources:</p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li class="govuk-body-s">
+            @await Html.PartialAsync("_HighNeedsSpendingLineCodes", Model)
+        </li>
+        <li class="govuk-body-s">
+            @if (Model.SubCategory.AdditionalInfo == HighNeedsSpendingCategories.HighNeedsSpendingDataSourceInfoType.Glossary)
+            {
+            <text>
+            Place funding for academies. You can read about how we calculate this in the
+            <a href="/guidance/high-needs-glossary" class="govuk-link govuk-link--no-visited-state">
+                glossary
+            </a>
+            </text>
+            }
+            else if (Model.SubCategory.AdditionalInfo == HighNeedsSpendingCategories.HighNeedsSpendingDataSourceInfoType.Hospital)
+            {
+            <text>Dedicated Schools Grant (@(Model.Year - 1)/@(Model.Year)): total hospital education deductions</text>
+            }
+        </li>
+    </ul>
+    }
+</div>

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_HighNeedsSpendingLineCodes.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_HighNeedsSpendingLineCodes.cshtml
@@ -1,0 +1,19 @@
+@model Web.App.ViewModels.LocalAuthorityHighNeedsSpendingDataViewModel
+
+Section 251 (@(Model.Year - 1)/@(Model.Year)),
+@if (Model.SubCategory.LineCodes!.Length > 1)
+{
+    <text>lines</text>
+}
+else
+{ 
+    <text>line</text>
+}
+@foreach (var (i, code) in Model.SubCategory.LineCodes.Select((code, i) => (i, code)))
+{
+    <text> @(code)</text>
+    if (i + 1 < Model.SubCategory.LineCodes.Length)
+    {
+        <text>,</text>
+    }
+}

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_HighNeedsSpendingTable.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/_HighNeedsSpendingTable.cshtml
@@ -34,4 +34,6 @@
         }
         </tbody>
     </table>
+    
+    @await Html.PartialAsync("_HighNeedsSpendingDataSources", Model)
 </div>


### PR DESCRIPTION
## 🧾 Summary
> Briefly describe the changes and why they are needed.

Fixes [AB#295179](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/295179) [AB#311590](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/311590)

### ✨ Feature Details
> - **Functionality:** Adds data source information to the High Needs Spending benchmarking page, under each chart/table
> - **Implementation:**
>   - Extends the chart information in the domain so that the categories contain data source info
>     - I did consider storing the different line codes as arrays of enums rather than arrays of strings, but decided that might be over engineering
>   - Extends the `BenchmarkingViewModelCostSubCategory` class to make each category's data source details available to the views
>   - Uses a new partial to display the data source information under each chart/table

<img width="838" height="455" alt="Screenshot 2026-05-08 at 15 36 16" src="https://github.com/user-attachments/assets/48cf7ada-eb19-4256-8909-71d1bb87e6a0" />

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [x] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes
> Add any additional context for reviewers, required dependencies, or specific testing instructions.

Because the S251 year needs to be displayed in the data source block I made a specific decision here to add the `IFinanceService` into the high needs controller via dependency injection to obtain the year info.  That service does already get used in the page, in the `DataSourceViewComponent` which does mean that this page is calling `IFinanceService.GetYears()` twice. The alternative was to refactor that view component so that the year information is passed in, rather than have it fetch it itself, but that would have entailed modifying all pages that use the component.