### PR TITLE
chore: remove Microsoft.Azure.StackExchangeRedis from dependabot ignore for Platform

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -148,11 +148,8 @@ updates:
     rebase-strategy: auto
     commit-message:
       prefix: "chore: "
-    # Mar 2026 Microsoft.Azure.StackExchangeRedis issues with our test setup following version 3.3.1, ignored pending work on AB#305821
     # Mar 2026 Microsoft.ApplicationInsights.WorkerService breaking changes 3.x ignored pending work on AB#305698
     ignore:
-      - dependency-name: "Microsoft.Azure.StackExchangeRedis"
-        versions: [">=3.3.1"]
       - dependency-name: "Microsoft.ApplicationInsights.WorkerService"
         versions: [">=3.0.0"]
       - dependency-name: "*"


### PR DESCRIPTION
## 🧾 Summary

Following the work completed on this story this package has now been updated and future updates are now valid for us.

This PR updates the dependabot config to reflect that.

~~I suggest we avoid merging this PR until closer to the normal dependabot window for monthly updates to prevent additional Dependabot noise.~~

[AB#305821](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/305821)
[AB#320371](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/320371)

### ⛓️ Tech Debt & Refactor Details
**Major Changes:**

Updates dependabot ignore list for Platform

**Benefits:**

Ensures the correct package updates are raised

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [ ] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.
