### PR TITLE
feat: add tooltip to charts for school benchmark spending

### DIFF
--- a/web/src/Web.App/AssetSrc/ts/components/school-comparison-chart-tooltip/SchoolComparisonChartTooltip.vue
+++ b/web/src/Web.App/AssetSrc/ts/components/school-comparison-chart-tooltip/SchoolComparisonChartTooltip.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { ref, watch } from "vue";
+import type { SchoolComparisonChartTooltipProps } from ".";
+
+const { datum, x, y, focusSource } = defineProps<SchoolComparisonChartTooltipProps>();
+const top = ref(0);
+const left = ref(0);
+const offsetX = ref(0);
+const tooltip = ref<HTMLDivElement>();
+const gutter = 30;
+const maxWidth = 300;
+
+watch([() => x, () => y], ([newX, newY]) => {
+  left.value = newX;
+  top.value = newY;
+});
+
+watch(tooltip, () => {
+  offsetX.value = 0;
+
+  // reposition tooltip if it overflows the right edge of the window from a mouse focus trigger
+  const bounds = tooltip.value?.getBoundingClientRect();
+  if (
+    focusSource === "mouse" &&
+    bounds &&
+    bounds.x + bounds.width + gutter > window.outerWidth &&
+    window.outerWidth > bounds.width
+  ) {
+    offsetX.value = -1 * (maxWidth - (window.outerWidth - bounds.x)) - gutter;
+  }
+});
+</script>
+
+<template>
+  <div
+    v-if="!!datum"
+    class="school-chart-tooltip"
+    :style="{
+      top: top + 'px',
+      left: left + 'px',
+      transform: offsetX !== 0 ? 'translate(' + offsetX + 'px,0px)' : undefined,
+      width: offsetX !== 0 ? maxWidth + 'px' : undefined,
+    }"
+    ref="tooltip"
+  >
+    <div v-if="!(datum?.periodCoveredByReturn === 12)" class="school-tags">
+      <strong class="govuk-tag govuk-tag--red">
+        Only has {{ datum?.periodCoveredByReturn }}
+        {{ datum?.periodCoveredByReturn === 1 ? "month" : "months" }} of data
+      </strong>
+    </div>
+    <table class="govuk-table govuk-table--small-text-until-tablet tooltip-table">
+      <caption class="govuk-table__caption govuk-table__caption--s">
+        {{
+          datum?.schoolName
+        }}
+      </caption>
+      <thead class="govuk-table__head govuk-visually-hidden">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Item</th>
+        <th scope="col" class="govuk-table__header">Value</th>
+      </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Local authority</th>
+        <td class="govuk-table__cell">{{ datum?.laName }}</td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">School type</th>
+        <td class="govuk-table__cell">{{ datum?.schoolType }}</td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Number of pupils</th>
+        <td class="govuk-table__cell">
+          {{ datum?.totalPupils?.toString() }}
+        </td>
+      </tr>
+      <tr v-if="(datum?.shouldShowTag)" class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Progress 8 banding</th>
+        <td class="govuk-table__cell">
+          <strong
+            :class="[
+              'govuk-tag',
+              `govuk-tag--${datum?.progressBandingColour}`,
+              'govuk-!-font-size-16'
+            ]">
+            {{ datum?.progressBanding }}
+          </strong>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+</template>

