### PR TITLE
feat: chart legend for progress 8 in school spending benchmarking

### DIFF
--- a/documentation/features/13_Chart-Rendering-Api.md
+++ b/documentation/features/13_Chart-Rendering-Api.md
@@ -349,7 +349,12 @@ When support for stacked bar charts was added, it was decided that all horizonta
 
 ### Chart legend
 
-The legend on a stacked horizontal bar chart is built using the `legendLabels` request property. The `valueField` property must be an array of strings, each string being a property on objects in `data`.  `legendLabels` should contain the names of these properties, eg.:
+Legends are displayed on single data stack horizontal bar charts with grouped keys, and on horizontal bar charts with
+multiple data stacks, but without grouped keys.  Multiple data stacks are not compatible with grouped keys.
+Legends for both scenarios are built using the `legendLabels` request property.
+
+For charts with multiple data stacks the `valueField` property must be an array of strings, each string being a property
+on objects in `data`, and `legendLabels` should contain the names of these properties, eg.:
 
 ```json
 {
@@ -369,6 +374,52 @@ The legend on a stacked horizontal bar chart is built using the `legendLabels` r
   ]
 
   ...
+}
+```
+
+For charts with a single data stack and grouped keys the site scss must contain specifically named css classes to
+to provide each legend with the appropriate colour. The CSS class providing the colour should be inside the class
+hierarchy `ssr-chart` > `chart-cell`, and  named `chart-legend-` followed by the text of the legend label, with spaces
+replaced by hyphens, and in lower case. Care should be taken to align these css classes with those that provide the
+colour for the bars themselves.  For example, if `legendLabels` contains the following ...
+
+```json
+  ...
+
+  "legendLabels": [
+    "Well above average",
+    "Above average"
+  ]
+
+  ...
+
+```
+
+... the SCSS should contain classes like this ...
+
+```css
+.ssr-chart {
+    .chart-cell {
+        &.chart-cell__group-banding-well-above-average {
+            fill: govuk-colour("turquoise");
+            stroke: govuk-colour("turquoise");
+        }
+
+        &.chart-cell__group-banding-above-average {
+            fill: govuk-colour("light-blue");
+            stroke: govuk-colour("light-blue");
+        }
+
+        &.chart-legend-well-above-average {
+            fill: govuk-colour("turquoise");
+            stroke: govuk-colour("turquoise");
+        }
+
+        &.chart-legend-above-average {
+            fill: govuk-colour("light-blue");
+            stroke: govuk-colour("light-blue");
+        }
+    }
 }
 ```
 

--- a/platform/src/apis/Platform.Api.ChartRendering/src/functions/horizontalBarChart/template.ts
+++ b/platform/src/apis/Platform.Api.ChartRendering/src/functions/horizontalBarChart/template.ts
@@ -53,9 +53,13 @@ export default class HorizontalBarChartTemplate {
     }
 
     const isStackedChart: boolean = valueFields.length > 1;
-    const hasGroupedKeys: boolean = groupedKeys !== undefined && Object.keys(groupedKeys as Record<string, DatumKey[]>).length > 0;
-    const hasLegendLabels: boolean = legendLabels !== undefined && legendLabels.length > 0;
-    const requiresLegend: boolean = isStackedChart || (hasGroupedKeys && hasLegendLabels);
+    const hasGroupedKeys: boolean =
+      groupedKeys !== undefined &&
+      Object.keys(groupedKeys as Record<string, DatumKey[]>).length > 0;
+    const hasLegendLabels: boolean =
+      legendLabels !== undefined && legendLabels.length > 0;
+    const requiresLegend: boolean =
+      isStackedChart || (hasGroupedKeys && hasLegendLabels);
 
     // Declare the chart dimensions and margins.
     const legendRows = requiresLegend
