### PR TITLE
chore: enable HighNeedsBenchmarking feature flag in lower environments

### DIFF
--- a/web/terraform/variables.tf
+++ b/web/terraform/variables.tf
@@ -53,7 +53,8 @@ variable "configuration" {
       front_door_waf_policy_sku_name = "Standard_AzureFrontDoor"
       waf_mode                       = "Detection"
       features = {
-        News = true
+        News                  = true,
+        HighNeedsBenchmarking = true
       },
       CacheOptions = {
         ReturnYears = {
@@ -79,7 +80,8 @@ variable "configuration" {
       front_door_waf_policy_sku_name = "Standard_AzureFrontDoor"
       waf_mode                       = "Detection"
       features = {
-        News = true
+        News                  = true,
+        HighNeedsBenchmarking = true
       },
       CacheOptions = {
         ReturnYears = {
@@ -104,7 +106,8 @@ variable "configuration" {
       front_door_waf_policy_sku_name = "Standard_AzureFrontDoor"
       waf_mode                       = "Prevention"
       features = {
-        News = true
+        News                  = true,
+        HighNeedsBenchmarking = true
       },
       CacheOptions = {
         ReturnYears = {
@@ -130,7 +133,8 @@ variable "configuration" {
       front_door_waf_policy_sku_name = "Standard_AzureFrontDoor"
       waf_mode                       = "Detection"
       features = {
-        News = true
+        News                  = true,
+        HighNeedsBenchmarking = true
       },
       CacheOptions = {
         ReturnYears = {


### PR DESCRIPTION
## 🧾 Summary

[AB#295179](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/295179) 
[AB#312103](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/312103)

### ✨ Feature Details
**Functionality:**
Enable the feature flag for `HighNeedsBenchmarking` in all lower environments. Note Pre-Production and Production remain `false`
**Implementation:**
Terraform updated

## ✅ Checklist
- [ ] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [ ] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.