--- a/web/src/Web.App/AssetSrc/ts/components/school-comparison-chart-tooltip/SchoolComparisonChartTooltips.vue
+++ b/web/src/Web.App/AssetSrc/ts/components/school-comparison-chart-tooltip/SchoolComparisonChartTooltips.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+import { SchoolComparisonChartTooltip } from "@/main";
+import type { FocusSource, SchoolComparisonChartTooltipsProps, SchoolComparisonChartTooltipPropsData } from ".";
+import { onMounted, onUnmounted, ref } from "vue";
+
+const { data } = defineProps<SchoolComparisonChartTooltipsProps>();
+const tooltipX = ref(0);
+const tooltipY = ref(0);
+const datum = ref<SchoolComparisonChartTooltipPropsData | null>(null);
+const focusSource = ref<FocusSource>();
+const keyAttribute = "data-key";
+
+const eventListenerMouseEnter = (e: MouseEvent, d: SchoolComparisonChartTooltipPropsData) => {
+  const tooltipOffset = 10;
+  const x = e.clientX + tooltipOffset;
+  const y = e.clientY + window.scrollY + tooltipOffset;
+
+  datum.value = d;
+  tooltipX.value = x;
+  tooltipY.value = y;
+  focusSource.value = "mouse";
+};
+
+const eventListenerElementFocus = (e: Event, d: SchoolComparisonChartTooltipPropsData) => {
+  const rect = (e.target as Element).getBoundingClientRect();
+  const x = rect.right + 18;
+  const y = rect.top + window.scrollY + 6;
+
+  datum.value = d;
+  tooltipX.value = x;
+  tooltipY.value = y;
+  focusSource.value = "keyboard";
+};
+
+const eventListenerExit = () => {
+  datum.value = null;
+};
+
+const addMouseListeners = (el: SVGGeometryElement, d: SchoolComparisonChartTooltipPropsData) => {
+  el.addEventListener("mouseenter", (e) => eventListenerMouseEnter(e, d));
+  el.addEventListener("mouseleave", eventListenerExit);
+};
+
+const addFocusListeners = (el: Element, d: SchoolComparisonChartTooltipPropsData) => {
+  el.addEventListener("focus", (e) => eventListenerElementFocus(e, d));
+  el.addEventListener("blur", eventListenerExit);
+};
+
+const removeMouseListeners = (el: SVGGeometryElement, d: SchoolComparisonChartTooltipPropsData) => {
+  el.removeEventListener("mouseenter", (e) => eventListenerMouseEnter(e, d));
+  el.removeEventListener("mouseleave", eventListenerExit);
+};
+
+const removeFocusListeners = (el: Element, d: SchoolComparisonChartTooltipPropsData) => {
+  el.removeEventListener("focus", (e) => eventListenerElementFocus(e, d));
+  el.removeEventListener("blur", eventListenerExit);
+};
+
+onMounted(() => {
+  const elements = document.querySelectorAll(`[${keyAttribute}]`);
+
+  elements.forEach((el) => {
+    const key = el.getAttribute(keyAttribute);
+    const datum = data.find((d) => d.urn === key);
+    if (!datum) {
+      return;
+    }
+
+    switch (el.tagName.toLowerCase()) {
+      case "rect":
+        addMouseListeners(el as SVGGeometryElement, datum);
+        break;
+      case "a":
+        addFocusListeners(el, datum);
+        break;
+    }
+  });
+});
+
+onUnmounted(() => {
+  const elements = document.querySelectorAll(`[${keyAttribute}]`);
+
+  elements.forEach((el) => {
+    const key = el.getAttribute(keyAttribute);
+    const datum = data.find((d) => d.urn === key);
+    if (!datum) {
+      return;
+    }
+
+    switch (el.tagName.toLowerCase()) {
+      case "rect":
+        removeMouseListeners(el as SVGGeometryElement, datum);
+        break;
+      case "a":
+        removeFocusListeners(el, datum);
+        break;
+    }
+  });
+});
+
+defineOptions({
+  name: "SchoolChartTooltips",
+});
+</script>
+
+<template>
+  <Teleport to="body">
+    <SchoolComparisonChartTooltip :datum="datum" :x="tooltipX" :y="tooltipY" :focus-source="focusSource" />
+  </Teleport>
+</template>

