### PR TITLE
test: update e2e tests for compare your costs and spending costs

### DIFF
--- a/web/tests/Web.E2ETests/Features/School/SpendingCosts.feature
+++ b/web/tests/Web.E2ETests/Features/School/SpendingCosts.feature
@@ -128,7 +128,7 @@
             | Administrative supplies             | Administrative supplies                    |
             | Educational supplies                | Educational supplies                       |
             | Catering staff and supplies         | Catering staff services                    |
-            | Premises staff and services         | Premises staff and services                |
+            | Premises staff and services         | Premises and staff services                |
             | Utilities                           | Utilities                                  |
             | Educational ICT                     | Educational ICT                            |
 

--- a/web/tests/Web.E2ETests/Features/School/SpendingCosts.feature
+++ b/web/tests/Web.E2ETests/Features/School/SpendingCosts.feature
@@ -96,6 +96,7 @@
           | Utilities                           | View all utilities costs. This includes energy and water and sewerage.                                                                                                                      |
           | Educational ICT                     | View all educational ICT costs. This includes ICT learning resources.                                                                                                                       |
 
+    @SchoolComparisonFilterDisabled
     Scenario Outline: Click on view all links for each chart
         Given I am on spending and costs page for school with URN '777042'
         When I click on view all '<CostCategory>' link
@@ -103,15 +104,33 @@
         And the accordion '<CostCategory>'is expanded
 
         Examples:
-          | CostCategory                        |
-          | Teaching and Teaching support staff |
-          | Non-educational support staff       |
-          | Administrative supplies             |
-          | Educational supplies                |
-          | Catering staff and supplies         |
-          | Premises staff and services         |
-          | Utilities                           |
-          | Educational ICT                     |
+            | CostCategory                        |
+            | Teaching and Teaching support staff |
+            | Non-educational support staff       |
+            | Administrative supplies             |
+            | Educational supplies                |
+            | Catering staff and supplies         |
+            | Premises staff and services         |
+            | Utilities                           |
+            | Educational ICT                     |
+
+    @SchoolComparisonFilterEnabled
+    Scenario Outline: Click on view all links for each chart when SchoolComparisonFilter feature is enabled
+        Given I am on spending and costs page for school with URN '777042'
+        When I click on view all '<CostCategory>' link while feature SpendingComparisonFilters is enabled
+        Then I am directed to the benchmark spending page
+        And the filter accordion '<FilterCategory>'is expanded
+
+        Examples:
+            | CostCategory                        | FilterCategory                             |
+            | Teaching and Teaching support staff | Teaching and Teaching support staff        |
+            | Non-educational support staff       | Non-educational support staff and services |
+            | Administrative supplies             | Administrative supplies                    |
+            | Educational supplies                | Educational supplies                       |
+            | Catering staff and supplies         | Catering staff services                    |
+            | Premises staff and services         | Premises staff and services                |
+            | Utilities                           | Utilities                                  |
+            | Educational ICT                     | Educational ICT                            |
 
     Scenario Outline: Click on View more details on cost categories link
         Given I am on spending and costs page for school with URN '777042'

--- a/web/tests/Web.E2ETests/Pages/School/BenchmarkSpendingPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/BenchmarkSpendingPage.cs
@@ -18,6 +18,9 @@ public class BenchmarkSpendingPage(IPage page)
     private ILocator SchoolLinksInCharts => page.Locator(Selectors.SsrOrgNamesLinksInCharts);
     private ILocator ChartBars => page.Locator(Selectors.BenchmarkSpendingChartBars);
     private ILocator ChartTooltip => page.Locator(Selectors.EnhancementSchoolChartTooltip);
