### PR TITLE
fix: ensure env vars are loaded into configuration object, and correctly read section and values

### DIFF
--- a/platform/README.md
+++ b/platform/README.md
@@ -78,12 +78,12 @@ The Platform APIs use Azure Functions (Isolated Worker Process), which intention
 The following secrets must be configured for the `platform-local` environment using the `dotnet user-secrets` tool:
 
 ```bash
-dotnet user-secrets set "Sql__ConnectionString" "[value]" --id "platform-local"
-dotnet user-secrets set "Cache__Host" "[value]" --id "platform-local"
-dotnet user-secrets set "Cache__Port" "[value]" --id "platform-local"
-dotnet user-secrets set "Cache__Password" "[value]" --id "platform-local"
-dotnet user-secrets set "Search__Name" "[value]" --id "platform-local"
-dotnet user-secrets set "Search__Key" "[value]" --id "platform-local"
+dotnet user-secrets set "Sql:ConnectionString" "[value]" --id "platform-local"
+dotnet user-secrets set "Cache:Host" "[value]" --id "platform-local"
+dotnet user-secrets set "Cache:Port" "[value]" --id "platform-local"
+dotnet user-secrets set "Cache:Password" "[value]" --id "platform-local"
+dotnet user-secrets set "Search:Name" "[value]" --id "platform-local"
+dotnet user-secrets set "Search:Key" "[value]" --id "platform-local"
 ```
 
 For full details on local environment profiles and managing `local.settings.json`, please read the **Configuration Management** section in the [Platform APIs Developer Guide](../documentation/developers/11_Platform-APIs.md#configuration-management).
@@ -103,29 +103,29 @@ dotnet test --filter "FullyQualifiedName~.Tests"
 Add the required configuration for `Platform.ApiTests` using the `dotnet user-secrets` tool:
 
 ```bash
-dotnet user-secrets set "School__Host" "http://localhost:7302" --id "platform-api-tests-local"
-dotnet user-secrets set "School__Key" "x" --id "platform-api-tests-local"
+dotnet user-secrets set "School:Host" "http://localhost:7302" --id "platform-api-tests-local"
+dotnet user-secrets set "School:Key" "x" --id "platform-api-tests-local"
 
-dotnet user-secrets set "Trust__Host" "http://localhost:7303" --id "platform-api-tests-local"
-dotnet user-secrets set "Trust__Key" "x" --id "platform-api-tests-local"
+dotnet user-secrets set "Trust:Host" "http://localhost:7303" --id "platform-api-tests-local"
+dotnet user-secrets set "Trust:Key" "x" --id "platform-api-tests-local"
 
-dotnet user-secrets set "LocalAuthority__Host" "http://localhost:7301" --id "platform-api-tests-local"
-dotnet user-secrets set "LocalAuthority__Key" "x" --id "platform-api-tests-local"
+dotnet user-secrets set "LocalAuthority:Host" "http://localhost:7301" --id "platform-api-tests-local"
+dotnet user-secrets set "LocalAuthority:Key" "x" --id "platform-api-tests-local"
 
-dotnet user-secrets set "Insight__Host" "http://localhost:7071" --id "platform-api-tests-local"
-dotnet user-secrets set "Insight__Key" "x" --id "platform-api-tests-local"
+dotnet user-secrets set "Insight:Host" "http://localhost:7071" --id "platform-api-tests-local"
+dotnet user-secrets set "Insight:Key" "x" --id "platform-api-tests-local"
 
-dotnet user-secrets set "Benchmark__Host" "http://localhost:7072" --id "platform-api-tests-local"
-dotnet user-secrets set "Benchmark__Key" "x" --id "platform-api-tests-local"
+dotnet user-secrets set "Benchmark:Host" "http://localhost:7072" --id "platform-api-tests-local"
+dotnet user-secrets set "Benchmark:Key" "x" --id "platform-api-tests-local"
 
-dotnet user-secrets set "Establishment__Host" "http://localhost:7073" --id "platform-api-tests-local"
-dotnet user-secrets set "Establishment__Key" "x" --id "platform-api-tests-local"
+dotnet user-secrets set "Establishment:Host" "http://localhost:7073" --id "platform-api-tests-local"
+dotnet user-secrets set "Establishment:Key" "x" --id "platform-api-tests-local"
 
-dotnet user-secrets set "ChartRendering__Host" "http://localhost:7076" --id "platform-api-tests-local"
-dotnet user-secrets set "ChartRendering__Key" "x" --id "platform-api-tests-local"
+dotnet user-secrets set "ChartRendering:Host" "http://localhost:7076" --id "platform-api-tests-local"
+dotnet user-secrets set "ChartRendering:Key" "x" --id "platform-api-tests-local"
 
-dotnet user-secrets set "Content__Host" "http://localhost:7077" --id "platform-api-tests-local"
-dotnet user-secrets set "Content__Key" "x" --id "platform-api-tests-local"
+dotnet user-secrets set "Content:Host" "http://localhost:7077" --id "platform-api-tests-local"
+dotnet user-secrets set "Content:Key" "x" --id "platform-api-tests-local"
 ```
 
 From the root of the `platform` run:

--- a/platform/src/abstractions/Platform.Cache/CacheExtensions.cs
+++ b/platform/src/abstractions/Platform.Cache/CacheExtensions.cs
@@ -36,10 +36,13 @@ public static class CacheExtensions
 
     private static RedisCacheOptions GetOptions(IConfiguration configuration)
     {
-        var cacheHost = configuration["Cache__Host"];
-        var cachePort = configuration["Cache__Port"];
-        var cachePassword = configuration["Cache__Password"];
-        var cacheAllowAdmin = configuration["Cache__AllowAdmin"];
+        var section = configuration.GetSection("Cache");
+
+        var cacheHost = section.GetValue<string>("Host");
+        var cachePort = section.GetValue<string>("Port");
+        var cachePassword = section.GetValue<string>("Password");
+        var cacheAllowAdmin = section.GetValue<string>("AllowAdmin");
+
         ArgumentNullException.ThrowIfNull(cacheHost);
         ArgumentNullException.ThrowIfNull(cachePort);
 

--- a/platform/src/abstractions/Platform.Search/Platform.Search.csproj
+++ b/platform/src/abstractions/Platform.Search/Platform.Search.csproj
@@ -14,6 +14,7 @@
         <PackageReference Include="Microsoft.ApplicationInsights"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder"/>
         <PackageReference Include="AspNetCore.HealthChecks.AzureSearch"/>
     </ItemGroup>
     <ItemGroup>

--- a/platform/src/abstractions/Platform.Search/SearchExtensions.cs
+++ b/platform/src/abstractions/Platform.Search/SearchExtensions.cs
@@ -50,8 +50,11 @@ public static class SearchExtensions
 
     private static PlatformSearchOptions GetOptions(IConfiguration configuration)
     {
-        var name = configuration["Search__Name"];
-        var key = configuration["Search__Key"];
+        var section = configuration.GetSection("Search");
+
+        var name = section.GetValue<string>("Name");
+        var key = section.GetValue<string>("Key");
+
         ArgumentNullException.ThrowIfNull(name);
         ArgumentNullException.ThrowIfNull(key);
 

--- a/platform/src/abstractions/Platform.Search/packages.lock.json
+++ b/platform/src/abstractions/Platform.Search/packages.lock.json
@@ -36,6 +36,16 @@
           "System.Diagnostics.DiagnosticSource": "5.0.0"
         }
       },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Direct",
+        "requested": "[10.0.8, )",
+        "resolved": "10.0.8",
+        "contentHash": "R3NN1X+kVu14uoxLEW6sBSQyhogDSbaOQzILnCtuXxBN4hx22AgjWPwZX6v/suERFkEDgU1lk12AglHTrUxhlw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Direct",
         "requested": "[10.0.8, )",
@@ -134,6 +144,16 @@
       },
       "platform.infrastructure": {
         "type": "Project"
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[8.0.0, )",
+        "resolved": "10.0.8",
+        "contentHash": "ehZcoPbjzWzS4XFvuz7R3V55SmpdkyMqFURLH3yXaN9NtXd9tR6CGB7pd49HYtCkenl+G7ctXSFLhNI08xLfRg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",

--- a/platform/src/abstractions/Platform.Sql/Platform.Sql.csproj
+++ b/platform/src/abstractions/Platform.Sql/Platform.Sql.csproj
@@ -16,6 +16,7 @@
         <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"/>
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder"/>
         <PackageReference Include="AspNetCore.HealthChecks.SqlServer"/>
     </ItemGroup>
     <ItemGroup>

--- a/platform/src/abstractions/Platform.Sql/SqlExtensions.cs
+++ b/platform/src/abstractions/Platform.Sql/SqlExtensions.cs
@@ -30,7 +30,8 @@ public static class SqlExtensions
 
     private static PlatformSqlOptions GetOptions(IConfiguration configuration)
     {
-        var conn = configuration["Sql__ConnectionString"];
+        var conn = configuration.GetSection("Sql").GetValue<string>("ConnectionString");
+
         ArgumentNullException.ThrowIfNull(conn);
 
         return new PlatformSqlOptions(conn);

--- a/platform/src/abstractions/Platform.Sql/packages.lock.json
+++ b/platform/src/abstractions/Platform.Sql/packages.lock.json
@@ -68,6 +68,16 @@
           "Microsoft.Identity.Client": "4.83.0"
         }
       },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Direct",