--- a/web/src/Web.App/AssetSrc/ts/components/school-comparison-chart-tooltip/index.d.ts
+++ b/web/src/Web.App/AssetSrc/ts/components/school-comparison-chart-tooltip/index.d.ts
@@ -1,0 +1,23 @@
+export interface SchoolComparisonChartTooltipProps {
+  datum: SchoolChartTooltipPropsData | null;
+  x: number;
+  y: number;
+  focusSource?: FocusSource;
+}
+
+export interface SchoolComparisonChartTooltipPropsData {
+  urn?: string;
+  schoolName?: string;
+  laName?: string;
+  totalPupils?: number;
+  periodCoveredByReturn?: number;
+  progressBanding?: string;
+  progressBandingColour?: string;
+  shouldShowTag?: boolean;
+}
+
+export interface SchoolComparisonChartTooltipsProps {
+  data: SchoolComparisonChartTooltipPropsData[];
+}
+
+export type FocusSource = "keyboard" | "mouse";

--- a/web/src/Web.App/AssetSrc/ts/main.ts
+++ b/web/src/Web.App/AssetSrc/ts/main.ts
@@ -5,6 +5,8 @@ import PageActions from "./components/page-actions/PageActions.vue";
 import ProgressIndicator from "./components/progress-indicator/ProgressIndicator.vue";
 import SchoolChartTooltip from "./components/school-chart-tooltip/SchoolChartTooltip.vue";
 import SchoolChartTooltips from "./components/school-chart-tooltip/SchoolChartTooltips.vue";
+import SchoolComparisonChartTooltip from "./components/school-comparison-chart-tooltip/SchoolComparisonChartTooltip.vue";
+import SchoolComparisonChartTooltips from "./components/school-comparison-chart-tooltip/SchoolComparisonChartTooltips.vue";
 import SeniorLeadershipChartTooltip from "./components/senior-leadership-chart-tooltip/SeniorLeadershipChartTooltip.vue";
 import SeniorLeadershipChartTooltips from "./components/senior-leadership-chart-tooltip/SeniorLeadershipChartTooltips.vue";
 import { Suggester } from "./components/suggester/Suggester.ts";
