### PR TITLE
chore: bump undici from 7.25.0 to 7.28.0

### DIFF
--- a/web/src/Web.App/package-lock.json
+++ b/web/src/Web.App/package-lock.json
@@ -8916,9 +8916,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha1-fXL8QpoEIXacopZv0Hysh1yFt4E=",
+      "version": "7.28.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/s198-DfE-Benchmarking-service/_packaging/education-benchmarking/npm/registry/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha1-l9ZFZBmLKFvCgfDo4pWX49Ef5+w=",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## 🧾 Summary

Bumps `undici` to 7.28.0 to resolve a number of security vulnerabilities flagged for Web.App

<!-- List related work items -->
[AB#319567](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/319567)
[AB#319568](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/319568)

### ⛓️ Tech Debt & Refactor Details
**Major Changes:**

Updates undici via npm audit fix

**Benefits:**

Ensures the project remains stable and up to date.

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.
