### PR TITLE
chore: update terraform config by replacing deprecated storage_account_name and updating runbook_type

### DIFF
--- a/core-infrastructure/terraform/automation.tf
+++ b/core-infrastructure/terraform/automation.tf
@@ -35,7 +35,7 @@ resource "azurerm_automation_runbook" "backup-database-runbook" {
   log_verbose             = "true"
   log_progress            = "true"
   description             = "Performs a backup of the given database to the specified blob storage container"
-  runbook_type            = "PowerShell72"
+  runbook_type            = "PowerShell"
   tags                    = local.common-tags
   content                 = data.local_file.backup-database-script.content
 }
@@ -75,7 +75,7 @@ resource "azurerm_automation_runbook" "backup-raw-data-runbook" {
   log_verbose             = "true"
   log_progress            = "true"
   description             = "Performs a backup of the given container to the specified blob storage container"
-  runbook_type            = "PowerShell72"
+  runbook_type            = "PowerShell"
   tags                    = local.common-tags
   content                 = data.local_file.backup-container-script.content
 }

--- a/core-infrastructure/terraform/storage.tf
+++ b/core-infrastructure/terraform/storage.tf
@@ -51,28 +51,28 @@ resource "azurerm_storage_account_queue_properties" "data-queue-properties" {
 }
 
 resource "azurerm_storage_queue" "pipeline-message-pending-queue" {
-  name                 = "data-pipeline-job-pending"
-  storage_account_name = azurerm_storage_account.data.name
+  name               = "data-pipeline-job-pending"
+  storage_account_id = azurerm_storage_account.data.name
 }
 
 resource "azurerm_storage_queue" "pipeline-message-default-start-queue" {
-  name                 = "data-pipeline-job-default-start"
-  storage_account_name = azurerm_storage_account.data.name
+  name               = "data-pipeline-job-default-start"
+  storage_account_id = azurerm_storage_account.data.name
 }
 
 resource "azurerm_storage_queue" "pipeline-message-custom-start-queue" {
-  name                 = "data-pipeline-job-custom-start"
-  storage_account_name = azurerm_storage_account.data.name
+  name               = "data-pipeline-job-custom-start"
+  storage_account_id = azurerm_storage_account.data.name
 }
 
 resource "azurerm_storage_queue" "pipeline-message-finished-queue" {
-  name                 = "data-pipeline-job-finished"
-  storage_account_name = azurerm_storage_account.data.name
+  name               = "data-pipeline-job-finished"
+  storage_account_id = azurerm_storage_account.data.name
 }
 
 resource "azurerm_storage_queue" "pipeline-message-dead-letter-queue" {
-  name                 = "data-pipeline-job-dlq"
-  storage_account_name = azurerm_storage_account.data.name
+  name               = "data-pipeline-job-dlq"
+  storage_account_id = azurerm_storage_account.data.name
 }
 
 resource "azurerm_storage_container" "pipeline-raw-data" {


### PR DESCRIPTION
## 🧾 Summary

Following #4312, our pipelines began failing after upgrading the AzureRM provider. This PR should resolve those build errors.

[AB#316634](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/316634)
[AB#317271](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/317271)

### ⛓️ Tech Debt & Refactor Details

**Major Changes:**

This PR updates the following:

- Replace storage_account_name with storage_account_id on azurerm_storage_queue. The former is deprecated, the provider supports migration without resource recreation.
- update runbook_type on azurerm_automation_runbook to match the current deployment and avoid unnecessary destroy/create cycles.

**Benefits:**

- ensures our Terraform configuration aligns with the latest AzureRM provider expectations.
- prevents unintended recreation of azurerm_automation_runbook resources.


## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes

See the latest Core build logs for full error output.

Refer to the [provider docs](https://registry.terraform.io/providers/hashicorp/Azurerm/latest/docs/resources/storage_queue) for storage_queue deprecation and migration guidance.