@@ -16,6 +18,8 @@ export { ChartActions,
          ProgressIndicator,
          SchoolChartTooltip,
          SchoolChartTooltips,
+         SchoolComparisonChartTooltip,
+         SchoolComparisonChartTooltips,
          SeniorLeadershipChartTooltip,
          SeniorLeadershipChartTooltips,
          Suggester

--- a/web/src/Web.App/Controllers/SchoolComparisonController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparisonController.cs
@@ -72,10 +72,13 @@ public class SchoolComparisonController(
 
                 SpendingComparisonSubCategoriesViewModel? subCategories = null;
 
+                SchoolExpenditureWithProgress[]? buildingResult = null;
+                SchoolExpenditureWithProgress[]? pupilResult = null;
+
                 if (await featureManager.IsEnabledAsync(FeatureFlags.SchoolComparisonFilter))
                 {
-                    var buildingResult = MergeProgressBandings(await GetDefaultSchoolExpenditure(urn, true, resultAs), bandings);
-                    var pupilResult = MergeProgressBandings(await GetDefaultSchoolExpenditure(urn, false, resultAs), bandings);
+                    buildingResult = MergeProgressBandings(await GetDefaultSchoolExpenditure(urn, true, resultAs), bandings);
+                    pupilResult = MergeProgressBandings(await GetDefaultSchoolExpenditure(urn, false, resultAs), bandings);
 
                     subCategories = new SpendingComparisonSubCategoriesViewModel(
                         buildingResult,
@@ -107,7 +110,9 @@ public class SchoolComparisonController(
                     expenditure,
                     defaultComparatorSet,
                     bandings,
-                    subCategories)
+                    subCategories,
+                    buildingResult,
+                    pupilResult)
                 {
                     SelectedSubCategories = selectedSubCategories,
                     ViewAs = viewAs,

--- a/web/src/Web.App/Domain/ProgressBandings.cs
+++ b/web/src/Web.App/Domain/ProgressBandings.cs
@@ -1,6 +1,7 @@
 ﻿// ReSharper disable NotAccessedPositionalProperty.Global
 
 using System.Runtime.Serialization;
+using Web.App.Domain.Charts;
 
 namespace Web.App.Domain;
 
@@ -53,6 +54,23 @@ public class KS4ProgressBandings : ISerializable
     {
         info.AddValue(nameof(Items), Items);
     }
+
+    public static bool ShouldShowTagForSchoolSpending(
+        Banding banding,
+        SchoolSpendingDimensions.BandingsAsOptions[] selected)
+    {
+        var option = ToSchoolSpendingBandingsAsOption(banding);
+        return option.HasValue && selected.Contains(option.Value);
+    }
+
+    public static SchoolSpendingDimensions.BandingsAsOptions? ToSchoolSpendingBandingsAsOption(
+        Banding banding)
+        => banding switch
+        {
+            Banding.WellAboveAverage => SchoolSpendingDimensions.BandingsAsOptions.WellAbove,
+            Banding.AboveAverage => SchoolSpendingDimensions.BandingsAsOptions.Above,
+            _ => null
+        };
 }
 
 [Serializable]

--- a/web/src/Web.App/ViewModels/SchoolComparisonChartTooltipDataViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolComparisonChartTooltipDataViewModel.cs
@@ -1,0 +1,17 @@
+using Web.App.Domain;
+using Web.App.Domain.Charts;
+
+namespace Web.App.ViewModels;
+
+public record SchoolComparisonChartTooltipViewModel
+{
+    public SchoolComparisonChartTooltipData[]? Data { get; init; }
+}
+
+public record SchoolComparisonChartTooltipData : SchoolChartTooltipData
+{
+    public string? ProgressBanding { get; init; }
+    public string? SchoolType { get; init; }
+    public string? ProgressBandingColour { get; init; }
+    public bool ShouldShowTag { get; init; }
+}

--- a/web/src/Web.App/ViewModels/SchoolComparisonViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolComparisonViewModel.cs
@@ -14,8 +14,9 @@ public class SchoolComparisonViewModel(
     SchoolExpenditure? expenditure = null,
     SchoolComparatorSet? defaultComparatorSet = null,
     KS4ProgressBandings? ks4ProgressBandings = null,
-    SpendingComparisonSubCategoriesViewModel? subCategories = null
-    )
+    SpendingComparisonSubCategoriesViewModel? subCategories = null,
+    SchoolExpenditureWithProgress[]? buildingResult = null,
+    SchoolExpenditureWithProgress[]? pupilResult = null)
 {
     public string? Urn => school.URN;
     public string? Name => school.SchoolName;
@@ -37,7 +38,7 @@ public class SchoolComparisonViewModel(
 
     public SchoolSpendingDimensions.BandingsAsOptions[] AvailableBandingsAs =>
         WellOrAboveAverageKS4ProgressBandingsInComparatorSet
-            .Select(x => ToBandingsAsOption(x.Banding))
+            .Select(x => KS4ProgressBandings.ToSchoolSpendingBandingsAsOption(x.Banding))
             .Where(x => x.HasValue)
             .Select(x => x!.Value)
             .Distinct()
@@ -73,15 +74,27 @@ public class SchoolComparisonViewModel(
         FinanceTools.Spending,
         FinanceTools.BenchmarkCensus);
 
-    private static SchoolSpendingDimensions.BandingsAsOptions? ToBandingsAsOption(KS4ProgressBandings.Banding banding)
-    {
-        return banding switch
+    public SchoolComparisonChartTooltipData[] TooltipData =>
+        (pupilResult?.Concat(buildingResult!) ?? [])
+        .Select(x =>
         {
-            KS4ProgressBandings.Banding.WellAboveAverage => SchoolSpendingDimensions.BandingsAsOptions.WellAbove,
-            KS4ProgressBandings.Banding.AboveAverage => SchoolSpendingDimensions.BandingsAsOptions.Above,
-            _ => null
-        };
-    }
+            var banding = x.ProgressBanding.ToBanding() ?? KS4ProgressBandings.Banding.Unknown;
+
+            return new SchoolComparisonChartTooltipData
+            {
+                Urn = x.URN,
+                SchoolName = x.SchoolName,
+                SchoolType = x.SchoolType,
+                LAName = x.LAName,
+                TotalPupils = x.TotalPupils,
+                PeriodCoveredByReturn = x.PeriodCoveredByReturn,
+                ProgressBanding = x.ProgressBanding,
+                ProgressBandingColour = banding.ToGdsColour(),
+                ShouldShowTag = KS4ProgressBandings.ShouldShowTagForSchoolSpending(banding, BandingsAs)
+            };
+        })
+        .Distinct()
+        .ToArray();
 }
 
 public class SchoolSpendingDataViewModel(
@@ -104,13 +117,5 @@ public class ProgressBandingCellViewModel(
     public KS4ProgressBandings.Banding ProgressBanding { get; init; } = progressBanding.ToBanding() ?? KS4ProgressBandings.Banding.Unknown;
     public SchoolSpendingDimensions.BandingsAsOptions[] SelectedBandings => selectedBandings;
 
-    public bool ShouldShowTag =>
-        ProgressBanding switch
-        {
-            KS4ProgressBandings.Banding.WellAboveAverage =>
-                SelectedBandings.Contains(SchoolSpendingDimensions.BandingsAsOptions.WellAbove),
-            KS4ProgressBandings.Banding.AboveAverage =>
-                SelectedBandings.Contains(SchoolSpendingDimensions.BandingsAsOptions.Above),
-            _ => false
-        };
+    public bool ShouldShowTag => KS4ProgressBandings.ShouldShowTagForSchoolSpending(ProgressBanding, SelectedBandings);
 }

--- a/web/src/Web.App/Views/SchoolComparison/IndexFilters.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/IndexFilters.cshtml
@@ -183,6 +183,10 @@
 
 @section scripts
 {
+    @await Html.PartialAsync("_SchoolComparisonChartTooltip", new SchoolComparisonChartTooltipViewModel
+    {
+        Data = Model.TooltipData
+    })
 
     @await Html.PartialAsync("Enhancements/_PageActions", new PageActionsViewModel
     {

--- a/web/src/Web.App/Views/Shared/_SchoolComparisonChartTooltip.cshtml
+++ b/web/src/Web.App/Views/Shared/_SchoolComparisonChartTooltip.cshtml
@@ -1,0 +1,15 @@
+@using Web.App.Extensions
+@model Web.App.ViewModels.SchoolComparisonChartTooltipViewModel
+
+<script type="module" add-nonce="true">
+    import {createApp, SchoolComparisonChartTooltips} from "@Html.FileVersionedPath("/js/main.js")";
+
+    const data = @Html.Raw(Json.Serialize(Model.Data));
+
+    const container = document.createElement("div");
+    const main = document.querySelector("main");
+    main.appendChild(container);
+
+    const app = createApp(SchoolComparisonChartTooltips, {data});
+    const vm = app.mount(container);
+</script>


### PR DESCRIPTION
## 🧾 Summary

Adds chart tooltips for the school benchmark spending page. To add additional information for users when hovering over the bar charts.

[AB#298070](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/298070)
[AB#312903](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/312903)

### ✨ Feature Details
**Functionality:**

When users hover over a bar in the charts the tooltip is rendered with additional information for that establishment

<img width="868" height="292" alt="image" src="https://github.com/user-attachments/assets/1f21eea6-ec74-42d5-8471-0ca33fd9528e" />

As default:
- school name
- LA name
- school type
- number of pupils

<img width="660" height="384" alt="image" src="https://github.com/user-attachments/assets/95c159ef-9d51-4ac2-81a8-c9ff33c63bbb" />
<img width="619" height="404" alt="image" src="https://github.com/user-attachments/assets/96067430-cf4e-4d67-810a-84987aabe818" />


When applicable:
- part year
- progress 8 banding

**Implementation:**

Implementated as a progressive enhancement using Vue components. Largely follows the same implementation as school benchmark it spending. View models have been updated with the required properties and some now shared logic for bandings has been moved into KS4ProgressBandings in domain.

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [x] Screenshots or Demo included _(for UI/frontend changes)_.
