### PR TITLE
chore: remove specifc line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,1 @@
-# Enforce LF line endings for shell scripts and INI files to prevent Docker execution errors
-*.sh text eol=lf
-*.ini text eol=lf
+* text=auto eol=lf


### PR DESCRIPTION
## 🧾 Summary
 Enforce LF line endings globally for all text files via .gitattributes. This ensures consistency across different operating systems and prevents environment-specific line ending issues (e.g., in Docker or shell script execution).

Updated .gitattributes to use * text=auto eol=lf instead of specific overrides for .sh and .ini files. Guarantees uniform line endings (LF) for all text-based files in the repository, simplifying ross-platform development and CI/CD consistency.

## 🔍 Notes
This change standardises the repository's line-ending strategy. Any existing files with CRLF will be converted to LF upon their next modification or via a manual `git add --renormalize .` if required.