### PR TITLE
fix: income and balance for trust dimension

### DIFF
--- a/web/src/Web.App/Infrastructure/Apis/TrustApi.cs
+++ b/web/src/Web.App/Infrastructure/Apis/TrustApi.cs
@@ -31,8 +31,8 @@ public class TrustApi(HttpClient httpClient, string? key = null) : ApiBase(httpC
 
     public async Task<ApiResult> ItSpendingForecastAsync(string? companyNumber, CancellationToken cancellationToken = default) => await GetAsync(Routes.ItSpendingForecast(companyNumber), cancellationToken);
 
-    public async Task<ApiResult> QueryIncomeHistoryAsync(string? companyNumber, ApiQuery? query = null, CancellationToken cancellationToken = default) => await GetAsync(Routes.QueryIncomeHistory(companyNumber), cancellationToken);
-    public async Task<ApiResult> QueryBalanceHistoryAsync(string? companyNumber, ApiQuery? query = null, CancellationToken cancellationToken = default) => await GetAsync(Routes.QueryBalanceHistory(companyNumber), cancellationToken);
+    public async Task<ApiResult> QueryIncomeHistoryAsync(string? companyNumber, ApiQuery? query = null, CancellationToken cancellationToken = default) => await GetAsync($"{Routes.QueryIncomeHistory(companyNumber)}{query?.ToQueryString()}", cancellationToken);
+    public async Task<ApiResult> QueryBalanceHistoryAsync(string? companyNumber, ApiQuery? query = null, CancellationToken cancellationToken = default) => await GetAsync($"{Routes.QueryBalanceHistory(companyNumber)}{query?.ToQueryString()}", cancellationToken);
 
     private static class Routes
     {

--- a/web/tests/Web.E2ETests/Features/Trust/HistoricData.feature
+++ b/web/tests/Web.E2ETests/Features/Trust/HistoricData.feature
@@ -31,9 +31,9 @@
 
         Examples:
           | tab      | charts | warnings |
-          | spending | 34     | 5        |
-          | income   | 11     | 5        |
-          | balance  | 2      | 0        |
+          | spending |     34 |        5 |
+          | income   |     11 |        5 |
+          | balance  |      2 |        0 |
 
     Scenario Outline: Change all charts to table view
         Given I am on '<tab>' history page for trust with company number '04464331'
@@ -76,3 +76,27 @@
           | 2019 to 2020 |        |
           | 2020 to 2021 |        |
           | 2021 to 2022 | £6,927 |
+
+    Scenario: Change Total income chart to table view and dimension set to per unit
+        Given I am on 'income' history page for trust with company number '04464331'
+        When I change 'income' dimension to '£ per pupil'
+        And I click on view as table on 'income' tab
+        Then the table on the 'income' tab 'Total income' chart contains:
+            | Year         | Amount |
+            | 2017 to 2018 |        |
+            | 2018 to 2019 |        |
+            | 2019 to 2020 |        |
+            | 2020 to 2021 |        |
+            | 2021 to 2022 | £7,035 |
+
+    Scenario: Change In-year balance chart to table view and dimension set to per unit
+        Given I am on 'balance' history page for trust with company number '04464331'
+        When I change 'balance' dimension to '£ per pupil'
+        And I click on view as table on 'balance' tab
+        Then the table on the 'balance' tab 'In-year balance' chart contains:
+            | Year         | Amount |
+            | 2017 to 2018 |        |
+            | 2018 to 2019 |        |
+            | 2019 to 2020 |        |
+            | 2020 to 2021 |        |
+            | 2021 to 2022 | £108   |


### PR DESCRIPTION
## 🧾 Summary

Corrects QueryIncomeHistory and QueryBalanceHistory in TrustApi so that the incoming query is properly passed through rather than ignored.

[AB#316452](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/316452)
[AB#316453](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/316453)

### 🛠️ Bug Fix Description
**Root Cause:**

A previous change introduced a typo/oversight that caused both methods to ignore the provided query, resulting in all requests defaulting to Platform’s fallback dimensions.

**Changes:**

The query string is now passed correctly, and E2E test coverage has been expanded.


## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.
