### PR TITLE
feat: update school spending page when SchoolComparisonFilter is enabled. Use query param for links to school benchmark spending

### DIFF
--- a/web/src/Web.App/Controllers/SchoolComparisonController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparisonController.cs
@@ -41,7 +41,8 @@ public class SchoolComparisonController(
         SchoolSpendingCategories.SubCategoryFilter[] selectedSubCategories,
         SchoolSpendingDimensions.BandingsAsOptions[] bandingsAs,
         Views.ViewAsOptions viewAs = Views.ViewAsOptions.Chart,
-        SchoolSpendingDimensions.ResultAsOptions resultAs = SchoolSpendingDimensions.ResultAsOptions.SpendPerUnit)
+        SchoolSpendingDimensions.ResultAsOptions resultAs = SchoolSpendingDimensions.ResultAsOptions.SpendPerUnit,
+        SchoolSpendingCategories.CategoryGroup? expandFilterGroup = null)
     {
         using (logger.BeginScope(new
         {
@@ -112,7 +113,8 @@ public class SchoolComparisonController(
                     SelectedSubCategories = selectedSubCategories,
                     ViewAs = viewAs,
                     ResultAs = resultAs,
-                    BandingsAs = bandingsAs
+                    BandingsAs = bandingsAs,
+                    ExpandFilterGroup = expandFilterGroup
                 };
 
                 var viewName = await GetViewName(nameof(Index));

--- a/web/src/Web.App/Domain/CostCategories.cs
+++ b/web/src/Web.App/Domain/CostCategories.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using Web.App.Domain.Schools;
 using Web.App.Extensions;
 
 namespace Web.App.Domain;
@@ -98,6 +99,8 @@ public abstract class CostCategory(RagRating rating)
     public ReadOnlyDictionary<string, Category> Values => _values.AsReadOnly();
 
     public abstract string[] SubCategories { get; }
+    public abstract SchoolSpendingCategories.CategoryGroup SubCategoryGroup { get; }
+    public abstract SchoolSpendingCategories.SubCategoryFilter[] SubCategoryFilters { get; }
 
     public virtual bool CanShowCommercialResources => Rating.RAG != "green";
     public abstract void Add(string urn, SchoolExpenditure expenditure);
@@ -106,6 +109,8 @@ public abstract class CostCategory(RagRating rating)
 public class AdministrativeSupplies(RagRating rating) : CostCategory(rating)
 {
     public override string[] SubCategories => SubCostCategories.AdministrativeSupplies.SubCategories;
+    public override SchoolSpendingCategories.CategoryGroup SubCategoryGroup => SubCostCategories.AdministrativeSupplies.SubCategoryGroup;
+    public override SchoolSpendingCategories.SubCategoryFilter[] SubCategoryFilters => SubCostCategories.AdministrativeSupplies.SubCategoryFilters;
 
     public override void Add(string urn, SchoolExpenditure expenditure)
     {
@@ -116,6 +121,8 @@ public class AdministrativeSupplies(RagRating rating) : CostCategory(rating)
 public class CateringStaffServices(RagRating rating) : CostCategory(rating)
 {
     public override string[] SubCategories => SubCostCategories.CateringStaffServices.SubCategories;
+    public override SchoolSpendingCategories.CategoryGroup SubCategoryGroup => SubCostCategories.CateringStaffServices.SubCategoryGroup;
+    public override SchoolSpendingCategories.SubCategoryFilter[] SubCategoryFilters => SubCostCategories.CateringStaffServices.SubCategoryFilters;
 
     public override void Add(string urn, SchoolExpenditure expenditure)
     {
@@ -126,6 +133,8 @@ public class CateringStaffServices(RagRating rating) : CostCategory(rating)
 public class EducationalIct(RagRating rating) : CostCategory(rating)
 {
     public override string[] SubCategories => SubCostCategories.EducationalIct.SubCategories;
+    public override SchoolSpendingCategories.CategoryGroup SubCategoryGroup => SubCostCategories.EducationalIct.SubCategoryGroup;
+    public override SchoolSpendingCategories.SubCategoryFilter[] SubCategoryFilters => SubCostCategories.EducationalIct.SubCategoryFilters;
 
     public override bool CanShowCommercialResources => base.CanShowCommercialResources && Rating.Value >= Rating.Median;
 
@@ -138,6 +147,8 @@ public class EducationalIct(RagRating rating) : CostCategory(rating)
 public class EducationalSupplies(RagRating rating) : CostCategory(rating)
 {
     public override string[] SubCategories => SubCostCategories.EducationalSupplies.SubCategories;
+    public override SchoolSpendingCategories.CategoryGroup SubCategoryGroup => SubCostCategories.EducationalSupplies.SubCategoryGroup;
+    public override SchoolSpendingCategories.SubCategoryFilter[] SubCategoryFilters => SubCostCategories.EducationalSupplies.SubCategoryFilters;
 
     public override bool CanShowCommercialResources => base.CanShowCommercialResources && Rating.Value >= Rating.Median;
 
@@ -150,6 +161,8 @@ public class EducationalSupplies(RagRating rating) : CostCategory(rating)
 public class NonEducationalSupportStaff(RagRating rating) : CostCategory(rating)
 {
     public override string[] SubCategories => SubCostCategories.NonEducationalSupportStaff.SubCategories;
+    public override SchoolSpendingCategories.CategoryGroup SubCategoryGroup => SubCostCategories.NonEducationalSupportStaff.SubCategoryGroup;
+    public override SchoolSpendingCategories.SubCategoryFilter[] SubCategoryFilters => SubCostCategories.NonEducationalSupportStaff.SubCategoryFilters;
 
     public override void Add(string urn, SchoolExpenditure expenditure)
     {
@@ -160,6 +173,8 @@ public class NonEducationalSupportStaff(RagRating rating) : CostCategory(rating)
 public class TeachingStaff(RagRating rating) : CostCategory(rating)
 {
     public override string[] SubCategories => SubCostCategories.TeachingStaff.SubCategories;
+    public override SchoolSpendingCategories.CategoryGroup SubCategoryGroup => SubCostCategories.TeachingStaff.SubCategoryGroup;
+    public override SchoolSpendingCategories.SubCategoryFilter[] SubCategoryFilters => SubCostCategories.TeachingStaff.SubCategoryFilters;
 
     public override bool CanShowCommercialResources => base.CanShowCommercialResources && Rating.Value >= Rating.Median;
 
@@ -172,6 +187,8 @@ public class TeachingStaff(RagRating rating) : CostCategory(rating)
 public class Other(RagRating rating) : CostCategory(rating)
 {
     public override string[] SubCategories => SubCostCategories.Other.SubCategories;
+    public override SchoolSpendingCategories.CategoryGroup SubCategoryGroup => SubCostCategories.Other.SubCategoryGroup;
+    public override SchoolSpendingCategories.SubCategoryFilter[] SubCategoryFilters => SubCostCategories.Other.SubCategoryFilters;
 
     public override void Add(string urn, SchoolExpenditure expenditure)
     {
@@ -182,6 +199,8 @@ public class Other(RagRating rating) : CostCategory(rating)
 public class PremisesStaffServices(RagRating rating) : CostCategory(rating)
 {
     public override string[] SubCategories => SubCostCategories.PremisesStaffServices.SubCategories;
+    public override SchoolSpendingCategories.CategoryGroup SubCategoryGroup => SubCostCategories.PremisesStaffServices.SubCategoryGroup;
+    public override SchoolSpendingCategories.SubCategoryFilter[] SubCategoryFilters => SubCostCategories.PremisesStaffServices.SubCategoryFilters;
 
     public override void Add(string urn, SchoolExpenditure expenditure)
     {
@@ -192,6 +211,8 @@ public class PremisesStaffServices(RagRating rating) : CostCategory(rating)
 public class Utilities(RagRating rating) : CostCategory(rating)
 {
     public override string[] SubCategories => SubCostCategories.Utilities.SubCategories;
+    public override SchoolSpendingCategories.CategoryGroup SubCategoryGroup => SubCostCategories.Utilities.SubCategoryGroup;
+    public override SchoolSpendingCategories.SubCategoryFilter[] SubCategoryFilters => SubCostCategories.Utilities.SubCategoryFilters;
 
     public override void Add(string urn, SchoolExpenditure expenditure)
     {
@@ -299,7 +320,24 @@ public static class SubCostCategories
         public const string EducationSupportStaffCosts = "Education support staff";
         public const string EducationalConsultancyCosts = "Educational consultancy";
 
-        public static string[] SubCategories { get; } = [TeachingStaffCosts, SupplyTeachingStaffCosts, AgencySupplyTeachingStaffCosts, EducationSupportStaffCosts, EducationalConsultancyCosts];
+        public static string[] SubCategories { get; } =
+            [
+                TeachingStaffCosts,
+                SupplyTeachingStaffCosts,
+                AgencySupplyTeachingStaffCosts,
+                EducationSupportStaffCosts,
+                EducationalConsultancyCosts
+            ];
+        public static SchoolSpendingCategories.CategoryGroup SubCategoryGroup { get; } = SchoolSpendingCategories.CategoryGroup.TeachingStaff;
+        public static SchoolSpendingCategories.SubCategoryFilter[] SubCategoryFilters { get; } =
+            [
+                SchoolSpendingCategories.SubCategoryFilter.TotalTeachingSupportStaffCosts,
+                SchoolSpendingCategories.SubCategoryFilter.TeachingStaffCosts,
+                SchoolSpendingCategories.SubCategoryFilter.SupplyTeachingStaffCosts,
+                SchoolSpendingCategories.SubCategoryFilter.EducationalConsultancyCosts,
+                SchoolSpendingCategories.SubCategoryFilter.EducationSupportStaffCosts,
+                SchoolSpendingCategories.SubCategoryFilter.AgencySupplyTeachingStaffCosts
+            ];
     }
 
     public static class NonEducationalSupportStaff
@@ -309,7 +347,22 @@ public static class SubCostCategories
         public const string OtherStaffCosts = "Other staff";
         public const string ProfessionalServicesNonCurriculumCosts = "Professional services (non-curriculum)";
 
-        public static string[] SubCategories { get; } = [AdministrativeClericalStaffCosts, AuditorsCosts, OtherStaffCosts, ProfessionalServicesNonCurriculumCosts];
+        public static string[] SubCategories { get; } =
+            [
+                AdministrativeClericalStaffCosts,
+                AuditorsCosts,
+                OtherStaffCosts,
+                ProfessionalServicesNonCurriculumCosts
+            ];
+        public static SchoolSpendingCategories.CategoryGroup SubCategoryGroup { get; } = SchoolSpendingCategories.CategoryGroup.NonEducationalSupportStaff;
+        public static SchoolSpendingCategories.SubCategoryFilter[] SubCategoryFilters { get; } =
+        [
+            SchoolSpendingCategories.SubCategoryFilter.TotalNonEducationalSupportStaffCosts,
+            SchoolSpendingCategories.SubCategoryFilter.AdministrativeClericalStaffCosts,
+            SchoolSpendingCategories.SubCategoryFilter.AuditorsCosts,
+            SchoolSpendingCategories.SubCategoryFilter.OtherStaffCosts,
+            SchoolSpendingCategories.SubCategoryFilter.ProfessionalServicesNonCurriculumCosts
+        ];
     }
 
     public static class EducationalSupplies
@@ -317,7 +370,18 @@ public static class SubCostCategories
         public const string ExaminationFeesCosts = "Examination fees";
         public const string LearningResourcesNonIctCosts = "Learning resources (not ICT equipment)";
 
-        public static string[] SubCategories { get; } = [ExaminationFeesCosts, LearningResourcesNonIctCosts];
+        public static string[] SubCategories { get; } =
+            [
+                ExaminationFeesCosts,
+                LearningResourcesNonIctCosts
+            ];
+        public static SchoolSpendingCategories.CategoryGroup SubCategoryGroup { get; } = SchoolSpendingCategories.CategoryGroup.EducationalSupplies;
+        public static SchoolSpendingCategories.SubCategoryFilter[] SubCategoryFilters { get; } =
+        [
+            SchoolSpendingCategories.SubCategoryFilter.TotalEducationalSuppliesCosts,
+            SchoolSpendingCategories.SubCategoryFilter.ExaminationFeesCosts,
+            SchoolSpendingCategories.SubCategoryFilter.LearningResourcesNonIctCosts,
+        ];
     }
 
     public static class EducationalIct
@@ -325,6 +389,8 @@ public static class SubCostCategories
         public const string LearningResourcesIctCosts = "ICT learning resources";
 
         public static string[] SubCategories { get; } = [LearningResourcesIctCosts];
+        public static SchoolSpendingCategories.CategoryGroup SubCategoryGroup { get; } = SchoolSpendingCategories.CategoryGroup.EducationalIct;
+        public static SchoolSpendingCategories.SubCategoryFilter[] SubCategoryFilters { get; } = [SchoolSpendingCategories.SubCategoryFilter.LearningResourcesIctCosts];
     }
 
     public static class PremisesStaffServices
@@ -334,7 +400,22 @@ public static class SubCostCategories
         public const string OtherOccupationCosts = "Other occupation costs";
         public const string PremisesStaffCosts = "Premises staff";
 
-        public static string[] SubCategories { get; } = [CleaningCaretakingCosts, MaintenancePremisesCosts, OtherOccupationCosts, PremisesStaffCosts];
+        public static string[] SubCategories { get; } =
+            [
+                CleaningCaretakingCosts,
+                MaintenancePremisesCosts,
+                OtherOccupationCosts,
+                PremisesStaffCosts
+            ];
+        public static SchoolSpendingCategories.CategoryGroup SubCategoryGroup { get; } = SchoolSpendingCategories.CategoryGroup.PremisesStaffServices;
+        public static SchoolSpendingCategories.SubCategoryFilter[] SubCategoryFilters { get; } =
+        [
+            SchoolSpendingCategories.SubCategoryFilter.TotalPremisesStaffServiceCosts,
+            SchoolSpendingCategories.SubCategoryFilter.CleaningCaretakingCosts,
+            SchoolSpendingCategories.SubCategoryFilter.MaintenancePremisesCosts,
+            SchoolSpendingCategories.SubCategoryFilter.OtherOccupationCosts,
+            SchoolSpendingCategories.SubCategoryFilter.PremisesStaffCosts,
+        ];
     }
 
     public static class Utilities
@@ -342,7 +423,18 @@ public static class SubCostCategories
         public const string EnergyCosts = "Energy";
         public const string WaterSewerageCosts = "Water and sewerage";
 
-        public static string[] SubCategories { get; } = [EnergyCosts, WaterSewerageCosts];
+        public static string[] SubCategories { get; } =
+            [
+                EnergyCosts,
+                WaterSewerageCosts
+            ];
+        public static SchoolSpendingCategories.CategoryGroup SubCategoryGroup { get; } = SchoolSpendingCategories.CategoryGroup.Utilities;
+        public static SchoolSpendingCategories.SubCategoryFilter[] SubCategoryFilters { get; } =
+        [
+            SchoolSpendingCategories.SubCategoryFilter.TotalUtilitiesCosts,
+            SchoolSpendingCategories.SubCategoryFilter.EnergyCosts,
+            SchoolSpendingCategories.SubCategoryFilter.WaterSewerageCosts
+        ];
     }
 
     public static class AdministrativeSupplies
@@ -350,6 +442,8 @@ public static class SubCostCategories
         public const string AdministrativeSuppliesNonEducationalCosts = "Administrative supplies (non-educational)";
 
         public static string[] SubCategories { get; } = [AdministrativeSuppliesNonEducationalCosts];
+        public static SchoolSpendingCategories.CategoryGroup SubCategoryGroup { get; } = SchoolSpendingCategories.CategoryGroup.AdministrativeSupplies;
+        public static SchoolSpendingCategories.SubCategoryFilter[] SubCategoryFilters { get; } = [SchoolSpendingCategories.SubCategoryFilter.AdministrativeSuppliesNonEducationalCosts];
     }
 
     public static class CateringStaffServices
@@ -357,7 +451,19 @@ public static class SubCostCategories
         public const string CateringStaffCosts = "Catering staff";
         public const string CateringSuppliesCosts = "Catering supplies";
 
-        public static string[] SubCategories { get; } = [CateringStaffCosts, CateringSuppliesCosts];
+        public static string[] SubCategories { get; } =
+            [
+                CateringStaffCosts,
+                CateringSuppliesCosts
+            ];
+        public static SchoolSpendingCategories.CategoryGroup SubCategoryGroup { get; } = SchoolSpendingCategories.CategoryGroup.CateringStaffServices;
+        public static SchoolSpendingCategories.SubCategoryFilter[] SubCategoryFilters { get; } =
+        [
+            SchoolSpendingCategories.SubCategoryFilter.TotalGrossCateringCosts,
+            SchoolSpendingCategories.SubCategoryFilter.TotalNetCateringCosts,
+            SchoolSpendingCategories.SubCategoryFilter.CateringStaffCosts,
+            SchoolSpendingCategories.SubCategoryFilter.CateringSuppliesCosts
+        ];
     }
 
     public static class Other
@@ -390,6 +496,24 @@ public static class SubCostCategories
             SupplyTeacherInsurableCosts,
             CommunityFocusedSchoolStaff,
             CommunityFocusedSchoolCosts
+        ];
+        public static SchoolSpendingCategories.CategoryGroup SubCategoryGroup { get; } = SchoolSpendingCategories.CategoryGroup.Other;
+        public static SchoolSpendingCategories.SubCategoryFilter[] SubCategoryFilters { get; } =
+        [
+            SchoolSpendingCategories.SubCategoryFilter.TotalOtherCosts,
+            SchoolSpendingCategories.SubCategoryFilter.OtherInsurancePremiumsCosts,
+            SchoolSpendingCategories.SubCategoryFilter.GroundsMaintenanceCosts,
+            SchoolSpendingCategories.SubCategoryFilter.IndirectEmployeeExpenses,
+            SchoolSpendingCategories.SubCategoryFilter.InterestChargesLoanBank,
+            SchoolSpendingCategories.SubCategoryFilter.PrivateFinanceInitiativeCharges,
+            SchoolSpendingCategories.SubCategoryFilter.RentRatesCosts,
+            SchoolSpendingCategories.SubCategoryFilter.SpecialFacilitiesCosts,
+            SchoolSpendingCategories.SubCategoryFilter.StaffDevelopmentTrainingCosts,
+            SchoolSpendingCategories.SubCategoryFilter.StaffRelatedInsuranceCosts,
+            SchoolSpendingCategories.SubCategoryFilter.StaffRelatedInsuranceCosts,
+            SchoolSpendingCategories.SubCategoryFilter.SupplyTeacherInsurableCosts,
+            SchoolSpendingCategories.SubCategoryFilter.CommunityFocusedSchoolStaff,
+            SchoolSpendingCategories.SubCategoryFilter.CommunityFocusedSchoolCosts
         ];
     }
 }

--- a/web/src/Web.App/Domain/Schools/SchoolSpendingCategories.cs
+++ b/web/src/Web.App/Domain/Schools/SchoolSpendingCategories.cs
@@ -60,7 +60,7 @@ public static class SchoolSpendingCategories
         StaffRelatedInsuranceCosts = 38,
         SupplyTeacherInsurableCosts = 39,
         CommunityFocusedSchoolStaff = 40,
-        CommunityFocusedSchoolCosts = 41,
+        CommunityFocusedSchoolCosts = 41
     }
 
     public static readonly SubCategoryFilter[] All =

--- a/web/src/Web.App/ViewModels/Components/SchoolSpendingCostsViewModel.cs
+++ b/web/src/Web.App/ViewModels/Components/SchoolSpendingCostsViewModel.cs
@@ -31,6 +31,8 @@ public class SchoolSpendingCostsViewModelCostCategory<T>
     public string? ChartSvg { get; set; }
     public bool HasNegativeOrZeroValues { get; init; }
     public T[]? Data { get; init; }
+    public int CategoryGroup { get; init; }
+    public int[] CategoryFilters { get; init; } = [];
 }
 
 public class SchoolSpendingCostsViewModelCostCategories : List<SchoolSpendingCostsViewModelCostCategory<PriorityCostCategoryDatum>>
@@ -53,7 +55,9 @@ public class SchoolSpendingCostsViewModelCostCategories : List<SchoolSpendingCos
                 Uuid = uuid,
                 Category = costCategory,
                 HasNegativeOrZeroValues = hasNegativeOrZeroValues,
-                Data = filteredData
+                Data = filteredData,
+                CategoryGroup = (int)costCategory.SubCategoryGroup,
+                CategoryFilters = costCategory.SubCategoryFilters.Select(x => (int)x).ToArray()
             });
         }
     }

--- a/web/src/Web.App/ViewModels/SchoolComparisonViewModel.cs
+++ b/web/src/Web.App/ViewModels/SchoolComparisonViewModel.cs
@@ -47,6 +47,7 @@ public class SchoolComparisonViewModel(
     public KeyValuePair<SchoolSpendingCategories.CategoryGroup, SchoolSpendingCategories.SubCategoryFilter[]>[] AllGroups =>
         SchoolSpendingCategories.Groups.ToArray();
     public List<SchoolSpendingComparisonGroup> Groups => subCategories?.Groups ?? [];
+    public SchoolSpendingCategories.CategoryGroup? ExpandFilterGroup { get; init; }
     public SchoolSpendingCategories.SubCategoryFilter[] SelectedSubCategories { get; init; } = [];
     public HashSet<int> SelectedIds =>
         SelectedSubCategories

--- a/web/src/Web.App/Views/SchoolComparison/_SchoolComparisonFilter.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/_SchoolComparisonFilter.cshtml
@@ -55,12 +55,13 @@
                 @for (var i = 0; i < Model.AllGroups.Length; i++)
                 {
                     var group = Model.AllGroups[i];
+                    var expandAccordion = group.Key.GetOpenByDefault() || Model.ExpandFilterGroup == group.Key;
                     var headingId = $"accordion-default-heading-{i + 1}";
                     var contentId = $"accordion-default-content-{i + 1}";
 
                     var groupSelectedCount = group.Value.Count(x => Model.SelectedIds.Contains((int)x));
 
-                    <div class="govuk-accordion__section@(group.Key.GetOpenByDefault() ? " govuk-accordion__section--expanded" : "")">
+                    <div class="govuk-accordion__section@(expandAccordion ? " govuk-accordion__section--expanded" : "")">
                         <div class="govuk-accordion__section-header">
                             <h2 class="govuk-accordion__section-heading">
                                 <span class="govuk-accordion__section-button"

--- a/web/src/Web.App/Views/Shared/Components/SchoolSpendingCostsSsr/Default.cshtml
+++ b/web/src/Web.App/Views/Shared/Components/SchoolSpendingCostsSsr/Default.cshtml
@@ -1,9 +1,11 @@
-﻿@using Microsoft.Extensions.Primitives
+﻿@using Microsoft.FeatureManagement
 @using Newtonsoft.Json
 @using Web.App.Domain
 @using Web.App.Extensions
 @using Web.App.ViewModels
 @model Web.App.ViewModels.Components.SchoolSpendingCostsViewModel
+
+@inject IFeatureManager FeatureManager
 
 @if (Model.Costs.Any())
 {
@@ -16,9 +18,25 @@
             ? "Non-educational support staff"
             : category?.Rating.Category;
 
+        var isFiltersEnabled = await FeatureManager.IsEnabledAsync(FeatureFlags.SchoolComparisonFilter);
+
+        var anchorId = !isFiltersEnabled ? $"#{category?.Rating.CostCategoryAnchorId}" : "";
         var categoryUri = Model.IsCustomData
-            ? Url.Action("CustomData", "SchoolComparison", new { urn = Model.Urn })
-            : Url.Action("Index", "SchoolComparison", new { urn = Model.Urn });
+            ? Url.Action("CustomData", "SchoolComparison", new
+            {
+                urn = Model.Urn
+            })
+            : isFiltersEnabled
+                ? Url.Action("Index", "SchoolComparison", new
+                {
+                    urn = Model.Urn,
+                    selectedSubCategories = cost?.CategoryFilters,
+                    expandFilterGroup = cost?.CategoryGroup,
+                })
+                : Url.Action("Index", "SchoolComparison", new
+                {
+                    urn = Model.Urn
+                });
 
         var costCodes = category?.SubCategories
             .SelectMany(c => Model.CostCodes.GetCostCodes(c).ToArray())
@@ -147,7 +165,7 @@
                         var subCategories = category?.SubCategories ?? [];
                     }
                     <p class="govuk-body category-commentary">
-                        <a href="@categoryUri#@category?.Rating.CostCategoryAnchorId"
+                        <a href="@categoryUri@anchorId"
                            class="govuk-link govuk-link--no-visited-state">View
                             all @category?.Rating.Category?.ToLower(true) costs</a>@(subCategories.Any() ? ". " : string.Empty)
                         @if (subCategories.Any())

--- a/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingSpending.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/WhenViewingSpending.cs
@@ -66,11 +66,13 @@ public class WhenViewingSpending(SchoolBenchmarkingWebAppClient client)
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task CanNavigateUsingViewAllCategories(bool isPartOfTrust)
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    public async Task CanNavigateUsingViewAllCategories(bool isPartOfTrust, bool schoolComparisonFilterEnabled)
     {
-        var (page, school, _, _) = await SetupNavigateInitPage(isPartOfTrust);
+        var (page, school, _, _) = await SetupNavigateInitPage(isPartOfTrust, ssrFeatureEnabled: true, schoolComparisonFilterEnabled: schoolComparisonFilterEnabled);
 
         var categorySections = page.QuerySelectorAll("main section");
 
@@ -83,18 +85,38 @@ public class WhenViewingSpending(SchoolBenchmarkingWebAppClient client)
             var sectionHeading = section.QuerySelector("h3")?.TextContent;
             Assert.NotNull(sectionHeading);
 
-            var id = CategoryHeadingToIdMap[sectionHeading];
-
             var anchor = section.QuerySelector(".govuk-link");
             Assert.NotNull(anchor);
 
             var targetPage = await Client.Follow(anchor);
 
+            if (schoolComparisonFilterEnabled)
+            {
+                var expectedQueryParams = CategoryHeadingToQueryParamsMap[sectionHeading];
+                DocumentAssert.AssertPageUrl(targetPage, $"{expectedUrl}{expectedQueryParams}".ToAbsolute());
+                DocumentAssert.TitleAndH1(targetPage, "Benchmark spending - Financial Benchmarking and Insights Tool - GOV.UK",
+                    "Benchmark spending");
+                return;
+            }
+
+            var id = CategoryHeadingToIdMap[sectionHeading];
             DocumentAssert.AssertPageUrl(targetPage, $"{expectedUrl}#{id}".ToAbsolute());
             DocumentAssert.TitleAndH1(targetPage, "Benchmark spending - Financial Benchmarking and Insights Tool - GOV.UK",
                 "Benchmark spending");
         }
     }
+
+    private static Dictionary<string, string> CategoryHeadingToQueryParamsMap => new()
+    {
+        { "Teaching and Teaching support staff", "?selectedSubCategories=1&selectedSubCategories=2&selectedSubCategories=3&selectedSubCategories=4&selectedSubCategories=5&selectedSubCategories=6&expandFilterGroup=1" },
+        { "Non-educational support staff", "?selectedSubCategories=7&selectedSubCategories=8&selectedSubCategories=9&selectedSubCategories=10&selectedSubCategories=11&expandFilterGroup=2" },
+        { "Educational supplies", "?selectedSubCategories=12&selectedSubCategories=13&selectedSubCategories=14&expandFilterGroup=3" },
+        { "Educational ICT", "?selectedSubCategories=15&expandFilterGroup=4" },
+        { "Premises staff and services", "?selectedSubCategories=16&selectedSubCategories=17&selectedSubCategories=18&selectedSubCategories=19&selectedSubCategories=20&expandFilterGroup=5" },
+        { "Utilities", "?selectedSubCategories=21&selectedSubCategories=22&selectedSubCategories=23&expandFilterGroup=6" },
+        { "Administrative supplies", "?selectedSubCategories=24&expandFilterGroup=7" },
+        { "Catering staff and supplies", "?selectedSubCategories=25&selectedSubCategories=26&selectedSubCategories=27&selectedSubCategories=28&expandFilterGroup=8" }
+    };
 
     [Theory]
     [InlineData(true)]
@@ -159,7 +181,8 @@ public class WhenViewingSpending(SchoolBenchmarkingWebAppClient client)
         SchoolComparatorSet? comparatorSet = null,
         bool ssrFeatureEnabled = false,
         bool chartApiException = false,
-        bool cfrItSpendBreakdownEnabled = false)
+        bool cfrItSpendBreakdownEnabled = false,
+        bool schoolComparisonFilterEnabled = false)
     {
         var school = Fixture.Build<School>()
             .With(x => x.URN, "123456")
@@ -188,6 +211,11 @@ public class WhenViewingSpending(SchoolBenchmarkingWebAppClient client)
         if (!cfrItSpendBreakdownEnabled)
         {
             disabledFeatureFlags.Add(FeatureFlags.CfrItSpendBreakdown);
+        }
+
+        if (!schoolComparisonFilterEnabled)
+        {
+            disabledFeatureFlags.Add(FeatureFlags.SchoolComparisonFilter);
         }
 
         var client = Client


### PR DESCRIPTION
## 🧾 Summary

Updates category links on the School Spending page so that, when SchoolComparisonFilter is enabled, navigation to the School Benchmark Spending page includes the correct query parameters to automatically select the charts belonging to that category. Behaviour remains unchanged when the feature flag is off.

[AB#298070](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/298070)
[AB#312961](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/312961)

### ✨ Feature Details
**Functionality:**

With SchoolComparisonFilter enabled, clicking a category on the School Spending page now takes users to the School Benchmark Spending page with:
- the relevant charts for that category pre‑selected
- the corresponding accordion group expanded by default

**Implementation:**

Each CostCategory now exposes two additional properties:
- SubCategoryGroup
- SubCategoryFilters
 
These values are surfaced through SchoolSpendingCostsViewModelCostCategory and used as route values when constructing the categoryUri in the SchoolSpendingCostsSsr component.

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [x] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes

I believe the behaviour is correct, but there’s still some conceptual tension between CostCategory and SchoolSpendingCategories. I’m already thinking about how we might simplify or realign these responsibilities, so a follow‑up refactor is probably worthwhile.