### PR TITLE
chore: remove "Fixes" from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,9 @@
 ## 🧾 Summary
 > Briefly describe the changes and why they are needed.
 
-Fixes AB#[issue number]
+<!-- List related work items -->
+AB#[issue number]
+AB#[issue number]
 
 <!--
 


### PR DESCRIPTION
## 🧾 Summary

Azure DevOps automatically closes work items when a PR description includes the keyword “Fixes” followed by a linked ticket. This behaviour is undesirable as a default for our PR template as stories should move to resolved first, and only once all child tasks are completed.

This PR updates the PR template to remove that keyword and clarifies that contributors should only list related work items.

Fixes [AB#316663](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/316663), [AB#316664](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/316664)

### ⛓️ Tech Debt & Refactor Details
**Benefits:**
Improves board hygiene by preventing accidental task closures and reducing admin overhead.


## ✅ Checklist
- [ ] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [ ] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.