### PR TITLE
fix: ensure no accordion sections open by default

### DIFF
--- a/web/src/Web.App/Domain/Schools/SchoolSpendingCategories.cs
+++ b/web/src/Web.App/Domain/Schools/SchoolSpendingCategories.cs
@@ -207,14 +207,6 @@ public static class SchoolSpendingCategories
         _ => ComparatorSetTypes.Pupil
     };
 
-    public static bool GetOpenByDefault(this CategoryGroup group) => group switch
-    {
-        CategoryGroup.TotalExpenditure => true,
-        CategoryGroup.EducationalIct => true,
-        CategoryGroup.AdministrativeSupplies => true,
-        _ => false
-    };
-
     public static string GetHeading(this SubCategoryFilter filter) => filter switch
     {
         SubCategoryFilter.TotalExpenditure => "Total expenditure",

--- a/web/src/Web.App/Views/SchoolComparison/_SchoolComparisonFilter.cshtml
+++ b/web/src/Web.App/Views/SchoolComparison/_SchoolComparisonFilter.cshtml
@@ -55,7 +55,7 @@
                 @for (var i = 0; i < Model.AllGroups.Length; i++)
                 {
                     var group = Model.AllGroups[i];
-                    var expandAccordion = group.Key.GetOpenByDefault() || Model.ExpandFilterGroup == group.Key;
+                    var expandAccordion = Model.ExpandFilterGroup == group.Key;
                     var headingId = $"accordion-default-heading-{i + 1}";
                     var contentId = $"accordion-default-content-{i + 1}";
 


### PR DESCRIPTION
## 🧾 Summary
> Briefly describe the changes and why they are needed.

Fixes [AB#298070](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/298070) [AB#315865](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/315865)

### ✨ Feature Details
> - **Functionality:** Removes directives ensuring that specific filter section in school spending benchmarking are open by default
> - **Implementation:** Removal of extension method in `SchoolSpendingCategories`, and removal of view code which sets accordion section open css

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes
> Add any additional context for reviewers, required dependencies, or specific testing instructions.
