### PR TITLE
feat: add Shared Private Link between the Azure AI Search service and the Azure SQL Database

### DIFF
--- a/platform/terraform/search.tf
+++ b/platform/terraform/search.tf
@@ -22,3 +22,11 @@ resource "azurerm_key_vault_secret" "platform-search-key" {
   key_vault_id = data.azurerm_key_vault.key-vault.id
   content_type = "key"
 }
+
+resource "azurerm_search_shared_private_link_service" "search-sql-link" {
+  name               = "search-to-sql-link"
+  search_service_id  = azurerm_search_service.search.id
+  target_resource_id = data.azurerm_mssql_server.sql-server.id
+  subresource_name   = "sqlServer"
+  request_message    = "Shared Private Link connection from Search Service to SQL Database"
+}


### PR DESCRIPTION
## 🧾 Summary
This PR prepares our infrastructure for stricter SQL Server firewall rules by establishing a Shared Private Link between the Azure AI Search service and the Azure SQL Database. Once this connection is applied and manually approved in the Azure Portal, we will be able to safely remove the global "Allow Azure Services" firewall rule (0.0.0.0 - 0.0.0.0) on the SQL Server without breaking the Search indexer's access to the database.

[AB#317245](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/317245) 
[AB#316772](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/316772)

## ⛓️ Tech Debt & Refactor Details
- Major Changes: 
  - Added azurerm_search_shared_private_link_service to platform/terraform/search.tf.
  - Targets the sqlServer subresource of the core Azure SQL Server.


## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated (if applicable).
- [x] Tested by running locally (validated via terraform validate).
- [ ] Relevant documentation updated (if applicable).
- [ ] Screenshots or Demo included (for UI/frontend changes).

## 🔍 Notes
Deployment Steps / Post-Deployment Action Required:
After this Terraform change is applied, the Private Endpoint connection will be in a Pending state. An administrator must approve the connection for the Search indexer to function securely. 

This can be done in the Azure Portal under the SQL Server > Networking > Private access tab,