+        "requested": "[10.0.8, )",
+        "resolved": "10.0.8",
+        "contentHash": "R3NN1X+kVu14uoxLEW6sBSQyhogDSbaOQzILnCtuXxBN4hx22AgjWPwZX6v/suERFkEDgU1lk12AglHTrUxhlw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Direct",
         "requested": "[10.0.8, )",
@@ -357,6 +367,16 @@
         "contentHash": "1Po+Ypf0SjCeEKx5+C89Nb5OgTcqNvfS3uTI46MUM+KEp6Rq/M0h+vVsTUt/6DFRwZMTpsAJM4yJrZmEObVANA==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[8.0.0, )",
+        "resolved": "10.0.8",
+        "contentHash": "ehZcoPbjzWzS4XFvuz7R3V55SmpdkyMqFURLH3yXaN9NtXd9tR6CGB7pd49HYtCkenl+G7ctXSFLhNI08xLfRg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {

--- a/platform/src/abstractions/tests/Platform.Search.Tests/packages.lock.json
+++ b/platform/src/abstractions/tests/Platform.Search.Tests/packages.lock.json
@@ -201,6 +201,7 @@
           "Azure.Search.Documents": "[11.7.0, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.ApplicationInsights": "[2.23.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Infrastructure": "[1.0.0, )"
