### PR TITLE
feat: add cost codes for school benchmark spending

### DIFF
--- a/web/src/Web.App/Controllers/SchoolComparisonController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparisonController.cs
@@ -75,7 +75,7 @@ public class SchoolComparisonController(
                 {
                     var buildingResult = await GetDefaultSchoolExpenditure(urn, true, resultAs);
                     var pupilResult = await GetDefaultSchoolExpenditure(urn, false, resultAs);
-                    subCategories = new SpendingComparisonSubCategoriesViewModel(buildingResult, pupilResult, selectedSubCategories, urn);
+                    subCategories = new SpendingComparisonSubCategoriesViewModel(buildingResult, pupilResult, selectedSubCategories, urn, costCodes);
 
                     var charts = await BuildCharts(urn, subCategories, resultAs);
 

--- a/web/src/Web.App/Domain/Schools/SchoolSpendingCategories.cs
+++ b/web/src/Web.App/Domain/Schools/SchoolSpendingCategories.cs
@@ -301,4 +301,109 @@ public static class SchoolSpendingCategories
             SubCategoryFilter.CommunityFocusedSchoolCosts => e.CommunityFocusedSchoolCosts,
             _ => null
         };
+
+    public static string[] GetCostCodes(this SubCategoryFilter filter, CostCodes costCodes)
+    {
+        return filter
+            .GetSubCategoriesListForCostCodes()
+            .SelectMany(s => costCodes.GetCostCodes(s))
+            .Where(code => code is not null)
+            .Select(code => code!)
+            .ToArray();
+    }
+
+    private static string[] GetSubCategoriesListForCostCodes(this SubCategoryFilter filter) => filter switch
+    {
+        SubCategoryFilter.TotalTeachingSupportStaffCosts => [
+            SubCostCategories.TeachingStaff.TeachingStaffCosts,
+            SubCostCategories.TeachingStaff.SupplyTeachingStaffCosts,
+            SubCostCategories.TeachingStaff.EducationalConsultancyCosts,
+            SubCostCategories.TeachingStaff.EducationSupportStaffCosts,
+            SubCostCategories.TeachingStaff.AgencySupplyTeachingStaffCosts
+        ],
+        SubCategoryFilter.TeachingStaffCosts => [SubCostCategories.TeachingStaff.TeachingStaffCosts],
+        SubCategoryFilter.SupplyTeachingStaffCosts => [SubCostCategories.TeachingStaff.SupplyTeachingStaffCosts],
+        SubCategoryFilter.EducationalConsultancyCosts => [SubCostCategories.TeachingStaff.EducationalConsultancyCosts],
+        SubCategoryFilter.EducationSupportStaffCosts => [SubCostCategories.TeachingStaff.EducationSupportStaffCosts],
+        SubCategoryFilter.AgencySupplyTeachingStaffCosts => [SubCostCategories.TeachingStaff.AgencySupplyTeachingStaffCosts],
+
+        SubCategoryFilter.TotalNonEducationalSupportStaffCosts => [
+            SubCostCategories.NonEducationalSupportStaff.AdministrativeClericalStaffCosts,
+            SubCostCategories.NonEducationalSupportStaff.AuditorsCosts,
+            SubCostCategories.NonEducationalSupportStaff.OtherStaffCosts,
+            SubCostCategories.NonEducationalSupportStaff.ProfessionalServicesNonCurriculumCosts
+        ],
+        SubCategoryFilter.AdministrativeClericalStaffCosts => [SubCostCategories.NonEducationalSupportStaff.AdministrativeClericalStaffCosts],
+        SubCategoryFilter.AuditorsCosts => [SubCostCategories.NonEducationalSupportStaff.AuditorsCosts],
+        SubCategoryFilter.OtherStaffCosts => [SubCostCategories.NonEducationalSupportStaff.OtherStaffCosts],
+        SubCategoryFilter.ProfessionalServicesNonCurriculumCosts => [SubCostCategories.NonEducationalSupportStaff.ProfessionalServicesNonCurriculumCosts],
+
+        SubCategoryFilter.TotalEducationalSuppliesCosts => [
+            SubCostCategories.EducationalSupplies.ExaminationFeesCosts,
+            SubCostCategories.EducationalSupplies.LearningResourcesNonIctCosts
+        ],
+        SubCategoryFilter.ExaminationFeesCosts => [SubCostCategories.EducationalSupplies.ExaminationFeesCosts],
+        SubCategoryFilter.LearningResourcesNonIctCosts => [SubCostCategories.EducationalSupplies.LearningResourcesNonIctCosts],
+
+        SubCategoryFilter.LearningResourcesIctCosts => [SubCostCategories.EducationalIct.LearningResourcesIctCosts],
+
+        SubCategoryFilter.TotalPremisesStaffServiceCosts => [
+            SubCostCategories.PremisesStaffServices.CleaningCaretakingCosts,
+            SubCostCategories.PremisesStaffServices.MaintenancePremisesCosts,
+            SubCostCategories.PremisesStaffServices.OtherOccupationCosts,
+            SubCostCategories.PremisesStaffServices.PremisesStaffCosts
+        ],
+        SubCategoryFilter.CleaningCaretakingCosts => [SubCostCategories.PremisesStaffServices.CleaningCaretakingCosts],
+        SubCategoryFilter.MaintenancePremisesCosts => [SubCostCategories.PremisesStaffServices.MaintenancePremisesCosts],
+        SubCategoryFilter.OtherOccupationCosts => [SubCostCategories.PremisesStaffServices.OtherOccupationCosts],
+        SubCategoryFilter.PremisesStaffCosts => [SubCostCategories.PremisesStaffServices.PremisesStaffCosts],
+
+        SubCategoryFilter.TotalUtilitiesCosts => [
+            SubCostCategories.Utilities.EnergyCosts,
+            SubCostCategories.Utilities.WaterSewerageCosts
+        ],
+        SubCategoryFilter.EnergyCosts => [SubCostCategories.Utilities.EnergyCosts],
+        SubCategoryFilter.WaterSewerageCosts => [SubCostCategories.Utilities.WaterSewerageCosts],
+
+        SubCategoryFilter.AdministrativeSuppliesNonEducationalCosts => [SubCostCategories.AdministrativeSupplies.AdministrativeSuppliesNonEducationalCosts],
+
+        SubCategoryFilter.TotalGrossCateringCosts => [
+            SubCostCategories.CateringStaffServices.CateringStaffCosts,
+            SubCostCategories.CateringStaffServices.CateringSuppliesCosts
+        ],
+        SubCategoryFilter.TotalNetCateringCosts => [
+            SubCostCategories.CateringStaffServices.CateringStaffCosts,
+            SubCostCategories.CateringStaffServices.CateringSuppliesCosts
+        ],
+        SubCategoryFilter.CateringStaffCosts => [SubCostCategories.CateringStaffServices.CateringStaffCosts],
+        SubCategoryFilter.CateringSuppliesCosts => [SubCostCategories.CateringStaffServices.CateringSuppliesCosts],
+
+        SubCategoryFilter.TotalOtherCosts => [
+            SubCostCategories.Other.OtherInsurancePremiumsCosts,
+            SubCostCategories.Other.GroundsMaintenanceCosts,
+            SubCostCategories.Other.IndirectEmployeeExpenses,
+            SubCostCategories.Other.InterestChargesLoanBank,
+            SubCostCategories.Other.PrivateFinanceInitiativeCharges,
+            SubCostCategories.Other.RentRatesCosts,
+            SubCostCategories.Other.SpecialFacilitiesCosts,
+            SubCostCategories.Other.StaffDevelopmentTrainingCosts,
+            SubCostCategories.Other.StaffRelatedInsuranceCosts,
+            SubCostCategories.Other.SupplyTeacherInsurableCosts,
+            SubCostCategories.Other.CommunityFocusedSchoolCosts,
+            SubCostCategories.Other.CommunityFocusedSchoolStaff
+        ],
+        SubCategoryFilter.OtherInsurancePremiumsCosts => [SubCostCategories.Other.OtherInsurancePremiumsCosts],
+        SubCategoryFilter.GroundsMaintenanceCosts => [SubCostCategories.Other.GroundsMaintenanceCosts],
+        SubCategoryFilter.IndirectEmployeeExpenses => [SubCostCategories.Other.IndirectEmployeeExpenses],
+        SubCategoryFilter.InterestChargesLoanBank => [SubCostCategories.Other.InterestChargesLoanBank],
+        SubCategoryFilter.PrivateFinanceInitiativeCharges => [SubCostCategories.Other.PrivateFinanceInitiativeCharges],
+        SubCategoryFilter.RentRatesCosts => [SubCostCategories.Other.RentRatesCosts],
+        SubCategoryFilter.SpecialFacilitiesCosts => [SubCostCategories.Other.SpecialFacilitiesCosts],
+        SubCategoryFilter.StaffDevelopmentTrainingCosts => [SubCostCategories.Other.StaffDevelopmentTrainingCosts],
+        SubCategoryFilter.StaffRelatedInsuranceCosts => [SubCostCategories.Other.StaffRelatedInsuranceCosts],
+        SubCategoryFilter.SupplyTeacherInsurableCosts => [SubCostCategories.Other.SupplyTeacherInsurableCosts],
+        SubCategoryFilter.CommunityFocusedSchoolStaff => [SubCostCategories.Other.CommunityFocusedSchoolCosts],
+        SubCategoryFilter.CommunityFocusedSchoolCosts => [SubCostCategories.Other.CommunityFocusedSchoolStaff],
+        _ => []
+    };
 }

