### PR TITLE
feat: add progress 8 indicators to school benchmark spending

### DIFF
--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -1239,6 +1239,9 @@ table#current-comparators-la {
   }
 }
 
+.options-form .govuk-checkboxes__item {
+  white-space: nowrap;
+}
 
 .actions-form
 {
@@ -1305,4 +1308,10 @@ table#current-comparators-la {
 
 .min-height-two-lines {
   min-height: 2lh;
+}
+
+.wide-page {
+  .govuk-width-container {
+    @include govuk-width-container(1200px);
+  }
 }

--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -903,6 +903,16 @@ table#current-comparators-la {
       stroke: govuk-colour("red");
     }
 
+    &.chart-cell__group-banding-well-above-average {
+      fill: govuk-colour("turquoise");
+      stroke: govuk-colour("turquoise");
+    }
+
+    &.chart-cell__group-banding-above-average {
+      fill: govuk-colour("light-blue");
+      stroke: govuk-colour("light-blue");
+    }
+
     &.chart-data-stack-0 {
       fill: govuk-colour("light-blue");
       stroke: govuk-colour("light-blue");

--- a/web/src/Web.App/Constants/LayoutClass.cs
+++ b/web/src/Web.App/Constants/LayoutClass.cs
@@ -1,0 +1,6 @@
+namespace Web.App;
+
+public static class LayoutClass
+{
+    public const string WidePage = "wide-page";
+}

--- a/web/src/Web.App/Constants/ViewDataKeys.cs
+++ b/web/src/Web.App/Constants/ViewDataKeys.cs
@@ -7,4 +7,5 @@ public static class ViewDataKeys
     public const string BreadcrumbNode = nameof(BreadcrumbNode);
     public const string UseJsBackLink = nameof(UseJsBackLink);
     public const string HiddenNavigation = nameof(HiddenNavigation);
+    public const string BodyClass = nameof(BodyClass);
 }

