### PR TITLE
feat: add filters to school benchmark spending

### DIFF
--- a/web/src/Web.App/Controllers/SchoolComparisonController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparisonController.cs
@@ -37,6 +37,7 @@ public class SchoolComparisonController(
     [SchoolRequestTelemetry(TrackedRequestFeature.BenchmarkCosts)]
     public async Task<IActionResult> Index(
         string urn,
+        SchoolSpendingCategories.SubCategoryFilter[] selectedSubCategories,
         // TODO: this should default to chart but until functionality to toggle view as options is implemented we default to table
         Views.ViewAsOptions viewAs = Views.ViewAsOptions.Table,
         SchoolSpendingDimensions.ResultAsOptions resultAs = SchoolSpendingDimensions.ResultAsOptions.SpendPerUnit)
@@ -74,8 +75,7 @@ public class SchoolComparisonController(
                 {
                     var buildingResult = await GetDefaultSchoolExpenditure(urn, true, resultAs);
                     var pupilResult = await GetDefaultSchoolExpenditure(urn, false, resultAs);
-                    // TODO: replace SpendingCategories.All with selectedSubCategories once filters are implemented
-                    subCategories = new SpendingComparisonSubCategoriesViewModel(buildingResult, pupilResult, SchoolSpendingCategories.All, urn);
+                    subCategories = new SpendingComparisonSubCategoriesViewModel(buildingResult, pupilResult, selectedSubCategories, urn);
                 }
 
                 var viewModel = new SchoolComparisonViewModel(
@@ -88,6 +88,7 @@ public class SchoolComparisonController(
                     bandings,
                     subCategories)
                 {
+                    SelectedSubCategories = selectedSubCategories,
                     ViewAs = viewAs,
                     ResultAs = resultAs
                 };
@@ -102,6 +103,14 @@ public class SchoolComparisonController(
             }
         }
     }
+
+    // TODO: once to form options have been implemented this should pass viewAs and resultAs as route values
+    [HttpPost]
+    public IActionResult Index(string urn, int[]? selectedSubCategories, int viewAs, int resultAs) => RedirectToAction("Index", new
+    {
+        urn,
+        selectedSubCategories
+    });
 
     [HttpGet]
     [Route("custom-data")]

--- a/web/src/Web.App/Views/SchoolComparison/IndexFilters.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/IndexFilters.cshtml
@@ -39,7 +39,7 @@
 {
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
-            <p class="govuk-body">filters under construction</p>
+            @await Html.PartialAsync("_SchoolComparisonFilter", Model)
         </div>
         <div class="govuk-grid-column-two-thirds">
             <p class="govuk-body">page actions under construction</p>

--- a/web/src/Web.App/Views/SchoolComparison/_SchoolComparisonFilter.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/_SchoolComparisonFilter.cshtml
@@ -1,0 +1,118 @@
+@using Web.App.Domain.Schools
+@using Web.App.ViewModels
+@model Web.App.ViewModels.SchoolComparisonViewModel
+
+<div class="app-filter">
+    <div class="app-filter__header">
+        <h2 class="govuk-heading-m govuk-!-margin-0">
+            Filters
+        </h2>
+    </div>
+
+    @if (Model.SelectedSubCategories.Length > 0)
+    {
+        <div class="app-filter__selected">
+            <div class="app-filter__selected-header">
+                <h2 class="govuk-heading-m">
+                    Selected filters
+                </h2>
+                <a href="@Url.Action("Index", "SchoolComparison", new { Model.Urn, viewAs = (int)Model.ViewAs, resultAs = (int)Model.ResultAs }))"
+                   class="govuk-link govuk-link--no-visited-state">Clear</a>
+            </div>
+            @foreach (var group in Model.SelectedGroups)
+            {
+                <h3 class="govuk-heading-s">@group.Group</h3>
+
+                <ul class="govuk-list">
+                    @foreach (var item in group.SelectedItems(Model.SelectedIds))
+                    {
+                        <li>
+                            <a href="@Url.Action("Index", new {
+                                        Model.Urn,
+                                        viewAs = (int)Model.ViewAs,
+                                        resultAs = (int)Model.ResultAs,
+                                        selectedSubCategories = Model.SelectedSubCategories
+                                            .Where(x => (int)x != item.SubCategoryId)
+                                            .Select(x => (int)x)
+                                             })"
+                           class="app-filter__tag">
+                            @item.SubCategory
+                        </a>
+                        </li>
+                    }
+                </ul>
+            }
+        </div>
+    }
+    <div class="app-filter__body">
+        @using (Html.BeginForm(FormMethod.Post, true, new { novalidate = "novalidate", role = "search" }))
+        {
+            <input type="hidden"
+                   name="@nameof(LocalAuthorityHighNeedsSpendingViewModel.SelectedSubCategories)"
+                   value="@Model.SelectedSubCategories"/>
+
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+                @for (var i = 0; i < Model.AllGroups.Length; i++)
+                {
+                    var group = Model.AllGroups[i];
+                    var headingId = $"accordion-default-heading-{i + 1}";
+                    var contentId = $"accordion-default-content-{i + 1}";
+
+                    var groupSelectedCount = group.Value.Count(x => Model.SelectedIds.Contains((int)x));
+
+                    <div class="govuk-accordion__section">
+                        <div class="govuk-accordion__section-header">
+                            <h2 class="govuk-accordion__section-heading">
+                                <span class="govuk-accordion__section-button"
+                                      id="@headingId">
+                                    @group.Key.GetCategoryGroupDescription()
+
+                                    @if (groupSelectedCount > 0)
+                                    {
+                                        <span class="govuk-hint app-filter__selected-hint">
+                                            @($"{groupSelectedCount} selected")
+                                        </span>
+                                    }
+
+                                </span>
+                            </h2>
+                        </div>
+
+                        <div id="@contentId" class="govuk-accordion__section-content">
+                            <div class="govuk-form-group">
+                                <fieldset class="govuk-fieldset">
+                                    <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+
+                                        @foreach (var sub in group.Value)
+                                        {
+                                            var id = (int)sub;
+                                            var isChecked = Model.SelectedIds.Contains(id);
+
+                                            <div class="govuk-checkboxes__item">
+                                                <input class="govuk-checkboxes__input"
+                                                       id="subcategory-@id"
+                                                       name="@nameof(Model.SelectedSubCategories)"
+                                                       value="@id"
+                                                       type="checkbox"
+                                                       @(isChecked ? "checked" : "") />
+
+                                                <label class="govuk-label govuk-checkboxes__label"
+                                                       for="subcategory-@id">
+                                                    @sub.GetHeading()
+                                                </label>
+                                            </div>
+                                        }
+
+                                    </div>
+                                </fieldset>
+                            </div>
+                        </div>
+                    </div>
+                }
+            </div>
+            <button type="submit" class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-1" data-module="govuk-button">
+                Apply filters
+            </button>
+        }
+    </div>
+</div>


### PR DESCRIPTION
## 🧾 Summary

Enables sub category filtering on the School Benchmark Spending page when the SchoolComparisonFilter feature flag is active, allowing users to narrow the displayed data to only the categories they care about.

[AB#298070](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/298070)
[AB#312895](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/312895)

### ✨ Feature Details
**Functionality:**

This update introduces filtering capabilities for the School Benchmark Spending page. Users can now:
- select one or more sub categories via grouped accordion filter
- view selected filters as removeable tags

<img width="1653" height="1345" alt="image" src="https://github.com/user-attachments/assets/cf31e068-fd94-4497-a890-5272d30c2735" />

**Implementation:**

Follows the established pattern used for high needs spending and elsewhere. Primarily a lift and shift of the existing approach, with only minor adjustments needed.

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [x] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [x] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes

Integration tests will be added in a follow up task.
