### PR TITLE
fix: correctly pass dimension for user defined result in school benchmark spending

### DIFF
--- a/web/src/Web.App/Controllers/SchoolComparisonController.cs
+++ b/web/src/Web.App/Controllers/SchoolComparisonController.cs
@@ -334,7 +334,7 @@ public class SchoolComparisonController(
         }
 
         var userDefinedResult = await expenditureApi
-            .QuerySchools(BuildApiQuery(userDefinedSet.Set))
+            .QuerySchools(BuildApiQuery(userDefinedSet.Set, resultAs))
             .GetResultOrThrow<SchoolExpenditure[]>();
 
         return userDefinedResult;

--- a/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenViewingComparison.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenViewingComparison.cs
@@ -2,10 +2,12 @@
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using AutoFixture;
+using Moq;
 using Web.App;
 using Web.App.Domain;
 using Web.App.Domain.Charts;
 using Web.App.Extensions;
+using Web.App.Infrastructure.Apis;
 using Xunit;
 
 namespace Web.Integration.Tests.Pages.Schools.Comparison;
@@ -366,6 +368,91 @@ public class WhenViewingComparison(SchoolBenchmarkingWebAppClient client)
             filtersEnabled: true,
             hasProgressIndicatorsWellAboveAverage: hasProgressIndicatorsWellAboveAverage,
             hasProgressIndicatorsAboveAverage: hasProgressIndicatorsAboveAverage);
