### PR TITLE
feat: display data as tables for school benchmarking spending

### DIFF
--- a/web/src/Web.App/Controllers/SchoolCensusController.cs
+++ b/web/src/Web.App/Controllers/SchoolCensusController.cs
@@ -7,6 +7,7 @@ using Web.App.Attributes;
 using Web.App.Attributes.RequestTelemetry;
 using Web.App.Domain;
 using Web.App.Domain.Charts;
+using Web.App.Domain.Schools;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.Benchmark;
 using Web.App.Infrastructure.Apis.Insight;

--- a/web/src/Web.App/Controllers/SchoolComparisonController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparisonController.cs
@@ -5,6 +5,8 @@ using Web.App.ActionResults;
 using Web.App.Attributes;
 using Web.App.Attributes.RequestTelemetry;
 using Web.App.Domain;
+using Web.App.Domain.Charts;
+using Web.App.Domain.Schools;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.Benchmark;
 using Web.App.Infrastructure.Apis.Establishment;
@@ -33,7 +35,11 @@ public class SchoolComparisonController(
 {
     [HttpGet]
     [SchoolRequestTelemetry(TrackedRequestFeature.BenchmarkCosts)]
-    public async Task<IActionResult> Index(string urn)
+    public async Task<IActionResult> Index(
+        string urn,
+        // TODO: this should default to chart but until functionality to toggle view as options is implemented we default to table
+        Views.ViewAsOptions viewAs = Views.ViewAsOptions.Table,
+        SchoolSpendingDimensions.ResultAsOptions resultAs = SchoolSpendingDimensions.ResultAsOptions.SpendPerUnit)
     {
         using (logger.BeginScope(new
         {
@@ -61,7 +67,30 @@ public class SchoolComparisonController(
                 var bandings = await featureManager.IsEnabledAsync(FeatureFlags.KS4ProgressBanding)
                     ? await progressBandingsService.GetKS4ProgressBandings(customComparatorSet ?? defaultComparatorSet?.All ?? [])
                     : null;
-                var viewModel = new SchoolComparisonViewModel(school, costCodes, userData.ComparatorSet, userData.CustomData, expenditure, defaultComparatorSet, bandings);
+
+                SpendingComparisonSubCategoriesViewModel? subCategories = null;
+
+                if (await featureManager.IsEnabledAsync(FeatureFlags.SchoolComparisonFilter))
+                {
+                    var buildingResult = await GetDefaultSchoolExpenditure(urn, true, resultAs);
+                    var pupilResult = await GetDefaultSchoolExpenditure(urn, false, resultAs);
+                    // TODO: replace SpendingCategories.All with selectedSubCategories once filters are implemented
+                    subCategories = new SpendingComparisonSubCategoriesViewModel(buildingResult, pupilResult, SchoolSpendingCategories.All, urn);
+                }
+
+                var viewModel = new SchoolComparisonViewModel(
+                    school,
+                    costCodes,
+                    userData.ComparatorSet,
+                    userData.CustomData,
+                    expenditure,
+                    defaultComparatorSet,
+                    bandings,
+                    subCategories)
+                {
+                    ViewAs = viewAs,
+                    ResultAs = resultAs
+                };
 
                 var viewName = await GetViewName(nameof(Index));
                 return View(viewName, viewModel);
@@ -193,7 +222,10 @@ public class SchoolComparisonController(
             : defaultResult;
     }
 
-    private async Task<SchoolExpenditure[]> GetDefaultSchoolExpenditure(string urn, bool useBuildingSet)
+    private async Task<SchoolExpenditure[]> GetDefaultSchoolExpenditure(
+        string urn,
+        bool useBuildingSet,
+        SchoolSpendingDimensions.ResultAsOptions resultAs = SchoolSpendingDimensions.ResultAsOptions.Actuals)
     {
         var userData = await userDataService.GetSchoolDataAsync(User, urn);
         if (string.IsNullOrEmpty(userData.ComparatorSet))
@@ -209,7 +241,7 @@ public class SchoolComparisonController(
             }
 
             var defaultResult = await expenditureApi
-                .QuerySchools(BuildApiQuery(set))
+                .QuerySchools(BuildApiQuery(set, resultAs))
                 .GetResultOrThrow<SchoolExpenditure[]>();
 
             return defaultResult;
@@ -228,10 +260,12 @@ public class SchoolComparisonController(
         return userDefinedResult;
     }
 
-    private static ApiQuery BuildApiQuery(IEnumerable<string>? urns = null, string? dimension = "Actuals")
+    private static ApiQuery BuildApiQuery(
+        IEnumerable<string>? urns = null,
+        SchoolSpendingDimensions.ResultAsOptions resultAs = SchoolSpendingDimensions.ResultAsOptions.Actuals)
     {
         var query = new ApiQuery()
-            .AddIfNotNull("dimension", dimension);
+            .AddIfNotNull("dimension", resultAs.GetQueryParam());
 
         foreach (var urn in urns ?? [])
         {

--- a/web/src/Web.App/Domain/Charts/SchoolComparisonDatum.cs
+++ b/web/src/Web.App/Domain/Charts/SchoolComparisonDatum.cs
@@ -1,0 +1,12 @@
+namespace Web.App.Domain.Charts;
+
+public class SchoolComparisonDatum
+{
+    public string? Urn { get; init; }
+    public string? SchoolName { get; init; }
+    public decimal? Expenditure { get; init; }
+    public string? LAName { get; init; }
+    public string? SchoolType { get; init; }
+    public decimal? TotalPupils { get; init; }
+    public int? PeriodCoveredByReturn { get; init; }
+}

--- a/web/src/Web.App/Domain/Charts/SchoolComparisonItSpendHorizontalBarChartRequest.cs
+++ b/web/src/Web.App/Domain/Charts/SchoolComparisonItSpendHorizontalBarChartRequest.cs
@@ -40,14 +40,3 @@ public record SchoolComparisonItSpendHorizontalBarChartRequest : PostHorizontalB
         }
     }
 }
-
-public class SchoolComparisonDatum
-{
-    public string? Urn { get; init; }
-    public string? SchoolName { get; init; }
-    public decimal? Expenditure { get; init; }
-    public string? LAName { get; init; }
-    public string? SchoolType { get; init; }
-    public decimal? TotalPupils { get; init; }
-    public int? PeriodCoveredByReturn { get; init; }
-}

--- a/web/src/Web.App/Domain/Charts/SchoolSeniorLeadershipHorizontalBarChartRequest.cs
+++ b/web/src/Web.App/Domain/Charts/SchoolSeniorLeadershipHorizontalBarChartRequest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using Web.App.Domain.Schools;
 using Web.App.Infrastructure.Apis;
 
 // ReSharper disable ClassNeverInstantiated.Global

--- a/web/src/Web.App/Domain/Charts/SchoolSpendingDimensions.cs
+++ b/web/src/Web.App/Domain/Charts/SchoolSpendingDimensions.cs
@@ -1,0 +1,63 @@
+using Web.App.Extensions;
+// ReSharper disable ConvertToExtensionBlock
+
+namespace Web.App.Domain.Charts;
+
+public static class SchoolSpendingDimensions
+{
+    public enum ResultAsOptions
+    {
+        SpendPerUnit = 0,
+        Actuals = 1,
+        PercentExpenditure = 2,
+        PercentIncome = 3
+    }
+
+    public static string GetQueryParam(this ResultAsOptions option) => option switch
+    {
+        ResultAsOptions.SpendPerUnit => "PerUnit",
+        ResultAsOptions.Actuals => "Actuals",
+        ResultAsOptions.PercentExpenditure => "PercentExpenditure",
+        ResultAsOptions.PercentIncome => "PercentIncome",
+        _ => ""
+    };
+
+    public static string GetValueType(this ResultAsOptions option) => option switch
+    {
+        ResultAsOptions.SpendPerUnit or ResultAsOptions.Actuals => ValueType.Currency,
+        ResultAsOptions.PercentExpenditure or ResultAsOptions.PercentIncome => ValueType.Percent,
+        _ => ""
+    };
+
+    public static string GetXAxisLabel(this ResultAsOptions option, string set) => option switch
+    {
+        ResultAsOptions.SpendPerUnit => set == ComparatorSetTypes.Building ? "£ per m²" : "£ per pupil",
+        ResultAsOptions.Actuals => "actuals",
+        ResultAsOptions.PercentExpenditure => "percentage of expenditure",
+        ResultAsOptions.PercentIncome => "percentage of income",
+        _ => ""
+    };
+
+    public static string GetFormattedValue(this ResultAsOptions option, decimal? value) => option switch
+    {
+        ResultAsOptions.SpendPerUnit or ResultAsOptions.Actuals => value.ToCurrency(),
+        ResultAsOptions.PercentExpenditure or ResultAsOptions.PercentIncome => value.ToPercent(),
+        _ => throw new ArgumentOutOfRangeException(nameof(option))
+    };
+
+    public static string GetTableHeader(this ResultAsOptions option) => option switch
+    {
+        ResultAsOptions.SpendPerUnit or ResultAsOptions.Actuals => "Amount",
+        ResultAsOptions.PercentExpenditure or ResultAsOptions.PercentIncome => "Percentage",
+        _ => throw new ArgumentOutOfRangeException(nameof(option))
+    };
+
+    public static string GetDescription(this ResultAsOptions option) => option switch
+    {
+        ResultAsOptions.SpendPerUnit => "£ per pupil",
+        ResultAsOptions.Actuals => "actuals",
+        ResultAsOptions.PercentExpenditure => "% of expenditure",
+        ResultAsOptions.PercentIncome => "% of income",
+        _ => throw new ArgumentOutOfRangeException(nameof(option))
+    };
+}

--- a/web/src/Web.App/Domain/ComparatorSetTypes.cs
+++ b/web/src/Web.App/Domain/ComparatorSetTypes.cs
@@ -1,0 +1,7 @@
+namespace Web.App.Domain;
+
+public static class ComparatorSetTypes
+{
+    public const string Building = "Building";
+    public const string Pupil = "Pupil";
+}

--- a/web/src/Web.App/Domain/Schools/SchoolSpendingCategories.cs
+++ b/web/src/Web.App/Domain/Schools/SchoolSpendingCategories.cs
@@ -1,0 +1,304 @@
+// ReSharper disable ConvertToExtensionBlock
+namespace Web.App.Domain.Schools;
+
+public static class SchoolSpendingCategories
+{
+    public enum CategoryGroup
+    {
+        TotalExpenditure,
+        TeachingStaff,
+        NonEducationalSupportStaff,
+        EducationalSupplies,
+        EducationalIct,
+        PremisesStaffServices,
+        Utilities,
+        AdministrativeSupplies,
+        CateringStaffServices,
+        Other
+    }
+
+    public enum SubCategoryFilter
+    {
+        TotalExpenditure = 0,
+        TotalTeachingSupportStaffCosts = 1,
+        TeachingStaffCosts = 2,
+        SupplyTeachingStaffCosts = 3,
+        EducationalConsultancyCosts = 4,
+        EducationSupportStaffCosts = 5,
+        AgencySupplyTeachingStaffCosts = 6,
+        TotalNonEducationalSupportStaffCosts = 7,
+        AdministrativeClericalStaffCosts = 8,
+        AuditorsCosts = 9,
+        OtherStaffCosts = 10,
+        ProfessionalServicesNonCurriculumCosts = 11,
+        TotalEducationalSuppliesCosts = 12,
+        ExaminationFeesCosts = 13,
+        LearningResourcesNonIctCosts = 14,
+        LearningResourcesIctCosts = 15,
+        TotalPremisesStaffServiceCosts = 16,
+        CleaningCaretakingCosts = 17,
+        MaintenancePremisesCosts = 18,
+        OtherOccupationCosts = 19,
+        PremisesStaffCosts = 20,
+        TotalUtilitiesCosts = 21,
+        EnergyCosts = 22,
+        WaterSewerageCosts = 23,
+        AdministrativeSuppliesNonEducationalCosts = 24,
+        TotalGrossCateringCosts = 25,
+        TotalNetCateringCosts = 26,
+        CateringStaffCosts = 27,
+        CateringSuppliesCosts = 28,
+        TotalOtherCosts = 29,
+        OtherInsurancePremiumsCosts = 30,
+        GroundsMaintenanceCosts = 31,
+        IndirectEmployeeExpenses = 32,
+        InterestChargesLoanBank = 33,
+        PrivateFinanceInitiativeCharges = 34,
+        RentRatesCosts = 35,
+        SpecialFacilitiesCosts = 36,
+        StaffDevelopmentTrainingCosts = 37,
+        StaffRelatedInsuranceCosts = 38,
+        SupplyTeacherInsurableCosts = 39,
+        CommunityFocusedSchoolStaff = 40,
+        CommunityFocusedSchoolCosts = 41,
+    }
+
+    public static readonly SubCategoryFilter[] All =
+    [
+        SubCategoryFilter.TotalExpenditure,
+        SubCategoryFilter.TotalTeachingSupportStaffCosts,
+        SubCategoryFilter.TeachingStaffCosts,
+        SubCategoryFilter.SupplyTeachingStaffCosts,
+        SubCategoryFilter.EducationalConsultancyCosts,
+        SubCategoryFilter.EducationSupportStaffCosts,
+        SubCategoryFilter.AgencySupplyTeachingStaffCosts,
+        SubCategoryFilter.TotalNonEducationalSupportStaffCosts,
+        SubCategoryFilter.AdministrativeClericalStaffCosts,
+        SubCategoryFilter.AuditorsCosts,
+        SubCategoryFilter.OtherStaffCosts,
+        SubCategoryFilter.ProfessionalServicesNonCurriculumCosts,
+        SubCategoryFilter.TotalEducationalSuppliesCosts,
+        SubCategoryFilter.ExaminationFeesCosts,
+        SubCategoryFilter.LearningResourcesNonIctCosts,
+        SubCategoryFilter.LearningResourcesIctCosts,
+        SubCategoryFilter.TotalPremisesStaffServiceCosts,
+        SubCategoryFilter.CleaningCaretakingCosts,
+        SubCategoryFilter.MaintenancePremisesCosts,
+        SubCategoryFilter.OtherOccupationCosts,
+        SubCategoryFilter.PremisesStaffCosts,
+        SubCategoryFilter.TotalUtilitiesCosts,
+        SubCategoryFilter.EnergyCosts,
+        SubCategoryFilter.WaterSewerageCosts,
+        SubCategoryFilter.AdministrativeSuppliesNonEducationalCosts,
+        SubCategoryFilter.TotalGrossCateringCosts,
+        SubCategoryFilter.TotalNetCateringCosts,
+        SubCategoryFilter.CateringStaffCosts,
+        SubCategoryFilter.CateringSuppliesCosts,
+        SubCategoryFilter.TotalOtherCosts,
+        SubCategoryFilter.OtherInsurancePremiumsCosts,
+        SubCategoryFilter.GroundsMaintenanceCosts,
+        SubCategoryFilter.IndirectEmployeeExpenses,
+        SubCategoryFilter.InterestChargesLoanBank,
+        SubCategoryFilter.PrivateFinanceInitiativeCharges,
+        SubCategoryFilter.RentRatesCosts,
+        SubCategoryFilter.SpecialFacilitiesCosts,
+        SubCategoryFilter.StaffDevelopmentTrainingCosts,
+        SubCategoryFilter.StaffRelatedInsuranceCosts,
+        SubCategoryFilter.SupplyTeacherInsurableCosts,
+        SubCategoryFilter.CommunityFocusedSchoolStaff,
+        SubCategoryFilter.CommunityFocusedSchoolCosts
+    ];
+
+    public static readonly Dictionary<CategoryGroup, SubCategoryFilter[]> Groups = new()
+    {
+        [CategoryGroup.TotalExpenditure] =
+        [
+            SubCategoryFilter.TotalExpenditure
+        ],
+        [CategoryGroup.TeachingStaff] =
+        [
+            SubCategoryFilter.TotalTeachingSupportStaffCosts,
+            SubCategoryFilter.TeachingStaffCosts,
+            SubCategoryFilter.SupplyTeachingStaffCosts,
+            SubCategoryFilter.EducationalConsultancyCosts,
+            SubCategoryFilter.EducationSupportStaffCosts,
+            SubCategoryFilter.AgencySupplyTeachingStaffCosts
+        ],
+        [CategoryGroup.NonEducationalSupportStaff] =
+        [
+            SubCategoryFilter.TotalNonEducationalSupportStaffCosts,
+            SubCategoryFilter.AdministrativeClericalStaffCosts,
+            SubCategoryFilter.AuditorsCosts,
+            SubCategoryFilter.OtherStaffCosts,
+            SubCategoryFilter.ProfessionalServicesNonCurriculumCosts
+        ],
+        [CategoryGroup.EducationalSupplies] =
+        [
+            SubCategoryFilter.TotalEducationalSuppliesCosts,
+            SubCategoryFilter.ExaminationFeesCosts,
+            SubCategoryFilter.LearningResourcesNonIctCosts
+        ],
+        [CategoryGroup.EducationalIct] =
+        [
+            SubCategoryFilter.LearningResourcesIctCosts
+        ],
+        [CategoryGroup.PremisesStaffServices] =
+        [
+            SubCategoryFilter.TotalPremisesStaffServiceCosts,
+            SubCategoryFilter.CleaningCaretakingCosts,
+            SubCategoryFilter.MaintenancePremisesCosts,
+            SubCategoryFilter.OtherOccupationCosts,
+            SubCategoryFilter.PremisesStaffCosts
+        ],
+        [CategoryGroup.Utilities] =
+        [
+            SubCategoryFilter.TotalUtilitiesCosts,
+            SubCategoryFilter.EnergyCosts,
+            SubCategoryFilter.WaterSewerageCosts
+        ],
+        [CategoryGroup.AdministrativeSupplies] =
+        [
+            SubCategoryFilter.AdministrativeSuppliesNonEducationalCosts
+        ],
+        [CategoryGroup.CateringStaffServices] =
+        [
+            SubCategoryFilter.TotalGrossCateringCosts,
+            SubCategoryFilter.TotalNetCateringCosts,
+            SubCategoryFilter.CateringStaffCosts,
+            SubCategoryFilter.CateringSuppliesCosts
+        ],
+        [CategoryGroup.Other] =
+        [
+            SubCategoryFilter.TotalOtherCosts,
+            SubCategoryFilter.OtherInsurancePremiumsCosts,
+            SubCategoryFilter.GroundsMaintenanceCosts,
+            SubCategoryFilter.IndirectEmployeeExpenses,
+            SubCategoryFilter.InterestChargesLoanBank,
+            SubCategoryFilter.PrivateFinanceInitiativeCharges,
+            SubCategoryFilter.RentRatesCosts,
+            SubCategoryFilter.SpecialFacilitiesCosts,
+            SubCategoryFilter.StaffDevelopmentTrainingCosts,
+            SubCategoryFilter.StaffRelatedInsuranceCosts,
+            SubCategoryFilter.SupplyTeacherInsurableCosts,
+            SubCategoryFilter.CommunityFocusedSchoolStaff,
+            SubCategoryFilter.CommunityFocusedSchoolCosts
+        ]
+    };
+
+    public static string GetCategoryGroupDescription(this CategoryGroup group) => group switch
+    {
+        CategoryGroup.TotalExpenditure => "Total expenditure",
+        CategoryGroup.TeachingStaff => "Teaching and Teaching support staff",
+        CategoryGroup.NonEducationalSupportStaff => "Non-educational support staff and services",
+        CategoryGroup.EducationalSupplies => "Educational supplies",
+        CategoryGroup.EducationalIct => "Educational ICT",
+        CategoryGroup.PremisesStaffServices => "Premises and staff services",
+        CategoryGroup.Utilities => "Utilities",
+        CategoryGroup.AdministrativeSupplies => "Administrative supplies",
+        CategoryGroup.CateringStaffServices => "Catering staff services",
+        CategoryGroup.Other => "Other costs",
+        _ => ""
+    };
+
+    public static string GetCategoryGroupSetType(this CategoryGroup group) => group switch
+    {
+        CategoryGroup.PremisesStaffServices => ComparatorSetTypes.Building,
+        CategoryGroup.Utilities => ComparatorSetTypes.Building,
+        _ => ComparatorSetTypes.Pupil
+    };
+
+    public static string GetHeading(this SubCategoryFilter filter) => filter switch
+    {
+        SubCategoryFilter.TotalExpenditure => "Total expenditure",
+        SubCategoryFilter.TotalTeachingSupportStaffCosts => "Total teaching and teaching support staff costs",
+        SubCategoryFilter.TeachingStaffCosts => "Teaching staff costs",
+        SubCategoryFilter.SupplyTeachingStaffCosts => "Supply teaching staff costs",
+        SubCategoryFilter.EducationalConsultancyCosts => "Educational consultancy costs",
+        SubCategoryFilter.EducationSupportStaffCosts => "Educational support staff costs",
+        SubCategoryFilter.AgencySupplyTeachingStaffCosts => "Agency supply teaching staff costs",
+        SubCategoryFilter.TotalNonEducationalSupportStaffCosts => "Total non-educational support staff costs",
+        SubCategoryFilter.AdministrativeClericalStaffCosts => "Administrative and clerical staff costs",
+        SubCategoryFilter.AuditorsCosts => "Auditors costs",
+        SubCategoryFilter.OtherStaffCosts => "Other staff costs",
+        SubCategoryFilter.ProfessionalServicesNonCurriculumCosts => "Professional services (non-curriculum) costs",
+        SubCategoryFilter.TotalEducationalSuppliesCosts => "Total educational supplies costs",
+        SubCategoryFilter.ExaminationFeesCosts => "Examination fees costs",
+        SubCategoryFilter.LearningResourcesNonIctCosts => "Learning resources (not ICT equipment) costs",
+        SubCategoryFilter.LearningResourcesIctCosts => "Educational learning resources costs",
+        SubCategoryFilter.TotalPremisesStaffServiceCosts => "Total premises staff and service costs",
+        SubCategoryFilter.CleaningCaretakingCosts => "Cleaning and caretaking costs",
+        SubCategoryFilter.MaintenancePremisesCosts => "Maintenance of premises costs",
+        SubCategoryFilter.OtherOccupationCosts => "Other occupation costs",
+        SubCategoryFilter.PremisesStaffCosts => "Premises staff costs",
+        SubCategoryFilter.TotalUtilitiesCosts => "Total utilities costs",
+        SubCategoryFilter.EnergyCosts => "Energy costs",
+        SubCategoryFilter.WaterSewerageCosts => "Water and sewerage costs",
+        SubCategoryFilter.AdministrativeSuppliesNonEducationalCosts => "Administrative supplies (Non-educational)",
+        SubCategoryFilter.TotalGrossCateringCosts => "Total catering costs (gross)",
+        SubCategoryFilter.TotalNetCateringCosts => "Total catering costs (net)",
+        SubCategoryFilter.CateringStaffCosts => "Catering staff costs",
+        SubCategoryFilter.CateringSuppliesCosts => "Catering supplies costs",
+        SubCategoryFilter.TotalOtherCosts => "Total other costs",
+        SubCategoryFilter.OtherInsurancePremiumsCosts => "Other insurance premiums costs",
+        SubCategoryFilter.GroundsMaintenanceCosts => "Grounds maintenance costs",
+        SubCategoryFilter.IndirectEmployeeExpenses => "Indirect employee expenses",
+        SubCategoryFilter.InterestChargesLoanBank => "Interest charges for loan and bank",
+        SubCategoryFilter.PrivateFinanceInitiativeCharges => "PFI charges",
+        SubCategoryFilter.RentRatesCosts => "Rent and rates costs",
+        SubCategoryFilter.SpecialFacilitiesCosts => "Special facilities costs",
+        SubCategoryFilter.StaffDevelopmentTrainingCosts => "Staff development and training costs",
+        SubCategoryFilter.StaffRelatedInsuranceCosts => "Staff-related insurance costs",
+        SubCategoryFilter.SupplyTeacherInsurableCosts => "Supply teacher insurance costs",
+        SubCategoryFilter.CommunityFocusedSchoolStaff => "Community focused school staff (maintained schools only)",
+        SubCategoryFilter.CommunityFocusedSchoolCosts => "Community focused school costs (maintained schools only)",
+        _ => ""
+    };
+
+    public static decimal? GetValue(this SubCategoryFilter filter, SchoolExpenditure e) =>
+        filter switch
+        {
+            SubCategoryFilter.TotalExpenditure => e.TotalExpenditure,
+            SubCategoryFilter.TotalTeachingSupportStaffCosts => e.TotalTeachingSupportStaffCosts,
+            SubCategoryFilter.TeachingStaffCosts => e.TeachingStaffCosts,
+            SubCategoryFilter.SupplyTeachingStaffCosts => e.SupplyTeachingStaffCosts,
+            SubCategoryFilter.EducationalConsultancyCosts => e.EducationalConsultancyCosts,
+            SubCategoryFilter.EducationSupportStaffCosts => e.EducationSupportStaffCosts,
+            SubCategoryFilter.AgencySupplyTeachingStaffCosts => e.AgencySupplyTeachingStaffCosts,
+            SubCategoryFilter.TotalNonEducationalSupportStaffCosts => e.TotalNonEducationalSupportStaffCosts,
+            SubCategoryFilter.AdministrativeClericalStaffCosts => e.AdministrativeClericalStaffCosts,
+            SubCategoryFilter.AuditorsCosts => e.AuditorsCosts,
+            SubCategoryFilter.OtherStaffCosts => e.OtherStaffCosts,
+            SubCategoryFilter.ProfessionalServicesNonCurriculumCosts => e.ProfessionalServicesNonCurriculumCosts,
+            SubCategoryFilter.TotalEducationalSuppliesCosts => e.TotalEducationalSuppliesCosts,
+            SubCategoryFilter.ExaminationFeesCosts => e.ExaminationFeesCosts,
+            SubCategoryFilter.LearningResourcesNonIctCosts => e.LearningResourcesNonIctCosts,
+            SubCategoryFilter.LearningResourcesIctCosts => e.LearningResourcesIctCosts,
+            SubCategoryFilter.TotalPremisesStaffServiceCosts => e.TotalPremisesStaffServiceCosts,
+            SubCategoryFilter.CleaningCaretakingCosts => e.CleaningCaretakingCosts,
+            SubCategoryFilter.MaintenancePremisesCosts => e.MaintenancePremisesCosts,
+            SubCategoryFilter.OtherOccupationCosts => e.OtherOccupationCosts,
+            SubCategoryFilter.PremisesStaffCosts => e.PremisesStaffCosts,
+            SubCategoryFilter.TotalUtilitiesCosts => e.TotalUtilitiesCosts,
+            SubCategoryFilter.EnergyCosts => e.EnergyCosts,
+            SubCategoryFilter.WaterSewerageCosts => e.WaterSewerageCosts,
+            SubCategoryFilter.AdministrativeSuppliesNonEducationalCosts => e.AdministrativeSuppliesNonEducationalCosts,
+            SubCategoryFilter.TotalGrossCateringCosts => e.TotalGrossCateringCosts,
+            SubCategoryFilter.TotalNetCateringCosts => e.TotalNetCateringCosts,
+            SubCategoryFilter.CateringStaffCosts => e.CateringStaffCosts,
+            SubCategoryFilter.CateringSuppliesCosts => e.CateringSuppliesCosts,
+            SubCategoryFilter.TotalOtherCosts => e.TotalOtherCosts,
+            SubCategoryFilter.OtherInsurancePremiumsCosts => e.OtherInsurancePremiumsCosts,
+            SubCategoryFilter.GroundsMaintenanceCosts => e.GroundsMaintenanceCosts,
+            SubCategoryFilter.IndirectEmployeeExpenses => e.IndirectEmployeeExpenses,
+            SubCategoryFilter.InterestChargesLoanBank => e.InterestChargesLoanBank,
+            SubCategoryFilter.PrivateFinanceInitiativeCharges => e.PrivateFinanceInitiativeCharges,
+            SubCategoryFilter.RentRatesCosts => e.RentRatesCosts,
+            SubCategoryFilter.SpecialFacilitiesCosts => e.SpecialFacilitiesCosts,
+            SubCategoryFilter.StaffDevelopmentTrainingCosts => e.StaffDevelopmentTrainingCosts,
+            SubCategoryFilter.StaffRelatedInsuranceCosts => e.StaffRelatedInsuranceCosts,
+            SubCategoryFilter.SupplyTeacherInsurableCosts => e.SupplyTeacherInsurableCosts,
+            SubCategoryFilter.CommunityFocusedSchoolStaff => e.CommunityFocusedSchoolStaff,
+            SubCategoryFilter.CommunityFocusedSchoolCosts => e.CommunityFocusedSchoolCosts,
+            _ => null
+        };
+}

--- a/web/src/Web.App/Domain/Schools/SeniorLeadershipGroup.cs
+++ b/web/src/Web.App/Domain/Schools/SeniorLeadershipGroup.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 
-namespace Web.App.Domain;
+namespace Web.App.Domain.Schools;
 
 [ExcludeFromCodeCoverage]
 public record SeniorLeadershipGroup

--- a/web/src/Web.App/ViewModels/SchoolComparisonViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolComparisonViewModel.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Extensions.Primitives;
 using Web.App.Domain;
+using Web.App.Domain.Charts;
+using Web.App.Domain.Schools;
 using Web.App.ViewModels.Shared;
 
 namespace Web.App.ViewModels;
@@ -11,7 +13,9 @@ public class SchoolComparisonViewModel(
     string? customDataId = null,
     SchoolExpenditure? expenditure = null,
     SchoolComparatorSet? defaultComparatorSet = null,
-    KS4ProgressBandings? ks4ProgressBandings = null)
+    KS4ProgressBandings? ks4ProgressBandings = null,
+    SpendingComparisonSubCategoriesViewModel? subCategories = null
+    )
 {
     public string? Urn => school.URN;
     public string? Name => school.SchoolName;
@@ -31,6 +35,23 @@ public class SchoolComparisonViewModel(
         .ToArray() ?? [];
     public bool HasProgressIndicators => WellOrAboveAverageKS4ProgressBandingsInComparatorSet.Length > 0;
 
+    public KeyValuePair<SchoolSpendingCategories.CategoryGroup, SchoolSpendingCategories.SubCategoryFilter[]>[] AllGroups =>
+        SchoolSpendingCategories.Groups.ToArray();
+    public List<SpendingComparisonGroup> Groups => subCategories?.Groups ?? [];
+    public SchoolSpendingCategories.SubCategoryFilter[] SelectedSubCategories { get; init; } = [];
+    public HashSet<int> SelectedIds =>
+        SelectedSubCategories
+            .Select(x => (int)x)
+            .ToHashSet();
+
+    public IEnumerable<SpendingComparisonGroup> SelectedGroups =>
+        Groups.Where(g => g.SelectedCount(SelectedIds) > 0);
+
+    // TODO: this should default to chart but until functionality to toggle view as options is implemented we default to table
+    public Views.ViewAsOptions ViewAs { get; init; } = Views.ViewAsOptions.Table;
+
+    public SchoolSpendingDimensions.ResultAsOptions ResultAs { get; init; } = SchoolSpendingDimensions.ResultAsOptions.SpendPerUnit;
+
     public FinanceToolsViewModel Tools => new(
         school.URN,
         FinanceTools.FinancialPlanning,
@@ -41,4 +62,14 @@ public class SchoolComparisonViewModel(
         FinanceTools.SpendingComparison,
         FinanceTools.Spending,
         FinanceTools.BenchmarkCensus);
+}
+
+public class SchoolSpendingDataViewModel(
+    BenchmarkingViewModelCostSubCategory<SchoolComparisonDatum> subCategory,
+    SchoolSpendingDimensions.ResultAsOptions resultAs,
+    string urn)
+{
+    public BenchmarkingViewModelCostSubCategory<SchoolComparisonDatum> SubCategory => subCategory;
+    public SchoolSpendingDimensions.ResultAsOptions ResultAs => resultAs;
+    public string Urn => urn;
 }

--- a/web/src/Web.App/ViewModels/SchoolSeniorLeadershipViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolSeniorLeadershipViewModel.cs
@@ -1,5 +1,6 @@
 using Web.App.Domain;
 using Web.App.Domain.Charts;
+using Web.App.Domain.Schools;
 using Web.App.ViewModels.Shared;
 
 namespace Web.App.ViewModels;

--- a/web/src/Web.App/ViewModels/SpendingComparisonSubCategoriesViewModel.cs
+++ b/web/src/Web.App/ViewModels/SpendingComparisonSubCategoriesViewModel.cs
@@ -1,0 +1,81 @@
+using Web.App.Domain;
+using Web.App.Domain.Charts;
+using Web.App.Domain.Schools;
+
+namespace Web.App.ViewModels;
+
+public class SpendingComparisonSubCategoriesViewModel
+{
+    public List<SpendingComparisonGroup> Groups { get; } = [];
+
+    public SpendingComparisonSubCategoriesViewModel(
+        SchoolExpenditure[] buildingResult,
+        SchoolExpenditure[] pupilResult,
+        SchoolSpendingCategories.SubCategoryFilter[] filters,
+        string urn)
+    {
+        filters = filters.Length > 0 ? filters : SchoolSpendingCategories.All;
+
+        foreach (var (group, children) in SchoolSpendingCategories.Groups)
+        {
+            var activeChildren = children.Where(filters.Contains).ToArray();
+            if (activeChildren.Length == 0)
+                continue;
+
+            var groupVm = new SpendingComparisonGroup
+            {
+                Group = group.GetCategoryGroupDescription(),
+                Items = []
+            };
+
+            var expenditures = group.GetCategoryGroupSetType() == ComparatorSetTypes.Building ? buildingResult : pupilResult;
+
+            foreach (var filter in activeChildren)
+            {
+                var sub = BuildSubCategory(filter, expenditures, urn);
+                groupVm.Items.Add(sub);
+            }
+
+            Groups.Add(groupVm);
+        }
+    }
+
+    private static BenchmarkingViewModelCostSubCategory<SchoolComparisonDatum> BuildSubCategory(
+        SchoolSpendingCategories.SubCategoryFilter filter,
+        SchoolExpenditure[] expenditures,
+        string urn)
+    {
+        var data = expenditures
+            .Select(e => new SchoolComparisonDatum
+            {
+                Urn = e.URN,
+                SchoolName = e.SchoolName,
+                LAName = e.LAName,
+                SchoolType = e.SchoolType,
+                Expenditure = filter.GetValue(e),
+                TotalPupils = e.TotalPupils,
+                PeriodCoveredByReturn = e.PeriodCoveredByReturn
+            })
+            .Where(x => x.Urn == urn || x.Expenditure != null)
+            .OrderByDescending(x => x.Expenditure)
+            .ToArray();
+
+        return new BenchmarkingViewModelCostSubCategory<SchoolComparisonDatum>
+        {
+            Uuid = Guid.NewGuid().ToString(),
+            SubCategory = filter.GetHeading(),
+            SubCategoryId = (int)filter,
+            Data = data
+        };
+    }
+}
+
+public class SpendingComparisonGroup
+{
+    public string Group { get; init; } = "";
+    public List<BenchmarkingViewModelCostSubCategory<SchoolComparisonDatum>> Items { get; init; } = [];
+    public int SelectedCount(HashSet<int> selectedIds) =>
+        Items.Count(i => i.SubCategoryId.HasValue && selectedIds.Contains(i.SubCategoryId.Value));
+    public IEnumerable<BenchmarkingViewModelCostSubCategory<SchoolComparisonDatum>> SelectedItems(HashSet<int> selectedIds) =>
+        Items.Where(i => i.SubCategoryId.HasValue && selectedIds.Contains(i.SubCategoryId.Value));
+}

--- a/web/src/Web.App/Views/SchoolComparison/IndexFilters.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/IndexFilters.cshtml
@@ -1,3 +1,6 @@
+@using Web.App.Domain.Charts
+@using Web.App.Extensions
+@using Web.App.ViewModels
 @model Web.App.ViewModels.SchoolComparisonViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.Comparison;
@@ -32,20 +35,47 @@
     showAsBulletedList = true
 })
 
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-third">
-        <p class="govuk-body">filters under construction</p>
-    </div>
-    <div class="govuk-grid-column-two-thirds">
-        <p class="govuk-body">page actions under construction</p>
-        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+@if (!hasMissingComparatorSet)
+{
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-third">
+            <p class="govuk-body">filters under construction</p>
+        </div>
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body">page actions under construction</p>
+            <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-        <p class="govuk-body">form options under construction</p>
-        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+            <p class="govuk-body">form options under construction</p>
+            <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-        <p class="govuk-body">charts and tables under construction</p>
+            @foreach (var group in Model.Groups.Where(group => group.Items.Any()))
+            {
+                <section id="school-subcategory-@group.Group.ToSlug()">
+                    <h2 class="govuk-heading-m">@group.Group</h2>
+
+                    @foreach (var subCategory in group.Items)
+                    {
+                        <section id="school-subcategory-@subCategory.SubCategory?.ToSlug()"
+                                 class="govuk-!-margin-bottom-4"
+                                 data-testid="subcategory-section">
+
+                            <h3 class="govuk-heading-s">@subCategory.SubCategory</h3>
+
+                            @if (Model.ViewAs == Views.ViewAsOptions.Chart)
+                            {
+                                <p class="govuk-body">charts under construction</p>
+                            }
+                            else
+                            {
+                                @await Html.PartialAsync("_SchoolComparisonTable", new SchoolSpendingDataViewModel(subCategory, Model.ResultAs, Model.Urn!))
+                            }
+                        </section>
+                    }
+                </section>
+            }
+        </div>
     </div>
-</div>
+}
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 

--- a/web/src/Web.App/Views/SchoolComparison/_SchoolComparisonTable.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/_SchoolComparisonTable.cshtml
@@ -1,0 +1,51 @@
+@using Web.App.Domain.Charts
+@model Web.App.ViewModels.SchoolSpendingDataViewModel
+
+@if (Model.SubCategory.Data is null)
+{
+    <div
+        class="govuk-warning-text govuk-!-margin-top-2 govuk-!-margin-bottom-2 ssr-chart-warning">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+            <span class="govuk-visually-hidden">Warning</span>
+            Unable to display data
+        </strong>
+    </div>
+    return;
+}
+<div>
+    <table class="govuk-table">
+        <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">School name</th>
+            <th scope="col" class="govuk-table__header">Local Authority</th>
+            <th scope="col" class="govuk-table__header">School type</th>
+            <th scope="col" class="govuk-table__header govuk-table__header--numeric">Number of pupils</th>
+            <th scope="col" class="govuk-table__header govuk-table__header--numeric">@Model.ResultAs.GetTableHeader()</th>
+        </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        @foreach (var row in Model.SubCategory.Data)
+        {
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell @(row.Urn == Model.Urn ? " govuk-!-font-weight-bold" : "")">
+                    <a class="govuk-link govuk-link--no-visited-state" href="@Url.ActionLink("Index", "School", new { urn = row.Urn })">@row.SchoolName</a>
+                    @if (row.PeriodCoveredByReturn is not 12)
+                    {
+                        <p class="govuk-table__cell_commentary">
+                            <strong class="govuk-tag govuk-tag--red">
+                                Only has @row.PeriodCoveredByReturn
+                                @(row.PeriodCoveredByReturn == 1 ? "month" : "months") of data
+                            </strong>
+                        </p>
+                    }
+                </td>
+                <td class="govuk-table__cell">@row.LAName</td>
+                <td class="govuk-table__cell">@row.SchoolType</td>
+                <td class="govuk-table__cell govuk-table__cell--numeric">@(row.TotalPupils?.ToString("N0"))</td>
+                <td class="govuk-table__cell govuk-table__cell--numeric">@Model.ResultAs.GetFormattedValue(row.Expenditure)</td>
+            </tr>
+        }
+        </tbody>
+    </table>
+</div>

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -11,6 +11,7 @@ using Web.App.Domain.Charts;
 using Web.App.Domain.Content;
 using Web.App.Domain.LocalAuthorities;
 using Web.App.Domain.NonFinancial;
+using Web.App.Domain.Schools;
 using Web.App.Infrastructure.Apis;
 using Web.App.Infrastructure.Apis.Benchmark;
 using Web.App.Infrastructure.Apis.Content;
@@ -488,7 +489,10 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         return this;
     }
 
-    public BenchmarkingWebAppClient SetupExpenditure(School school, SchoolExpenditure? expenditure = null)
+    public BenchmarkingWebAppClient SetupExpenditure(
+        School school,
+        SchoolExpenditure? expenditure = null,
+        SchoolExpenditure[]? expenditures = null)
     {
         ExpenditureApi.Reset();
         ExpenditureApi
@@ -497,15 +501,9 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
             {
                 PeriodCoveredByReturn = 12
             }));
-        return this;
-    }
-
-    public BenchmarkingWebAppClient SetupExpenditure(SchoolExpenditure[] expenditures)
-    {
-        ExpenditureApi.Reset();
         ExpenditureApi
             .Setup(api => api.QuerySchools(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(ApiResult.Ok(expenditures));
+            .ReturnsAsync(ApiResult.Ok(expenditures ?? []));
         return this;
     }
 

--- a/web/tests/Web.Integration.Tests/Pages/Schools/Census/WhenRequestingSeniorLeadershipDownload.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/Census/WhenRequestingSeniorLeadershipDownload.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using AutoFixture;
 using Web.App.Domain;
+using Web.App.Domain.Schools;
 using Xunit;
 
 namespace Web.Integration.Tests.Pages.Schools.Census;

--- a/web/tests/Web.Integration.Tests/Pages/Schools/Census/WhenViewingSeniorLeadership.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/Census/WhenViewingSeniorLeadership.cs
@@ -4,6 +4,7 @@ using AngleSharp.Html.Dom;
 using AutoFixture;
 using Web.App.Domain;
 using Web.App.Domain.Charts;
+using Web.App.Domain.Schools;
 using Xunit;
 
 namespace Web.Integration.Tests.Pages.Schools.Census;

--- a/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenRequestingComparisonDownload.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenRequestingComparisonDownload.cs
@@ -35,7 +35,7 @@ public class WhenRequestingComparisonDownload : PageBase<SchoolBenchmarkingWebAp
         var response = await _client
             .SetupDisableFeatureFlags(features)
             .SetupComparatorSet(school, comparatorSet)
-            .SetupExpenditure(_schoolExpenditures)
+            .SetupExpenditure(school, expenditures: _schoolExpenditures)
             .Get(Paths.SchoolComparisonDownload(school.URN!));
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -86,7 +86,7 @@ public class WhenRequestingComparisonDownload : PageBase<SchoolBenchmarkingWebAp
         var response = await _client
             .SetupDisableFeatureFlags(features)
             .SetupComparatorSet(school, comparatorSet)
-            .SetupExpenditure(_schoolExpenditures)
+            .SetupExpenditure(school, expenditures: _schoolExpenditures)
             .SetupUserData(userData)
             .Get(Paths.SchoolComparisonDownload(school.URN!));
 
@@ -137,7 +137,7 @@ public class WhenRequestingComparisonDownload : PageBase<SchoolBenchmarkingWebAp
         var response = await _client
             .SetupDisableFeatureFlags(features)
             .SetupCustomComparatorSet(school, comparatorSet, userDefinedComparatorSet)
-            .SetupExpenditure(_schoolExpenditures)
+            .SetupExpenditure(school, expenditures: _schoolExpenditures)
             .SetupExpenditureForCustomData(school, school.URN!, expenditure)
             .Get(Paths.SchoolComparisonDownload(school.URN!, customDataId));
 


### PR DESCRIPTION
## 🧾 Summary

Updates the School Benchmark Spending page so that, when the SchoolComparisonFilter feature flag is enabled, all sub category data is displayed as tables grouped under their parent categories.

[AB#298070](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/298070)
[AB#312894](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/312894)

### ✨ Feature Details
**Functionality:**

When the SchoolComparisonFilter feature flag is on:

- each subcategory in the School Benchmark Spending page is now rendered as a table
 - subcategories are grouped under their main category
- the page currently defaults to ViewAsOptions.Table and ResultAsOptions.SpendPerUnit
- filtering and alternative view modes will be added in future work

**Implementation:**

- mirrors the pattern used for the High Needs Spending page
- introduces SchoolSpendingDimensions to supply the required ResultAsOptions and supporting extension methods
- renames Domain/School to Domain/Schools to avoid namespace conflicts with Domain.School, and corrects the namespace used for SeniorLeadershipGroup. This results in a number of updates to using declarations
- adds SchoolSpendingCategories with CategoryGroup, SubCategoryFilter, and related extension methods
  - includes a new GetCategoryGroupSetType() extension method to determine whether a category group uses building or pupil results
  - introduces ComparatorSetTypes to support this logic
- moves SchoolComparisonDatum into its own file, as it is no longer specific to IT spending
- updates SchoolComparisonController so that when the feature flag is enabled it fetches expenditure data for both building and pupil result sets
- ViewModels follow the same pattern as High Needs Spending, with the key difference that GetCategoryGroupSetType() determines which result set to use when iterating through groups
- Adds a new partial view to render sub category tables, including commentary for any part‑year rows
- updates the test helper SetupExpenditure() to return either provided expenditures or an empty array.


## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [x] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes

Integration tests will be added in a follow up task.

This PR lays most of the groundwork for adding filters and view options. Minor adjustments may still be needed.

Progress 8 banding data integration is intentionally deferred to a later task.