--- a/web/src/Web.App/Controllers/SchoolComparisonController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparisonController.cs
@@ -39,6 +39,7 @@ public class SchoolComparisonController(
     public async Task<IActionResult> Index(
         string urn,
         SchoolSpendingCategories.SubCategoryFilter[] selectedSubCategories,
+        SchoolSpendingDimensions.BandingsAsOptions[] bandingsAs,
         Views.ViewAsOptions viewAs = Views.ViewAsOptions.Chart,
         SchoolSpendingDimensions.ResultAsOptions resultAs = SchoolSpendingDimensions.ResultAsOptions.SpendPerUnit)
     {
@@ -73,11 +74,17 @@ public class SchoolComparisonController(
 
                 if (await featureManager.IsEnabledAsync(FeatureFlags.SchoolComparisonFilter))
                 {
-                    var buildingResult = await GetDefaultSchoolExpenditure(urn, true, resultAs);
-                    var pupilResult = await GetDefaultSchoolExpenditure(urn, false, resultAs);
-                    subCategories = new SpendingComparisonSubCategoriesViewModel(buildingResult, pupilResult, selectedSubCategories, urn, costCodes);
+                    var buildingResult = MergeProgressBandings(await GetDefaultSchoolExpenditure(urn, true, resultAs), bandings);
+                    var pupilResult = MergeProgressBandings(await GetDefaultSchoolExpenditure(urn, false, resultAs), bandings);
 
-                    var charts = await BuildCharts(urn, subCategories, resultAs);
+                    subCategories = new SpendingComparisonSubCategoriesViewModel(
+                        buildingResult,
+                        pupilResult,
+                        selectedSubCategories,
+                        urn,
+                        costCodes);
+
+                    var charts = await BuildCharts(urn, subCategories, resultAs, bandingsAs);
 
                     subCategories.Groups.ForEach(group =>
                     {
@@ -104,7 +111,8 @@ public class SchoolComparisonController(
                 {
                     SelectedSubCategories = selectedSubCategories,
                     ViewAs = viewAs,
-                    ResultAs = resultAs
+                    ResultAs = resultAs,
+                    BandingsAs = bandingsAs
                 };
 
                 var viewName = await GetViewName(nameof(Index));
@@ -118,7 +126,11 @@ public class SchoolComparisonController(
         }
     }
 
-    private async Task<ChartResponse[]> BuildCharts(string urn, SpendingComparisonSubCategoriesViewModel subCategories, SchoolSpendingDimensions.ResultAsOptions resultAs)
+    private async Task<ChartResponse[]> BuildCharts(
+        string urn,
+        SpendingComparisonSubCategoriesViewModel subCategories,
+        SchoolSpendingDimensions.ResultAsOptions resultAs,
+        SchoolSpendingDimensions.BandingsAsOptions[] bandingsAs)
     {
         var requests = subCategories
             .Groups
@@ -133,7 +145,8 @@ public class SchoolComparisonController(
                         urn = format
                     }) ?? string.Empty),
                 resultAs,
-                x.group.ComparatorSetType));
+                x.group.ComparatorSetType,
+                bandingsAs));
 
         ChartResponse[] charts = [];
         try
@@ -151,12 +164,13 @@ public class SchoolComparisonController(
     }
 
     [HttpPost]
-    public IActionResult Index(string urn, int[]? selectedSubCategories, int viewAs, int resultAs) => RedirectToAction("Index", new
+    public IActionResult Index(string urn, int[]? selectedSubCategories, int viewAs, int resultAs, int[]? bandingsAs) => RedirectToAction("Index", new
     {
         urn,
         selectedSubCategories,
         viewAs,
-        resultAs
+        resultAs,
+        bandingsAs
     });
 
     [HttpGet]
@@ -236,7 +250,10 @@ public class SchoolComparisonController(
                     bandings = await progressBandingsService.GetKS4ProgressBandings(urns?.ToArray() ?? []);
                 }
 
-                string[] exclude = [nameof(SchoolExpenditure.TotalInternalFloorArea)];
+                string[] exclude = bandings == null || bandings.Items.Length == 0
+                    ? [nameof(SchoolExpenditure.TotalInternalFloorArea), nameof(SchoolExpenditureWithProgress.ProgressBanding)]
+                    : [nameof(SchoolExpenditure.TotalInternalFloorArea)];
+
                 IEnumerable<CsvResult> csvResults =
                 [
                     new(MergeProgressBandings(buildingResult, bandings), $"comparison-{urn}-building.csv", exclude),
@@ -331,84 +348,20 @@ public class SchoolComparisonController(
         return query;
     }
 
-    private static IEnumerable<object>? MergeProgressBandings(SchoolExpenditure[]? expenditures, KS4ProgressBandings? bandings)
+    private static SchoolExpenditureWithProgress[] MergeProgressBandings(SchoolExpenditure[]? expenditures, KS4ProgressBandings? bandings)
     {
-        if (expenditures == null || bandings == null)
+        if (expenditures == null)
         {
-            return expenditures;
+            return [];
         }
-
-        return expenditures.Select(e => new SchoolExpenditureWithProgress(e, bandings[e.URN]));
+        return bandings == null
+            ? expenditures.Select(e => new SchoolExpenditureWithProgress(e, null)).ToArray()
+            : expenditures.Select(e => new SchoolExpenditureWithProgress(e, bandings[e.URN])).ToArray();
     }
 
     private async Task<string> GetViewName(string baseViewName)
     {
         var useFilters = await featureManager.IsEnabledAsync(FeatureFlags.SchoolComparisonFilter);
         return useFilters ? $"{baseViewName}Filters" : baseViewName;
-    }
-
-    private record SchoolExpenditureWithProgress : SchoolExpenditure
-    {
-        public SchoolExpenditureWithProgress(SchoolExpenditure expenditure, KS4ProgressBanding? banding) : base(expenditure)
-        {
-            TotalExpenditure = expenditure.TotalExpenditure;
-            TotalTeachingSupportStaffCosts = expenditure.TotalTeachingSupportStaffCosts;
-            TeachingStaffCosts = expenditure.TeachingStaffCosts;
-            SupplyTeachingStaffCosts = expenditure.SupplyTeachingStaffCosts;
-            EducationalConsultancyCosts = expenditure.EducationalConsultancyCosts;
-            EducationSupportStaffCosts = expenditure.EducationSupportStaffCosts;
-            AgencySupplyTeachingStaffCosts = expenditure.AgencySupplyTeachingStaffCosts;
-            TotalNonEducationalSupportStaffCosts = expenditure.TotalNonEducationalSupportStaffCosts;
-            AdministrativeClericalStaffCosts = expenditure.AdministrativeClericalStaffCosts;
-            AuditorsCosts = expenditure.AuditorsCosts;
-            OtherStaffCosts = expenditure.OtherStaffCosts;
-            ProfessionalServicesNonCurriculumCosts = expenditure.ProfessionalServicesNonCurriculumCosts;
-            TotalEducationalSuppliesCosts = expenditure.TotalEducationalSuppliesCosts;
-            ExaminationFeesCosts = expenditure.ExaminationFeesCosts;
-            LearningResourcesNonIctCosts = expenditure.LearningResourcesNonIctCosts;
-            LearningResourcesIctCosts = expenditure.LearningResourcesIctCosts;
-            TotalPremisesStaffServiceCosts = expenditure.TotalPremisesStaffServiceCosts;
-            CleaningCaretakingCosts = expenditure.CleaningCaretakingCosts;
-            MaintenancePremisesCosts = expenditure.MaintenancePremisesCosts;
-            OtherOccupationCosts = expenditure.OtherOccupationCosts;
-            PremisesStaffCosts = expenditure.PremisesStaffCosts;
-            TotalUtilitiesCosts = expenditure.TotalUtilitiesCosts;
-            EnergyCosts = expenditure.EnergyCosts;
-            WaterSewerageCosts = expenditure.WaterSewerageCosts;
-            AdministrativeSuppliesNonEducationalCosts = expenditure.AdministrativeSuppliesNonEducationalCosts;
-            TotalGrossCateringCosts = expenditure.TotalGrossCateringCosts;
-            TotalNetCateringCosts = expenditure.TotalNetCateringCosts;
-            CateringStaffCosts = expenditure.CateringStaffCosts;
-            CateringSuppliesCosts = expenditure.CateringSuppliesCosts;
-            TotalOtherCosts = expenditure.TotalOtherCosts;
-            GroundsMaintenanceCosts = expenditure.GroundsMaintenanceCosts;
-            IndirectEmployeeExpenses = expenditure.IndirectEmployeeExpenses;
-            InterestChargesLoanBank = expenditure.InterestChargesLoanBank;
-            OtherInsurancePremiumsCosts = expenditure.OtherInsurancePremiumsCosts;
-            PrivateFinanceInitiativeCharges = expenditure.PrivateFinanceInitiativeCharges;
-            RentRatesCosts = expenditure.RentRatesCosts;
-            SpecialFacilitiesCosts = expenditure.SpecialFacilitiesCosts;
-            StaffDevelopmentTrainingCosts = expenditure.StaffDevelopmentTrainingCosts;
-            StaffRelatedInsuranceCosts = expenditure.StaffRelatedInsuranceCosts;
-            SupplyTeacherInsurableCosts = expenditure.SupplyTeacherInsurableCosts;
-            CommunityFocusedSchoolStaff = expenditure.CommunityFocusedSchoolStaff;
-            CommunityFocusedSchoolCosts = expenditure.CommunityFocusedSchoolCosts;
-
-            URN = expenditure.URN;
-            SchoolName = expenditure.SchoolName;
-            SchoolType = expenditure.SchoolType;
-            LAName = expenditure.LAName;
-            PeriodCoveredByReturn = expenditure.PeriodCoveredByReturn;
-            TotalPupils = expenditure.TotalPupils;
-            TotalInternalFloorArea = expenditure.TotalInternalFloorArea;
-
-            if (banding?.Banding is KS4ProgressBandings.Banding.AboveAverage or KS4ProgressBandings.Banding.WellAboveAverage)
-            {
-                ProgressBanding = banding.Banding.ToStringValue();
-            }
-        }
-
-        [PropertyOrder(int.MaxValue)]
-        public string? ProgressBanding { get; set; }
     }
 }

--- a/web/src/Web.App/Domain/Charts/GroupType.cs
+++ b/web/src/Web.App/Domain/Charts/GroupType.cs
@@ -6,4 +6,6 @@ public static class GroupType
     public const string Forecast = "forecast";
     public const string PartYear = "part-year";
     public const string Previous = "previous";
+    public const string Progress8WellAboveAverage = "banding-well-above-average";
+    public const string Progress8AboveAverage = "banding-above-average";
 }

--- a/web/src/Web.App/Domain/Charts/SchoolComparisonDatum.cs
+++ b/web/src/Web.App/Domain/Charts/SchoolComparisonDatum.cs
@@ -9,4 +9,5 @@ public class SchoolComparisonDatum
     public string? SchoolType { get; init; }
     public decimal? TotalPupils { get; init; }
     public int? PeriodCoveredByReturn { get; init; }
+    public string? ProgressBanding { get; init; }
 }

