### PR TITLE
feat: add page options to school benchmark spending page

### DIFF
--- a/web/src/Web.App/Controllers/SchoolComparisonController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparisonController.cs
@@ -38,8 +38,7 @@ public class SchoolComparisonController(
     public async Task<IActionResult> Index(
         string urn,
         SchoolSpendingCategories.SubCategoryFilter[] selectedSubCategories,
-        // TODO: this should default to chart but until functionality to toggle view as options is implemented we default to table
-        Views.ViewAsOptions viewAs = Views.ViewAsOptions.Table,
+        Views.ViewAsOptions viewAs = Views.ViewAsOptions.Chart,
         SchoolSpendingDimensions.ResultAsOptions resultAs = SchoolSpendingDimensions.ResultAsOptions.SpendPerUnit)
     {
         using (logger.BeginScope(new
@@ -104,12 +103,13 @@ public class SchoolComparisonController(
         }
     }
 
-    // TODO: once to form options have been implemented this should pass viewAs and resultAs as route values
     [HttpPost]
     public IActionResult Index(string urn, int[]? selectedSubCategories, int viewAs, int resultAs) => RedirectToAction("Index", new
     {
         urn,
-        selectedSubCategories
+        selectedSubCategories,
+        viewAs,
+        resultAs
     });
 
     [HttpGet]

--- a/web/src/Web.App/Domain/Charts/SchoolSpendingDimensions.cs
+++ b/web/src/Web.App/Domain/Charts/SchoolSpendingDimensions.cs
@@ -13,6 +13,14 @@ public static class SchoolSpendingDimensions
         PercentIncome = 3
     }
 
+    public static readonly ResultAsOptions[] AllResultsAsOptions =
+    [
+        ResultAsOptions.SpendPerUnit,
+        ResultAsOptions.Actuals,
+        ResultAsOptions.PercentExpenditure,
+        ResultAsOptions.PercentIncome,
+    ];
+
     public static string GetQueryParam(this ResultAsOptions option) => option switch
     {
         ResultAsOptions.SpendPerUnit => "PerUnit",
@@ -54,7 +62,7 @@ public static class SchoolSpendingDimensions
 
     public static string GetDescription(this ResultAsOptions option) => option switch
     {
-        ResultAsOptions.SpendPerUnit => "£ per pupil",
+        ResultAsOptions.SpendPerUnit => "£ per unit",
         ResultAsOptions.Actuals => "actuals",
         ResultAsOptions.PercentExpenditure => "% of expenditure",
         ResultAsOptions.PercentIncome => "% of income",

--- a/web/src/Web.App/ViewModels/SchoolComparisonViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolComparisonViewModel.cs
@@ -47,8 +47,7 @@ public class SchoolComparisonViewModel(
     public IEnumerable<SpendingComparisonGroup> SelectedGroups =>
         Groups.Where(g => g.SelectedCount(SelectedIds) > 0);
 
-    // TODO: this should default to chart but until functionality to toggle view as options is implemented we default to table
-    public Views.ViewAsOptions ViewAs { get; init; } = Views.ViewAsOptions.Table;
+    public Views.ViewAsOptions ViewAs { get; init; } = Views.ViewAsOptions.Chart;
 
     public SchoolSpendingDimensions.ResultAsOptions ResultAs { get; init; } = SchoolSpendingDimensions.ResultAsOptions.SpendPerUnit;
 

--- a/web/src/Web.App/Views/SchoolComparison/IndexFilters.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/IndexFilters.cshtml
@@ -45,7 +45,60 @@
             <p class="govuk-body">page actions under construction</p>
             <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-            <p class="govuk-body">form options under construction</p>
+            @using (Html.BeginForm(FormMethod.Post, true, new
+            {
+                @class = "options-form",
+                novalidate = "novalidate",
+                role = "search"
+            }))
+        {
+            <div class="options-form__view-as">
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-label">
+                        View as
+                    </legend>
+                    <div class="govuk-radios govuk-radios--small" data-module="govuk-radios"
+                         id="@nameof(SchoolComparisonViewModel.ViewAs)">
+                        @foreach (var view in Views.All)
+                        {
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input"
+                                       id="view-@view"
+                                       name="@nameof(SchoolComparisonViewModel.ViewAs)" type="radio"
+                                       value="@((int)view)"
+                                       @(Model.ViewAs == view ? "checked" : "")>
+                                <label class="govuk-label govuk-radios__label"
+                                       for="view-@view">
+                                    @view.GetDescription()
+                                </label>
+                            </div>
+                        }
+                    </div>
+                </fieldset>
+            </div>
+
+            <div class="options-form__compare-by">
+                <label class="govuk-label" for="@nameof(SchoolComparisonViewModel.ResultAs)">
+                    Compare by
+                </label>
+                <select class="govuk-select" id="@nameof(SchoolComparisonViewModel.ResultAs)" name="@nameof(SchoolComparisonViewModel.ResultAs)">
+                    @foreach (var option in SchoolSpendingDimensions.AllResultsAsOptions)
+                    {
+                        <option
+                            value="@((int)option)"
+                            selected="@(Model.ResultAs == option ? "selected" : null)">
+                            @option.GetDescription()
+                        </option>
+                    }
+                </select>
+            </div>
+
+            <div class="options-form__apply">
+                <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+                    Apply
+                </button>
+            </div>
+        }
             <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
             @foreach (var group in Model.Groups.Where(group => group.Items.Any()))


### PR DESCRIPTION
## 🧾 Summary

Adds view switching and comparison mode options to the School Benchmark Spending page, allowing users to choose between chart/table views and select how spending should be compared (e.g., £ per unit, % of income).

[AB#298070](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/298070)
[AB#312896](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/312896)

### ✨ Feature Details
**Functionality:**

This update introduces the same chart/table and comparison‑mode controls already used elsewhere (e.g., high needs spending). Users can now:
- switch between chart and table views
- choose how to compare spending (e.g., £ per unit, % of income, etc.)

<img width="1708" height="1006" alt="image" src="https://github.com/user-attachments/assets/d6e45278-1db3-4d4c-9070-0407b05fe0c5" />

**Implementation:**

Follows the established pattern used for high needs spending and elsewhere. Primarily a lift and shift of the existing approach, with only minor adjustments needed.

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [x] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [x] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes

Integration tests will be added in a follow up task.

The school performance checkbox and the wider progress 8 banding integration are intentionally deferred to a later piece of work.