### PR TITLE
chore: bump Web.App dependencies

### DIFF
--- a/web/src/Web.App/package-lock.json
+++ b/web/src/Web.App/package-lock.json
@@ -54,7 +54,7 @@
         "typescript-eslint": "^8.59.4",
         "vite": "^8.0.16",
         "vite-plugin-vue-devtools": "^8.1.2",
-        "vitest": "^4.1.8",
+        "vitest": "^4.1.9",
         "vue-eslint-parser": "^10.4.0",
         "vue-tsc": "^3.3.3"
       },
@@ -2857,16 +2857,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.8",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@vitest/expect/-/expect-4.1.8.tgz",
-      "integrity": "sha1-RRVPH4VZ9VxSgesNyxrDe1gah9g=",
+      "version": "4.1.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha1-uhr3OuUyYuPcm1GMt7dvthTg71M=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2875,13 +2875,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.8",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@vitest/mocker/-/mocker-4.1.8.tgz",
-      "integrity": "sha1-0Aa/xYlKGvUedN7d7yU11r1DaxY=",
+      "version": "4.1.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha1-pIPeebNYq6PdjzGaDYqxfIn1x10=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.8",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2912,9 +2912,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-      "integrity": "sha1-2dLiSLkA162VVsQ3T83xhxxhUZM=",
+      "version": "4.1.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha1-iFz+n8tv899ECepmGSzB+yPWL64=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2925,13 +2925,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.8",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@vitest/runner/-/runner-4.1.8.tgz",
-      "integrity": "sha1-RjGAjzmWNZt0zMPKJimQ4UwpXVA=",
+      "version": "4.1.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha1-u3QpR85IQd+y2JhKL5AUhQvhD1E=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.8",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2939,14 +2939,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.8",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@vitest/snapshot/-/snapshot-4.1.8.tgz",
-      "integrity": "sha1-N0cBNdZOoRuyqDmxxrf13nAY9u4=",
+      "version": "4.1.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha1-vftnCuVhdhPqh3bpPQZmpm3v7rc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2955,9 +2955,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.8",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@vitest/spy/-/spy-4.1.8.tgz",
-      "integrity": "sha1-Or/pMB0lw5+Ajcqp8Q/sDdNw5WQ=",
+      "version": "4.1.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha1-v8QNSPub0aEii/v95/VVXn9rOGc=",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2965,13 +2965,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@vitest/utils/-/utils-4.1.8.tgz",
-      "integrity": "sha1-CZ6lJVzsCHNUEM9wftq6LBWMWtk=",
+      "version": "4.1.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha1-AYTH5usyNHObK2s7mF940e2CPuE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
+        "@vitest/pretty-format": "4.1.9",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -9476,19 +9476,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.8",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/vitest/-/vitest-4.1.8.tgz",
-      "integrity": "sha1-n+0XJ3v3NQSX5UM4iYp6/Ubf1Qk=",
+      "version": "4.1.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha1-mPIvvXDioYxKkrsgYkvJLl36xfM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.8",
-        "@vitest/mocker": "4.1.8",
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/runner": "4.1.8",
-        "@vitest/snapshot": "4.1.8",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -9516,12 +9516,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.8",
-        "@vitest/browser-preview": "4.1.8",
-        "@vitest/browser-webdriverio": "4.1.8",
-        "@vitest/coverage-istanbul": "4.1.8",
-        "@vitest/coverage-v8": "4.1.8",
-        "@vitest/ui": "4.1.8",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/web/src/Web.App/package-lock.json
+++ b/web/src/Web.App/package-lock.json
@@ -114,13 +114,13 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha1-fNelnxWzzA3NgDA493knEqfQsVw=",
+      "version": "7.29.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha1-8vu/6ofESiFZDsUVt3iywm2IZuc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -129,9 +129,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/compat-data/-/compat-data-7.29.3.tgz",
-      "integrity": "sha1-4/U0fwWJWWyR0ifMtqVB03+xMHs=",
+      "version": "7.29.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha1-bwI38PNtLlHAVwpjb67Z0tDv5ik=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -139,21 +139,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha1-UoateF33951lbojOhuZQ0Wyl8yI=",
+      "version": "7.29.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha1-gMELFySAgpaLV6hXuRZAlx8gcPc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -180,14 +180,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha1-0Jh2KQERq7sA75Yqe4OlMH+6DVA=",
+      "version": "7.29.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha1-zKC4gn5rzzuhdniOfzsYCtbbL6M=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -210,14 +210,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha1-MsSj9B8S7RUyF5sQik10bhBcKyU=",
+      "version": "7.29.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha1-eh3vcEMCQBxH9k+oVYnpdK4hcEI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -269,9 +269,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha1-uUMN8qpOF7woZl6t6uiqHZheZnQ=",
+      "version": "7.29.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha1-8EqW+9hHMkGxB5JD9bPwOjAQq3s=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -293,29 +293,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha1-YGMsvW/7cLIoIxhyARFnYqA+LVw=",
+      "version": "7.29.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha1-7yUEilGOgo1zk/rFiC3dc5Idc5Y=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha1-kxLZ2eVu3DWutulcJdQQa1C56x4=",
+      "version": "7.29.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha1-sGJ0elmXuhOGNyATKLv/d5YFdK4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -380,27 +380,27 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha1-VNp5YJerGc5n7Z+ItHuy7Ek2doc=",
+      "version": "7.29.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha1-fwhx2Zgk0jE31g+G/PYTD9WhtR8=",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha1-AQtpOPq3y333SqK7wGqlA7j+X7Q=",
+      "version": "7.29.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha1-vYcITO0MeW7Ea9pJLeboPSnon8I=",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha1-+lL1sefbGrBJRFtCHERxMDiXcC8=",
+      "version": "7.29.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha1-zzFb6UAhOzVOtKvMC9Aevj9zvCo=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -408,26 +408,26 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha1-nPvMsCuOIpiSwLBwOAUswahwnEk=",
+      "version": "7.29.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha1-Rav951SJl+NDdsPmn+tHXP+0pgc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha1-EW9wp3lYMH/OrCd0dXMDL4pi+I4=",
+      "version": "7.29.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha1-g3uHOHy/XsVTDLY0s8Yi9o7bkzQ=",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -561,33 +561,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha1-Dn5W7O23iu72bOeXKwgvznaiPlc=",
+      "version": "7.29.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha1-TZ1ABPZFzdME3pWMclFieE7KxwA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha1-8yPQUAFEAlPurTychYrb4AuQMQo=",
+      "version": "7.29.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha1-xHsHpBuV2gkH0Ca13YlNmN59Ly0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -595,13 +595,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha1-n1seg4xEbnLPPNS5GBUrjGBeN8c=",
+      "version": "7.29.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha1-gAXjHYJxLuetrvbiPGO3GmJ3CpI=",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3658,9 +3658,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.31",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
-      "integrity": "sha1-nGgl8FJgHOaXSpDdSWg7FyaIews=",
+      "version": "2.10.37",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+      "integrity": "sha1-PmNkdbaykyROKyPixxoqudnmun0=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3838,9 +3838,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001793",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-      "integrity": "sha1-I4iH3fX8/Iw22HI5TQp4pRcxKnI=",
+      "version": "1.0.30001799",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha1-XJCROMJ/GmEhnT4JIHHBzH0y3FU=",
       "dev": true,
       "funding": [
         {
@@ -4527,9 +4527,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.361",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
-      "integrity": "sha1-uZO8ezTqg/NIqheHpgjs8S45uQk=",
+      "version": "1.5.373",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.373.tgz",
+      "integrity": "sha1-eim1XHm9mo9H0M1QGYXE2iutL54=",
       "dev": true,
       "license": "ISC"
     },
@@ -7059,9 +7059,9 @@
       "optional": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.46",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/node-releases/-/node-releases-2.0.46.tgz",
-      "integrity": "sha1-0YihKag/XgOhAarLWPJg8u6PqqE=",
+      "version": "2.0.47",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha1-UhuyeG2o6xQLdIhBwLOzp1M0/8Q=",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/web/src/Web.App/package.json
+++ b/web/src/Web.App/package.json
@@ -48,7 +48,7 @@
     "typescript-eslint": "^8.59.4",
     "vite": "^8.0.16",
     "vite-plugin-vue-devtools": "^8.1.2",
-    "vitest": "^4.1.8",
+    "vitest": "^4.1.9",
     "vue-eslint-parser": "^10.4.0",
     "vue-tsc": "^3.3.3"
   },


### PR DESCRIPTION
## 🧾 Summary

Addresses one Dependabot alert raised for Web.App this morning and the remaining dependabot PR for Web.App npm dependencies

[AB#316634](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/316634)
[AB#316554](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/316554)

### ⛓️ Tech Debt & Refactor Details
**Major Changes:**
- brings the remaining Web.App npm dependency with an open dependabot PR up to its latest compatible version.
- applies a security fix via npm audit fix

**Benefits:**
Ensures the project remains stable and up to date.

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.
