### PR TITLE
feat: add save chart images and download data to school benchmark spending

### DIFF
--- a/web/src/Web.App/Views/SchoolComparison/IndexFilters.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/IndexFilters.cshtml
@@ -1,6 +1,7 @@
 @using Web.App.Domain.Charts
 @using Web.App.Extensions
 @using Web.App.ViewModels
+@using Web.App.ViewModels.Enhancements
 @model Web.App.ViewModels.SchoolComparisonViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.Comparison;
@@ -42,7 +43,21 @@
             @await Html.PartialAsync("_SchoolComparisonFilter", Model)
         </div>
         <div class="govuk-grid-column-two-thirds">
-            <p class="govuk-body">page actions under construction</p>
+            <div class="page-actions-wrapper-horizontal">
+                <div class="page-actions">
+                    @if (Model.ViewAs == Views.ViewAsOptions.Chart)
+                    {
+                        <div id="page-actions-button"></div>
+                    }
+                    <a href="@Url.Action("Download", "SchoolComparison", new
+                             {
+                                 urn = Model.Urn
+                             })" role="button"
+                   class="govuk-button govuk-button--secondary" data-module="govuk-button">
+                    Download page data
+                </a>
+                </div>
+            </div>
             <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
             @using (Html.BeginForm(FormMethod.Post, true, new
@@ -133,3 +148,17 @@
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
 @await Html.PartialAsync("FinanceTools/_School", Model.Tools)
+
+@section scripts
+{
+
+    @await Html.PartialAsync("Enhancements/_PageActions", new PageActionsViewModel
+    {
+        All = true,
+        ElementId = "page-actions-button",
+        SaveClassName = "costs-chart-container",
+        SaveFileName = $"comparison-{Model.Urn}.zip",
+        SaveTitleAttr = "data-title",
+        StartImmediately = true
+    })
+}


### PR DESCRIPTION
## 🧾 Summary

[AB#298070](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/298070)
[AB#312900](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/312900)
[AB#312901](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/312901)

<img width="1430" height="449" alt="image" src="https://github.com/user-attachments/assets/dd8248fc-5ab2-460b-9c35-02c191e2b13a" />

**Functionality:**

This PR updates the school benchmark spending page to allow users to download charts as images and download the page data

**Implementation:**

Following the existing pattern save images functionality is added to the page as a progressive enhancement when javascript is available. 

Download functionality uses the existing Download action in the controller and therefore is a case of simply implementing the button.

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [x] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes

validated cost codes are present in images following #4236 
