### PR TITLE
chore: update codeowners file to use child team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jrabbott @benlav-50 @benmurch-hippo @Faizan-ahmad00 @J05h-L @mattb-hippo @murdo-hippo @willemvangerwen-hippo
+* @DFE-Digital/benchmarking-and-insights-dev


### PR DESCRIPTION
## 🧾 Summary

Updates codeowners file to use child team, rather than named people
