### PR TITLE
docs: update QA docs for data releases

### DIFF
--- a/documentation/quality-assurance/10_Data-Release-Test-Approach.md
+++ b/documentation/quality-assurance/10_Data-Release-Test-Approach.md
@@ -1,0 +1,96 @@
+# Test Approach: Data Releases
+
+## Context
+
+This document is the tactical companion to the data release strategy, which is the Data Releases section of [Test Strategy: Data Ingestion](./3_Test-strategy-data-ingestion.md). It follows the same relationship that the service [Test Approach](./4_Test-Approach.md) has to the service [Test Strategy](./1_Test-strategy-service.md).
+
+The strategy defines what is tested for a data release and the validation model that is applied. This document describes how QA works to deliver that: how QA embeds with the data team, plans each release, and runs the checks step by step with the right people. It does not restate the validation model, nor the release process itself, which is in the [data release guide](../guides/data-release-guide/01_Overview.md).
+
+## Objectives
+
+- Describe how QA operates through a data release, as part of the data team rather than as a gate at the end.
+- Clarify how QA divides the work with the data analysts and data engineers.
+- Set out how QA plans and runs the checks for each step of a release.
+- Keep every release repeatable and evidenced for handover.
+
+## How QA Works With the Data Team
+
+A data release is delivered by QA working closely with the data analysts and data engineers throughout, not by testing a finished output. The analysts own the source data, the engineers own the pipeline, and QA owns the assurance that the data lands correctly and appears accurately in the service. QA holds the end to end view from source file to what the user sees, which neither the analyst nor the engineer sees on their own.
+
+| QA works with | On | How QA works with them |
+| :--- | :--- | :--- |
+| **Data Analysts** | Source and ancillary files, schema, business rules | Walk through the incoming files and expected schema before the run; agree what "correct" looks like for the release specific logic; triage anything that looks wrong together, so QA can separate an upstream data issue from a pipeline issue; review completeness gaps and the transparency figures with them. |
+| **Data Engineers** | Pipeline execution, logs, database | Agree the run steps and environments; pair on triggering the pipeline and reading the logs; run the reconciliation and regression queries together; debug ingestion failures side by side; confirm the `Parameters` flags at go-live. |
+| **Stakeholders / Product Owner** | Acceptance of the data in the service | Agree the UAT scope; walk the service together for the reporting year; capture sign-off and the go/no-go decision. |
+
+## Planning Each Release
+
+QA produces the individual release plan for every release. This is where the approach becomes concrete, and it is done with the team, not in isolation.
+
+- At kickoff QA drafts the release plan from the template in the [Data Release Test Plan](./11_Data-Release-Test-Plan.md), tailored to the release using the variation matrix in [Test Strategy: Data Ingestion](./3_Test-strategy-data-ingestion.md): the right files, the checks that apply, and the release specific business logic.
+- QA turns the validation model into concrete steps in the plan, names the owner for each step (analyst, engineer or QA), and agrees the order with the team.
+- QA writes and maintains the validation scripts, queries and completeness reports the plan depends on, so they are ready before the run and reusable next cycle.
+- QA agrees the cutoff and the `test`, `preprod` and `prod` run points with the team, and books the stakeholders for UAT.
+
+The plan is a shared, living artefact for the release: the team works to it, and QA updates it as steps complete and evidence is captured.
+
+## How QA Engages Across the Release Lifecycle
+
+The release runs in four phases, documented in the [data release guide overview](../guides/data-release-guide/01_Overview.md). QA contributes to each phase as follows.
+
+| Phase | How QA works |
+| :--- | :--- |
+| Pre-Release | Attend kickoff, agree the plan and owners with the team, walk the incoming files with the analyst, validate the transparency file schema (CFR, AAR), and pair with the engineer on speculative pre-cutoff runs to surface schema drift early. |
+| Submission and Cutoff | Agree the cutoff snapshot with the analyst and engineer, and confirm the correct files are landed in the right `raw` year directory. |
+| Ingestion and Verification | Run the plan step by step with the team in `test` then `preprod`, pairing with the engineer on the pipeline and queries and with the analyst on the figures, log defects, and drive stakeholder UAT. |
+| Promotion and Go-Live | Smoke check each environment with the engineer as data is promoted, and confirm the `Parameters` flags are incremented so the new data shows on the frontend. |
+
+## Running the Checks
+
+During the run QA carries out the validation model defined in the strategy by working through the plan with the team. The point of this section is who QA works with for each check, not what each check covers, which is in the strategy and the plan template.
+
+- QA runs the schema and file checks on the incoming files, raising anything off spec with the analyst before the pipeline runs.
+- QA and the engineer trigger the pipeline, watch the logs, and reconcile the database against source totals; QA runs the completeness report and reviews the gaps with the analyst.
+- QA verifies the release specific business logic (for example AAR fund apportionment, CFR data, S251 budget and outturn) with the analyst who owns the rules.
+- QA spot checks the service for the reporting year.
+- QA runs the regression checks with the engineer to confirm historical data is untouched, and verifies the transparency file with the analyst where the release has one.
+
+QA records the outcome of each check against the plan as it goes, so the plan doubles as the evidence trail.
+
+## Reusable QA Assets
+
+QA reuses the same assets each cycle rather than rebuilding them.
+
+- The assurance, reconciliation and coverage queries in the [data release guide](../guides/data-release-guide/01_Overview.md).
+- The completeness report script in SharePoint under `Documents > General > Analytics Discovery > Completeness Report - Data Drops`.
+- The regression comparison queries over prior years, and the transparency file verification.
+
+## Assuring the LAA Risk Indicators (CFR)
+
+From the 2025-2026 cycle the CFR release also refreshes the LAA risk indicators (see [decision 0023](../architecture/decisions/0023-laa-risk-indicators-data-architecture.md)). Because the raw inputs are not stored in the database, QA assures these figures through files rather than queries, which changes how QA works with the team.
+
+- QA confirms with the engineer that LAA processing runs after the CFR refresh, and takes the parquet saved at calculation time as the QA artefact.
+- QA works with the analyst to check the figures against the input files and the webpage data download, since the six non-financial datapoints cannot be queried in the database.
+- QA and the engineer confirm the headline and breakdown tables populate the new pages, and the regression checks.
+
+The specific checks are captured in the LAA block of the plan template.
+
+## Defect Handling and Evidence
+
+- QA logs defects and QA subtasks in Azure DevOps against the release tickets, giving an audit trail from preparation to go-live, as in the service [Test Approach](./4_Test-Approach.md).
+- QA classifies severity with the team; High or Critical issues block the exit criteria and feed the go/no-go decision.
+- QA captures evidence for each step (query outputs, completeness reports, transparency and LAA verification, UAT notes) and links it to the release plan so sign-off is traceable.
+
+## Collaboration and Communication Cadence
+
+| Cadence         | Who                                   | Purpose                                             |
+|:----------------|:--------------------------------------|:----------------------------------------------------|
+| Release kickoff | QA, engineers, analysts, project team | Confirm sources, scope, plan and foreseen blockers  |
+| Daily           | Release thread or standup             | Share submission volumes, run progress and blockers |
+| Cutoff sync     | QA, analysts, engineers               | Agree and enact the cutoff snapshot                 |
+| Sign-off review | QA, stakeholders, tech lead           | Review evidence and take the go/no-go decision      |
+
+Release communication follows the [data release guide](../guides/data-release-guide/01_Overview.md) and [Release Comms](./8_Release-Comms.md).
+
+<!-- Leave the rest of this page blank -->
+\newpage