@@ -238,6 +239,26 @@
         "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "5.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[8.0.0, )",
+        "resolved": "10.0.8",
+        "contentHash": "ehZcoPbjzWzS4XFvuz7R3V55SmpdkyMqFURLH3yXaN9NtXd9tR6CGB7pd49HYtCkenl+G7ctXSFLhNI08xLfRg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.8, )",
+        "resolved": "10.0.8",
+        "contentHash": "R3NN1X+kVu14uoxLEW6sBSQyhogDSbaOQzILnCtuXxBN4hx22AgjWPwZX6v/suERFkEDgU1lk12AglHTrUxhlw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {

--- a/platform/src/abstractions/tests/Platform.Sql.Tests/packages.lock.json
+++ b/platform/src/abstractions/tests/Platform.Sql.Tests/packages.lock.json
@@ -364,6 +364,7 @@
           "Dapper.SqlBuilder": "[2.1.66, )",
           "Microsoft.Data.SqlClient": "[7.0.1, )",
           "Microsoft.Data.SqlClient.Extensions.Azure": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Domain": "[1.0.0, )"
@@ -442,6 +443,26 @@
           "Microsoft.Data.SqlClient.Internal.Logging": "1.0.0",
           "Microsoft.Extensions.Caching.Memory": "8.0.1",
           "Microsoft.Identity.Client": "4.83.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[8.0.0, )",
+        "resolved": "10.0.8",
+        "contentHash": "ehZcoPbjzWzS4XFvuz7R3V55SmpdkyMqFURLH3yXaN9NtXd9tR6CGB7pd49HYtCkenl+G7ctXSFLhNI08xLfRg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.8, )",
+        "resolved": "10.0.8",
+        "contentHash": "R3NN1X+kVu14uoxLEW6sBSQyhogDSbaOQzILnCtuXxBN4hx22AgjWPwZX6v/suERFkEDgU1lk12AglHTrUxhlw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {

--- a/platform/src/apis/Platform.Api.Benchmark/Configuration/Services.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/Configuration/Services.cs
@@ -25,7 +25,7 @@ internal static class Services
         var configuration = context.Configuration;
 
         serviceCollection
-            .AddTelemetry()
+            .AddTelemetry(configuration)
             .AddHealthCheckServices(configuration)
             .AddPlatformServices(configuration)
             .AddFeatures();
@@ -42,13 +42,13 @@ internal static class Services
         return serviceCollection;
     }
 
-    private static IServiceCollection AddTelemetry(this IServiceCollection serviceCollection)
+    private static IServiceCollection AddTelemetry(this IServiceCollection serviceCollection, IConfiguration configuration)
     {
         //TODO: Add serilog configuration AB#227696
         // App Insights must be BEFORE any keyed services:
         // • https://github.com/microsoft/ApplicationInsights-dotnet/issues/2828
         // • https://github.com/microsoft/ApplicationInsights-dotnet/issues/2879
-        var sqlTelemetryEnabled = Environment.GetEnvironmentVariable("Sql__TelemetryEnabled");
+        var sqlTelemetryEnabled = configuration.GetSection("Sql").GetValue<string>("TelemetryEnabled");
         serviceCollection
             .AddApplicationInsightsTelemetryWorkerService()
             .ConfigureFunctionsApplicationInsights()

--- a/platform/src/apis/Platform.Api.Benchmark/Program.cs
+++ b/platform/src/apis/Platform.Api.Benchmark/Program.cs
@@ -12,7 +12,9 @@ var hostBuilder = new HostBuilder()
     .ConfigureAppConfiguration((context, builder) =>
     {
         var env = context.HostingEnvironment.EnvironmentName.ToLower();
-        builder.AddUserSecrets($"platform-{env}");
+        builder
+            .AddEnvironmentVariables()
+            .AddUserSecrets($"platform-{env}");
     });
 
 hostBuilder.Build().Run();

--- a/platform/src/apis/Platform.Api.Benchmark/packages.lock.json
+++ b/platform/src/apis/Platform.Api.Benchmark/packages.lock.json
@@ -2011,6 +2011,7 @@
           "Dapper.SqlBuilder": "[2.1.66, )",
           "Microsoft.Data.SqlClient": "[7.0.1, )",
           "Microsoft.Data.SqlClient.Extensions.Azure": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Domain": "[1.0.0, )"

--- a/platform/src/apis/Platform.Api.Content/Configuration/Services.cs
+++ b/platform/src/apis/Platform.Api.Content/Configuration/Services.cs
@@ -30,7 +30,7 @@ internal static class Services
             .AddSingleton<IFunctionContextDataProvider, FunctionContextDataProvider>();
 
         serviceCollection
-            .AddTelemetry()
+            .AddTelemetry(configuration)
             .AddHealthCheckServices(configuration)
             .AddPlatformServices(configuration)
             .AddFeatures();
@@ -48,13 +48,13 @@ internal static class Services
         return serviceCollection;
     }
 