--- a/web/src/Web.App/ViewModels/SpendingComparisonSubCategoriesViewModel.cs
+++ b/web/src/Web.App/ViewModels/SpendingComparisonSubCategoriesViewModel.cs
@@ -12,7 +12,8 @@ public class SpendingComparisonSubCategoriesViewModel
         SchoolExpenditure[] buildingResult,
         SchoolExpenditure[] pupilResult,
         SchoolSpendingCategories.SubCategoryFilter[] filters,
-        string urn)
+        string urn,
+        CostCodes costCodes)
     {
         filters = filters.Length > 0 ? filters : SchoolSpendingCategories.All;
 
@@ -35,7 +36,8 @@ public class SpendingComparisonSubCategoriesViewModel
 
             foreach (var filter in activeChildren)
             {
-                var sub = BuildSubCategory(filter, expenditures, urn);
+                var codes = filter.GetCostCodes(costCodes);
+                var sub = BuildSubCategory(filter, expenditures, urn, codes);
                 groupVm.Items.Add(sub);
             }
 
@@ -46,7 +48,8 @@ public class SpendingComparisonSubCategoriesViewModel
     private static BenchmarkingViewModelCostSubCategory<SchoolComparisonDatum> BuildSubCategory(
         SchoolSpendingCategories.SubCategoryFilter filter,
         SchoolExpenditure[] expenditures,
-        string urn)
+        string urn,
+        string[] costCodes)
     {
         var data = expenditures
             .Select(e => new SchoolComparisonDatum
@@ -68,7 +71,8 @@ public class SpendingComparisonSubCategoriesViewModel
             Uuid = Guid.NewGuid().ToString(),
             SubCategory = filter.GetHeading(),
             SubCategoryId = (int)filter,
-            Data = data
+            Data = data,
+            LineCodes = costCodes
         };
     }
 }

