### PR TITLE
chore: bump prettier from 3.8.4 to 3.9.4 and lint project

### DIFF
--- a/front-end-components/package-lock.json
+++ b/front-end-components/package-lock.json
@@ -52,7 +52,7 @@
         "jest": "^30.2.0",
         "jest-environment-jsdom": "^30.3.0",
         "jest-theories": "^1.5.1",
-        "prettier": "^3.8.4",
+        "prettier": "^3.9.4",
         "sass-embedded": "^1.99.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.62.1",
@@ -9102,9 +9102,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/front-end-components/package.json
+++ b/front-end-components/package.json
@@ -61,7 +61,7 @@
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.3.0",
     "jest-theories": "^1.5.1",
-    "prettier": "^3.8.4",
+    "prettier": "^3.9.4",
     "sass-embedded": "^1.99.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.62.1",

--- a/front-end-components/src/components/charts/table-chart/component.tsx
+++ b/front-end-components/src/components/charts/table-chart/component.tsx
@@ -39,9 +39,7 @@ export const TableChart: React.FC<
   const resolvedValueFormatter = valueFormatter ?? fullValueFormatter;
 
   const dataPointKey = (trust ? "totalValue" : "value") as keyof (
-    | SchoolChartData
-    | TrustChartData
-    | LaChartData
+    SchoolChartData | TrustChartData | LaChartData
   );
 
   const keyField = (

--- a/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
+++ b/front-end-components/src/composed/horizontal-bar-chart-wrapper/composed.tsx
@@ -100,14 +100,11 @@ export function HorizontalBarChartWrapper<
   // if a `sort` is not provided, the default sorting method will be used (value DESC)
   const sortedDataPoints = useMemo(() => {
     let dataPoint = "value" as keyof (
-      | SchoolChartData
-      | TrustChartData
-      | LaChartData
+      SchoolChartData | TrustChartData | LaChartData
     );
     if (trust) {
       dataPoint = "totalValue" as keyof (
-        | SchoolChartData
-        | Omit<TrustChartData, "totalPupils">
+        SchoolChartData | Omit<TrustChartData, "totalPupils">
       );
     }
 

--- a/front-end-components/src/views/historic-data-2/types.tsx
+++ b/front-end-components/src/views/historic-data-2/types.tsx
@@ -19,10 +19,7 @@ export type HistoricData2ViewProps = ViewProps &
   };
 
 export type HistoricData2SectionName =
-  | "spending"
-  | "income"
-  | "balance"
-  | "census";
+  "spending" | "income" | "balance" | "census";
 
 export type HistoricData2Section<T extends HistoryBase> = {
   heading: string;


### PR DESCRIPTION
## 🧾 Summary

Bump prettier package for front end compenents and run lint:fix across the project to comply with the latest rules. 

See [Don't break union type when it can fit from prettier](https://prettier.io/blog/2026/06/27/3.9.0#change-18827-2) for info on that change.

[AB#319567](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/319567)
[AB#320690](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/320690)

### ⛓️ Tech Debt & Refactor Details
**Major Changes:**

Updates prettier and lint 3 files to comply with the latest rules. 

**Benefits:**

Ensures the project remains stable and up to date.


## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [x] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes

Should close the following dependabot PRs:
- #4364