-    private static IServiceCollection AddTelemetry(this IServiceCollection serviceCollection)
+    private static IServiceCollection AddTelemetry(this IServiceCollection serviceCollection, IConfiguration configuration)
     {
         //TODO: Add serilog configuration AB#227696
         // App Insights must be BEFORE any keyed services:
         // • https://github.com/microsoft/ApplicationInsights-dotnet/issues/2828
         // • https://github.com/microsoft/ApplicationInsights-dotnet/issues/2879
-        var sqlTelemetryEnabled = Environment.GetEnvironmentVariable("Sql__TelemetryEnabled");
+        var sqlTelemetryEnabled = configuration.GetSection("Sql").GetValue<string>("TelemetryEnabled");
         serviceCollection
             .AddApplicationInsightsTelemetryWorkerService()
             .ConfigureFunctionsApplicationInsights()

--- a/platform/src/apis/Platform.Api.Content/Program.cs
+++ b/platform/src/apis/Platform.Api.Content/Program.cs
@@ -12,7 +12,9 @@ var hostBuilder = new HostBuilder()
     .ConfigureAppConfiguration((context, builder) =>
     {
         var env = context.HostingEnvironment.EnvironmentName.ToLower();
-        builder.AddUserSecrets($"platform-{env}");
+        builder
+            .AddEnvironmentVariables()
+            .AddUserSecrets($"platform-{env}");
     });
 
 

--- a/platform/src/apis/Platform.Api.Content/packages.lock.json
+++ b/platform/src/apis/Platform.Api.Content/packages.lock.json
@@ -1962,6 +1962,7 @@
           "Dapper.SqlBuilder": "[2.1.66, )",
           "Microsoft.Data.SqlClient": "[7.0.1, )",
           "Microsoft.Data.SqlClient.Extensions.Azure": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Domain": "[1.0.0, )"

--- a/platform/src/apis/Platform.Api.Insight/Configuration/Services.cs
+++ b/platform/src/apis/Platform.Api.Insight/Configuration/Services.cs
@@ -35,7 +35,7 @@ internal static class Services
             .AddSingleton<IFunctionContextDataProvider, FunctionContextDataProvider>();
 
         serviceCollection
-            .AddTelemetry()
+            .AddTelemetry(configuration)
             .AddHealthCheckServices(configuration)
             .AddPlatformServices(configuration)
             .AddFeatures();
@@ -53,13 +53,13 @@ internal static class Services
         return serviceCollection;
     }
 
