### PR TITLE
fix: update supporting text and sub category headings for high needs spending

### DIFF
--- a/web/src/Web.App/Domain/LocalAuthorities/HighNeedsSpendingCategories.cs
+++ b/web/src/Web.App/Domain/LocalAuthorities/HighNeedsSpendingCategories.cs
@@ -199,7 +199,7 @@ public static class HighNeedsSpendingCategories
         SubCategoryFilter.TotalAlternativeProvisionServices => "Alternative provision services",
         SubCategoryFilter.TotalHospitalServices => "Hospital education services",
         SubCategoryFilter.TotalOtherHealthServices => "Therapies and other health related services",
-        SubCategoryFilter.PlaceFundingPrimary => "Place funding",
+        SubCategoryFilter.PlaceFundingPrimary => "Primary place funding",
         SubCategoryFilter.PlaceFundingSecondary => "Secondary place funding",
         SubCategoryFilter.PlaceFundingSpecial => "Special place funding",
         SubCategoryFilter.PlaceFundingAlternativeProvision => "PRU and alternative provision place funding",

--- a/web/src/Web.App/Domain/LocalAuthorities/HighNeedsSpendingCategories.cs
+++ b/web/src/Web.App/Domain/LocalAuthorities/HighNeedsSpendingCategories.cs
@@ -147,6 +147,13 @@ public static class HighNeedsSpendingCategories
         _ => ""
     };
 
+    public static string? GetCategoryGroupAdditionalText(this CategoryGroup group) => group switch
+    {
+        CategoryGroup.TopUpFundingMaintained => "Maintained schools, academies, free schools and colleges. This section is split by phase (for mainstream) and type of institution (for specialist provision).",
+        CategoryGroup.TopUpFundingNonMaintained => "Non-maintained schools and independent schools and colleges. This section is split by phase (for mainstream) and type of institution (for specialist provision).",
+        _ => null
+    };
+
     public static string GetSubCategoryFilterDescription(this SubCategoryFilter filter) => filter switch
     {
         SubCategoryFilter.TotalPlaceFunding => "Total place funding for special schools and AP/PRUs",

--- a/web/src/Web.App/ViewModels/HighNeedsSpendingComparisonSubCategoriesViewModel.cs
+++ b/web/src/Web.App/ViewModels/HighNeedsSpendingComparisonSubCategoriesViewModel.cs
@@ -23,6 +23,7 @@ public class HighNeedsSpendingComparisonSubCategoriesViewModel
             var groupVm = new HighNeedsSpendingComparisonGroup
             {
                 Group = group.GetCategoryGroupDescription(),
+                AdditionalText = group.GetCategoryGroupAdditionalText(),
                 Items = []
             };
 
@@ -68,6 +69,7 @@ public class HighNeedsSpendingComparisonSubCategoriesViewModel
 public class HighNeedsSpendingComparisonGroup
 {
     public string Group { get; init; } = "";
+    public string? AdditionalText { get; set; }
     public List<BenchmarkingViewModelCostSubCategory<HighNeedsSpendingComparisonDatum>> Items { get; init; } = [];
     public int SelectedCount(HashSet<int> selectedIds) =>
         Items.Count(i => i.SubCategoryId.HasValue && selectedIds.Contains(i.SubCategoryId.Value));

--- a/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
+++ b/web/src/Web.App/Views/LocalAuthorityHighNeedsSpending/Index.cshtml
@@ -122,6 +122,10 @@
         {
             <section id="highneeds-subcategory-@group.Group.ToSlug()">
                 <h2 class="govuk-heading-m">@group.Group</h2>
+                @if (group.AdditionalText != null)
+                {
+                    <p class="govuk-body">@group.AdditionalText</p>
+                }
 
                 @foreach (var subCategory in group.Items)
                 {

--- a/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsSpending.cs
+++ b/web/tests/Web.Integration.Tests/Pages/LocalAuthorities/WhenViewingHighNeedsSpending.cs
@@ -240,7 +240,7 @@ public class WhenViewingHighNeedsSpending(SchoolBenchmarkingWebAppClient client)
         var filterSection = page.QuerySelector(".app-filter");
         Assert.NotNull(filterSection);
 
-        AssertFilterSection(filterSection, viewAs, expectedSubCategories);
+        AssertFilterSection(filterSection, expectedSubCategories);
 
         if (viewAs == 0)
         {
@@ -298,7 +298,6 @@ public class WhenViewingHighNeedsSpending(SchoolBenchmarkingWebAppClient client)
 
     private static void AssertFilterSection(
         IElement filterSection,
-        int viewAs,
         SubCategoryId[] expectedSubCategories)
     {
         var applyFiltersButton = filterSection.QuerySelectorAll("button")
@@ -408,7 +407,7 @@ public class WhenViewingHighNeedsSpending(SchoolBenchmarkingWebAppClient client)
         s => s.TotalHospitalServices),
     ("highneeds-subcategory-therapies-and-other-health-related-services",
         s => s.TotalOtherHealthServices),
-    ("highneeds-subcategory-place-funding",
+    ("highneeds-subcategory-primary-place-funding",
         s => s.PlaceFundingPrimary),
     ("highneeds-subcategory-secondary-place-funding",
         s => s.PlaceFundingSecondary),


### PR DESCRIPTION
## 🧾 Summary

[AB#295179](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/295179)
[AB#312333](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/312333)

### 🛠️ Bug Fix Description
**Root Cause:**
The requirement for top up funding groups to display supporting explanatory text was missed during the original implementation, leaving those sections incomplete.

The heading for Primary Place Funding is also incorrect.

**Changes:**
- adds a new `GetCategoryGroupAdditionalText()` extension on `HighNeedsSpendingCategories.CategoryGroup` to supply the required supporting text.
- updates the view models to populate the new `AdditionalText` property for each group using this extension.
- updates the view to conditionally render the supporting text beneath the group heading when present.
- updates `GetHeading()` on `HighNeedsSpendingCategories.SubCategoryFilter` to correct the heading for `SubCategoryFilter.PlaceFundingPrimary`

<img width="877" height="691" alt="image" src="https://github.com/user-attachments/assets/6d42131a-2594-456d-8e98-120f2f81fd78" />

<img width="921" height="262" alt="image" src="https://github.com/user-attachments/assets/5c8817f9-0210-4f60-b251-f97dfcc62e10" />

<img width="993" height="302" alt="image" src="https://github.com/user-attachments/assets/770b6275-9f2c-4f1a-87f0-39f70c364658" />


## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [x] Tested by running locally _(or docs render correctly locally)_.
- [x] Screenshots or Demo included _(for UI/frontend changes)_.
