### PR TITLE
fix: Trust percentage income and expenditure test fixes

### DIFF
--- a/platform/tests/Platform.ApiTests/Data/TrustExpenditureUtilitiesPercentExpenditure.json
+++ b/platform/tests/Platform.ApiTests/Data/TrustExpenditureUtilitiesPercentExpenditure.json
@@ -1,6 +1,10 @@
 {
   "companyNumber": "10192252",
   "trustName": "Test Company/Trust  31",
+  "centralTotalExpenditure": 0.0,
+  "centralTotalUtilitiesCosts": 0.0,
+  "centralEnergyCosts": 0.0,
+  "centralWaterSewerageCosts": 0.0,
   "schoolTotalExpenditure": 100.0,
   "schoolTotalUtilitiesCosts": 1.6852119436343158,
   "schoolEnergyCosts": 1.429674763889192,

--- a/platform/tests/Platform.ApiTests/Data/TrustExpenditureUtilitiesPercentIncome.json
+++ b/platform/tests/Platform.ApiTests/Data/TrustExpenditureUtilitiesPercentIncome.json
@@ -1,6 +1,10 @@
 {
   "companyNumber": "10192252",
   "trustName": "Test Company/Trust  31",
+  "centralTotalExpenditure": 0.0,
+  "centralTotalUtilitiesCosts": 0.0,
+  "centralEnergyCosts": 0.0,
+  "centralWaterSewerageCosts": 0.0,
   "schoolTotalExpenditure": 93.30316436521395,
   "schoolTotalUtilitiesCosts": 1.5723560696713423,
   "schoolEnergyCosts": 1.3339317948395173,

--- a/platform/tests/Platform.ApiTests/Data/TrustsExpenditureNonEduStaffPercentIncomeIncludeCentral.json
+++ b/platform/tests/Platform.ApiTests/Data/TrustsExpenditureNonEduStaffPercentIncomeIncludeCentral.json
@@ -2,6 +2,10 @@
   {
     "companyNumber": "10249712",
     "trustName": "Test Company/Trust  229",
+    "centralTotalExpenditure": 0.0,
+    "centralTotalUtilitiesCosts": 0.0,
+    "centralEnergyCosts": 0.0,
+    "centralWaterSewerageCosts": 0.0,
     "schoolTotalExpenditure": 108.12693265828267,
     "schoolTotalNonEducationalSupportStaffCosts": 10.672952493295712,
     "schoolAdministrativeClericalStaffCosts": 6.08897001130366,
@@ -18,6 +22,10 @@
   {
     "companyNumber": "10259334",
     "trustName": "Test Company/Trust  157",
+    "centralTotalExpenditure": 0.0,
+    "centralTotalUtilitiesCosts": 0.0,
+    "centralEnergyCosts": 0.0,
+    "centralWaterSewerageCosts": 0.0,
     "schoolTotalExpenditure": 96.07927382555172,
     "schoolTotalNonEducationalSupportStaffCosts": 8.514166101594975,
     "schoolAdministrativeClericalStaffCosts": 5.902997664370346,
@@ -34,6 +42,10 @@
   {
     "companyNumber": "10264735",
     "trustName": "Test Company/Trust  262",
+    "centralTotalExpenditure": 0.0,
+    "centralTotalUtilitiesCosts": 0.0,
+    "centralEnergyCosts": 0.0,
+    "centralWaterSewerageCosts": 0.0,
     "schoolTotalExpenditure": 105.4618266508167,
     "schoolTotalNonEducationalSupportStaffCosts": 11.088622335282233,
     "schoolAdministrativeClericalStaffCosts": 5.326786723062443,


### PR DESCRIPTION
## 🧾 Summary
Fix broken platform test from bugfix - the new denominator for percentage income fields now give zeros and are included in API responses instead of being null and being absent from API responses

[AB#316765](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/316765)