--- a/web/src/Web.App/Domain/Charts/SchoolComparisonHorizontalBarChartRequest.cs
+++ b/web/src/Web.App/Domain/Charts/SchoolComparisonHorizontalBarChartRequest.cs
@@ -12,7 +12,8 @@ public record SchoolComparisonHorizontalBarChartRequest : PostHorizontalBarChart
         SchoolComparisonDatum[] filteredData,
         Func<string, string?> linkFormatter,
         SchoolSpendingDimensions.ResultAsOptions resultsAs,
-        string comparatorSetType)
+        string comparatorSetType,
+        SchoolSpendingDimensions.BandingsAsOptions[] bandingsAs)
     {
         BarHeight = 22;
         Data = filteredData;
@@ -29,16 +30,57 @@ public record SchoolComparisonHorizontalBarChartRequest : PostHorizontalBarChart
         ValueType = resultsAs.GetValueType();
         XAxisLabel = resultsAs.GetXAxisLabel(comparatorSetType);
 
+        GroupedKeys = new ChartRequestGroupedKeys();
+
         var partYear = filteredData
             .Where(x => x.PeriodCoveredByReturn is not 12)
             .Select(x => x.Urn!)
             .ToArray();
         if (partYear.Length > 0)
         {
-            GroupedKeys = new ChartRequestGroupedKeys
-            {
-                [GroupType.PartYear] = partYear
-            };
+            GroupedKeys[GroupType.PartYear] = partYear;
+        }
+
+        if (bandingsAs.Length == 0)
+        {
+            return;
+        }
+
+        // use only full year records for banding groups to prevent overlap with part‑year grouping
+        var fullYearData = filteredData
+            .Where(x => x.PeriodCoveredByReturn == 12)
+            .ToArray();
+
+        if (bandingsAs.Contains(SchoolSpendingDimensions.BandingsAsOptions.WellAbove))
+        {
+            AddBandingGroup(
+                fullYearData,
+                KS4ProgressBandings.Banding.WellAboveAverage,
+                GroupType.Progress8WellAboveAverage);
+        }
+
+        if (bandingsAs.Contains(SchoolSpendingDimensions.BandingsAsOptions.Above))
+        {
+            AddBandingGroup(
+                fullYearData,
+                KS4ProgressBandings.Banding.AboveAverage,
+                GroupType.Progress8AboveAverage);
+        }
+    }
+
+    private void AddBandingGroup(
+        SchoolComparisonDatum[] data,
+        KS4ProgressBandings.Banding banding,
+        string groupType)
+    {
+        var items = data
+            .Where(x => x.ProgressBanding == banding.ToStringValue())
+            .Select(x => x.Urn!)
+            .ToArray();
+
+        if (items.Length > 0)
+        {
+            GroupedKeys?[groupType] = items;
         }
     }
 }

--- a/web/src/Web.App/Domain/Charts/SchoolSpendingDimensions.cs
+++ b/web/src/Web.App/Domain/Charts/SchoolSpendingDimensions.cs
@@ -21,6 +21,18 @@ public static class SchoolSpendingDimensions
         ResultAsOptions.PercentIncome,
     ];
 