-    private static IServiceCollection AddTelemetry(this IServiceCollection serviceCollection)
+    private static IServiceCollection AddTelemetry(this IServiceCollection serviceCollection, IConfiguration configuration)
     {
         //TODO: Add serilog configuration AB#227696
         // App Insights must be BEFORE any keyed services:
         // � https://github.com/microsoft/ApplicationInsights-dotnet/issues/2828
         // � https://github.com/microsoft/ApplicationInsights-dotnet/issues/2879
-        var sqlTelemetryEnabled = Environment.GetEnvironmentVariable("Sql__TelemetryEnabled");
+        var sqlTelemetryEnabled = configuration.GetSection("Sql").GetValue<string>("TelemetryEnabled");
         serviceCollection
             .AddApplicationInsightsTelemetryWorkerService()
             .ConfigureFunctionsApplicationInsights()

--- a/platform/src/apis/Platform.Api.Insight/Program.cs
+++ b/platform/src/apis/Platform.Api.Insight/Program.cs
@@ -15,7 +15,9 @@ var hostBuilder = new HostBuilder()
     .ConfigureAppConfiguration((context, builder) =>
     {
         var env = context.HostingEnvironment.EnvironmentName.ToLower();
-        builder.AddUserSecrets($"platform-{env}");
+        builder
+            .AddEnvironmentVariables()
+            .AddUserSecrets($"platform-{env}");
     });
 
 

--- a/platform/src/apis/Platform.Api.Insight/packages.lock.json
+++ b/platform/src/apis/Platform.Api.Insight/packages.lock.json
@@ -1457,6 +1457,7 @@
           "Dapper.SqlBuilder": "[2.1.66, )",
           "Microsoft.Data.SqlClient": "[7.0.1, )",
           "Microsoft.Data.SqlClient.Extensions.Azure": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Domain": "[1.0.0, )"

--- a/platform/src/apis/Platform.Api.LocalAuthority/Configuration/Services.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthority/Configuration/Services.cs
@@ -31,7 +31,7 @@ internal static class Services
             .AddSingleton<IFunctionContextDataProvider, FunctionContextDataProvider>();
 
         serviceCollection
-            .AddTelemetry()
+            .AddTelemetry(configuration)
             .AddHealthCheckServices(configuration)
             .AddPlatformServices(configuration)
             .AddFeatures();
@@ -49,13 +49,13 @@ internal static class Services
         return serviceCollection;
     }
 
-    private static IServiceCollection AddTelemetry(this IServiceCollection serviceCollection)
+    private static IServiceCollection AddTelemetry(this IServiceCollection serviceCollection, IConfiguration configuration)
     {
         //TODO: Add serilog configuration AB#227696
         // App Insights must be BEFORE any keyed services:
         // • https://github.com/microsoft/ApplicationInsights-dotnet/issues/2828
         // • https://github.com/microsoft/ApplicationInsights-dotnet/issues/2879
-        var sqlTelemetryEnabled = Environment.GetEnvironmentVariable("Sql__TelemetryEnabled");
+        var sqlTelemetryEnabled = configuration.GetSection("Sql").GetValue<string>("TelemetryEnabled");
         serviceCollection
             .AddApplicationInsightsTelemetryWorkerService()
             .ConfigureFunctionsApplicationInsights()

--- a/platform/src/apis/Platform.Api.LocalAuthority/Program.cs
+++ b/platform/src/apis/Platform.Api.LocalAuthority/Program.cs
@@ -12,7 +12,9 @@ var hostBuilder = new HostBuilder()
     .ConfigureAppConfiguration((context, builder) =>
     {
         var env = context.HostingEnvironment.EnvironmentName.ToLower();
-        builder.AddUserSecrets($"platform-{env}");
+        builder
+            .AddEnvironmentVariables()
+            .AddUserSecrets($"platform-{env}");
     });
 
 

--- a/platform/src/apis/Platform.Api.LocalAuthority/packages.lock.json
+++ b/platform/src/apis/Platform.Api.LocalAuthority/packages.lock.json
@@ -1978,6 +1978,7 @@
           "Azure.Search.Documents": "[11.7.0, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.ApplicationInsights": "[2.23.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Infrastructure": "[1.0.0, )"
@@ -1992,6 +1993,7 @@
           "Dapper.SqlBuilder": "[2.1.66, )",
           "Microsoft.Data.SqlClient": "[7.0.1, )",
           "Microsoft.Data.SqlClient.Extensions.Azure": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Domain": "[1.0.0, )"

--- a/platform/src/apis/Platform.Api.School/Configuration/Services.cs
+++ b/platform/src/apis/Platform.Api.School/Configuration/Services.cs
@@ -33,7 +33,7 @@ internal static class Services
             .AddSingleton<IFunctionContextDataProvider, FunctionContextDataProvider>();
 
         serviceCollection
-            .AddTelemetry()
+            .AddTelemetry(configuration)
             .AddHealthCheckServices(configuration)
             .AddPlatformServices(configuration)
             .AddFeatures();
@@ -52,13 +52,13 @@ internal static class Services
         return serviceCollection;
     }
 