+    }
+
+    [Theory]
+    [InlineData(0, true, "PerUnit")]
+    [InlineData(1, true, "Actuals")]
+    [InlineData(2, true, "PercentExpenditure")]
+    [InlineData(3, true, "PercentIncome")]
+    [InlineData(0, false, "PerUnit")]
+    [InlineData(1, false, "Actuals")]
+    [InlineData(2, false, "PercentExpenditure")]
+    [InlineData(3, false, "PercentIncome")]
+    public async Task CanPassResultAsDimensionToApiQuery(
+        int resultAs,
+        bool withUserDefinedSet,
+        string expected)
+    {
+        var school = Fixture.Build<School>()
+            .With(x => x.URN, "123456")
+            .Create();
+
+        var comparatorSet = Fixture.Build<SchoolComparatorSet>()
+            .With(x => x.Building, ["building"])
+            .Create();
+
+        var expenditures = Fixture.Build<SchoolExpenditure>()
+            .With(f => f.PeriodCoveredByReturn, 12)
+            .CreateMany(3)
+            .ToArray();
+
+        expenditures[0].URN = school.URN;
+
+        var userDefinedSetUserData = new[]
+        {
+            new UserData
+            {
+                Type = "comparator-set",
+                Id = "456"
+            }
+        };
+
+        var horizontalBarChart = new ChartResponse
+        {
+            Html = "<svg />"
+        };
+
+        ApiQuery? capturedQuery = null;
+
+        Client.ExpenditureApi.Reset();
+
+        Client.ExpenditureApi
+            .Setup(api => api.School(school.URN, It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ApiResult.Ok(new SchoolExpenditure
+            {
+                PeriodCoveredByReturn = 12
+            }));
+
+        Client.ExpenditureApi
+            .Setup(api => api.QuerySchools(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
+            .Callback<ApiQuery?, CancellationToken>((query, _) =>
+            {
+                capturedQuery = query;
+            })
+            .ReturnsAsync(ApiResult.Ok(expenditures));
+
+        var client = Client
+            .SetupEstablishment(school)
+            .SetupSchool(school)
+            .SetupInsights()
+            .SetupSchoolInsight()
+            .SetupUserData(withUserDefinedSet ? userDefinedSetUserData : null)
+            .SetupComparatorSet(school, comparatorSet)
+            .SetupChartRendering<SchoolComparisonDatum>(horizontalBarChart);
+
+        if (withUserDefinedSet)
+        {
+            var userDefinedComparatorSet = Fixture.Build<UserDefinedSchoolComparatorSet>().Create();
+
+            client.SetupComparatorSet(school, userDefinedComparatorSet);
+        }
+
+        await client.Navigate($"{Paths.SchoolComparison(school.URN)}?viewAs=1&resultAs={resultAs}".ToAbsolute());
+
+        Assert.NotNull(capturedQuery);
+        Assert.Contains(capturedQuery, p => p.Key == "dimension");
+        Assert.Equal(expected, capturedQuery.First(p => p.Key == "dimension").Value);
     }
 
     #endregion

--- a/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenViewingComparison.cs
+++ b/web/tests/Web.Integration.Tests/Pages/Schools/Comparison/WhenViewingComparison.cs
@@ -370,91 +370,6 @@ public class WhenViewingComparison(SchoolBenchmarkingWebAppClient client)
             hasProgressIndicatorsAboveAverage: hasProgressIndicatorsAboveAverage);
     }
 
-    [Theory]
-    [InlineData(0, true, "PerUnit")]
-    [InlineData(1, true, "Actuals")]
-    [InlineData(2, true, "PercentExpenditure")]
-    [InlineData(3, true, "PercentIncome")]
-    [InlineData(0, false, "PerUnit")]
-    [InlineData(1, false, "Actuals")]
-    [InlineData(2, false, "PercentExpenditure")]
-    [InlineData(3, false, "PercentIncome")]
-    public async Task CanPassResultAsDimensionToApiQuery(
-        int resultAs,
-        bool withUserDefinedSet,
-        string expected)
-    {
-        var school = Fixture.Build<School>()
-            .With(x => x.URN, "123456")
-            .Create();
-
-        var comparatorSet = Fixture.Build<SchoolComparatorSet>()
-            .With(x => x.Building, ["building"])
-            .Create();
-
-        var expenditures = Fixture.Build<SchoolExpenditure>()
-            .With(f => f.PeriodCoveredByReturn, 12)
-            .CreateMany(3)
-            .ToArray();
-
-        expenditures[0].URN = school.URN;
-
-        var userDefinedSetUserData = new[]
-        {
-            new UserData
-            {
-                Type = "comparator-set",
-                Id = "456"
-            }
-        };
-
-        var horizontalBarChart = new ChartResponse
-        {
-            Html = "<svg />"
-        };
-
-        ApiQuery? capturedQuery = null;
-
-        Client.ExpenditureApi.Reset();
-
-        Client.ExpenditureApi
-            .Setup(api => api.School(school.URN, It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(ApiResult.Ok(new SchoolExpenditure
-            {
-                PeriodCoveredByReturn = 12
-            }));
-
-        Client.ExpenditureApi
-            .Setup(api => api.QuerySchools(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
-            .Callback<ApiQuery?, CancellationToken>((query, _) =>
-            {
-                capturedQuery = query;
-            })
-            .ReturnsAsync(ApiResult.Ok(expenditures));
-
-        var client = Client
-            .SetupEstablishment(school)
-            .SetupSchool(school)
-            .SetupInsights()
-            .SetupSchoolInsight()
-            .SetupUserData(withUserDefinedSet ? userDefinedSetUserData : null)
-            .SetupComparatorSet(school, comparatorSet)
-            .SetupChartRendering<SchoolComparisonDatum>(horizontalBarChart);
-
-        if (withUserDefinedSet)
-        {
-            var userDefinedComparatorSet = Fixture.Build<UserDefinedSchoolComparatorSet>().Create();
-
-            client.SetupComparatorSet(school, userDefinedComparatorSet);
-        }
-
-        await client.Navigate($"{Paths.SchoolComparison(school.URN)}?viewAs=1&resultAs={resultAs}".ToAbsolute());
-
-        Assert.NotNull(capturedQuery);
-        Assert.Contains(capturedQuery, p => p.Key == "dimension");
-        Assert.Equal(expected, capturedQuery.First(p => p.Key == "dimension").Value);
-    }
-
     #endregion
 
     #region Methods
@@ -1175,4 +1090,94 @@ public class WhenViewingComparison(SchoolBenchmarkingWebAppClient client)
     ];
 
     #endregion
+}
+
+// Isolated to prevent other tests mutating the shared Client.ExpenditureApi mock.
+public class WhenViewingComparisonApiQueryIsBuiltCorrectly(SchoolBenchmarkingWebAppClient client)
+    : PageBase<SchoolBenchmarkingWebAppClient>(client)
+{
+    [Theory]
+    [InlineData(0, true, "PerUnit")]
+    [InlineData(1, true, "Actuals")]
+    [InlineData(2, true, "PercentExpenditure")]
+    [InlineData(3, true, "PercentIncome")]
+    [InlineData(0, false, "PerUnit")]
+    [InlineData(1, false, "Actuals")]
+    [InlineData(2, false, "PercentExpenditure")]
+    [InlineData(3, false, "PercentIncome")]
+    public async Task CanPassResultAsDimensionToApiQuery(
+        int resultAs,
+        bool withUserDefinedSet,
+        string expected)
+    {
+        var school = Fixture.Build<School>()
+            .With(x => x.URN, "123456")
+            .Create();
+
+        var comparatorSet = Fixture.Build<SchoolComparatorSet>()
+            .With(x => x.Building, ["building"])
+            .Create();
+
+        var expenditures = Fixture.Build<SchoolExpenditure>()
+            .With(f => f.PeriodCoveredByReturn, 12)
+            .CreateMany(3)
+            .ToArray();
+
+        expenditures[0].URN = school.URN;
+
+        var userDefinedSetUserData = new[]
+        {
+            new UserData
+            {
+                Type = "comparator-set",
+                Id = "456"
+            }
+        };
+
+        var horizontalBarChart = new ChartResponse
+        {
+            Html = "<svg />"
+        };
+
+        var client = Client
+            .SetupEstablishment(school)
+            .SetupSchool(school)
+            .SetupInsights()
+            .SetupSchoolInsight()
+            .SetupUserData(withUserDefinedSet ? userDefinedSetUserData : null)
+            .SetupComparatorSet(school, comparatorSet)
+            .SetupChartRendering<SchoolComparisonDatum>(horizontalBarChart);
+
+        if (withUserDefinedSet)
+        {
+            var userDefinedComparatorSet = Fixture.Build<UserDefinedSchoolComparatorSet>().Create();
+
+            client.SetupComparatorSet(school, userDefinedComparatorSet);
+        }
+
+        ApiQuery? capturedQuery = null;
+
+        client.ExpenditureApi.Reset();
+
+        client.ExpenditureApi
+            .Setup(api => api.School(school.URN, It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ApiResult.Ok(new SchoolExpenditure
+            {
+                PeriodCoveredByReturn = 12
+            }));
+
+        client.ExpenditureApi
+            .Setup(api => api.QuerySchools(It.IsAny<ApiQuery?>(), It.IsAny<CancellationToken>()))
+            .Callback<ApiQuery?, CancellationToken>((query, _) =>
+            {
+                capturedQuery = query;
+            })
+            .ReturnsAsync(ApiResult.Ok(expenditures));
+
+        await client.Navigate($"{Paths.SchoolComparison(school.URN)}?viewAs=1&resultAs={resultAs}".ToAbsolute());
+
+        Assert.NotNull(capturedQuery);
+        Assert.Contains(capturedQuery, p => p.Key == "dimension");
+        Assert.Equal(expected, capturedQuery.First(p => p.Key == "dimension").Value);
+    }
 }


### PR DESCRIPTION
## 🧾 Summary

Fixes an issue where the resultAs value was not passed into the API query for the user defined comparator set journey on the school benchmark spending page, causing all dimension requests to fall back to Actuals.

[AB#318282](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/318282)
[AB#320372](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/320372)

### 🛠️ Bug Fix Description
**Root Cause:**

GetDefaultSchoolExpenditure() did not include the resultAs value when constructing the ApiQuery for user defined comparator sets. This meant QuerySchools() always used Platform’s fallback dimension (Actuals), regardless of the user’s selected option.

**Changes:**

- Updated GetDefaultSchoolExpenditure() to correctly pass the resultAs dimension when building the ApiQuery for user‑defined sets.
- Added a dedicated test to ensure the dimension is included in the query, strengthening coverage and preventing regressions.

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [x] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [x] Screenshots or Demo included _(for UI/frontend changes)_.