+    private ILocator FilterAccordionButton(string categoryName) =>
+        page.Locator(Selectors.AppFilter)
+            .GetByRole(AriaRole.Button, new LocatorGetByRoleOptions { Name = categoryName });
 
     private ILocator ComparatorSetDetails =>
         page.Locator(Selectors.GovLink,
@@ -38,7 +41,7 @@ public class BenchmarkSpendingPage(IPage page)
 
     public async Task IsDisplayed(bool isMissingComparatorSet = false)
     {
-        await PageH1Heading.ShouldBeVisible();
+        await VerifyPageLoadedByHeading();
 
         if (!isMissingComparatorSet)
         {
@@ -53,6 +56,11 @@ public class BenchmarkSpendingPage(IPage page)
 
         await MissingComparatorSetMessage.ShouldContainText(
             "There is not enough information available to create a set of similar schools.");
+    }
+
+    public async Task VerifyPageLoadedByHeading()
+    {
+        await PageH1Heading.ShouldBeVisible();
     }
 
     public async Task ClickViewAsTable()
@@ -174,5 +182,12 @@ public class BenchmarkSpendingPage(IPage page)
     {
         await ApplyButton.Click();
         await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+    }
+
+    public async Task AccordionIsExpanded(string filterCategory)
+    {
+        var button = FilterAccordionButton(filterCategory);
+        await button.ShouldBeVisible();
+        await button.ShouldHaveAttribute("aria-expanded", "true");
     }
 }

--- a/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/CompareYourCostsPage.cs
@@ -140,8 +140,7 @@ public class CompareYourCostsPage(IPage page)
 
     public async Task IsDisplayed(bool isMissingComparatorSet = false)
     {
-        await PageH1Heading.ShouldBeVisible();
-        //await Breadcrumbs.ShouldBeVisible();
+        await VerifyPageLoadedByHeading();
 
         if (!isMissingComparatorSet)
         {
@@ -167,6 +166,11 @@ public class CompareYourCostsPage(IPage page)
 
         await MissingComparatorSetMessage.ShouldContainText(
             "There is not enough information available to create a set of similar schools.");
+    }
+
+    public async Task VerifyPageLoadedByHeading()
+    {
+        await PageH1Heading.ShouldBeVisible();
     }
 
     public async Task ClickSaveAsImage(ComparisonChartNames chartName)

--- a/web/tests/Web.E2ETests/Pages/School/SpendingCostsPage.cs
+++ b/web/tests/Web.E2ETests/Pages/School/SpendingCostsPage.cs
@@ -207,6 +207,25 @@ public partial class SpendingCostsPage(IPage page)
         return new CompareYourCostsPage(page);
     }
 
+    public async Task<BenchmarkSpendingPage> ClickOnLinkWhileSpendingComparisonFilterIsEnabled(CostCategoryNames costCategory)
+    {
+        var linkToClick = costCategory switch
+        {
+            CostCategoryNames.TeachingAndTeachingSupplyStaff => TeachingAndTeachingSupplyStaffLink,
+            CostCategoryNames.AdministrativeSupplies => AdministrativeSuppliesLink,
+            CostCategoryNames.CateringStaffAndServices => CateringStaffAndServicesLink,
+            CostCategoryNames.EducationalIct => EducationalIctLink,
+            CostCategoryNames.EducationalSupplies => EducationalSuppliesLink,
+            CostCategoryNames.NonEducationalSupportStaff => NonEducationalSupportStaffLink,
+            CostCategoryNames.Other => OtherLink,
+            CostCategoryNames.PremisesStaffAndServices => PremisesStaffAndServicesLink,
+            CostCategoryNames.Utilities => UtilitiesLink,
+            _ => throw new ArgumentOutOfRangeException(nameof(costCategory))
+        };
+        await linkToClick.Click();
+        return new BenchmarkSpendingPage(page);
+    }
+
     public async Task<CostCategoriesGuidancePage> ClickOnCostCategoriesGuidanceLink()
     {
         await page.Locator("#cost-categories-guidance").ClickAsync();

--- a/web/tests/Web.E2ETests/Selectors.cs
+++ b/web/tests/Web.E2ETests/Selectors.cs
@@ -246,4 +246,6 @@ public static class Selectors
     public const string BenchmarkSpendingChartsAndTables = "[data-title].costs-chart-container";
     public const string BenchmarkSpendingChartBars = "[data-title] .horizontal-bar-chart rect";
     public const string BenchmarkSpendingResultAs = "#ResultAs";
+
+    public const string AppFilter = ".app-filter";
 }

--- a/web/tests/Web.E2ETests/Steps/School/HomeSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/HomeSteps.cs
@@ -76,14 +76,14 @@ public class HomeSteps(PageDriver driver)
     public async Task ThenTheCompareYourCostsPageIsDisplayed()
     {
         Assert.NotNull(_compareYourCostsPage);
-        await _compareYourCostsPage.IsDisplayed();
+        await _compareYourCostsPage.VerifyPageLoadedByHeading();
     }
 
     [Then("the compare your costs page is displayed for part year")]
     public async Task ThenTheCompareYourCostsPageIsDisplayedForPartYear()
     {
         Assert.NotNull(_compareYourCostsPage);
-        await _compareYourCostsPage.IsDisplayed();
+        await _compareYourCostsPage.VerifyPageLoadedByHeading();
     }
 
     [When("I click on curriculum and financial planning")]

--- a/web/tests/Web.E2ETests/Steps/School/SchoolFinancialBenchmarkingInsightsSummarySteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/SchoolFinancialBenchmarkingInsightsSummarySteps.cs
@@ -153,7 +153,7 @@ public class SchoolFinancialBenchmarkingInsightsSummarySteps(PageDriver driver)
     public async Task ThenIAmDirectedToSchoolComparisonPageForTheSchoolWithUrn(string urn)
     {
         Assert.NotNull(_comparisonPage);
-        await _comparisonPage.IsDisplayed();
+        await _comparisonPage.VerifyPageLoadedByHeading();
     }
 
     [When("I click on the financial benchmarking and insight tool link under pupil and workforce metrics")]

--- a/web/tests/Web.E2ETests/Steps/School/SpendingCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/SpendingCostsSteps.cs
@@ -106,7 +106,7 @@ public class SpendingCostsSteps(PageDriver driver)
     public async Task ThenIAmDirectedToCompareYourCostsPage()
     {
         Assert.NotNull(_compareYourCostsPage);
-        await _compareYourCostsPage.IsDisplayed();
+        await _compareYourCostsPage.VerifyPageLoadedByHeading();
     }
 
     [Then("the accordion '(.*)'is expanded")]

--- a/web/tests/Web.E2ETests/Steps/School/SpendingCostsSteps.cs
+++ b/web/tests/Web.E2ETests/Steps/School/SpendingCostsSteps.cs
@@ -10,6 +10,7 @@ namespace Web.E2ETests.Steps.School;
 public class SpendingCostsSteps(PageDriver driver)
 {
     private CompareYourCostsPage? _compareYourCostsPage;
+    private BenchmarkSpendingPage? _benchmarkSpendingPage;
     private CostCategoriesGuidancePage? _costCategoriesGuidancePage;
     private SpendingCostsPage? _spendingCostsPage;
 
@@ -102,6 +103,13 @@ public class SpendingCostsSteps(PageDriver driver)
         _costCategoriesGuidancePage = await _spendingCostsPage.ClickOnCostCategoriesGuidanceLink();
     }
 
+    [When("I click on view all '(.*)' link while feature SpendingComparisonFilters is enabled")]
+    public async Task WhenIClickOnViewAllLinkWhileFeatureSpendingComparisonFiltersIsEnabled(string linkToClick)
+    {
+        Assert.NotNull(_spendingCostsPage);
+        _benchmarkSpendingPage = await _spendingCostsPage.ClickOnLinkWhileSpendingComparisonFilterIsEnabled(CostCategoryFromFriendlyName(linkToClick));
+    }
+
     [Then("I am directed to compare your costs page")]
     public async Task ThenIAmDirectedToCompareYourCostsPage()
     {
@@ -109,11 +117,25 @@ public class SpendingCostsSteps(PageDriver driver)
         await _compareYourCostsPage.VerifyPageLoadedByHeading();
     }
 
+    [Then("I am directed to the benchmark spending page")]
+    public async Task ThenIAmDirectedToTheBenchmarkSpendingPage()
+    {
+        Assert.NotNull(_benchmarkSpendingPage);
+        await _benchmarkSpendingPage.VerifyPageLoadedByHeading();
+    }
+
     [Then("the accordion '(.*)'is expanded")]
     public async Task ThenTheAccordionIsExpanded(string chartName)
     {
         Assert.NotNull(_compareYourCostsPage);
         await _compareYourCostsPage.IsSectionVisible(ChartNameFromFriendlyName(chartName), true, "Hide", "chart");
+    }
+
+    [Then("the filter accordion '(.*)'is expanded")]
+    public async Task ThenTheFilterAccordionIsExpanded(string filterCategory)
+    {
+        Assert.NotNull(_benchmarkSpendingPage);
+        await _benchmarkSpendingPage.AccordionIsExpanded(filterCategory);
     }
 
     [Then("I am directed to cost categories guidance page")]


### PR DESCRIPTION
## 🧾 Summary

Updates the spending and costs tests to reflect the behaviour of the SchoolComparisonFilter feature flag.
When the feature is enabled, tests now assert that the filter accordions within the app‑filter component are expanded, replacing checks tied to the previous implementation.

Also updates a number of navigation tests across the suite to replace the broad IsDisplayed() usage in cross‑page navigation tests with the new lightweight VerifyPageLoadedByHeading() method.

This keeps navigation tests focused on verifying that the destination page loads, while full UI validation remains the responsibility of page specific tests using IsDisplayed().

[AB#298070](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/298070)
[AB#316462](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/316462)

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes

The full e2e test suite minus those we filter in the pipeline now passes locally


This will resolve the currently failing tests in CI/CD piplines following #4290 
