### PR TITLE
feat: add container app environment ip to sql firewall rules

### DIFF
--- a/data-pipeline/terraform/container_apps.tf
+++ b/data-pipeline/terraform/container_apps.tf
@@ -61,3 +61,10 @@ module "container_app_custom" {
 
   common-tags = local.common-tags
 }
+
+resource "azurerm_mssql_firewall_rule" "cae-fw-rule" {
+  name             = "${var.environment-prefix}-ebis-cae-fw"
+  server_id        = data.azurerm_mssql_server.sql-server.id
+  start_ip_address = azurerm_container_app_environment.main.static_ip_address
+  end_ip_address   = azurerm_container_app_environment.main.static_ip_address
+}

--- a/data-pipeline/terraform/data.tf
+++ b/data-pipeline/terraform/data.tf
@@ -7,3 +7,8 @@ data "azurerm_log_analytics_workspace" "application-insights-workspace" {
   name                = "${var.environment-prefix}-ebis-aiw"
   resource_group_name = "${var.environment-prefix}-ebis-core"
 }
+
+data "azurerm_mssql_server" "sql-server" {
+  name                = "${var.environment-prefix}-sql"
+  resource_group_name = "${var.environment-prefix}-ebis-core"
+}


### PR DESCRIPTION
## 🧾 Summary
Configure the SQL Server firewall rules to allow traffic from the data-pipeline Container App Environment's static outbound IP. This enables database connectivity for the container apps running inside the environment without needing full VNet/subnet integration, which would trigger a destructive and risky recreation of the resources.

[AB#316772](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/316772)
[AB#317280](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/317280)

### ✨ Feature Details
- **Functionality:** Whitelists the outbound IP address of the data-pipeline Container App Environment on the core SQL Database Server firewall, establishing securecommunication.
- **Implementation:** 
  - Added a `data "azurerm_mssql_server" "sql-server"` source in the `data-pipeline` Terraform configurations to resolve the target SQL Server.
  - Added an `azurerm_mssql_firewall_rule` resource to `data-pipeline/terraform/container_apps.tf` that dynamically assigns the `static_ip_address` of the Container App Environment to the SQL Server firewall.

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [x] Tested by running locally _(or docs render correctly locally)_.

## 🔍 Notes
This change avoids VNet integration which would have forced a destroy-and-recreate cycle on the Container App Environment, a high-risk operation given Azure capacity constraints.