--- a/web/src/Web.App/Views/SchoolComparison/_SchoolComparisonChart.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/_SchoolComparisonChart.cshtml
@@ -14,6 +14,9 @@
 }
 
 <div id="@Model.SubCategory.Uuid" class="costs-chart-container" data-title="@Model.SubCategory.SubCategory">
+
+    @await Html.PartialAsync("_SchoolComparisonCostCodes", Model)
+
     <div class="costs-chart-wrapper">
         <div class="govuk-!-margin-bottom-2 ssr-chart horizontal-bar-chart">
             @Html.Raw(Model.SubCategory.ChartSvg)

--- a/web/src/Web.App/Views/SchoolComparison/_SchoolComparisonCostCodes.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/_SchoolComparisonCostCodes.cshtml
@@ -1,0 +1,16 @@
+@model Web.App.ViewModels.SchoolSpendingDataViewModel
+
+@if (Model.SubCategory.LineCodes == null || Model.SubCategory.LineCodes.Length == 0)
+{
+    return;
+}
+
+<div class="app-cost-code-list">
+    <p class="govuk-body">Cost category codes:</p>
+    <ul class="govuk-list">
+        @foreach (var costCode in Model.SubCategory.LineCodes)
+        {
+            <li><strong class="cost-code-item">@costCode</strong></li>
+        }
+    </ul>
+</div>

--- a/web/src/Web.App/Views/SchoolComparison/_SchoolComparisonTable.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/_SchoolComparisonTable.cshtml
@@ -14,6 +14,8 @@
     return;
 }
 <div>
+    @await Html.PartialAsync("_SchoolComparisonCostCodes", Model)
+
     <table class="govuk-table">
         <thead class="govuk-table__head">
         <tr class="govuk-table__row">
@@ -29,7 +31,10 @@
         {
             <tr class="govuk-table__row">
                 <td class="govuk-table__cell @(row.Urn == Model.Urn ? " govuk-!-font-weight-bold" : "")">
-                    <a class="govuk-link govuk-link--no-visited-state" href="@Url.ActionLink("Index", "School", new { urn = row.Urn })">@row.SchoolName</a>
+                    <a class="govuk-link govuk-link--no-visited-state" href="@Url.ActionLink("Index", "School", new
+                                                                             {
+                                                                                 urn = row.Urn
+                                                                             })">@row.SchoolName</a>
                     @if (row.PeriodCoveredByReturn is not 12)
                     {
                         <p class="govuk-table__cell_commentary">


### PR DESCRIPTION
## 🧾 Summary

Adds cost codes for the School Benchmark Spending page

[AB#298070](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/298070)
[AB#312899](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/312899)

### ✨ Feature Details
**Functionality:**

Cost codes are now shown beneath each chart/table heading on the school benchmark spending page.
The codes respect the school’s FinanceType, ensuring that academies and maintained schools see the correct set of codes.

<img width="957" height="348" alt="image" src="https://github.com/user-attachments/assets/659d47c0-b6c9-4018-80c7-ed4c1167737e" />

<img width="943" height="299" alt="image" src="https://github.com/user-attachments/assets/ddb2ed3b-868c-42f4-ba75-c92f110e6222" />

 **Implementation:**
 
 A new GetCostCodes() extension on SchoolSpendingCategories retrieves the relevant cost codes for each subcategory.
 
 A private helper maps filters to the existing domain subcategory definitions so the existing CostCodes.GetCostCodes() logic can be reused.

The controller now passes cost codes into SpendingComparisonSubCategoriesViewModel to be rendered in the UI via filter.GetCostCodes().

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [x] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes

Integration tests to be added as a later task.