@@ -322,11 +326,8 @@ export default class HorizontalBarChartTemplate {
   ${yAxisChartTicks.join("")}
 </g>`;
 
-    function legendToClassName (legendText: string)
-    {
-      return legendText
-        .replace(/ /g, "-")
-        .toLowerCase();
+    function legendToClassName(legendText: string) {
+      return legendText.replace(/ /g, "-").toLowerCase();
     }
 
     // Create a legend

--- a/platform/src/apis/Platform.Api.ChartRendering/src/functions/horizontalBarChart/template.ts
+++ b/platform/src/apis/Platform.Api.ChartRendering/src/functions/horizontalBarChart/template.ts
@@ -53,12 +53,14 @@ export default class HorizontalBarChartTemplate {
     }
 
     const stackedChart: boolean = valueFields.length > 1;
+    const hasGroupedKeys: boolean = Object.keys(groupedKeys as Record<string, DatumKey[]>).length > 0;
+    const requiresLegend: boolean = stackedChart || hasGroupedKeys;
 
     // Declare the chart dimensions and margins.
-    const legendRows = stackedChart
+    const legendRows = requiresLegend
       ? Math.floor((legendLabels.length + 1) / 2) // two legend labels per row
       : 0;
-    const legendHeight = stackedChart ? legendRows * 25 + 10 : 0;
+    const legendHeight = requiresLegend ? legendRows * 25 + 10 : 0;
     const marginTop = 20;
     const marginRight = 40;
     const marginLeft = 3;
@@ -319,13 +321,20 @@ export default class HorizontalBarChartTemplate {
   ${yAxisChartTicks.join("")}
 </g>`;
 
+    function legendToClassName (legendText: string)
+    {
+      return legendText
+        .replace(/ /g, "-")
+        .toLowerCase();
+    }
+
     // Create a legend
     let legend: string = "";
     const boxDim: number = y.bandwidth() / 2;
     let xPos: number = 0;
     let yPos: number = 0;
 
-    if (stackedChart) {
+    if (requiresLegend) {
       const rectsAndLabels = legendLabels.map((f, i) => {
         if (i % 2 == 0) {
           xPos = 0;
@@ -333,7 +342,10 @@ export default class HorizontalBarChartTemplate {
         }
 
         const field = f as string;
-        const box: string = `<rect class="chart-cell chart-data-stack-${i}" height="${boxDim}" width="${boxDim}" x="${xPos}" y="${yPos}" />`;
+        const cssClass: string = stackedChart
+          ? `chart-data-stack-${i}`
+          : `chart-legend-${legendToClassName(field)}`;
+        const box: string = `<rect class="chart-cell ${cssClass}" height="${boxDim}" width="${boxDim}" x="${xPos}" y="${yPos}" />`;
         xPos += boxDim + 5;
         const label: string = `<text x="${xPos}" y="${yPos}" dy="${boxDim}">${field}</text>`;
         xPos += 180;

--- a/platform/src/apis/Platform.Api.ChartRendering/src/functions/horizontalBarChart/template.ts
+++ b/platform/src/apis/Platform.Api.ChartRendering/src/functions/horizontalBarChart/template.ts
@@ -52,9 +52,10 @@ export default class HorizontalBarChartTemplate {
       valueFields = [valueField];
     }
 
-    const stackedChart: boolean = valueFields.length > 1;
-    const hasGroupedKeys: boolean = Object.keys(groupedKeys as Record<string, DatumKey[]>).length > 0;
-    const requiresLegend: boolean = stackedChart || hasGroupedKeys;
+    const isStackedChart: boolean = valueFields.length > 1;
+    const hasGroupedKeys: boolean = groupedKeys !== undefined && Object.keys(groupedKeys as Record<string, DatumKey[]>).length > 0;
+    const hasLegendLabels: boolean = legendLabels !== undefined && legendLabels.length > 0;
+    const requiresLegend: boolean = isStackedChart || (hasGroupedKeys && hasLegendLabels);
 
     // Declare the chart dimensions and margins.
     const legendRows = requiresLegend
@@ -143,13 +144,13 @@ export default class HorizontalBarChartTemplate {
           const widthAttr = x(d[1]) - xAttr; // increasing width for each bar (render order determines layering)
           const heightAttr = y.bandwidth();
           const dataKeyAttr = d.data[keyField] as string;
-          const stackCss = stackedChart ? "chart-data-stack-" + i : "";
+          const stackCss = isStackedChart ? "chart-data-stack-" + i : "";
           const classAttr = classnames(
             "chart-cell",
             "chart-cell__series-0",
             {
               "chart-cell__highlight":
-                d.data[keyField] === highlightKey && !stackedChart,
+                d.data[keyField] === highlightKey && !isStackedChart,
             },
             groups(d.data[keyField] as DatumKey).map(
               (g) => `chart-cell__group-${g}`
@@ -342,7 +343,7 @@ export default class HorizontalBarChartTemplate {
         }
 
         const field = f as string;
-        const cssClass: string = stackedChart
+        const cssClass: string = isStackedChart
           ? `chart-data-stack-${i}`
           : `chart-legend-${legendToClassName(field)}`;
         const box: string = `<rect class="chart-cell ${cssClass}" height="${boxDim}" width="${boxDim}" x="${xPos}" y="${yPos}" />`;

--- a/platform/tests/Platform.ApiTests/Data/HorizontalBarChartValidSingleCurrencyGroupedKeysLegendLabels.svg
+++ b/platform/tests/Platform.ApiTests/Data/HorizontalBarChartValidSingleCurrencyGroupedKeysLegendLabels.svg
@@ -1,0 +1,71 @@
+﻿<svg width="500" height="162" viewBox="0,0,500,162" data-chart-id="test-uuid" xmlns="http://www.w3.org/2000/svg">
+    <g>
+        <g data-stack="0">
+            <rect x="174.66666666666666" y="22.066666666666666" width="248.07257333333334" height="16.533333333333335" data-key="2023 – 2024" class="chart-cell chart-cell__series-0 chart-cell__group-previous" />
+            <rect x="174.66666666666666" y="42.733333333333334" width="225.64590666666666" height="16.533333333333335" data-key="2024 – 2025" class="chart-cell chart-cell__series-0 chart-cell__group-current" />
+            <rect x="174.66666666666666" y="63.400000000000006" width="203.21923999999999" height="16.533333333333335" data-key="2025 – 2026" class="chart-cell chart-cell__series-0 chart-cell__group-forecast" />
+        </g>
+    </g>
+    <g>
+        <text x="430.73924" y="30.333333333333336" dy="0.35em" class="chart-label chart-label__series-0">£22k</text>
+        <text x="408.3125733333333" y="51" dy="0.35em" class="chart-label chart-label__series-0">£20k</text>
+        <text x="385.88590666666664" y="71.66666666666667" dy="0.35em" class="chart-label chart-label__series-0">£18k</text>
+    </g>
+    <g class="chart-axis chart-axis__x" transform="translate(-2,82)">
+        <path class="domain" stroke="currentColor" d="M175.16666666666666,1V0.5H455.5V1" />
+        <g class="chart-tick" transform="translate(175.16666666666666,0)">
+            <line y2="6" x1="1" x2="1" />
+            <text y="9" dy="0.71em" x1="1" x2="1">£0</text>
+        </g>
+        <g class="chart-tick" transform="translate(231.23333333333332,0)">
+            <line y2="6" x1="1" x2="1" />
+            <text y="9" dy="0.71em" x1="1" x2="1">£5k</text>
+        </g>
+        <g class="chart-tick" transform="translate(287.3,0)">
+            <line y2="6" x1="1" x2="1" />
+            <text y="9" dy="0.71em" x1="1" x2="1">£10k</text>
+        </g>
+        <g class="chart-tick" transform="translate(343.3666666666667,0)">
+            <line y2="6" x1="1" x2="1" />
+            <text y="9" dy="0.71em" x1="1" x2="1">£15k</text>
+        </g>
+        <g class="chart-tick" transform="translate(399.43333333333334,0)">
+            <line y2="6" x1="1" x2="1" />
+            <text y="9" dy="0.71em" x1="1" x2="1">£20k</text>
+        </g>
+        <g class="chart-tick" transform="translate(455.5,0)">
+            <line y2="6" x1="1" x2="1" />
+            <text y="9" dy="0.71em" x1="1" x2="1">£25k</text>
+        </g>
+    </g>
+    <g class="chart-axis chart-axis__y" transform="translate(171.66666666666666,0)">
+        <path class="domain" stroke="currentColor" d="M0,20.5H0.5V82.5H0" transform="translate(0,0)" />
+        <g class="chart-tick" transform="translate(0,30.333333333333336)">
+            <line x2="-6" />
+            <text x="-9" dy="0.32em" class="text-tick">
+                <tspan>2023 </tspan>
+                <tspan>– </tspan>
+                <tspan>2024</tspan>
+            </text>
+        </g>
+        <g class="chart-tick" transform="translate(0,51)">
+            <line x2="-6" />
+            <text x="-9" dy="0.32em" class="text-tick">
+                <tspan>2024 </tspan>
+                <tspan>– </tspan>
+                <tspan>2025</tspan>
+            </text>
+        </g>
+        <g class="chart-tick" transform="translate(0,71.66666666666667)">
+            <line x2="-6" />
+            <text x="-9" dy="0.32em" class="text-tick">
+                <tspan>2025 </tspan>
+                <tspan>– </tspan>
+                <tspan>2026</tspan>
+            </text>
+        </g>
+    </g>
+    <g transform="translate(153.36666666666667,107)">
+        <rect class="chart-cell chart-legend-previous" height="8.266666666666667" width="8.266666666666667" x="0" y="0" />
+        <text x="13.266666666666667" y="0" dy="8.266666666666667">Previous</text>,<rect class="chart-cell chart-legend-current" height="8.266666666666667" width="8.266666666666667" x="193.26666666666668" y="0" /><text x="206.53333333333336" y="0" dy="8.266666666666667">Current</text>,<rect class="chart-cell chart-legend-forecast" height="8.266666666666667" width="8.266666666666667" x="0" y="25" /><text x="13.266666666666667" y="25" dy="8.266666666666667">Forecast</text></g>
+</svg>

--- a/platform/tests/Platform.ApiTests/Data/HorizontalBarChartValidSingleCurrencyGroupedKeysLegendLabelsRequest.json
+++ b/platform/tests/Platform.ApiTests/Data/HorizontalBarChartValidSingleCurrencyGroupedKeysLegendLabelsRequest.json
@@ -1,0 +1,36 @@
+{
+  "keyField": "key",
+  "valueField": "value",
+  "valueType": "currency",
+  "barHeight": 20,
+  "id": "test-uuid",
+  "width": 500,
+  "data": [
+    {
+      "key": "2023 – 2024",
+      "value": 22123
+    },
+    {
+      "key": "2024 – 2025",
+      "value": 20123
+    },
+    {
+      "key": "2025 – 2026",
+      "value": 18123
+    }
+  ],
+  "groupedKeys": {
+    "previous": [
+      "2023 – 2024"
+    ],
+    "current": [
+      "2024 – 2025"
+    ],
+    "forecast": [
+      "2025 – 2026"
+    ]
+  },
+  "legendLabels": [
+    "Previous", "Current", "Forecast"
+  ]
+}

--- a/platform/tests/Platform.ApiTests/Features/ChartRenderingHorizontalBarChart.feature
+++ b/platform/tests/Platform.ApiTests/Features/ChartRenderingHorizontalBarChart.feature
@@ -75,6 +75,12 @@
         When I submit the horizontal bar chart request
         Then the response should be ok, contain an SVG document and match the expected output of 'HorizontalBarChartValidSingleCurrencyGroupedKeys.svg'
 
+    Scenario: Sending a valid single horizontal bar chart request with grouped keys and legend labels and accept header image/svg+xml returns the correct HTML only
+        Given a single horizontal bar chart request with accept header 'image/svg+xml' and request input from 'HorizontalBarChartValidSingleCurrencyGroupedKeysLegendLabelsRequest.json'
+        When I submit the horizontal bar chart request
+        Then the response should be ok, contain an SVG document and match the expected output of 'HorizontalBarChartValidSingleCurrencyGroupedKeysLegendLabels.svg'
+
+
     Scenario: Sending a valid single horizontal bar chart request without SI units with accept header image/svg+xml returns the correct HTML only
         Given a single horizontal bar chart request with accept header 'image/svg+xml', highlighted item '123456', sort 'asc', width '500', bar height '20', id 'test-uuid', valueType 'currency' and the following data:
           | Key    | Value  |

--- a/platform/tests/Platform.ApiTests/Models/PostHorizontalBarChartRequest.cs
+++ b/platform/tests/Platform.ApiTests/Models/PostHorizontalBarChartRequest.cs
@@ -17,6 +17,7 @@ public record PostHorizontalBarChartRequest<T> : ChartRequest<T>
     public string? ValueField { get; set; }
     public string? ValueType { get; set; }
     public string? XAxisLabel { get; set; }
+    public string[]? LegendLabels { get; set; }
 }
 
 public class PostHorizontalBarChartsRequest<T>(IEnumerable<PostHorizontalBarChartRequest<T>> collection) : List<PostHorizontalBarChartRequest<T>>(collection);

--- a/web/src/Web.App/AssetSrc/scss/main.scss
+++ b/web/src/Web.App/AssetSrc/scss/main.scss
@@ -929,6 +929,18 @@ table#current-comparators-la {
       fill: govuk-colour("dark-blue");
       stroke: govuk-colour("dark-blue");
     }
+    &.chart-legend-your-chosen-school {
+      fill: govuk-colour("dark-blue");
+      stroke: govuk-colour("dark-blue");
+    }
+    &.chart-legend-well-above-average {
+      fill: govuk-colour("turquoise");
+      stroke: govuk-colour("turquoise");
+    }
+    &.chart-legend-above-average {
+      fill: govuk-colour("light-blue");
+      stroke: govuk-colour("light-blue");
+    }
   }
 
   .chart-label {

--- a/web/src/Web.App/Domain/Charts/SchoolComparisonHorizontalBarChartRequest.cs
+++ b/web/src/Web.App/Domain/Charts/SchoolComparisonHorizontalBarChartRequest.cs
@@ -46,6 +46,11 @@ public record SchoolComparisonHorizontalBarChartRequest : PostHorizontalBarChart
             return;
         }
 
+        var legendLabels = new List<string>
+        {
+            "Your chosen school"
+        };
+
         // use only full year records for banding groups to prevent overlap with part‑year grouping
         var fullYearData = filteredData
             .Where(x => x.PeriodCoveredByReturn == 12)
@@ -57,6 +62,7 @@ public record SchoolComparisonHorizontalBarChartRequest : PostHorizontalBarChart
                 fullYearData,
                 KS4ProgressBandings.Banding.WellAboveAverage,
                 GroupType.Progress8WellAboveAverage);
+            legendLabels.Add(KS4ProgressBandings.Banding.WellAboveAverage.ToStringValue());
         }
 
         if (bandingsAs.Contains(SchoolSpendingDimensions.BandingsAsOptions.Above))
@@ -65,7 +71,10 @@ public record SchoolComparisonHorizontalBarChartRequest : PostHorizontalBarChart
                 fullYearData,
                 KS4ProgressBandings.Banding.AboveAverage,
                 GroupType.Progress8AboveAverage);
+            legendLabels.Add(KS4ProgressBandings.Banding.AboveAverage.ToStringValue());
         }
+
+        LegendLabels = legendLabels.ToArray();
     }
 
     private void AddBandingGroup(

--- a/web/src/Web.App/Domain/Charts/SchoolSeniorLeadershipHorizontalBarChartRequest.cs
+++ b/web/src/Web.App/Domain/Charts/SchoolSeniorLeadershipHorizontalBarChartRequest.cs
@@ -8,11 +8,8 @@ namespace Web.App.Domain.Charts;
 
 public record SchoolSeniorLeadershipHorizontalBarChartRequest : PostHorizontalBarChartRequest<SeniorLeadershipGroup>
 {
-    // TODO: Move these into the base type once the Web Chart Rendering contract is finalised.
-    // They may become a single combined type for easier mapping.
-    // For now, LegendLabels must align with ValueField by index.
+    // TODO: potentially move ValueField into the base type once the Web Chart Rendering contract is finalised.
     public new string[]? ValueField { get; set; }
-    public string[]? LegendLabels { get; set; }
 
     public SchoolSeniorLeadershipHorizontalBarChartRequest(
         string uuid,

--- a/web/src/Web.App/Infrastructure/Apis/ApiRequests/PostHorizontalBarChartRequest.cs
+++ b/web/src/Web.App/Infrastructure/Apis/ApiRequests/PostHorizontalBarChartRequest.cs
@@ -17,6 +17,7 @@ public record PostHorizontalBarChartRequest<T> : ChartRequest<T>
     public decimal? PaddingOuter { get; set; }
     public string? ValueType { get; set; }
     public string? XAxisLabel { get; set; }
+    public string[]? LegendLabels { get; set; }
 }
 
 public class PostHorizontalBarChartsRequest<T>(IEnumerable<PostHorizontalBarChartRequest<T>> collection) : List<PostHorizontalBarChartRequest<T>>(collection);


### PR DESCRIPTION
## 🧾 Summary
> Briefly describe the changes and why they are needed.

Fixes [AB#298070](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/298070) [AB#315788](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/315788)

<img width="534" height="675" alt="Screenshot 2026-06-09 at 11 52 30" src="https://github.com/user-attachments/assets/bca9a45e-fac6-4e56-9336-9b43e1c595a4" />

### ✨ Feature Details
> - **Functionality:** Implements an optional chart legend for horizontal bar charts with grouped keys 
> - **Implementation:** 
>    - Moved the chart request property `LegendLabels` from `SchoolSeniorLeadershipHorizontalBarChartRequest` to the base class `PostHorizontalBarChartRequest` to allow legend labels to be specified for a wider subsection of horizontal bar charts, rather than just school secnior leadership charts
>    - Populated `LegendLabels` request property in `SchoolComparisonHorizontalBarChartRequest`
>    - Changed chart rendering API to handle legends labels on charts with a single data stack, as long as grouped keys are specified

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [x] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [x] Relevant documentation updated _(if applicable)_.
- [x] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes
> Add any additional context for reviewers, required dependencies, or specific testing instructions.

In `web/src/Web.App/Domain/Charts/SchoolComparisonHorizontalBarChartRequest.cs` I have specified the label for the default "Your chosen school" as a magic string. The other legend labels have a class in `Domain` which provides the label text, but this is not available for the default chosen school. Rather than work up a domain object just for this one use case, I chose to compromise with a magic string instead.