### PR TITLE
fix: use correct storage_account_id for queue resource

### DIFF
--- a/core-infrastructure/terraform/storage.tf
+++ b/core-infrastructure/terraform/storage.tf
@@ -52,27 +52,27 @@ resource "azurerm_storage_account_queue_properties" "data-queue-properties" {
 
 resource "azurerm_storage_queue" "pipeline-message-pending-queue" {
   name               = "data-pipeline-job-pending"
-  storage_account_id = azurerm_storage_account.data.name
+  storage_account_id = azurerm_storage_account.data.id
 }
 
 resource "azurerm_storage_queue" "pipeline-message-default-start-queue" {
   name               = "data-pipeline-job-default-start"
-  storage_account_id = azurerm_storage_account.data.name
+  storage_account_id = azurerm_storage_account.data.id
 }
 
 resource "azurerm_storage_queue" "pipeline-message-custom-start-queue" {
   name               = "data-pipeline-job-custom-start"
-  storage_account_id = azurerm_storage_account.data.name
+  storage_account_id = azurerm_storage_account.data.id
 }
 
 resource "azurerm_storage_queue" "pipeline-message-finished-queue" {
   name               = "data-pipeline-job-finished"
-  storage_account_id = azurerm_storage_account.data.name
+  storage_account_id = azurerm_storage_account.data.id
 }
 
 resource "azurerm_storage_queue" "pipeline-message-dead-letter-queue" {
   name               = "data-pipeline-job-dlq"
-  storage_account_id = azurerm_storage_account.data.name
+  storage_account_id = azurerm_storage_account.data.id
 }
 
 resource "azurerm_storage_container" "pipeline-raw-data" {


### PR DESCRIPTION
## 🧾 Summary

#4316 introduced an error where the deprecated storage_account_name value was still being used for the storage_account_id property. This PR corrects that.

[AB#316634](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/316634)
[AB#317271](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/317271)

### 🛠️ Bug Fix Description
**Root Cause:**

Incorrectly referencing the storage account name rather than the ID, causing Terraform to fail when parsing storage_account_id.

**Changes:**

Use azurerm_storage_account.data.id for storage_account_id

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [ ] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes

Together with the rollback to the provider version already deployed in #4319, this should stabilise the pipelines again.
