### PR TITLE
test: a11y tests for school benchmark spending

### DIFF
--- a/pipelines/web/steps/run-a11y-tests.yaml
+++ b/pipelines/web/steps/run-a11y-tests.yaml
@@ -32,3 +32,4 @@ steps:
     inputs:
       command: test
       projects: '${{ parameters.workspaceDir }}/a11y-tests-files/Web.A11yTests/Web.A11yTests.dll'
+      arguments: --filter "Category!=SchoolComparisonFilterEnabled"

--- a/web/tests/Web.A11yTests/Pages/Schools/WhenViewingCompareYourCosts.cs
+++ b/web/tests/Web.A11yTests/Pages/Schools/WhenViewingCompareYourCosts.cs
@@ -1,3 +1,4 @@
+using Microsoft.Playwright;
 using Web.A11yTests.Drivers;
 using Xunit;
 using Xunit.Abstractions;
@@ -11,6 +12,7 @@ public class WhenViewingCompareYourCosts(
 {
     protected override string PageUrl => $"/school/{TestConfiguration.School}/comparison";
 
+    [Trait("Category", "SchoolComparisonFilterDisabled")]
     [Theory]
     [InlineData("table")]
     [InlineData("chart")]
@@ -22,6 +24,7 @@ public class WhenViewingCompareYourCosts(
         await EvaluatePage();
     }
 
+    [Trait("Category", "SchoolComparisonFilterDisabled")]
     [Theory]
     [InlineData("table")]
     [InlineData("chart")]
@@ -29,6 +32,44 @@ public class WhenViewingCompareYourCosts(
     {
         await GoToPage();
         await Page.Locator($"#mode-{mode}").ClickAsync();
+        await EvaluatePage();
+    }
+
+    [Trait("Category", "SchoolComparisonFilterEnabled")]
+    [Fact]
+    public async Task ThenThereAreNoAccessibilityIssuesWhenApplyingOptionsAndFilters()
+    {
+        await GoToPage();
+        await EvaluatePage();
+
+        // apply options
+        await Page.Locator($"#view-Table").ClickAsync();
+
+        await Page
+            .Locator(".options-form__apply")
+            .GetByRole(AriaRole.Button, new LocatorGetByRoleOptions { Name = "Apply" })
+            .ClickAsync();
+
+        await EvaluatePage();
+
+        // apply filter
+        // expand accordion
+        await Page
+            .Locator(".app-filter")
+            .GetByRole(AriaRole.Button, new LocatorGetByRoleOptions { Name = "Total expenditure" })
+            .CheckAsync();
+
+        // tick checkbox
+        await Page
+            .Locator(".app-filter")
+            .GetByLabel("Total expenditure")
+            .CheckAsync();
+
+        // submit filters
+        await Page
+            .Locator(".app-filter")
+            .GetByRole(AriaRole.Button, new LocatorGetByRoleOptions { Name = "Apply filters" })
+            .ClickAsync();
         await EvaluatePage();
     }
 }

--- a/web/tests/Web.A11yTests/Pages/Schools/WhenViewingCompareYourCosts.cs
+++ b/web/tests/Web.A11yTests/Pages/Schools/WhenViewingCompareYourCosts.cs
@@ -57,12 +57,12 @@ public class WhenViewingCompareYourCosts(
         await Page
             .Locator(".app-filter")
             .GetByRole(AriaRole.Button, new LocatorGetByRoleOptions { Name = "Total expenditure" })
-            .CheckAsync();
+            .ClickAsync();
 
         // tick checkbox
         await Page
             .Locator(".app-filter")
-            .GetByLabel("Total expenditure")
+            .GetByRole(AriaRole.Checkbox, new LocatorGetByRoleOptions { Name = "Total expenditure" })
             .CheckAsync();
 
         // submit filters


### PR DESCRIPTION
## 🧾 Summary

Adds automated accessibility coverage for the School Benchmark Spending page.

The new tests evaluate the page:
- on initial load
- after switching to table view 
- after expanding filters, selecting a sub‑category, and applying filters

The trait SchoolComparisonFilterEnabled, has been added for the new test.
Existing tests have been updated with SchoolComparisonFilterDisabled.

[AB#298070](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/298070)
[AB#312524](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/312524)

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes

Because SchoolComparisonFilter is currently disabled in d02, this PR adds a CI argument to skip the new test. Once the E2E tests for this page are finalised, we can enable the feature in d02 and invert this so the old SchoolComparisonFilterDisabled tests are skipped instead.