### PR TITLE
feat: Guard local development of the data pipeline from secret leakage through LLMs

### DIFF
--- a/data-pipeline/.env-example
+++ b/data-pipeline/.env-example
@@ -1,5 +1,0 @@
-DATABASE_CONNECTION_STRING={platform database connection string}
-STORAGE_CONNECTION_STRING={azure storage account connection string}
-WORKER_QUEUE_NAME={the name of the worker queue}
-COMPLETE_QUEUE_NAME={the name of the complete queue}
-RAW_DATA_CONTAINER={the name of the raw data container}

--- a/data-pipeline/.envrc
+++ b/data-pipeline/.envrc
@@ -1,5 +1,6 @@
 export ENV="dev"
 export RAW_DATA_CONTAINER="raw"
+export DB_PORT="1433"
 export DB_ARGS="Encrypt=no;TrustServerCertificate=no;Connection Timeout=30"
 
 # Secrets are held outside the repository

--- a/data-pipeline/.envrc
+++ b/data-pipeline/.envrc
@@ -1,0 +1,17 @@
+export ENV="dev"
+export RAW_DATA_CONTAINER="raw"
+export DB_ARGS="Encrypt=no;TrustServerCertificate=no;Connection Timeout=30"
+
+# Secrets are held outside the repository
+if [ -f "$HOME/.config/fbit/data-pipeline.secrets.env" ]; then
+  source "$HOME/.config/fbit/data-pipeline.secrets.env"
+fi
+
+# For convenience, check for required secrets
+required_vars=(STORAGE_CONNECTION_STRING DB_HOST DB_NAME DB_USER DB_PWD)
+for v in "${required_vars[@]}"; do
+  if [ -z "${!v:-}" ]; then
+    echo "direnv: missing required env var: $v" >&2
+    exit 1
+  fi
+done

--- a/data-pipeline/README.md
+++ b/data-pipeline/README.md
@@ -91,7 +91,7 @@ For local development secret variables like API credentials and DB access keys a
 
 1. Ensure `direnv` is installed and [hooked into your shell](https://direnv.net/docs/hook.html).
 
-```bash
+```zsh
 brew install direnv
 echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc
 ```

--- a/data-pipeline/README.md
+++ b/data-pipeline/README.md
@@ -92,17 +92,16 @@ For local development secret variables like API credentials and DB access keys a
 1. Ensure `direnv` is installed and [hooked into your shell](https://direnv.net/docs/hook.html).
 1. Create a local-only secrets file outside this repository, for example:
 
-```zsh
+```bash
 touch ~/.config/fbit/data-pipeline.secrets.env
 ```
 
 1. Load secrets to this file with local values to start:
 
-```zsh
+```bash
 cat > ~/.config/fbit/data-pipeline.secrets.env <<'EOF'
 export STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=...;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;SkipApiVersionCheck=True"
 export DB_NAME="data"
-export DB_PORT="1433"
 export DB_HOST="127.0.0.1"
 export DB_USER="sa"
 export DB_PWD='mystrong!Pa55word'

--- a/data-pipeline/README.md
+++ b/data-pipeline/README.md
@@ -93,6 +93,7 @@ For local development secret variables like API credentials and DB access keys a
 
 ```bash
 brew install direnv
+echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc
 ```
 
 ```powershell

--- a/data-pipeline/README.md
+++ b/data-pipeline/README.md
@@ -90,6 +90,15 @@ The data pipeline uses environment variables from your shell.
 For local development secret variables like API credentials and DB access keys are stored outside of the repository structure to prevent secret leakage by use of LLM coding tools.
 
 1. Ensure `direnv` is installed and [hooked into your shell](https://direnv.net/docs/hook.html).
+
+```bash
+brew install direnv
+```
+
+```powershell
+winget install -e --id direnv.direnv
+```
+
 1. Create a local-only secrets file outside this repository, for example:
 
 ```bash

--- a/data-pipeline/README.md
+++ b/data-pipeline/README.md
@@ -84,6 +84,40 @@ These steps will avoid SSL errors due to DfE kit/VPN.
 
     * `poetry install`
 
+### Local environment variables with direnv
+
+The data pipeline uses environment variables from your shell.  
+For local development secret variables like API credentials and DB access keys are stored outside of the repository structure to prevent secret leakage by use of LLM coding tools.
+
+1. Ensure `direnv` is installed and [hooked into your shell](https://direnv.net/docs/hook.html).
+1. Create a local-only secrets file outside this repository, for example:
+
+```zsh
+touch ~/.config/fbit/data-pipeline.secrets.env
+```
+
+1. Load secrets to this file with local values to start:
+
+```zsh
+cat > ~/.config/fbit/data-pipeline.secrets.env <<'EOF'
+export STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=...;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;SkipApiVersionCheck=True"
+export DB_NAME="data"
+export DB_PORT="1433"
+export DB_HOST="127.0.0.1"
+export DB_USER="sa"
+export DB_PWD='mystrong!Pa55word'
+EOF
+chmod 600 ~/.config/fbit/data-pipeline.secrets.env
+```
+
+1. From the `data-pipeline` directory, run:
+
+```direnv allow```
+
+1. You should see that direnv has loaded all the environment variables
+
+```> direnv: export +DB_ARGS +DB_HOST +DB_NAME +DB_PORT +DB_PWD +DB_USER +ENV +RAW_DATA_CONTAINER +STORAGE_CONNECTION_STRING```
+
 ### Running the pipeline
 
 To run the pipeline locally, follow these steps:


### PR DESCRIPTION
## 🧾 Summary
Move secret variables out of the repository filesystem to prevent secret leakage though use LLM coding tools. The assumption here is that LLM coding tools are generally restricted to the repository they are working on.

### ✨ Feature Details
> - **Functionality:** This change uses the command line tool `direnv`, which automatically loads environment variables for a directory when that directory is navigated to. Since the loading of the variables is done via a `.envrc` script instead of a `.env` file, this allows for storing secrets in a location external to the repository.
> - **Implementation:** As per direnv docs!

### 📚 Documentation Updates
> - **Changes:** detail `direnv` setup in data-pipeline prerequisites.

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [x] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes
> While this increases the difficulty of LLMs reading your passwords directly from `.env`, many LLMs have access to `stout`. Bear this in mind when printing credentials to the command line as part of a program or debugging, to prevent secret leakage!
