### PR TITLE
feat: add outbound ip from container app to sql firewall rules

### DIFF
--- a/data-pipeline/terraform/container_app/outputs.tf
+++ b/data-pipeline/terraform/container_app/outputs.tf
@@ -1,0 +1,4 @@
+output "outbound_ip_addresses" {
+  value       = azurerm_container_app.data-pipeline.outbound_ip_addresses
+  description = "The outbound IP addresses of the container app."
+}

--- a/data-pipeline/terraform/container_apps.tf
+++ b/data-pipeline/terraform/container_apps.tf
@@ -68,3 +68,18 @@ resource "azurerm_mssql_firewall_rule" "cae-fw-rule" {
   start_ip_address = azurerm_container_app_environment.main.static_ip_address
   end_ip_address   = azurerm_container_app_environment.main.static_ip_address
 }
+
+locals {
+  container_app_outbound_ips = toset(concat(
+    module.container_app_default.outbound_ip_addresses,
+    module.container_app_custom.outbound_ip_addresses
+  ))
+}
+
+resource "azurerm_mssql_firewall_rule" "ca-fw-rule" {
+  for_each         = local.container_app_outbound_ips
+  name             = "${var.environment-prefix}-ebis-ca-fw-${replace(each.value, ".", "-")}"
+  server_id        = data.azurerm_mssql_server.sql-server.id
+  start_ip_address = each.value
+  end_ip_address   = each.value
+}


### PR DESCRIPTION
 ## 🧾 Summary
Added MSSQL Server firewall rules for the outbound IP addresses of the data pipeline container apps to ensure secure communication.

[AB#316772](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/316772)
[AB#317619](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/317619)

### ✨ Feature Details
 - **Functionality:** Dynamically opens the SQL Server firewall for the outbound IP addresses of both the default and custom container apps within the data pipeline.
- **Implementation:** 
  - Created `outputs.tf` in the `container_app` module to export the `outbound_ip_addresses` attribute.
  - Added a `locals` block in `container_apps.tf` to combine and deduplicate outbound IPs from both container app modules.
  - Added a new `azurerm_mssql_firewall_rule` resource using a `for_each` loop over the dynamic set of IP addresses.
  
## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes
Syntactic and structural correctness has been verified locally by running `terraform init -backend=false && terraform validate` in the `data-pipeline/terraform` directory, which completed successfully.