+    public enum BandingsAsOptions
+    {
+        WellAbove = 0,
+        Above = 1
+    }
+
+    public static readonly BandingsAsOptions[] AllBandingsAsOptions =
+    [
+        BandingsAsOptions.WellAbove,
+        BandingsAsOptions.Above
+    ];
+
     public static string GetQueryParam(this ResultAsOptions option) => option switch
     {
         ResultAsOptions.SpendPerUnit => "PerUnit",
@@ -60,12 +72,19 @@ public static class SchoolSpendingDimensions
         _ => throw new ArgumentOutOfRangeException(nameof(option))
     };
 
-    public static string GetDescription(this ResultAsOptions option) => option switch
+    public static string GetResultsAsDescription(this ResultAsOptions option) => option switch
     {
         ResultAsOptions.SpendPerUnit => "£ per unit",
         ResultAsOptions.Actuals => "actuals",
         ResultAsOptions.PercentExpenditure => "% of expenditure",
         ResultAsOptions.PercentIncome => "% of income",
+        _ => throw new ArgumentOutOfRangeException(nameof(option))
+    };
+
+    public static string GetBandingAsDescription(this BandingsAsOptions option) => option switch
+    {
+        BandingsAsOptions.WellAbove => "Well above average",
+        BandingsAsOptions.Above => "Above average",
         _ => throw new ArgumentOutOfRangeException(nameof(option))
     };
 }

--- a/web/src/Web.App/Domain/Insight/Expenditure.cs
+++ b/web/src/Web.App/Domain/Insight/Expenditure.cs
@@ -3,6 +3,8 @@
 // ReSharper disable UnusedAutoPropertyAccessor.Global
 // ReSharper disable UnusedMember.Global
 
+using Web.App.Attributes;
+
 namespace Web.App.Domain;
 
 public abstract record ExpenditureBase
@@ -163,4 +165,69 @@ public record ExpenditureHistoryRows
     public int? StartYear { get; set; }
     public int? EndYear { get; set; }
     public IEnumerable<ExpenditureHistory> Rows { get; set; } = [];
+}
+
+public record SchoolExpenditureWithProgress : SchoolExpenditure
+{
+    public SchoolExpenditureWithProgress(SchoolExpenditure expenditure, KS4ProgressBanding? banding) : base(expenditure)
+    {
+        TotalExpenditure = expenditure.TotalExpenditure;
+        TotalTeachingSupportStaffCosts = expenditure.TotalTeachingSupportStaffCosts;
+        TeachingStaffCosts = expenditure.TeachingStaffCosts;
+        SupplyTeachingStaffCosts = expenditure.SupplyTeachingStaffCosts;
+        EducationalConsultancyCosts = expenditure.EducationalConsultancyCosts;
+        EducationSupportStaffCosts = expenditure.EducationSupportStaffCosts;
+        AgencySupplyTeachingStaffCosts = expenditure.AgencySupplyTeachingStaffCosts;
+        TotalNonEducationalSupportStaffCosts = expenditure.TotalNonEducationalSupportStaffCosts;
+        AdministrativeClericalStaffCosts = expenditure.AdministrativeClericalStaffCosts;
+        AuditorsCosts = expenditure.AuditorsCosts;
+        OtherStaffCosts = expenditure.OtherStaffCosts;
+        ProfessionalServicesNonCurriculumCosts = expenditure.ProfessionalServicesNonCurriculumCosts;
+        TotalEducationalSuppliesCosts = expenditure.TotalEducationalSuppliesCosts;
+        ExaminationFeesCosts = expenditure.ExaminationFeesCosts;
+        LearningResourcesNonIctCosts = expenditure.LearningResourcesNonIctCosts;
+        LearningResourcesIctCosts = expenditure.LearningResourcesIctCosts;
+        TotalPremisesStaffServiceCosts = expenditure.TotalPremisesStaffServiceCosts;
+        CleaningCaretakingCosts = expenditure.CleaningCaretakingCosts;
+        MaintenancePremisesCosts = expenditure.MaintenancePremisesCosts;
+        OtherOccupationCosts = expenditure.OtherOccupationCosts;
+        PremisesStaffCosts = expenditure.PremisesStaffCosts;
+        TotalUtilitiesCosts = expenditure.TotalUtilitiesCosts;
+        EnergyCosts = expenditure.EnergyCosts;
+        WaterSewerageCosts = expenditure.WaterSewerageCosts;
+        AdministrativeSuppliesNonEducationalCosts = expenditure.AdministrativeSuppliesNonEducationalCosts;
+        TotalGrossCateringCosts = expenditure.TotalGrossCateringCosts;
+        TotalNetCateringCosts = expenditure.TotalNetCateringCosts;
+        CateringStaffCosts = expenditure.CateringStaffCosts;
+        CateringSuppliesCosts = expenditure.CateringSuppliesCosts;
+        TotalOtherCosts = expenditure.TotalOtherCosts;
+        GroundsMaintenanceCosts = expenditure.GroundsMaintenanceCosts;
+        IndirectEmployeeExpenses = expenditure.IndirectEmployeeExpenses;
+        InterestChargesLoanBank = expenditure.InterestChargesLoanBank;
+        OtherInsurancePremiumsCosts = expenditure.OtherInsurancePremiumsCosts;
+        PrivateFinanceInitiativeCharges = expenditure.PrivateFinanceInitiativeCharges;
+        RentRatesCosts = expenditure.RentRatesCosts;
+        SpecialFacilitiesCosts = expenditure.SpecialFacilitiesCosts;
+        StaffDevelopmentTrainingCosts = expenditure.StaffDevelopmentTrainingCosts;
+        StaffRelatedInsuranceCosts = expenditure.StaffRelatedInsuranceCosts;
+        SupplyTeacherInsurableCosts = expenditure.SupplyTeacherInsurableCosts;
+        CommunityFocusedSchoolStaff = expenditure.CommunityFocusedSchoolStaff;
+        CommunityFocusedSchoolCosts = expenditure.CommunityFocusedSchoolCosts;
+
+        URN = expenditure.URN;
+        SchoolName = expenditure.SchoolName;
+        SchoolType = expenditure.SchoolType;
+        LAName = expenditure.LAName;
+        PeriodCoveredByReturn = expenditure.PeriodCoveredByReturn;
+        TotalPupils = expenditure.TotalPupils;
+        TotalInternalFloorArea = expenditure.TotalInternalFloorArea;
+
+        if (banding?.Banding is KS4ProgressBandings.Banding.AboveAverage or KS4ProgressBandings.Banding.WellAboveAverage)
+        {
+            ProgressBanding = banding.Banding.ToStringValue();
+        }
+    }
+
+    [PropertyOrder(int.MaxValue)]
+    public string? ProgressBanding { get; set; }
 }

