### PR TITLE
feat: ensure specific filter groups are open by default

### DIFF
--- a/web/src/Web.App/Domain/Schools/SchoolSpendingCategories.cs
+++ b/web/src/Web.App/Domain/Schools/SchoolSpendingCategories.cs
@@ -207,6 +207,14 @@ public static class SchoolSpendingCategories
         _ => ComparatorSetTypes.Pupil
     };
 
+    public static bool GetOpenByDefault(this CategoryGroup group) => group switch
+    {
+        CategoryGroup.TotalExpenditure => true,
+        CategoryGroup.EducationalIct => true,
+        CategoryGroup.AdministrativeSupplies => true,
+        _ => false
+    };
+
     public static string GetHeading(this SubCategoryFilter filter) => filter switch
     {
         SubCategoryFilter.TotalExpenditure => "Total expenditure",

--- a/web/src/Web.App/Views/SchoolComparison/_SchoolComparisonFilter.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/_SchoolComparisonFilter.cshtml
@@ -60,7 +60,7 @@
 
                     var groupSelectedCount = group.Value.Count(x => Model.SelectedIds.Contains((int)x));
 
-                    <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section@(group.Key.GetOpenByDefault() ? " govuk-accordion__section--expanded" : "")">
                         <div class="govuk-accordion__section-header">
                             <h2 class="govuk-accordion__section-heading">
                                 <span class="govuk-accordion__section-button"


### PR DESCRIPTION
## 🧾 Summary
> Briefly describe the changes and why they are needed.

Fixes [AB#298070](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/298070) [AB#314337](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/314337)

### ✨ Feature Details
> - **Functionality:** Ensures that nominstaed filter groups in school spending benchmarking are displayed as open by default
> - **Implementation:** A very simple static extension method on the filter group class which returns a boolean for whether each group should be open by default, and then setting the appropriate css class in the view, based on the value returned by that extension method


## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes
> Add any additional context for reviewers, required dependencies, or specific testing instructions.
