### PR TITLE
chore: bump prettier from 3.8.4 to 3.9.4 and lint project

### DIFF
--- a/platform/src/apis/Platform.Api.ChartRendering/package-lock.json
+++ b/platform/src/apis/Platform.Api.ChartRendering/package-lock.json
@@ -35,7 +35,7 @@
         "jest": "^30.1.2",
         "jest-junit": "^17.0.0",
         "jest-theories": "^1.5.1",
-        "prettier": "^3.8.1",
+        "prettier": "^3.9.4",
         "rimraf": "^6.1.2",
         "swagger-ui-dist": "^5.32.8",
         "ts-jest": "^29.4.9",
@@ -8964,9 +8964,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/platform/src/apis/Platform.Api.ChartRendering/package.json
+++ b/platform/src/apis/Platform.Api.ChartRendering/package.json
@@ -45,7 +45,7 @@
     "jest": "^30.1.2",
     "jest-junit": "^17.0.0",
     "jest-theories": "^1.5.1",
-    "prettier": "^3.8.1",
+    "prettier": "^3.9.4",
     "rimraf": "^6.1.2",
     "swagger-ui-dist": "^5.32.8",
     "ts-jest": "^29.4.9",

--- a/platform/src/apis/Platform.Api.ChartRendering/src/functions/horizontalBarChart/index.d.ts
+++ b/platform/src/apis/Platform.Api.ChartRendering/src/functions/horizontalBarChart/index.d.ts
@@ -1,5 +1,4 @@
 import { HorizontalBarChartDefinition } from "..";
 
 type HorizontalBarChartPayload =
-  | HorizontalBarChartDefinition
-  | HorizontalBarChartDefinition[];
+  HorizontalBarChartDefinition | HorizontalBarChartDefinition[];

--- a/platform/src/apis/Platform.Api.ChartRendering/src/functions/verticalBarChart/index.d.ts
+++ b/platform/src/apis/Platform.Api.ChartRendering/src/functions/verticalBarChart/index.d.ts
@@ -1,5 +1,4 @@
 import { VerticalBarChartDefinition } from "..";
 
 type VerticalBarChartPayload =
-  | VerticalBarChartDefinition
-  | VerticalBarChartDefinition[];
+  VerticalBarChartDefinition | VerticalBarChartDefinition[];


### PR DESCRIPTION
## 🧾 Summary

Bump prettier package for Chart Rendering and run lint:fix across the project to comply with the latest rules. 

See [Don't break union type when it can fit from prettier](https://prettier.io/blog/2026/06/27/3.9.0#change-18827-2) for info on that change.

[AB#319567](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/319567)
[AB#320690](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/320690)

### ⛓️ Tech Debt & Refactor Details
**Major Changes:**

Updates prettier and lint 2 files to comply with the latest rules. 

**Benefits:**

Ensures the project remains stable and up to date.


## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes

Should close the following dependabot PRs:
- #4360