--- a/web/src/Web.App/ViewModels/SchoolComparisonViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolComparisonViewModel.cs
@@ -35,6 +35,15 @@ public class SchoolComparisonViewModel(
         .ToArray() ?? [];
     public bool HasProgressIndicators => WellOrAboveAverageKS4ProgressBandingsInComparatorSet.Length > 0;
 
+    public SchoolSpendingDimensions.BandingsAsOptions[] AvailableBandingsAs =>
+        WellOrAboveAverageKS4ProgressBandingsInComparatorSet
+            .Select(x => ToBandingsAsOption(x.Banding))
+            .Where(x => x.HasValue)
+            .Select(x => x!.Value)
+            .Distinct()
+            .OrderBy(x => x)
+            .ToArray();
+
     public KeyValuePair<SchoolSpendingCategories.CategoryGroup, SchoolSpendingCategories.SubCategoryFilter[]>[] AllGroups =>
         SchoolSpendingCategories.Groups.ToArray();
     public List<SchoolSpendingComparisonGroup> Groups => subCategories?.Groups ?? [];
@@ -51,6 +60,8 @@ public class SchoolComparisonViewModel(
 
     public SchoolSpendingDimensions.ResultAsOptions ResultAs { get; init; } = SchoolSpendingDimensions.ResultAsOptions.SpendPerUnit;
 
+    public SchoolSpendingDimensions.BandingsAsOptions[] BandingsAs { get; init; } = [];
+
     public FinanceToolsViewModel Tools => new(
         school.URN,
         FinanceTools.FinancialPlanning,
@@ -61,14 +72,45 @@ public class SchoolComparisonViewModel(
         FinanceTools.SpendingComparison,
         FinanceTools.Spending,
         FinanceTools.BenchmarkCensus);
+
+    private static SchoolSpendingDimensions.BandingsAsOptions? ToBandingsAsOption(KS4ProgressBandings.Banding banding)
+    {
+        return banding switch
+        {
+            KS4ProgressBandings.Banding.WellAboveAverage => SchoolSpendingDimensions.BandingsAsOptions.WellAbove,
+            KS4ProgressBandings.Banding.AboveAverage => SchoolSpendingDimensions.BandingsAsOptions.Above,
+            _ => null
+        };
+    }
 }
 
 public class SchoolSpendingDataViewModel(
     BenchmarkingViewModelCostSubCategory<SchoolComparisonDatum> subCategory,
     SchoolSpendingDimensions.ResultAsOptions resultAs,
-    string urn)
+    string urn,
+    SchoolSpendingDimensions.BandingsAsOptions[]? bandingsAs = null)
 {
     public BenchmarkingViewModelCostSubCategory<SchoolComparisonDatum> SubCategory => subCategory;
     public SchoolSpendingDimensions.ResultAsOptions ResultAs => resultAs;
+    public SchoolSpendingDimensions.BandingsAsOptions[]? BandingsAs => bandingsAs;
     public string Urn => urn;
+}
+
+public class ProgressBandingCellViewModel(
+    SchoolSpendingDimensions.BandingsAsOptions[] selectedBandings,
+    string? progressBanding
+    )
+{
+    public KS4ProgressBandings.Banding ProgressBanding { get; init; } = progressBanding.ToBanding() ?? KS4ProgressBandings.Banding.Unknown;
+    public SchoolSpendingDimensions.BandingsAsOptions[] SelectedBandings => selectedBandings;
+
+    public bool ShouldShowTag =>
+        ProgressBanding switch
+        {
+            KS4ProgressBandings.Banding.WellAboveAverage =>
+                SelectedBandings.Contains(SchoolSpendingDimensions.BandingsAsOptions.WellAbove),
+            KS4ProgressBandings.Banding.AboveAverage =>
+                SelectedBandings.Contains(SchoolSpendingDimensions.BandingsAsOptions.Above),
+            _ => false
+        };
 }

--- a/web/src/Web.App/ViewModels/SpendingComparisonSubCategoriesViewModel.cs
+++ b/web/src/Web.App/ViewModels/SpendingComparisonSubCategoriesViewModel.cs
@@ -9,8 +9,8 @@ public class SpendingComparisonSubCategoriesViewModel
     public List<SchoolSpendingComparisonGroup> Groups { get; } = [];
 
     public SpendingComparisonSubCategoriesViewModel(
-        SchoolExpenditure[] buildingResult,
-        SchoolExpenditure[] pupilResult,
+        SchoolExpenditureWithProgress[] buildingResult,
+        SchoolExpenditureWithProgress[] pupilResult,
         SchoolSpendingCategories.SubCategoryFilter[] filters,
         string urn,
         CostCodes costCodes)
@@ -47,7 +47,7 @@ public class SpendingComparisonSubCategoriesViewModel
 
     private static BenchmarkingViewModelCostSubCategory<SchoolComparisonDatum> BuildSubCategory(
         SchoolSpendingCategories.SubCategoryFilter filter,
-        SchoolExpenditure[] expenditures,
+        SchoolExpenditureWithProgress[] expenditures,
         string urn,
         string[] costCodes)
     {
@@ -60,7 +60,8 @@ public class SpendingComparisonSubCategoriesViewModel
                 SchoolType = e.SchoolType,
                 Expenditure = filter.GetValue(e),
                 TotalPupils = e.TotalPupils,
-                PeriodCoveredByReturn = e.PeriodCoveredByReturn
+                PeriodCoveredByReturn = e.PeriodCoveredByReturn,
+                ProgressBanding = e.ProgressBanding
             })
             .Where(x => x.Urn == urn || x.Expenditure is > 0)
             .OrderByDescending(x => x.Expenditure)