--- a/documentation/quality-assurance/11_Data-Release-Test-Plan.md
+++ b/documentation/quality-assurance/11_Data-Release-Test-Plan.md
@@ -1,0 +1,172 @@
+# Test Plan: Data Releases
+
+## Purpose
+
+This document is the practical planning layer for the annual data releases. It sits beneath the data release strategy in [Test Strategy: Data Ingestion](./3_Test-strategy-data-ingestion.md) and the [Data Release Test Approach](./10_Data-Release-Test-Approach.md), and above the dated per-release plans in [data-release-test-plans/](./data-release-test-plans/). Its job is to make producing an individual release plan fast and consistent by providing a reusable template.
+
+## How This Differs From Strategy and Approach
+
+Following the same split as the service documents (see the service [Test Plan](./5_Test-Plan.md)):
+
+- The [Data Ingestion Test Strategy](./3_Test-strategy-data-ingestion.md) defines why, what and where, including the Data Releases variation matrix.
+- The [Data Release Test Approach](./10_Data-Release-Test-Approach.md) defines how QA works during a release.
+- This Test Plan defines when each individual plan is produced and provides the template to generate it.
+
+## How To Use This Plan
+
+1. Copy the [template](#reusable-per-release-plan-template) below into [`data-release-test-plans/`](./data-release-test-plans/) as the next sequence number, named `0000N_<RELEASE>-<YYYY-YYYY>-data-release.md`.
+2. Fill the placeholders using the Per-Release Variation Matrix in [Test Strategy: Data Ingestion](./3_Test-strategy-data-ingestion.md): choose the correct files, keep only the layers that apply, and add release specific business logic.
+3. For a CFR release from 2025-2026 onward, keep the optional LAA Risk Indicator Validation block.
+4. Tick the exit criteria only as they are genuinely met.
+
+## When Each Plan Is Produced
+
+Individual plans are produced ahead of each release, on the calendar documented in [`data/05_Releases.md`](../data/05_Releases.md).
+
+## Reusable Per-Release Plan Template
+
+Copy the block below and replace the `<...>` placeholders. It mirrors the structure of the existing plans in [`data-release-test-plans/`](./data-release-test-plans/); refer to the [Approach](./10_Data-Release-Test-Approach.md) for how each validation layer is performed rather than restating it in the plan.
+
+---
+
+```markdown
+# Test Plan: <RELEASE> Data Release – <YYYY-YYYY>
+
+## Purpose
+
+This plan defines the QA strategy to validate the Data Release for the **<full release name> (<RELEASE>) covering the <YYYY-YYYY> period**. The primary focus is the integrity of the ingestion and transformation pipeline for <primary file(s)> into the FBIT platform, the accurate integration of ancillary datasets, and the verification of data availability and accuracy within the service.
+
+## Scope
+
+### In Scope
+
+- **Schema & Structural Validation:** Contract checking for the primary <RELEASE> file(s) and all listed ancillary datasets.
+- **End to End (E2E) Pipeline:** Monitoring the release from raw file landing to database persistence.
+- **Data Reconciliation:** Database records, row counts and key joins match source totals.
+- **Service/UI Validation:** Front end verification for the <YYYY> reporting year.
+- **Regression Testing:** Historical <RELEASE> data (<prior year> and earlier) remains unchanged.
+- <Transparency file integration, CFR and AAR only>
+- <LAA risk indicator validation, CFR only>
+
+### Out of Scope
+
+- Accuracy of the raw source data (upstream responsibility of Data Analysts).
+
+## Test Data Profile
+
+| Category | Files / Sources |
+| :--- | :--- |
+| **Primary <RELEASE>** | <primary file(s)> |
+| **Organisational** | <gias.csv, gias_links.csv, if applicable> |
+| **Census / Ancillary** | <ancillary files, if applicable> |
+| **Transparency** | <transparency file, CFR and AAR only> |
+
+## Test Activities & Methodologies
+
+### Schema & File Integrity Validation
+
+**Goal:** Ensure structural integrity to prevent pipeline failures and schema level data loss.
+
+- Constraint checking: headers, data types, mandatory or non-nullable fields.
+- Identifier consistency: <URNs, Trust UIDs or LA codes> follow the standard format.
+- Uniqueness: no duplicate primary keys.
+
+### Ancillary Data & Completeness Reporting
+
+Omit this activity where the release has no ancillary data (for example BFR).
+
+**Goal:** Quantify data readiness and identify gaps before final processing.
+
+- Cross reference ancillary data to the primary identifiers.
+- Generate volume, orphan and completeness percentage reports (reuse the completeness script).
+
+### Business Logic: <name>
+
+Include only where the release has specific logic (for example AAR CS fund allocation, BFR three year forecast, S251 budget and outturn).
+
+**Goal:** Verify the mathematical accuracy of the transformation.
+
+- <release specific checks; ensure totals reconcile with zero variance>
+
+### Database & Pipeline Validation
+
+**Goal:** Ensure clean processing and relational integrity.
+
+- Trigger ingestion; monitor logs for silent drops, duplicates or warnings.
+- Reconcile row counts and key joins against source totals.
+- Run regression guardrails or checksums on prior year data.
+
+### Service/UI Validation
+
+**Goal:** Final user acceptance of the data presentation.
+
+- Verify the <YYYY> toggle loads the correct dataset.
+- Spot check high value metrics against source files.
+- Confirm graceful handling of missing data.
+
+### Regression Testing
+
+**Goal:** Prevent degradation of historical datasets.
+
+- Confirm previous years' <RELEASE> data is unchanged via comparison queries.
+
+### Transparency File Integration
+
+Include for CFR and AAR only.
+
+**Goal:** Ensure the transparency file is correctly produced and matches the source.
+
+- Compare the generated transparency file against the inputs (1:1 mapping) and verify a sample via manual computation with zero variance.
+
+### LAA Risk Indicator Validation
+
+Include for CFR only, from the 2025-2026 cycle (see decision 0023).
+
+**Goal:** Validate the LAA risk indicators refreshed alongside CFR.
+
+- Confirm LAA processing runs on its custom trigger after the CFR refresh completes.
+- Assure the six non-persisted non-financial datapoints via the input files, the parquet saved at calculation time, and the webpage data download (not the database).
+- Confirm the headline and breakdown denormalised tables are populated and drive the two new webpages.
+- Validate the three risk categories (Financial, Educational performance, School and Pupil) and confirm per year calculation versioning.
+- Regression: confirm existing FBIT view latency (for example National Averages) is unaffected.
+
+## Responsibilities & Environment
+
+Responsibilities and environments follow the Data Ingestion Test Strategy and the Data Release Test Approach. Name the specific people for this release below.
+
+| Role | Responsibility |
+| --- | --- |
+| **Data Analyst(s)** | Produce and review source and ancillary files before the release. |
+| **Data Engineer** | Load files, execute pipeline runs, provide logs, support technical testing. |
+| **QA Lead** | Prepare test plan and scripts; manage overall execution. |
+| **Engineer(s)** | Assist with test execution, validation and regression scripts under QA guidance. |
+| **Technical Lead** | Oversee technical quality and architectural integrity of the pipeline. |
+| **Stakeholders** | Conduct UAT and provide formal sign-off. |
+| **Project Lead** | Final Go/No-Go decision for the release. |
+
+## Exit Criteria (Sign-off Requirements)
+
+- [ ] All primary and ancillary schemas pass validation
+- [ ] Completeness report generated and reviewed (where applicable)
+- [ ] Release specific business logic verified with zero variance (where applicable)
+- [ ] Pipeline completes E2E with no High or Critical errors
+- [ ] Database reconciles to source totals with expected mappings
+- [ ] Regression tests confirm historical data integrity
+- [ ] UI displays <YYYY> data accurately across metrics and filters
+- [ ] Transparency file verified (CFR and AAR only)
+- [ ] LAA risk indicators verified via files, parquet and data download (CFR only)
+- [ ] Stakeholder sign-off and Project Lead Go decision recorded
+```
+
+---
+
+## Deliverables and Sign-off
+
+Each release produces, and links from its individual plan, the completed plan with exit criteria met, the validation scripts and query outputs, the ancillary completeness report (where applicable), the transparency and LAA evidence (CFR, AAR), the UAT notes, and the recorded Go/No-Go decision. This follows the deliverables approach in the service [Test Plan](./5_Test-Plan.md).
+
+## Living Plan
+
+Like the service [Test Plan](./5_Test-Plan.md), this evolves each cycle. When a decision changes what a release must test, as [decision 0023](../architecture/decisions/0023-laa-risk-indicators-data-architecture.md) did for CFR and LAA, update the strategy, approach and template so the next generated plan inherits the change.
+
+<!-- Leave the rest of this page blank -->
+\newpage

--- a/documentation/quality-assurance/3_Test-strategy-data-ingestion.md
+++ b/documentation/quality-assurance/3_Test-strategy-data-ingestion.md
@@ -1,4 +1,4 @@
-﻿# Test Strategy: Data Ingestion
+# Test Strategy: Data Ingestion
 
 ## Purpose
 
@@ -79,6 +79,23 @@ This document defines **how ingestion testing is approached**, including the sco
 - Check key metrics, filters, and year switching functionality
 - Perform stakeholder review on representative data sets
 
+## Data Releases
+
+The service performs four data releases each year: S251, BFR, CFR and AAR. From the 2025-2026 cycle the Local Authority Risk Analysis (LAA) risk indicators are refreshed alongside CFR (see [decision 0023](../architecture/decisions/0023-laa-risk-indicators-data-architecture.md)).
+
+These releases all follow the ingestion validation model above, but differ in their primary files, ancillary datasets and business logic. Release timings, sourcing and the pipeline trigger are in [data/05_Releases.md](../data/05_Releases.md); acronyms are in the [glossary](../glossary.md) and the full source file list is in [data/02_Sources.md](../data/02_Sources.md).
+
+| Aspect                     | BFR                                  | CFR                                            | S251                                                     | AAR                                                                 |
+|----------------------------|--------------------------------------|------------------------------------------------|----------------------------------------------------------|---------------------------------------------------------------------|
+| **Primary files**          | `BFR_SOFA_raw.csv`, `BFR_3Y_raw.csv` | `maintained_schools_master_list.csv`           | Budget and outturn files                                 | `aar.csv`, `aar_cs.csv`                                             |
+| **Ancillary datasets**     | None                                 | GIAS, GIAS_Links, Census, SEN, CDC, KS2/4, ILR | EHCP (`sen2_estab_caseload.csv`), Statistical Neighbours | GIAS, Census, SEN, CDC, KS2/4, CFO, ILR, High Exec Pay, Workforce   |
+| **Unique business logic**  | Three year forecast aggregation      | Schema and reconciliation focused              | Budget and outturn integration, LA level mapping         | Trust CS fund apportionment (pupil ratio, part year, new academies) |
+| **Transparency file**      | No                                   | Yes                                            | No                                                       | Yes                                                                 |
+| **LAA risk indicators**    | No                                   | Yes (from 2025-2026)                           | No                                                       | No                                                                  |
+| **Completeness reporting** | Not required                         | Required                                       | Required                                                 | Required                                                            |
+
+How QA works through a release is described in the [Data Release Test Approach](./10_Data-Release-Test-Approach.md), and the reusable template for an individual release plan is in the [Data Release Test Plan](./11_Data-Release-Test-Plan.md). The individual dated plans live in [`data-release-test-plans/`](./data-release-test-plans/).
+
 ## Risk Mitigation
 
 | Risk                                      | Mitigation                                                |
@@ -86,6 +103,7 @@ This document defines **how ingestion testing is approached**, including the sco
 | Upstream schema or format change          | Validate files pre-ingestion and update mapping if needed |
 | Pipeline or job failure                   | Test run locally followed by in test                      |
 | Regression in existing data               | Execute 1-2 year regression script                        |
+| LAA raw non-financial inputs not stored in the database   | Assure figures via input files, the parquet saved at calculation time, and the risk indicator webpage data download |
 
 ## Supporting Documents
 


### PR DESCRIPTION
## 🧾 Summary
This PR adds generalised, reusable QA documentation for the data releases we do each year. The underlying plan was to update the CFR plan so it covers the changes for LAA which identified the gap for these documentation. 

This added benefit for this is also to stay on top of the potential handover.

[AB#320473](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/320473)
[AB#319975](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/319975)


## ✅ Checklist
- [ ] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [ ] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes
> N/A