-    private static IServiceCollection AddTelemetry(this IServiceCollection serviceCollection)
+    private static IServiceCollection AddTelemetry(this IServiceCollection serviceCollection, IConfiguration configuration)
     {
         //TODO: Add serilog configuration AB#227696
         // App Insights must be BEFORE any keyed services:
         // • https://github.com/microsoft/ApplicationInsights-dotnet/issues/2828
         // • https://github.com/microsoft/ApplicationInsights-dotnet/issues/2879
-        var sqlTelemetryEnabled = Environment.GetEnvironmentVariable("Sql__TelemetryEnabled");
+        var sqlTelemetryEnabled = configuration.GetSection("Sql").GetValue<string>("TelemetryEnabled");
         serviceCollection
             .AddApplicationInsightsTelemetryWorkerService()
             .ConfigureFunctionsApplicationInsights()

--- a/platform/src/apis/Platform.Api.School/Program.cs
+++ b/platform/src/apis/Platform.Api.School/Program.cs
@@ -12,7 +12,9 @@ var hostBuilder = new HostBuilder()
     .ConfigureAppConfiguration((context, builder) =>
     {
         var env = context.HostingEnvironment.EnvironmentName.ToLower();
-        builder.AddUserSecrets($"platform-{env}");
+        builder
+            .AddEnvironmentVariables()
+            .AddUserSecrets($"platform-{env}");
     });
 
 

--- a/platform/src/apis/Platform.Api.School/packages.lock.json
+++ b/platform/src/apis/Platform.Api.School/packages.lock.json
@@ -1447,6 +1447,7 @@
           "Azure.Search.Documents": "[11.7.0, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.ApplicationInsights": "[2.23.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Infrastructure": "[1.0.0, )"
@@ -1461,6 +1462,7 @@
           "Dapper.SqlBuilder": "[2.1.66, )",
           "Microsoft.Data.SqlClient": "[7.0.1, )",
           "Microsoft.Data.SqlClient.Extensions.Azure": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Domain": "[1.0.0, )"

--- a/platform/src/apis/Platform.Api.Trust/Configuration/Services.cs
+++ b/platform/src/apis/Platform.Api.Trust/Configuration/Services.cs
@@ -31,7 +31,7 @@ internal static class Services
             .AddSingleton<IFunctionContextDataProvider, FunctionContextDataProvider>();
 
         serviceCollection
-            .AddTelemetry()
+            .AddTelemetry(configuration)
             .AddHealthCheckServices(configuration)
             .AddPlatformServices(configuration)
             .AddFeatures();
@@ -49,13 +49,13 @@ internal static class Services
         return serviceCollection;
     }
 
-    private static IServiceCollection AddTelemetry(this IServiceCollection serviceCollection)
+    private static IServiceCollection AddTelemetry(this IServiceCollection serviceCollection, IConfiguration configuration)
     {
         //TODO: Add serilog configuration AB#227696
         // App Insights must be BEFORE any keyed services:
         // • https://github.com/microsoft/ApplicationInsights-dotnet/issues/2828
         // • https://github.com/microsoft/ApplicationInsights-dotnet/issues/2879
-        var sqlTelemetryEnabled = Environment.GetEnvironmentVariable("Sql__TelemetryEnabled");
+        var sqlTelemetryEnabled = configuration.GetSection("Sql").GetValue<string>("TelemetryEnabled");
         serviceCollection
             .AddApplicationInsightsTelemetryWorkerService()
             .ConfigureFunctionsApplicationInsights()

--- a/platform/src/apis/Platform.Api.Trust/Program.cs
+++ b/platform/src/apis/Platform.Api.Trust/Program.cs
@@ -12,7 +12,9 @@ var hostBuilder = new HostBuilder()
     .ConfigureAppConfiguration((context, builder) =>
     {
         var env = context.HostingEnvironment.EnvironmentName.ToLower();
-        builder.AddUserSecrets($"platform-{env}");
+        builder
+            .AddEnvironmentVariables()
+            .AddUserSecrets($"platform-{env}");
     });
 
 

--- a/platform/src/apis/Platform.Api.Trust/packages.lock.json
+++ b/platform/src/apis/Platform.Api.Trust/packages.lock.json
@@ -1978,6 +1978,7 @@
           "Azure.Search.Documents": "[11.7.0, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.ApplicationInsights": "[2.23.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Infrastructure": "[1.0.0, )"
@@ -1992,6 +1993,7 @@
           "Dapper.SqlBuilder": "[2.1.66, )",
           "Microsoft.Data.SqlClient": "[7.0.1, )",
           "Microsoft.Data.SqlClient.Extensions.Azure": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Domain": "[1.0.0, )"

--- a/platform/src/apis/Platform.MaintenanceTasks/Configuration/Services.cs
+++ b/platform/src/apis/Platform.MaintenanceTasks/Configuration/Services.cs
@@ -24,15 +24,15 @@ internal static class Services
 
         serviceCollection
             .AddPlatformServices(configuration)
-            .AddTelemetry()
+            .AddTelemetry(configuration)
             .AddFeatures();
 
         serviceCollection.Configure<JsonSerializerOptions>(SystemTextJsonExtensions.Options);
     }
 