--- a/web/src/Web.App/Views/SchoolComparison/IndexFilters.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/IndexFilters.cshtml
@@ -5,6 +5,7 @@
 @model Web.App.ViewModels.SchoolComparisonViewModel
 @{
     ViewData[ViewDataKeys.Title] = PageTitles.Comparison;
+    ViewData[ViewDataKeys.BodyClass] = LayoutClass.WidePage;
     var hasUserDefinedSet = !string.IsNullOrEmpty(Model.UserDefinedSetId);
     var hasCustomData = !string.IsNullOrEmpty(Model.CustomDataId);
     var hasMissingComparatorSet = !hasUserDefinedSet && !Model.HasDefaultComparatorSet;

--- a/web/src/Web.App/Views/SchoolComparison/IndexFilters.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/IndexFilters.cshtml
@@ -102,12 +102,43 @@
                         <option
                             value="@((int)option)"
                             selected="@(Model.ResultAs == option ? "selected" : null)">
-                            @option.GetDescription()
+                            @option.GetResultsAsDescription()
                         </option>
                     }
                 </select>
             </div>
 
+            @if (Model.HasProgressIndicators)
+            {
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-label">
+                            School performance
+                        </legend>
+                        <div class="govuk-checkboxes govuk-checkboxes--small progress-checkboxes" data-module="govuk-checkboxes">
+                            <input type="hidden" name="@nameof(SchoolComparisonViewModel.BandingsAs)" value="" />
+                            @foreach (var option in Model.AvailableBandingsAs)
+                            {
+                                var id = $"banding-{option}";
+                                var isChecked = Model.BandingsAs.Contains(option);
+
+                                <div class="govuk-checkboxes__item">
+                                    <input class="govuk-checkboxes__input"
+                                           id="@id"
+                                           name="@nameof(SchoolComparisonViewModel.BandingsAs)"
+                                           type="checkbox"
+                                           value="@((int)option)"
+                                           @(isChecked ? "checked" : "") />
+
+                                    <label class="govuk-label govuk-checkboxes__label" for="@id">
+                                        @option.GetBandingAsDescription()
+                                    </label>
+                                </div>
+                            }
+                        </div>
+                    </fieldset>
+                </div>
+            }
             <div class="options-form__apply">
                 <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button">
                     Apply
@@ -135,7 +166,7 @@
                             }
                             else
                             {
-                                @await Html.PartialAsync("_SchoolComparisonTable", new SchoolSpendingDataViewModel(subCategory, Model.ResultAs, Model.Urn!))
+                                @await Html.PartialAsync("_SchoolComparisonTable", new SchoolSpendingDataViewModel(subCategory, Model.ResultAs, Model.Urn!, Model.BandingsAs))
                             }
                         </section>
                     }

--- a/web/src/Web.App/Views/SchoolComparison/_ProgressBandingCell.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/_ProgressBandingCell.cshtml
@@ -1,0 +1,9 @@
+@using Web.App.Domain
+@model Web.App.ViewModels.ProgressBandingCellViewModel
+
+@if (Model.ShouldShowTag)
+{
+    <strong class="govuk-tag govuk-tag--@Model.ProgressBanding.ToGdsColour() govuk-!-font-size-16">
+        @Model.ProgressBanding.ToStringValue()
+    </strong>
+}

--- a/web/src/Web.App/Views/SchoolComparison/_SchoolComparisonTable.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/_SchoolComparisonTable.cshtml
@@ -1,4 +1,5 @@
 @using Web.App.Domain.Charts
+@using Web.App.ViewModels
 @model Web.App.ViewModels.SchoolSpendingDataViewModel
 
 @if (Model.SubCategory.Data is null)
@@ -24,6 +25,10 @@
             <th scope="col" class="govuk-table__header">School type</th>
             <th scope="col" class="govuk-table__header govuk-table__header--numeric">Number of pupils</th>
             <th scope="col" class="govuk-table__header govuk-table__header--numeric">@Model.ResultAs.GetTableHeader()</th>
+            @if (Model.BandingsAs?.Length > 0)
+            {
+                <th scope="col" class="govuk-table__header">Progress 8 banding</th>
+            }
         </tr>
         </thead>
         <tbody class="govuk-table__body">
