### PR TITLE
feat: filter out schools with spending < 0 from benchmarking

### DIFF
--- a/web/src/Web.App/ViewModels/SpendingComparisonSubCategoriesViewModel.cs
+++ b/web/src/Web.App/ViewModels/SpendingComparisonSubCategoriesViewModel.cs
@@ -59,7 +59,7 @@ public class SpendingComparisonSubCategoriesViewModel
                 TotalPupils = e.TotalPupils,
                 PeriodCoveredByReturn = e.PeriodCoveredByReturn
             })
-            .Where(x => x.Urn == urn || x.Expenditure != null)
+            .Where(x => x.Urn == urn || x.Expenditure is > 0)
             .OrderByDescending(x => x.Expenditure)
             .ToArray();
 


### PR DESCRIPTION
## 🧾 Summary
> Briefly describe the changes and why they are needed.

Fixes [AB#298070](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/298070) [AB#314510](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/314510)

### ✨ Feature Details
> - **Functionality:** Ensures that schools with zero expenditure figures are filtered out of school spending benchmarking charts, as long as they aren't the subject school 
> - **Implementation:** Simply changed a null equality test to an "is > 0" test

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes
> Add any additional context for reviewers, required dependencies, or specific testing instructions.