-    private static IServiceCollection AddTelemetry(this IServiceCollection serviceCollection)
+    private static IServiceCollection AddTelemetry(this IServiceCollection serviceCollection, IConfiguration configuration)
     {
-        var sqlTelemetryEnabled = Environment.GetEnvironmentVariable("Sql__TelemetryEnabled");
+        var sqlTelemetryEnabled = configuration.GetSection("Sql").GetValue<string>("TelemetryEnabled");
         serviceCollection
             .AddApplicationInsightsTelemetryWorkerService()
             .ConfigureFunctionsApplicationInsights()

--- a/platform/src/apis/Platform.MaintenanceTasks/Program.cs
+++ b/platform/src/apis/Platform.MaintenanceTasks/Program.cs
@@ -11,7 +11,9 @@ var hostBuilder = new HostBuilder()
     .ConfigureAppConfiguration((context, builder) =>
     {
         var env = context.HostingEnvironment.EnvironmentName.ToLower();
-        builder.AddUserSecrets($"platform-{env}");
+        builder
+            .AddEnvironmentVariables()
+            .AddUserSecrets($"platform-{env}");
     });
 
 

--- a/platform/src/apis/Platform.MaintenanceTasks/packages.lock.json
+++ b/platform/src/apis/Platform.MaintenanceTasks/packages.lock.json
@@ -851,6 +851,7 @@
           "Dapper.SqlBuilder": "[2.1.66, )",
           "Microsoft.Data.SqlClient": "[7.0.1, )",
           "Microsoft.Data.SqlClient.Extensions.Azure": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Domain": "[1.0.0, )"

--- a/platform/src/apis/Platform.Orchestrator/Configuration/Services.cs
+++ b/platform/src/apis/Platform.Orchestrator/Configuration/Services.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.ApplicationInsights.DependencyCollector;
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Platform.Cache;
@@ -21,8 +22,9 @@ internal static class Services
     {
         var configuration = context.Configuration;
 
-        var searchName = configuration["Search__Name"];
-        var searchKey = configuration["Search__Key"];
+        var section = configuration.GetSection("Search");
+        var searchName = section.GetValue<string>("Name");
+        var searchKey = section.GetValue<string>("Key");
 
         ArgumentNullException.ThrowIfNull(searchName);
         ArgumentNullException.ThrowIfNull(searchKey);
@@ -34,7 +36,7 @@ internal static class Services
             .AddSingleton<ITelemetryService, TelemetryService>();
 
         //TODO: Add serilog configuration AB#227696
-        var sqlTelemetryEnabled = Environment.GetEnvironmentVariable("Sql__TelemetryEnabled");
+        var sqlTelemetryEnabled = configuration.GetSection("Sql").GetValue<string>("TelemetryEnabled");
         serviceCollection
             .AddApplicationInsightsTelemetryWorkerService()
             .ConfigureFunctionsApplicationInsights()

--- a/platform/src/apis/Platform.Orchestrator/Program.cs
+++ b/platform/src/apis/Platform.Orchestrator/Program.cs
@@ -9,7 +9,9 @@ var hostBuilder = new HostBuilder()
     .ConfigureAppConfiguration((context, builder) =>
     {
         var env = context.HostingEnvironment.EnvironmentName.ToLower();
-        builder.AddUserSecrets($"platform-{env}");
+        builder
+            .AddEnvironmentVariables()
+            .AddUserSecrets($"platform-{env}");
     });
 
 

--- a/platform/src/apis/Platform.Orchestrator/packages.lock.json
+++ b/platform/src/apis/Platform.Orchestrator/packages.lock.json
@@ -1111,6 +1111,7 @@
           "Dapper.SqlBuilder": "[2.1.66, )",
           "Microsoft.Data.SqlClient": "[7.0.1, )",
           "Microsoft.Data.SqlClient.Extensions.Azure": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Domain": "[1.0.0, )"

--- a/platform/tests/Platform.ApiTests/packages.lock.json
+++ b/platform/tests/Platform.ApiTests/packages.lock.json
@@ -2120,6 +2120,7 @@
           "Dapper.SqlBuilder": "[2.1.66, )",
           "Microsoft.Data.SqlClient": "[7.0.1, )",
           "Microsoft.Data.SqlClient.Extensions.Azure": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Domain": "[1.0.0, )"

--- a/platform/tests/Platform.Benchmark.Tests/packages.lock.json
+++ b/platform/tests/Platform.Benchmark.Tests/packages.lock.json
@@ -2024,6 +2024,7 @@
           "Dapper.SqlBuilder": "[2.1.66, )",
           "Microsoft.Data.SqlClient": "[7.0.1, )",
           "Microsoft.Data.SqlClient.Extensions.Azure": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Domain": "[1.0.0, )"

--- a/platform/tests/Platform.Content.Tests/packages.lock.json
+++ b/platform/tests/Platform.Content.Tests/packages.lock.json
@@ -2014,6 +2014,7 @@
           "Dapper.SqlBuilder": "[2.1.66, )",
           "Microsoft.Data.SqlClient": "[7.0.1, )",
           "Microsoft.Data.SqlClient.Extensions.Azure": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Domain": "[1.0.0, )"

--- a/platform/tests/Platform.Insight.Tests/packages.lock.json
+++ b/platform/tests/Platform.Insight.Tests/packages.lock.json
@@ -2041,6 +2041,7 @@
           "Dapper.SqlBuilder": "[2.1.66, )",
           "Microsoft.Data.SqlClient": "[7.0.1, )",
           "Microsoft.Data.SqlClient.Extensions.Azure": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Domain": "[1.0.0, )"

--- a/platform/tests/Platform.LocalAuthority.Tests/packages.lock.json
+++ b/platform/tests/Platform.LocalAuthority.Tests/packages.lock.json
@@ -2021,6 +2021,7 @@
           "Azure.Search.Documents": "[11.7.0, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.ApplicationInsights": "[2.23.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Infrastructure": "[1.0.0, )"
@@ -2035,6 +2036,7 @@
           "Dapper.SqlBuilder": "[2.1.66, )",
           "Microsoft.Data.SqlClient": "[7.0.1, )",
           "Microsoft.Data.SqlClient.Extensions.Azure": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Domain": "[1.0.0, )"

--- a/platform/tests/Platform.MaintenanceTasks.Tests/packages.lock.json
+++ b/platform/tests/Platform.MaintenanceTasks.Tests/packages.lock.json
@@ -1647,6 +1647,7 @@
           "Dapper.SqlBuilder": "[2.1.66, )",
           "Microsoft.Data.SqlClient": "[7.0.1, )",
           "Microsoft.Data.SqlClient.Extensions.Azure": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Domain": "[1.0.0, )"

--- a/platform/tests/Platform.Orchestrator.Tests/packages.lock.json
+++ b/platform/tests/Platform.Orchestrator.Tests/packages.lock.json
@@ -2212,6 +2212,7 @@
           "Dapper.SqlBuilder": "[2.1.66, )",
           "Microsoft.Data.SqlClient": "[7.0.1, )",
           "Microsoft.Data.SqlClient.Extensions.Azure": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Domain": "[1.0.0, )"

--- a/platform/tests/Platform.School.Tests/packages.lock.json
+++ b/platform/tests/Platform.School.Tests/packages.lock.json
@@ -2043,6 +2043,7 @@
           "Azure.Search.Documents": "[11.7.0, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.ApplicationInsights": "[2.23.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Infrastructure": "[1.0.0, )"
@@ -2057,6 +2058,7 @@
           "Dapper.SqlBuilder": "[2.1.66, )",
           "Microsoft.Data.SqlClient": "[7.0.1, )",
           "Microsoft.Data.SqlClient.Extensions.Azure": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Domain": "[1.0.0, )"

--- a/platform/tests/Platform.Trust.Tests/packages.lock.json
+++ b/platform/tests/Platform.Trust.Tests/packages.lock.json
@@ -2021,6 +2021,7 @@
           "Azure.Search.Documents": "[11.7.0, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.ApplicationInsights": "[2.23.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Infrastructure": "[1.0.0, )"
@@ -2035,6 +2036,7 @@
           "Dapper.SqlBuilder": "[2.1.66, )",
           "Microsoft.Data.SqlClient": "[7.0.1, )",
           "Microsoft.Data.SqlClient.Extensions.Azure": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.0.8, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.8, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.0.8, )",
           "Platform.Domain": "[1.0.0, )"


### PR DESCRIPTION
## 🧾 Summary
 This PR standardises how configuration is handled across the Platform APIs. It ensures environment variables are explicitly loaded into the configuration builder and refactors service registration to consistently use the IConfiguration object instead of direct Environment.GetEnvironmentVariable calls.

### 🛠️ Bug Fix Description
- Root Cause: Inconsistencies existed in how environment variables were accessed across different Platform APIs, some were retrieved via IConfiguration while others were accessed directly using Environment.GetEnvironmentVariable. Additionally, some APIs were missing explicit .AddEnvironmentVariables() calls in their configuration builder, potentially leading to missing settings. Configuration was also being accessed using flat keys (e.g., Sql__ConnectionString) rather than the more idiomatic section-based approach.
- Changes:
  - Added .AddEnvironmentVariables() to the HostBuilder configuration in Program.cs across all Platform APIs to ensure environment variables are correctly loaded.
  - Updated Services.Configure methods to pass IConfiguration to sub-registration methods (e.g., AddTelemetry).
  - Refactored extension methods in Platform.Sql, Platform.Cache, and Platform.Search to use the section-based configuration access (e.g., configuration.GetSection("Sql").GetValue<string>("ConnectionString")).
  - Updated packages.lock.json files to ensure consistent dependency states.

## ✅ Checklist
- [x] Code follows project coding standards (e.g.,Trunk-based guidelines, small PR size).
- [x] Tested by running locally (or docs render correctlylocally).
- [x] Relevant documentation updated (if applicable).

## 🔍 Notes
These changes ensure that environment variables using the double-underscore delimiter (e.g., Sql__ConnectionString) are correctly mapped to hierarchical configuration keys (e.g., Sql:ConnectionString). This approach is more robust and provides a consistent interface regardless of whether settings originate from environment variables, appsettings.json, or User Secrets.