### PR TITLE
test: add e2e tests for the school benchmark spending page

### DIFF
--- a/pipelines/web/steps/run-a11y-tests.yaml
+++ b/pipelines/web/steps/run-a11y-tests.yaml
@@ -32,4 +32,4 @@ steps:
     inputs:
       command: test
       projects: '${{ parameters.workspaceDir }}/a11y-tests-files/Web.A11yTests/Web.A11yTests.dll'
-      arguments: --filter "Category!=SchoolComparisonFilterEnabled"
+      arguments: --filter "Category!=SchoolComparisonFilterDisabled"

--- a/pipelines/web/steps/run-e2e-tests.yaml
+++ b/pipelines/web/steps/run-e2e-tests.yaml
@@ -31,7 +31,7 @@ steps:
     inputs:
       command: test
       projects: '${{ parameters.workspaceDir }}/e2e-tests-files/Web.E2ETests/Web.E2ETests.dll'
-      arguments: --filter "Category!=LocalAuthorityHomepageV2FlagDisabled&Category!=DSISignIn&Category!=HighNeedsBenchmarkingFlagDisabled"
+      arguments: --filter "Category!=LocalAuthorityHomepageV2FlagDisabled&Category!=DSISignIn&Category!=HighNeedsBenchmarkingFlagDisabled&Category!=SchoolComparisonFilterDisabled"
 
   - publish: ${{ parameters.workspaceDir }}/e2e-tests-files/Web.E2ETests/screenshots
     artifact: e2e-test-outputs-$(System.JobAttempt)

