### PR TITLE
chore: constrain azurerm to 4.76.x

### DIFF
--- a/core-infrastructure/terraform/README.md
+++ b/core-infrastructure/terraform/README.md
@@ -5,7 +5,7 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.8 |
 | <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | ~> 2.10.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.77.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.76.0 |
 | <a name="requirement_mssql"></a> [mssql](#requirement\_mssql) | 0.3.1 |
 
 ## Providers
@@ -14,7 +14,7 @@
 |------|---------|
 | <a name="provider_azapi"></a> [azapi](#provider\_azapi) | 2.10.0 |
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.8.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.77.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.76.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | 2.9.0 |
 | <a name="provider_mssql"></a> [mssql](#provider\_mssql) | 0.3.1 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |

--- a/core-infrastructure/terraform/provider.tf
+++ b/core-infrastructure/terraform/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.77.0"
+      version = "~> 4.76.0"
     }
     azapi = {
       source  = "azure/azapi"


### PR DESCRIPTION
## 🧾 Summary

A regression in the azurerm provider is causing azurerm_storage_queue to fail with a 400 InvalidUri (“does not represent any resource”) during Terraform builds.

[AB#316634](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/316634)
[AB#317271](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/317271)

### ⛓️ Tech Debt & Refactor Details
**Major Changes:**

Apply a ~> 4.76.0 version constraint for the AzureRM provider to avoid the regression introduced in 4.77.

**Benefits:**

Prevents the InvalidUri errors currently observed.

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [ ] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes

See [AB#317271](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/317271) for additional context.

According to the linked issue, a fix has been implemented upstream and is expected to ship in 4.78.