@@ -49,6 +54,12 @@
                 <td class="govuk-table__cell">@row.SchoolType</td>
                 <td class="govuk-table__cell govuk-table__cell--numeric">@(row.TotalPupils?.ToString("N0"))</td>
                 <td class="govuk-table__cell govuk-table__cell--numeric">@Model.ResultAs.GetFormattedValue(row.Expenditure)</td>
+                @if (Model.BandingsAs?.Length > 0)
+                {
+                    <td class="govuk-table__cell">
+                        @await Html.PartialAsync("_ProgressBandingCell", new ProgressBandingCellViewModel(Model.BandingsAs, row.ProgressBanding))
+                    </td>
+                }
             </tr>
         }
         </tbody>

--- a/web/src/Web.App/Views/Shared/_Layout.cshtml
+++ b/web/src/Web.App/Views/Shared/_Layout.cshtml
@@ -30,7 +30,7 @@
     <link rel="stylesheet" href="/css/enhancements.css" asp-append-version="true"/>
     @await Component.InvokeAsync("Analytics")
 </head>
-<body class="govuk-template__body">
+<body class="govuk-template__body @(ViewData[ViewDataKeys.BodyClass])">
 <script add-nonce="true">
     document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
 </script>

--- a/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
+++ b/web/tests/Web.Integration.Tests/BenchmarkingWebAppWebAppClient.cs
@@ -493,7 +493,10 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
     public BenchmarkingWebAppClient SetupExpenditure(
         School school,
         SchoolExpenditure? expenditure = null,
-        SchoolExpenditure[]? expenditures = null)
+        SchoolExpenditure[]? expenditures = null,
+        SchoolExpenditure? customDataExpenditure = null,
+        string? customDataIdentifier = null
+        )
     {
         ExpenditureApi.Reset();
         ExpenditureApi
@@ -505,15 +508,12 @@ public abstract class BenchmarkingWebAppClient(IMessageSink messageSink, Action<
         ExpenditureApi
             .Setup(api => api.QuerySchools(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ApiResult.Ok(expenditures ?? []));
-        return this;
-    }
-
-    public BenchmarkingWebAppClient SetupExpenditureForCustomData(School school, string identifier, SchoolExpenditure expenditure)
-    {
-        ExpenditureApi.Reset();
-        ExpenditureApi
-            .Setup(api => api.SchoolCustom(school.URN, identifier, It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(ApiResult.Ok(expenditure));
+        if (customDataIdentifier != null)
+        {
+            ExpenditureApi
+                .Setup(api => api.SchoolCustom(school.URN, customDataIdentifier, It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ApiResult.Ok(customDataExpenditure));
+        }
         return this;
     }
 

--- a/web/tests/Web.Integration.Tests/Pages/Schools/Census/WhenRequestingCensusDownload.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/Census/WhenRequestingCensusDownload.cs
@@ -125,7 +125,9 @@ public class WhenRequestingCensusDownload : PageBase<SchoolBenchmarkingWebAppCli
             .SetupDisableFeatureFlags(features)
             .SetupCustomComparatorSet(school, comparatorSet, userDefinedComparatorSet)
             .SetupCensus(_censuses)
-            .SetupExpenditureForCustomData(school, school.URN!, expenditure)
+            .SetupExpenditure(school,
+                customDataIdentifier: customDataId,
+                customDataExpenditure: expenditure)
             .Get(Paths.SchoolCensusDownload(school.URN!, customDataId));
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenRequestingComparisonDownload.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenRequestingComparisonDownload.cs
@@ -26,6 +26,10 @@ public class WhenRequestingComparisonDownload : PageBase<SchoolBenchmarkingWebAp
             .With(x => x.URN, "123456")
             .Create();
 
+        var characteristics = Fixture.Build<SchoolCharacteristic>()
+            .With(x => x.KS4ProgressBanding, "Well above average")
+            .CreateMany().ToArray();
+
         var comparatorSet = Fixture.Build<SchoolComparatorSet>()
             .With(x => x.Pupil, ["pupil"])
             .With(x => x.Building, ["building"])
@@ -36,6 +40,7 @@ public class WhenRequestingComparisonDownload : PageBase<SchoolBenchmarkingWebAp
             .SetupDisableFeatureFlags(features)
             .SetupComparatorSet(school, comparatorSet)
             .SetupExpenditure(school, expenditures: _schoolExpenditures)
+            .SetupSchoolInsight(characteristics)
             .Get(Paths.SchoolComparisonDownload(school.URN!));
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -70,6 +75,10 @@ public class WhenRequestingComparisonDownload : PageBase<SchoolBenchmarkingWebAp
             .With(x => x.URN, "123456")
             .Create();
 
+        var characteristics = Fixture.Build<SchoolCharacteristic>()
+            .With(x => x.KS4ProgressBanding, "Well above average")
+            .CreateMany().ToArray();
+
         var comparatorSet = Fixture.Build<UserDefinedSchoolComparatorSet>()
             .Create();
 
@@ -87,6 +96,7 @@ public class WhenRequestingComparisonDownload : PageBase<SchoolBenchmarkingWebAp
             .SetupDisableFeatureFlags(features)
             .SetupComparatorSet(school, comparatorSet)
             .SetupExpenditure(school, expenditures: _schoolExpenditures)
+            .SetupSchoolInsight(characteristics)
             .SetupUserData(userData)
             .Get(Paths.SchoolComparisonDownload(school.URN!));
 
@@ -119,8 +129,9 @@ public class WhenRequestingComparisonDownload : PageBase<SchoolBenchmarkingWebAp
     public async Task CanReturnOkForCustomDataComparatorSet(bool ks4ProgressBandingEnabled)
     {
         const string customDataId = nameof(customDataId);
+        const string schoolUrn = "123456";
         var school = Fixture.Build<School>()
-            .With(x => x.URN, "123456")
+            .With(x => x.URN, schoolUrn)
             .Create();
 
         var userDefinedComparatorSet = Fixture.Build<UserDefinedSchoolComparatorSet>()
@@ -131,14 +142,25 @@ public class WhenRequestingComparisonDownload : PageBase<SchoolBenchmarkingWebAp
             .With(x => x.Building, ["building"])
             .Create();
 
-        var expenditure = Fixture.Build<SchoolExpenditure>().Create();
+
+        var customDataExpenditure = Fixture.Build<SchoolExpenditure>()
+            .With(x => x.URN, schoolUrn)
+            .Create();
+
+        var characteristics = Fixture.Build<SchoolCharacteristic>()
+            .With(x => x.KS4ProgressBanding, "Well above average")
+            .CreateMany().ToArray();
 
         string[] features = ks4ProgressBandingEnabled ? [] : [FeatureFlags.KS4ProgressBanding];
         var response = await _client
             .SetupDisableFeatureFlags(features)
             .SetupCustomComparatorSet(school, comparatorSet, userDefinedComparatorSet)
-            .SetupExpenditure(school, expenditures: _schoolExpenditures)
-            .SetupExpenditureForCustomData(school, school.URN!, expenditure)
+            .SetupExpenditure(
+                school,
+                expenditures: _schoolExpenditures,
+                customDataExpenditure: customDataExpenditure,
+                customDataIdentifier: customDataId)
+            .SetupSchoolInsight(characteristics)
             .Get(Paths.SchoolComparisonDownload(school.URN!, customDataId));
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -159,8 +181,11 @@ public class WhenRequestingComparisonDownload : PageBase<SchoolBenchmarkingWebAp
                 expectedColumns += ",ProgressBanding";
             }
 
+            // expenditures + custom data
+            var expectedLength = _schoolExpenditures.Length + 1;
+
             Assert.Equal(expectedColumns, csvLines.First());
-            Assert.Equal(_schoolExpenditures.Length, csvLines.Length - 1);
+            Assert.Equal(expectedLength, csvLines.Length - 1);
         }
     }
 

--- a/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataSpending.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/CustomData/WhenViewingCustomDataSpending.cs
@@ -200,7 +200,9 @@ public class WhenViewingCustomDataSpending(SchoolBenchmarkingWebAppClient client
             page = await Client
                 .SetupUserData(userData)
                 .SetupMetricRagRatingIncCustom(customDataId, rating)
-                .SetupExpenditureForCustomData(school, customDataId, expenditure)
+                .SetupExpenditure(school,
+                    customDataIdentifier: customDataId,
+                    customDataExpenditure: expenditure)
                 .Navigate(Paths.SchoolSpendingCustomData(school.URN));
         }
         else


### PR DESCRIPTION
## 🧾 Summary

Adds progress 8 indicators and school performance checkboxes to the School Benchmark Spending page, allowing users to optionally overlay school performance context on both charts and tables.

Also increases the page width to 1200px (this page only), matching the design requirements.

[AB#298070](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/298070)
[AB#312897](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/312897)

### ✨ Feature Details
**Functionality:**

When Progress 8 indicators are available for the selected dataset, users now see a School performance section with checkboxes for:
- Well above average
- Above average
 
**Charts** 

<img width="1861" height="944" alt="image" src="https://github.com/user-attachments/assets/7ea630ae-3ccb-4325-a690-2605398824d5" />

When enabled, selected bandings are highlighted using distinct colours on the chart, consistent with the existing client‑side implementation.

**Tables** 

<img width="1973" height="1190" alt="image" src="https://github.com/user-attachments/assets/26783028-361a-452c-9b7a-e57362881c67" />

When viewing the table, an additional column appears showing the Progress 8 banding for each school, rendered using GOV.UK tag styles.

This column appears only when:
- progress indicators exist for the dataset, and
- the user has selected at least one banding

**Implementation:**

**Controller**

- updated the controller so both buildingResult and pupilResult are now produced via the existing MergeProgressBandings() helper.
- refactored MergeProgressBandings() to always return SchoolExpenditureWithProgress[]
- SchoolExpenditureWithProgress has been moved into domain and made public 
- the Download action now conditionally strips the ProgressBanding field when:
  - the feature is disabled
  - no bandings exist for the dataset

**Charts**

Updated the chart request builder to include the correct GroupedKeys, ensuring part‑year remains the primary grouping (matching existing behaviour).

**Tables**

- added a new ProgressBandingCellViewModel and a dedicated partial to render the banding tag cleanly.
- the view now:
  - shows the school performance checkboxes when indicators are available
  - renders the additional table column when the user selects bandings

**Layout / Page Width**

- _Layout now accepts an optional body class via ViewData to enable page‑specific width changes.
- added scoped CSS to:
  - apply the wider layout
  - fix wrapping issues in the options form

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [x] Screenshots or Demo included _(for UI/frontend changes)

## 🔍 Notes

Tests for WhenRequestingComparisonDownload have been updated, as part of this the helper method SetupExpenditureForCustomData() has been removed and the functionality merged into SetupExpenditure(). Therefore the setup for a few otherwise unrelated tests have been updated