--- a/web/terraform/variables.tf
+++ b/web/terraform/variables.tf
@@ -81,7 +81,8 @@ variable "configuration" {
       front_door_waf_policy_sku_name = "Standard_AzureFrontDoor"
       waf_mode                       = "Detection"
       features = {
-        News = true
+        News                   = true,
+        SchoolComparisonFilter = true
       },
       CacheOptions = {
         ReturnYears = {
@@ -133,7 +134,8 @@ variable "configuration" {
       front_door_waf_policy_sku_name = "Standard_AzureFrontDoor"
       waf_mode                       = "Detection"
       features = {
-        News = true
+        News                   = true,
+        SchoolComparisonFilter = true
       },
       CacheOptions = {
         ReturnYears = {

--- a/web/tests/Web.E2ETests/Features/School/BenchmarkSpending.feature
+++ b/web/tests/Web.E2ETests/Features/School/BenchmarkSpending.feature
@@ -1,0 +1,163 @@
+﻿@SchoolComparisonFilterEnabled
+Feature: School benchmark spending
+
+    This feature tests the new Benchmark Spending view, which is enabled when the SchoolComparisonFilter feature flag is enabled.
+    Scenarios are high-level E2E tests for the new filtered view with table and chart modes.
+
+    Scenario: Clicking download chart images button downloads .zip file
+        Given I am on benchmark spending page for school with URN '777042'
+        Then the save chart images button is visible
+        When I click the save chart images button
+        Then the save chart images modal is visible
+        And the 'comparison-777042.zip' file is downloaded
+
+    Scenario: Table view for total expenditure for school(s) with part-year data
+        Given I am on benchmark spending page for part year school with URN '777045'
+        And table view is selected for benchmark spending
+        Then the following benchmark spending table is shown for 'Total expenditure'
+          | School name                                                                              | Local Authority                  | School type                    | Number of pupils | Amount  |
+          | Test academy school 273                                                                  | Kensington and Chelsea           | Academy converter              | 114              | £13,051 |
+          | Test school 88                                                                           | Slough                           | Community school               | 134              | £9,916  |
+          | Test part year with pupil and without building comparator\n\nOnly has 3 months of data   | Bromley                          | Pupil referral unit            | 260              | £9,068  |
+          | Test school 197                                                                          | Windsor and Maidenhead           | Community school               | 167              | £9,050  |
+          | Test academy school 470                                                                  | Waltham Forest                   | Academy 16-19 converter        | 167              | £9,050  |
+          | Test academy school 77                                                                   | Hartlepool                       | Academy converter              | 1,040            | £9,023  |
+          | Test academy school 469                                                                  | Hillingdon                       | Free school 16 to 19           | 235              | £8,981  |
+          | Test school 198                                                                          | West Berkshire                   | Community school               | 174              | £8,882  |
+          | Test academy school 255                                                                  | Stockton-on-Tees                 | Academy converter              | 174              | £8,882  |
+          | Test school 181                                                                          | Dorset                           | Voluntary aided school         | 399              | £8,584  |
+          | Test school 87                                                                           | Reading                          | Foundation school              | 206              | £8,224  |
+          | Test school 124                                                                          | Newham                           | Voluntary aided school         | 769              | £8,089  |
+          | Test academy school 82                                                                   | Bournemouth Christchurch & Poole | Academy converter              | 991              | £8,088  |
+          | Test academy school 53                                                                   | Salford                          | Free school                    | 407              | £8,028  |
+          | Test school 260                                                                          | Kingston upon Thames             | Community school               | 853              | £7,880  |
+          | Test academy school 450                                                                  | Surrey                           | Academy 16-19 converter        | 367              | £7,703  |
+          | Test Part year school with pupil and builiding comparators\n\nOnly has 10 months of data | Bracknell Forest                 | Foundation school              | 214              | £7,470  |
+          | Test school 205                                                                          | Plymouth                         | Community school               | 196              | £7,385  |
+          | Test academy school 20                                                                   | Waltham Forest                   | Academy converter              | 449              | £7,356  |
+          | Test academy school 98                                                                   | Southwark                        | Academy converter              | 449              | £7,356  |
+          | Test academy school 244                                                                  | Islington                        | Academy converter              | 446              | £7,342  |
+          | Test school 68                                                                           | Derbyshire                       | Local authority nursery school | 339              | £7,318  |
+          | Test academy school 37                                                                   | North Lincolnshire               | Academy converter              | 339              | £7,318  |
+          | Test school 270                                                                          | Solihull                         | Voluntary aided school         | 230              | £7,281  |
+          | Test school 237                                                                          | City of London                   | Voluntary aided school         | 231              | £6,918  |
+          | Test academy school 465                                                                  | Enfield                          | Academy 16-19 converter        | 231              | £6,918  |
+          | Test academy school 375                                                                  | Reading                          | Academy special sponsor led    | 232              | £6,814  |
+          | Test school 132                                                                          | Solihull                         | Community school               | 418              | £6,676  |
+          | Test academy school 32                                                                   | Stockton-on-Tees                 | Academy converter              | 418              | £6,676  |
+          | Test academy school 160                                                                  | West Sussex                      | Academy special converter      | 190              | £6,208  |
+
+    Scenario: Benchmarking for school with missing comparators does not display comparators
+        Given I am on benchmark spending page for missing comparator school with URN '990754'
+        Then the benchmark spending comparison charts and tables are not displayed
+
+    Scenario: View additional details upon hover
+        Given I am on benchmark spending page for school with URN '777042'
+        When I hover over a benchmark spending chart bar
+        Then additional benchmark spending information is displayed
+        And additional benchmark spending information contains
+          | Item             | Value            |
+          | Local authority  | Redbridge        |
+          | School type      | Community school |
+          | Number of pupils | 114              |
+
+    Scenario: Clicking school name in chart directs to homepage
+        Given I am on benchmark spending page for school with URN '777042'
+        When I select the school name on the benchmark spending chart
+        Then I am navigated to selected school home page
+
+    Scenario: Tabbing to and selecting school name in chart directs to homepage
+        Given I am on benchmark spending page for school with URN '777042'
+        When I tab to the school name on the benchmark spending chart
+        And I press the Enter key when focused on the benchmark spending school name
+        Then I am navigated to selected school home page
+
+    Scenario: Tabbing to school name in chart displays tooltip
+        Given I am on benchmark spending page for school with URN '777042'
+        When I tab to the school name on the benchmark spending chart
+        Then I can view the benchmark spending tooltip
+
+    Scenario Outline: View comparators for part year school
+        Given I am on benchmark spending page for part year school with URN '<URN>'
+        When I click on benchmark spending comparators link
+        Then I am taken to comparators page
+        And pupil cost comparators are <PupilComparators>
+        And building cost comparators are <BuildingComparators>
+
+        Examples:
+          | URN    | PupilComparators | BuildingComparators |
+          | 777043 | not null         | not null            |
+          | 777045 | not null         | null                |
+
+    Scenario: Table view should not display progress bandings when checkbox not selected
+        Given I am on benchmark spending page for school with URN '990002'
+        And table view is selected for benchmark spending
+        Then the following benchmark spending table is shown for 'Total expenditure'
+          | School name             | Local Authority                  | School type                    | Number of pupils | Amount   |
+          | Test school 22          | Cheshire East                    | Voluntary aided school         | 17               | £112,411 |
+          | Test academy school 231 | West Berkshire                   | Academy sponsor led            | 17               | £112,411 |
+          | Test academy school 274 | Lambeth                          | Academy converter              | 37               | £50,829  |
+          | Test academy school 144 | Dudley                           | Free school special            | 37               | £50,829  |
+          | Test school 208         | Southend-on-Sea                  | Community school               | 883              | £10,121  |
+          | Test school 140         | Bury                             | Foundation special school      | 317              | £9,705   |
+          | Test school 118         | Haringey                         | Voluntary aided school         | 260              | £9,068   |
+          | Test academy school 470 | Waltham Forest                   | Academy 16-19 converter        | 167              | £9,050   |
+          | Test academy school 469 | Hillingdon                       | Free school 16 to 19           | 235              | £8,981   |
+          | Test school 154         | Test Local Authority             | Community school               | 174              | £8,882   |
+          | Test school 138         | Sefton                           | Voluntary aided school         | 399              | £8,584   |
+          | Test school 26          | Hounslow                         | Community school               | 769              | £8,089   |
+          | Test academy school 4   | Hillingdon                       | Academy converter              | 769              | £8,089   |
+          | Test academy school 228 | Swindon                          | Academy sponsor led            | 991              | £8,088   |
+          | Test school 70          | Bournemouth Christchurch & Poole | Local authority nursery school | 407              | £8,028   |
+          | Test school 215         | Blackpool                        | Voluntary aided school         | 853              | £7,880   |
+          | Test academy school 146 | Cheshire East                    | Academy special converter      | 335              | £7,754   |
+          | Test academy school 364 | North East Lincolnshire          | Academy special converter      | 367              | £7,703   |
+          | Test school 76          | Portsmouth                       | Community school               | 212              | £7,487   |
+          | Test academy school 200 | Hillingdon                       | Academy sponsor led            | 446              | £7,342   |
+          | Test school 228         | Oxfordshire                      | Community school               | 339              | £7,318   |
+          | Test academy school 412 | Cheshire East                    | Academy converter              | 339              | £7,318   |
+          | Test school 97          | Southend-on-Sea                  | Voluntary aided school         | 1,045             | £7,302   |
+          | Test academy school 208 | Wigan                            | Academy sponsor led            | 210              | £6,990   |
+          | Test academy school 176 | Wandsworth                       | Academy sponsor led            | 204              | £6,985   |
+          | Test academy school 421 | Southwark                        | Free school                    | 231              | £6,918   |
+          | Test academy school 56  | Trafford                         | Academy sponsor led            | 232              | £6,814   |
+          | Test school 176         | Test Local Authority             | Voluntary aided school         | 418              | £6,676   |
+          | Test academy school 88  | Portsmouth                       | Academy converter              | 418              | £6,676   |
+          | Test school 19          | Leicestershire                   | Local authority nursery school | 190              | £6,208   |
+
+    Scenario: Table view should display correct progress bandings when checkbox selected
+        Given I am on benchmark spending page for school with URN '990002'
+        And table view is selected for benchmark spending
+        When I click on benchmark spending 'Well above average' school performance
+        Then the following benchmark spending table is shown for 'Total expenditure'
+          | School name             | Local Authority                  | School type                    | Number of pupils | Amount   | Progress 8 banding |
+          | Test school 22          | Cheshire East                    | Voluntary aided school         | 17               | £112,411 |                    |
+          | Test academy school 231 | West Berkshire                   | Academy sponsor led            | 17               | £112,411 |                    |
+          | Test academy school 274 | Lambeth                          | Academy converter              | 37               | £50,829  |                    |
+          | Test academy school 144 | Dudley                           | Free school special            | 37               | £50,829  |                    |
+          | Test school 208         | Southend-on-Sea                  | Community school               | 883              | £10,121  |                    |
+          | Test school 140         | Bury                             | Foundation special school      | 317              | £9,705   |                    |
+          | Test school 118         | Haringey                         | Voluntary aided school         | 260              | £9,068   |                    |
+          | Test academy school 470 | Waltham Forest                   | Academy 16-19 converter        | 167              | £9,050   |                    |
+          | Test academy school 469 | Hillingdon                       | Free school 16 to 19           | 235              | £8,981   |                    |
+          | Test school 154         | Test Local Authority             | Community school               | 174              | £8,882   |                    |
+          | Test school 138         | Sefton                           | Voluntary aided school         | 399              | £8,584   |                    |
+          | Test school 26          | Hounslow                         | Community school               | 769              | £8,089   |                    |
+          | Test academy school 4   | Hillingdon                       | Academy converter              | 769              | £8,089   |                    |
+          | Test academy school 228 | Swindon                          | Academy sponsor led            | 991              | £8,088   |                    |
+          | Test school 70          | Bournemouth Christchurch & Poole | Local authority nursery school | 407              | £8,028   |                    |
+          | Test school 215         | Blackpool                        | Voluntary aided school         | 853              | £7,880   |                    |
+          | Test academy school 146 | Cheshire East                    | Academy special converter      | 335              | £7,754   |                    |
+          | Test academy school 364 | North East Lincolnshire          | Academy special converter      | 367              | £7,703   |                    |
+          | Test school 76          | Portsmouth                       | Community school               | 212              | £7,487   |                    |
+          | Test academy school 200 | Hillingdon                       | Academy sponsor led            | 446              | £7,342   |                    |
+          | Test school 228         | Oxfordshire                      | Community school               | 339              | £7,318   |                    |
+          | Test academy school 412 | Cheshire East                    | Academy converter              | 339              | £7,318   |                    |
+          | Test school 97          | Southend-on-Sea                  | Voluntary aided school         | 1,045             | £7,302   |                    |
+          | Test academy school 208 | Wigan                            | Academy sponsor led            | 210              | £6,990   |                    |
+          | Test academy school 176 | Wandsworth                       | Academy sponsor led            | 204              | £6,985   |                    |
+          | Test academy school 421 | Southwark                        | Free school                    | 231              | £6,918   |                    |
+          | Test academy school 56  | Trafford                         | Academy sponsor led            | 232              | £6,814   |                    |
+          | Test school 176         | Test Local Authority             | Voluntary aided school         | 418              | £6,676   | Well above average |
+          | Test academy school 88  | Portsmouth                       | Academy converter              | 418              | £6,676   |                    |
+          | Test school 19          | Leicestershire                   | Local authority nursery school | 190              | £6,208   |                    |

--- a/web/tests/Web.E2ETests/Features/School/CompareYourCosts.feature
+++ b/web/tests/Web.E2ETests/Features/School/CompareYourCosts.feature
@@ -1,3 +1,4 @@
+@SchoolComparisonFilterDisabled
 Feature: School compare your costs
 
     Scenario: Download total expenditure chart

--- a/web/tests/Web.E2ETests/Pages/School/BenchmarkSpendingPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/BenchmarkSpendingPage.cs
@@ -1,0 +1,178 @@
+﻿using Microsoft.Playwright;
+using Web.E2ETests.Pages.School.Comparators;
+
+namespace Web.E2ETests.Pages.School;
+
+public class BenchmarkSpendingPage(IPage page)
+{
+    private ILocator PageH1Heading => page.Locator(Selectors.H1);
+    private ILocator ViewAsTableRadio => page.Locator(Selectors.ViewAsTable);
+    private ILocator ViewAsChartRadio => page.Locator(Selectors.ViewAsChart);
+    private ILocator ResultAsSelector => page.Locator(Selectors.BenchmarkSpendingResultAs);
+    private ILocator ApplyButton => page.Locator(Selectors.Button, new PageLocatorOptions { HasText = "Apply" });
+    private ILocator SaveImagesButton => page.Locator(Selectors.Button, new PageLocatorOptions { HasText = "Save chart images" });
+
+    private ILocator SaveImagesModal => page.Locator(Selectors.Modal);
+
+    private ILocator ChartContainers => page.Locator(Selectors.SsrChartContainer);
+    private ILocator SchoolLinksInCharts => page.Locator(Selectors.SsrOrgNamesLinksInCharts);
+    private ILocator ChartBars => page.Locator(Selectors.BenchmarkSpendingChartBars);
+    private ILocator ChartTooltip => page.Locator(Selectors.EnhancementSchoolChartTooltip);
+
+    private ILocator ComparatorSetDetails =>
+        page.Locator(Selectors.GovLink,
+            new PageLocatorOptions
+            {
+                HasText = "view the 2 sets of similar schools we've chosen"
+            });
+
+    private ILocator MissingComparatorSetMessage => page.Locator(Selectors.MissingComparatorSetMessage);
+
+    private ILocator SchoolPerformanceCheckbox(string banding) => page.Locator(Selectors.GovCheckboxLabel,
+        new PageLocatorOptions
+        {
+            HasText = banding
+        });
+    private ILocator ChartContainer(string chartName) =>
+        page.Locator($"section[data-testid='subcategory-section']:has-text(\"{chartName}\")");
+
+    public async Task IsDisplayed(bool isMissingComparatorSet = false)
+    {
+        await PageH1Heading.ShouldBeVisible();
+
+        if (!isMissingComparatorSet)
+        {
+            //await ChartContainers.First.ShouldBeVisible();
+            await SaveImagesButton.ShouldBeVisible();
+            await ViewAsTableRadio.ShouldBeVisible();
+            await ViewAsChartRadio.ShouldBeVisible();
+            await ComparatorSetDetails.ShouldBeVisible();
+
+            return;
+        }
+
+        await MissingComparatorSetMessage.ShouldContainText(
+            "There is not enough information available to create a set of similar schools.");
+    }
+
+    public async Task ClickViewAsTable()
+    {
+        await ViewAsTableRadio.Click();
+        await ClickApplyButton();
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+    }
+
+    public async Task SelectResultAs(string resultValue)
+    {
+        await ResultAsSelector.SelectOption(resultValue);
+    }
+
+    public async Task ClickApplyButton()
+    {
+        await ApplyButton.Nth(1).Click();
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+    }
+
+    public async Task IsTableDataForChartDisplayed(string chartName, List<List<string>> expectedData)
+    {
+        var table = ChartContainer(chartName).Locator("table.govuk-table");
+        await table.ShouldBeVisible();
+        await table.ShouldHaveTableContent(expectedData, true);
+    }
+
+    public async Task AreComparisonChartsAndTablesDisplayed(bool displayed = true)
+    {
+        var locator = page.Locator(Selectors.BenchmarkSpendingChartsAndTables);
+        if (displayed)
+        {
+            var count = await locator.CountAsync();
+            Xunit.Assert.True(count > 0, "Expected at least one chart container to be visible");
+        }
+        else
+        {
+            var count = await locator.CountAsync();
+            Xunit.Assert.Equal(0, count);
+        }
+    }
+
+    public async Task IsSchoolDetailsPopUpVisible()
+    {
+        await ChartTooltip.ShouldBeVisible();
+    }
+
+    public async Task HoverOnGraphBar()
+    {
+        await ChartBars.First.HoverAsync();
+    }
+
+    public async Task<HomePage> ClickSchoolName()
+    {
+        await SchoolLinksInCharts.First.Click();
+        return new HomePage(page);
+    }
+
+    public async Task TabToSchoolName()
+    {
+        await ResultAsSelector.FocusAsync();
+        await page.Keyboard.PressAsync("Tab"); // Apply button
+        await page.Keyboard.PressAsync("Tab"); // First school link
+    }
+
+    public async Task AssertSchoolNameFocused()
+    {
+        await Assertions.Expect(SchoolLinksInCharts.First).ToBeFocusedAsync();
+    }
+
+    public async Task<HomePage> PressEnterKey()
+    {
+        await page.Keyboard.PressAsync(Keyboard.EnterKey);
+        return new HomePage(page);
+    }
+
+    public async Task TooltipIsDisplayed()
+    {
+        await ChartTooltip.ShouldBeVisible();
+    }
+
+    public async Task<ComparatorsPage> ClickComparatorSetDetails()
+    {
+        await ComparatorSetDetails.Click();
+        return new ComparatorsPage(page);
+    }
+
+    public async Task IsTableDataForTooltipDisplayed(List<List<string>> expectedData)
+    {
+        await TooltipIsDisplayed();
+        var table = ChartTooltip.Locator("table");
+        await table.ShouldHaveTableContent(expectedData, true);
+    }
+
+    public async Task IsSaveImagesButtonDisplayed()
+    {
+        await SaveImagesButton.ShouldBeVisible();
+    }
+
+    public async Task ClickSaveImagesButton()
+    {
+        await SaveImagesButton.ClickAsync();
+    }
+
+    public async Task IsSaveImagesModalDisplayed()
+    {
+        await SaveImagesModal.ShouldBeVisible();
+    }
+
+    public async Task ClickSchoolPerformanceCheckbox(string banding)
+    {
+        var checkbox = SchoolPerformanceCheckbox(banding);
+        await checkbox.ShouldBeVisible();
+        await checkbox.Click();
+        await ClickApplyButton();
+    }
+
+    public async Task ApplyFilters()
+    {
+        await ApplyButton.Click();
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+    }
+}

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -39,6 +39,7 @@ public static class Selectors
     public const string ModeChart = "#mode-chart";
     public const string ModeTable = "#mode-table";
     public const string ViewAsTable = "#view-Table";
+    public const string ViewAsChart = "#view-Chart";
     public const string SpendingModeTable = "#spending-mode-table";
     public const string CentralSpendingModeExclude = "#spending-exclude-breakdown";
     public const string SectionTable = ".govuk-accordion__section .govuk-table";
@@ -241,4 +242,8 @@ public static class Selectors
     public const string ApplyFiltersBtnLAFinancialTab = "[data-testid='apply-financial-filters']";
     public const string ApplyFiltersBtnLAWorkforceTab = "[data-testid='apply-workforce-filters']";
     public const string MissingComparatorSetMessage = "[data-testid='missing-comparator-set-message']";
+
+    public const string BenchmarkSpendingChartsAndTables = "[data-title].costs-chart-container";
+    public const string BenchmarkSpendingChartBars = "[data-title] .horizontal-bar-chart rect";
+    public const string BenchmarkSpendingResultAs = "#ResultAs";
 }

--- a/web/tests/Web.E2ETests/Steps/School/BenchmarkSpendingSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/BenchmarkSpendingSteps.cs
@@ -1,0 +1,222 @@
+﻿using Microsoft.Playwright;
+using Web.E2ETests.Drivers;
+using Web.E2ETests.Pages.School;
+using Web.E2ETests.Pages.School.Comparators;
+using Xunit;
+
+namespace Web.E2ETests.Steps.School;
+
+[Binding]
+[Scope(Feature = "School benchmark spending")]
+public class BenchmarkSpendingSteps(PageDriver driver)
+{
+    private BenchmarkSpendingPage? _benchmarkSpendingPage;
+    private ComparatorsPage? _comparatorsPage;
+    private IDownload? _download;
+    private HomePage? _schoolHomePage;
+
+    [Given("I am on benchmark spending page for school with URN '(.*)'")]
+    public async Task GivenIAmOnBenchmarkSpendingPageForSchoolWithUrn(string urn)
+    {
+        var url = BenchmarkSpendingUrl(urn);
+        var page = await driver.Current;
+        await page.GotoAndWaitForLoadAsync(url);
+
+        _benchmarkSpendingPage = new BenchmarkSpendingPage(page);
+        await _benchmarkSpendingPage.IsDisplayed();
+    }
+
+    [Given("I am on benchmark spending page for part year school with URN '(.*)'")]
+    public async Task GivenIAmOnBenchmarkSpendingPageForPartYearSchoolWithUrn(string urn)
+    {
+        var url = BenchmarkSpendingUrl(urn);
+        var page = await driver.Current;
+        await page.GotoAndWaitForLoadAsync(url);
+
+        _benchmarkSpendingPage = new BenchmarkSpendingPage(page);
+        await _benchmarkSpendingPage.IsDisplayed();
+    }
+
+    [Given("I am on benchmark spending page for missing comparator school with URN '(.*)'")]
+    public async Task GivenIAmOnBenchmarkSpendingPageForMissingComparatorSchoolWithUrn(string urn)
+    {
+        var url = BenchmarkSpendingUrl(urn);
+        var page = await driver.Current;
+        await page.GotoAndWaitForLoadAsync(url);
+
+        _benchmarkSpendingPage = new BenchmarkSpendingPage(page);
+        await _benchmarkSpendingPage.IsDisplayed(true);
+    }
+
+    [Given("table view is selected for benchmark spending")]
+    public async Task GivenTableViewIsSelectedForBenchmarkSpending()
+    {
+        Assert.NotNull(_benchmarkSpendingPage);
+        await _benchmarkSpendingPage.ClickViewAsTable();
+    }
+
+    [Given("the benchmark spending result is '(.*)'")]
+    public async Task GivenTheBenchmarkSpendingResultIs(string resultValue)
+    {
+        Assert.NotNull(_benchmarkSpendingPage);
+        await _benchmarkSpendingPage.SelectResultAs(resultValue);
+        await _benchmarkSpendingPage.ClickApplyButton();
+    }
+
+    [Then("the save chart images button is visible")]
+    public async Task ThenTheSaveChartImagesButtonIsVisible()
+    {
+        Assert.NotNull(_benchmarkSpendingPage);
+        await _benchmarkSpendingPage.IsSaveImagesButtonDisplayed();
+    }
+
+    [When("I click the save chart images button")]
+    public async Task WhenIClickTheSaveChartImagesButton()
+    {
+        Assert.NotNull(_benchmarkSpendingPage);
+        var page = await driver.Current;
+        _download = await page.RunAndWaitForDownloadAsync(() => _benchmarkSpendingPage.ClickSaveImagesButton(), new TimeSpan(0, 2, 0));
+    }
+
+    [Then("the save chart images modal is visible")]
+    public async Task ThenTheSaveChartImagesModalIsVisible()
+    {
+        Assert.NotNull(_benchmarkSpendingPage);
+        await _benchmarkSpendingPage.IsSaveImagesModalDisplayed();
+    }
+
+    [Then("the '(.*)' file is downloaded")]
+    public void ThenTheFileIsDownloaded(string fileName)
+    {
+        Assert.NotNull(_benchmarkSpendingPage);
+        Assert.NotNull(_download);
+        var downloadedFilePath = _download.SuggestedFilename;
+        Assert.Equal(fileName, downloadedFilePath);
+    }
+
+    [Then("the following benchmark spending table is shown for '(.*)'")]
+    public async Task ThenTheFollowingBenchmarkSpendingTableIsShownFor(string chartName, Table table)
+    {
+        var expected = GetExpectedTableData(table);
+        Assert.NotNull(_benchmarkSpendingPage);
+        await _benchmarkSpendingPage.IsTableDataForChartDisplayed(chartName, expected);
+    }
+
+    [Then("the benchmark spending comparison charts and tables are not displayed")]
+    public async Task ThenTheBenchmarkSpendingComparisonChartsAndTablesAreNotDisplayed()
+    {
+        Assert.NotNull(_benchmarkSpendingPage);
+        await _benchmarkSpendingPage.AreComparisonChartsAndTablesDisplayed(false);
+    }
+
+    [When("I hover over a benchmark spending chart bar")]
+    public async Task WhenIHoverOverABenchmarkSpendingChartBar()
+    {
+        Assert.NotNull(_benchmarkSpendingPage);
+        await _benchmarkSpendingPage.HoverOnGraphBar();
+    }
+
+    [Then("additional benchmark spending information is displayed")]
+    public async Task ThenAdditionalBenchmarkSpendingInformationIsDisplayed()
+    {
+        Assert.NotNull(_benchmarkSpendingPage);
+        await _benchmarkSpendingPage.IsSchoolDetailsPopUpVisible();
+    }
+
+    [Then("additional benchmark spending information contains")]
+    public async Task ThenAdditionalBenchmarkSpendingInformationContains(DataTable table)
+    {
+        var expected = new List<List<string>>();
+        {
+            var headers = table.Header.ToList();
+            expected.Add(headers);
+            expected.AddRange(table.Rows.Select(row => row.Select(cell => cell.Value).ToList()));
+        }
+
+        Assert.NotNull(_benchmarkSpendingPage);
+        await _benchmarkSpendingPage.IsTableDataForTooltipDisplayed(expected);
+    }
+
+    [When("I select the school name on the benchmark spending chart")]
+    public async Task WhenISelectTheSchoolNameOnTheBenchmarkSpendingChart()
+    {
+        Assert.NotNull(_benchmarkSpendingPage);
+        _schoolHomePage = await _benchmarkSpendingPage.ClickSchoolName();
+    }
+
+    [When("I tab to the school name on the benchmark spending chart")]
+    public async Task WhenITabToTheSchoolNameOnTheBenchmarkSpendingChart()
+    {
+        Assert.NotNull(_benchmarkSpendingPage);
+        await _benchmarkSpendingPage.TabToSchoolName();
+    }
+
+    [When("I press the Enter key when focused on the benchmark spending school name")]
+    public async Task WhenIPressTheEnterKeyWhenFocusedOnTheBenchmarkSpendingSchoolName()
+    {
+        Assert.NotNull(_benchmarkSpendingPage);
+        await _benchmarkSpendingPage.AssertSchoolNameFocused();
+        _schoolHomePage = await _benchmarkSpendingPage.PressEnterKey();
+    }
+
+    [Then("I am navigated to selected school home page")]
+    public async Task ThenIAmNavigatedToSelectedSchoolHomePage()
+    {
+        Assert.NotNull(_schoolHomePage);
+        await _schoolHomePage.IsDisplayed();
+    }
+
+    [Then("I can view the benchmark spending tooltip")]
+    public async Task ThenICanViewTheBenchmarkSpendingTooltip()
+    {
+        Assert.NotNull(_benchmarkSpendingPage);
+        await _benchmarkSpendingPage.TooltipIsDisplayed();
+    }
+
+    [When("I click on benchmark spending comparators link")]
+    public async Task WhenIClickOnBenchmarkSpendingComparatorsLink()
+    {
+        Assert.NotNull(_benchmarkSpendingPage);
+        _comparatorsPage = await _benchmarkSpendingPage.ClickComparatorSetDetails();
+    }
+
+    [Then("I am taken to comparators page")]
+    public async Task ThenIAmTakenToComparatorsPage()
+    {
+        Assert.NotNull(_comparatorsPage);
+        await _comparatorsPage.IsDisplayed();
+    }
+
+    [Then("pupil cost comparators are (.*)")]
+    public async Task ThenPupilCostComparatorsAre(string pupilComparators)
+    {
+        Assert.NotNull(_comparatorsPage);
+        await _comparatorsPage.CheckRunningCostComparators(pupilComparators == "not null");
+    }
+
+    [Then("building cost comparators are (.*)")]
+    public async Task ThenBuildingCostComparatorsAre(string buildingComparators)
+    {
+        Assert.NotNull(_comparatorsPage);
+        await _comparatorsPage.CheckBuildingCostComparators(buildingComparators == "not null");
+    }
+
+    [When("I click on benchmark spending '(.*)' school performance")]
+    public async Task WhenIClickOnBenchmarkSpendingSchoolPerformance(string banding)
+    {
+        Assert.NotNull(_benchmarkSpendingPage);
+        await _benchmarkSpendingPage.ClickSchoolPerformanceCheckbox(banding);
+    }
+
+    private List<List<string>> GetExpectedTableData(Table table)
+    {
+        var expected = new List<List<string>>();
+        var headers = table.Header.ToList();
+        expected.Add(headers);
+        expected.AddRange(table.Rows.Select(row => row.Select(cell => cell.Value).ToList()));
+
+        return expected;
+    }
+
+    private static string BenchmarkSpendingUrl(string urn) => $"{TestConfiguration.ServiceUrl}/school/{urn}/comparison";
+}


### PR DESCRIPTION
## 🧾 Summary
Added tests for the page when the feature is turned on

[AB#298070](https://dev.azure.com/dfe-ssp/s198-DfE-Benchmarking-service/_workitems/edit/312570)
[AB#312523](https://dev.azure.com/dfe-ssp/s198-DfE-Benchmarking-service/_workitems/edit/312523)
[AB#312525](https://dev.azure.com/dfe-ssp/s198-DfE-Benchmarking-service/_workitems/edit/312525)

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [x] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes
 the existing tests were not updated only the tag was added so those can be ignored in pipeline. 
<img width="674" height="156" alt="image" src="https://github.com/user-attachments/assets/738a2d30-3248-4316-a99e-df527c6fa77d" />
