### PR TITLE
feat: join function apps onto virtual network 

### DIFF
--- a/core-infrastructure/terraform/vnet.tf
+++ b/core-infrastructure/terraform/vnet.tf
@@ -40,6 +40,14 @@ resource "azurerm_subnet" "platform-subnet" {
   }
 }
 
+resource "azurerm_subnet" "orchestrator-subnet" {
+  name                 = "${var.environment-prefix}-orchestrator-subnet"
+  resource_group_name  = azurerm_resource_group.resource-group.name
+  virtual_network_name = azurerm_virtual_network.app-service-network.name
+  address_prefixes     = ["10.0.4.0/24"]
+  service_endpoints    = ["Microsoft.Sql", "Microsoft.Storage"]
+}
+
 resource "azurerm_subnet" "web-app-subnet" {
   name                 = "${var.environment-prefix}-web-app-subnet"
   resource_group_name  = azurerm_resource_group.resource-group.name

--- a/core-infrastructure/terraform/vnet.tf
+++ b/core-infrastructure/terraform/vnet.tf
@@ -15,6 +15,16 @@ resource "azurerm_subnet_network_security_group_association" "platform-subnet-ns
   network_security_group_id = azurerm_network_security_group.network-security-group.id
 }
 
+resource "azurerm_subnet_network_security_group_association" "orchestrator-subnet-nsg-association" {
+  subnet_id                 = azurerm_subnet.orchestrator-subnet.id
+  network_security_group_id = azurerm_network_security_group.network-security-group.id
+}
+
+resource "azurerm_subnet_network_security_group_association" "load-test-subnet-nsg-association" {
+  subnet_id                 = azurerm_subnet.load-test-subnet.id
+  network_security_group_id = azurerm_network_security_group.network-security-group.id
+}
+
 resource "azurerm_virtual_network" "app-service-network" {
   name                = "${var.environment-prefix}-app-service-network"
   address_space       = ["10.0.0.0/16"]
@@ -87,9 +97,4 @@ resource "azurerm_subnet" "load-test-subnet" {
   service_endpoints = [
     "Microsoft.Web"
   ]
-}
-
-resource "azurerm_subnet_network_security_group_association" "load-test-subnet-nsg-association" {
-  subnet_id                 = azurerm_subnet.load-test-subnet.id
-  network_security_group_id = azurerm_network_security_group.network-security-group.id
 }

--- a/core-infrastructure/terraform/vnet.tf
+++ b/core-infrastructure/terraform/vnet.tf
@@ -29,6 +29,15 @@ resource "azurerm_subnet" "platform-subnet" {
   virtual_network_name = azurerm_virtual_network.app-service-network.name
   address_prefixes     = ["10.0.2.0/24"]
   service_endpoints    = ["Microsoft.Sql", "Microsoft.Storage"]
+
+  delegation {
+    name = "flex-consumption-delegation"
+
+    service_delegation {
+      name    = "Microsoft.App/environments"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+    }
+  }
 }
 
 resource "azurerm_subnet" "web-app-subnet" {

--- a/core-infrastructure/terraform/vnet.tf
+++ b/core-infrastructure/terraform/vnet.tf
@@ -46,6 +46,15 @@ resource "azurerm_subnet" "orchestrator-subnet" {
   virtual_network_name = azurerm_virtual_network.app-service-network.name
   address_prefixes     = ["10.0.4.0/24"]
   service_endpoints    = ["Microsoft.Sql", "Microsoft.Storage"]
+
+  delegation {
+    name = "delegation"
+
+    service_delegation {
+      name    = "Microsoft.Web/serverFarms"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
 }
 
 resource "azurerm_subnet" "web-app-subnet" {

--- a/platform/Platform.sln
+++ b/platform/Platform.sln
@@ -141,6 +141,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "function_app", "function_ap
 		terraform\modules\function_app\provider.tf = terraform\modules\function_app\provider.tf
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "config", "config", "{2FB04641-73AD-4A29-BD5D-249BDC6FE475}"
+	ProjectSection(SolutionItems) = preProject
+		terraform\modules\config\README.md = terraform\modules\config\README.md
+		terraform\modules\config\outputs.tf = terraform\modules\config\outputs.tf
+		terraform\modules\config\variables.tf = terraform\modules\config\variables.tf
+		terraform\modules\config\main.tf = terraform\modules\config\main.tf
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -618,5 +626,6 @@ Global
 		{6649B269-28FA-4167-A4EE-5E48DA731B94} = {D52455F1-3BF5-46F4-9833-633817248295}
 		{6D5DFA24-74D5-473A-8233-F1DEAA28DAFB} = {D52455F1-3BF5-46F4-9833-633817248295}
 		{040B913B-998B-48D5-AD4A-CE961D5660D7} = {4150CD4C-2835-410D-BB90-B10FD04C6BE5}
+		{2FB04641-73AD-4A29-BD5D-249BDC6FE475} = {4150CD4C-2835-410D-BB90-B10FD04C6BE5}
 	EndGlobalSection
 EndGlobal

--- a/platform/Platform.sln
+++ b/platform/Platform.sln
@@ -30,6 +30,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "terraform", "terraform", "{
 		terraform\README.md = terraform\README.md
 		terraform\data.tf = terraform\data.tf
 		terraform\cache.tf = terraform\cache.tf
+		terraform\locals.tf = terraform\locals.tf
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "abstractions", "abstractions", "{D52455F1-3BF5-46F4-9833-633817248295}"

--- a/platform/terraform/data.tf
+++ b/platform/terraform/data.tf
@@ -31,6 +31,12 @@ data "azurerm_subnet" "load-test-subnet" {
   resource_group_name  = "${var.environment-prefix}-ebis-core"
 }
 
+data "azurerm_subnet" "orchestrator-subnet" {
+  name                 = "${var.environment-prefix}-orchestrator-subnet"
+  virtual_network_name = "${var.environment-prefix}-app-service-network"
+  resource_group_name  = "${var.environment-prefix}-ebis-core"
+}
+
 data "azurerm_client_config" "client" {}
 
 data "external" "agent_ip_address" {

--- a/platform/terraform/functions.tf
+++ b/platform/terraform/functions.tf
@@ -219,7 +219,7 @@ module "orchestrator-fa" {
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions
     subnet_ids          = [data.azurerm_subnet.web-app-subnet.id]
-    join_subnet_id      = data.azurerm_subnet.platform-subnet.id
+    join_subnet_id      = data.azurerm_subnet.orchestrator-subnet.id
   }
 
   service_plan = {

--- a/platform/terraform/functions.tf
+++ b/platform/terraform/functions.tf
@@ -256,7 +256,7 @@ module "content-fc-fa" {
 
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions,
-    subnet_id           = data.azurerm_subnet.platform-subnet
+    subnet_id           = data.azurerm_subnet.platform-subnet.id
   }
 
   identity = {
@@ -288,7 +288,7 @@ module "local-authority-fc-fa" {
 
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions,
-    subnet_id           = data.azurerm_subnet.platform-subnet
+    subnet_id           = data.azurerm_subnet.platform-subnet.id
   }
 
   identity = {
@@ -322,7 +322,7 @@ module "school-fc-fa" {
 
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions,
-    subnet_id           = data.azurerm_subnet.platform-subnet
+    subnet_id           = data.azurerm_subnet.platform-subnet.id
   }
 
   redis_cache = {
@@ -359,7 +359,7 @@ module "trust-fc-fa" {
 
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions,
-    subnet_id           = data.azurerm_subnet.platform-subnet
+    subnet_id           = data.azurerm_subnet.platform-subnet.id
   }
 
   identity = {
@@ -393,7 +393,7 @@ module "benchmark-fc-fa" {
 
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions,
-    subnet_id           = data.azurerm_subnet.platform-subnet
+    subnet_id           = data.azurerm_subnet.platform-subnet.id
   }
 
   identity = {
@@ -425,7 +425,7 @@ module "insight-fc-fa" {
 
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions,
-    subnet_id           = data.azurerm_subnet.platform-subnet
+    subnet_id           = data.azurerm_subnet.platform-subnet.id
   }
 
   redis_cache = {
@@ -458,10 +458,9 @@ module "maintenance-tasks-fc-fa" {
   shared_key_vault = local.shared_key_vault
   sql_server       = local.shared_sql_server
 
-
   networking = {
     enable_restrictions = false,
-    subnet_id           = data.azurerm_subnet.platform-subnet
+    subnet_id           = data.azurerm_subnet.platform-subnet.id
   }
 
   identity = {
@@ -491,7 +490,7 @@ module "chart-rendering-fc-fa" {
 
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions,
-    subnet_id           = data.azurerm_subnet.platform-subnet
+    subnet_id           = data.azurerm_subnet.platform-subnet.id
   }
 
   application_stack = {

--- a/platform/terraform/functions.tf
+++ b/platform/terraform/functions.tf
@@ -253,7 +253,11 @@ module "content-fc-fa" {
   monitoring       = local.shared_monitoring
   shared_key_vault = local.shared_key_vault
   sql_server       = local.shared_sql_server
-  networking       = local.shared_networking
+
+  networking = {
+    enable_restrictions = module.config.enable_ip_restrictions,
+    subnet_id           = data.azurerm_subnet.platform-subnet
+  }
 
   identity = {
     tenant_id = data.azurerm_client_config.client.tenant_id
@@ -281,7 +285,11 @@ module "local-authority-fc-fa" {
   monitoring       = local.shared_monitoring
   shared_key_vault = local.shared_key_vault
   sql_server       = local.shared_sql_server
-  networking       = local.shared_networking
+
+  networking = {
+    enable_restrictions = module.config.enable_ip_restrictions,
+    subnet_id           = data.azurerm_subnet.platform-subnet
+  }
 
   identity = {
     tenant_id = data.azurerm_client_config.client.tenant_id
@@ -311,7 +319,11 @@ module "school-fc-fa" {
   monitoring       = local.shared_monitoring
   shared_key_vault = local.shared_key_vault
   sql_server       = local.shared_sql_server
-  networking       = local.shared_networking
+
+  networking = {
+    enable_restrictions = module.config.enable_ip_restrictions,
+    subnet_id           = data.azurerm_subnet.platform-subnet
+  }
 
   redis_cache = {
     id          = azurerm_redis_cache.cache.id
@@ -344,7 +356,11 @@ module "trust-fc-fa" {
   monitoring       = local.shared_monitoring
   shared_key_vault = local.shared_key_vault
   sql_server       = local.shared_sql_server
-  networking       = local.shared_networking
+
+  networking = {
+    enable_restrictions = module.config.enable_ip_restrictions,
+    subnet_id           = data.azurerm_subnet.platform-subnet
+  }
 
   identity = {
     tenant_id = data.azurerm_client_config.client.tenant_id
@@ -374,7 +390,11 @@ module "benchmark-fc-fa" {
   monitoring       = local.shared_monitoring
   shared_key_vault = local.shared_key_vault
   sql_server       = local.shared_sql_server
-  networking       = local.shared_networking
+
+  networking = {
+    enable_restrictions = module.config.enable_ip_restrictions,
+    subnet_id           = data.azurerm_subnet.platform-subnet
+  }
 
   identity = {
     tenant_id = data.azurerm_client_config.client.tenant_id
@@ -402,7 +422,11 @@ module "insight-fc-fa" {
   monitoring       = local.shared_monitoring
   shared_key_vault = local.shared_key_vault
   sql_server       = local.shared_sql_server
-  networking       = local.shared_networking
+
+  networking = {
+    enable_restrictions = module.config.enable_ip_restrictions,
+    subnet_id           = data.azurerm_subnet.platform-subnet
+  }
 
   redis_cache = {
     id          = azurerm_redis_cache.cache.id
@@ -434,9 +458,10 @@ module "maintenance-tasks-fc-fa" {
   shared_key_vault = local.shared_key_vault
   sql_server       = local.shared_sql_server
 
+
   networking = {
-    enable_restrictions = false
-    subnet_ids          = [data.azurerm_subnet.web-app-subnet.id]
+    enable_restrictions = false,
+    subnet_id           = data.azurerm_subnet.platform-subnet
   }
 
   identity = {
@@ -463,7 +488,11 @@ module "chart-rendering-fc-fa" {
   monitoring       = local.shared_monitoring
   shared_key_vault = local.shared_key_vault
   sql_server       = local.shared_sql_server
-  networking       = local.shared_networking
+
+  networking = {
+    enable_restrictions = module.config.enable_ip_restrictions,
+    subnet_id           = data.azurerm_subnet.platform-subnet
+  }
 
   application_stack = {
     worker_runtime  = "node"

--- a/platform/terraform/functions.tf
+++ b/platform/terraform/functions.tf
@@ -256,7 +256,11 @@ module "content-fc-fa" {
 
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions,
-    subnet_id           = data.azurerm_subnet.platform-subnet.id
+    join_subnet_id      = data.azurerm_subnet.platform-subnet.id
+    allow_subnet_ids    = [
+      data.azurerm_subnet.web-app-subnet.id,
+      data.azurerm_subnet.load-test-subnet.id
+    ]
   }
 
   identity = {
@@ -288,7 +292,11 @@ module "local-authority-fc-fa" {
 
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions,
-    subnet_id           = data.azurerm_subnet.platform-subnet.id
+    join_subnet_id      = data.azurerm_subnet.platform-subnet.id
+    allow_subnet_ids    = [
+      data.azurerm_subnet.web-app-subnet.id,
+      data.azurerm_subnet.load-test-subnet.id
+    ]
   }
 
   identity = {
@@ -322,7 +330,11 @@ module "school-fc-fa" {
 
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions,
-    subnet_id           = data.azurerm_subnet.platform-subnet.id
+    join_subnet_id      = data.azurerm_subnet.platform-subnet.id
+    allow_subnet_ids    = [
+      data.azurerm_subnet.web-app-subnet.id,
+      data.azurerm_subnet.load-test-subnet.id
+    ]
   }
 
   redis_cache = {
@@ -359,7 +371,11 @@ module "trust-fc-fa" {
 
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions,
-    subnet_id           = data.azurerm_subnet.platform-subnet.id
+    join_subnet_id      = data.azurerm_subnet.platform-subnet.id
+    allow_subnet_ids    = [
+      data.azurerm_subnet.web-app-subnet.id,
+      data.azurerm_subnet.load-test-subnet.id
+    ]
   }
 
   identity = {
@@ -393,7 +409,11 @@ module "benchmark-fc-fa" {
 
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions,
-    subnet_id           = data.azurerm_subnet.platform-subnet.id
+    join_subnet_id      = data.azurerm_subnet.platform-subnet.id
+    allow_subnet_ids    = [
+      data.azurerm_subnet.web-app-subnet.id,
+      data.azurerm_subnet.load-test-subnet.id
+    ]
   }
 
   identity = {
@@ -425,7 +445,11 @@ module "insight-fc-fa" {
 
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions,
-    subnet_id           = data.azurerm_subnet.platform-subnet.id
+    join_subnet_id      = data.azurerm_subnet.platform-subnet.id
+    allow_subnet_ids    = [
+      data.azurerm_subnet.web-app-subnet.id,
+      data.azurerm_subnet.load-test-subnet.id
+    ]
   }
 
   redis_cache = {
@@ -460,7 +484,8 @@ module "maintenance-tasks-fc-fa" {
 
   networking = {
     enable_restrictions = false,
-    subnet_id           = data.azurerm_subnet.platform-subnet.id
+    join_subnet_id      = data.azurerm_subnet.platform-subnet.id
+    allow_subnet_ids    = [ data.azurerm_subnet.web-app-subnet.id ]
   }
 
   identity = {
@@ -490,7 +515,11 @@ module "chart-rendering-fc-fa" {
 
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions,
-    subnet_id           = data.azurerm_subnet.platform-subnet.id
+    join_subnet_id      = data.azurerm_subnet.platform-subnet.id
+    allow_subnet_ids    = [
+      data.azurerm_subnet.web-app-subnet.id,
+      data.azurerm_subnet.load-test-subnet.id
+    ]
   }
 
   application_stack = {

--- a/platform/terraform/functions.tf
+++ b/platform/terraform/functions.tf
@@ -219,6 +219,7 @@ module "orchestrator-fa" {
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions
     subnet_ids          = [data.azurerm_subnet.web-app-subnet.id]
+    join_subnet_id      = data.azurerm_subnet.platform-subnet.id
   }
 
   service_plan = {

--- a/platform/terraform/functions.tf
+++ b/platform/terraform/functions.tf
@@ -258,7 +258,7 @@ module "content-fc-fa" {
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions,
     join_subnet_id      = data.azurerm_subnet.platform-subnet.id
-    allow_subnet_ids    = [
+    allow_subnet_ids = [
       data.azurerm_subnet.web-app-subnet.id,
       data.azurerm_subnet.load-test-subnet.id
     ]
@@ -294,7 +294,7 @@ module "local-authority-fc-fa" {
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions,
     join_subnet_id      = data.azurerm_subnet.platform-subnet.id
-    allow_subnet_ids    = [
+    allow_subnet_ids = [
       data.azurerm_subnet.web-app-subnet.id,
       data.azurerm_subnet.load-test-subnet.id
     ]
@@ -332,7 +332,7 @@ module "school-fc-fa" {
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions,
     join_subnet_id      = data.azurerm_subnet.platform-subnet.id
-    allow_subnet_ids    = [
+    allow_subnet_ids = [
       data.azurerm_subnet.web-app-subnet.id,
       data.azurerm_subnet.load-test-subnet.id
     ]
@@ -373,7 +373,7 @@ module "trust-fc-fa" {
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions,
     join_subnet_id      = data.azurerm_subnet.platform-subnet.id
-    allow_subnet_ids    = [
+    allow_subnet_ids = [
       data.azurerm_subnet.web-app-subnet.id,
       data.azurerm_subnet.load-test-subnet.id
     ]
@@ -411,7 +411,7 @@ module "benchmark-fc-fa" {
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions,
     join_subnet_id      = data.azurerm_subnet.platform-subnet.id
-    allow_subnet_ids    = [
+    allow_subnet_ids = [
       data.azurerm_subnet.web-app-subnet.id,
       data.azurerm_subnet.load-test-subnet.id
     ]
@@ -447,7 +447,7 @@ module "insight-fc-fa" {
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions,
     join_subnet_id      = data.azurerm_subnet.platform-subnet.id
-    allow_subnet_ids    = [
+    allow_subnet_ids = [
       data.azurerm_subnet.web-app-subnet.id,
       data.azurerm_subnet.load-test-subnet.id
     ]
@@ -486,7 +486,7 @@ module "maintenance-tasks-fc-fa" {
   networking = {
     enable_restrictions = false,
     join_subnet_id      = data.azurerm_subnet.platform-subnet.id
-    allow_subnet_ids    = [ data.azurerm_subnet.web-app-subnet.id ]
+    allow_subnet_ids    = [data.azurerm_subnet.web-app-subnet.id]
   }
 
   identity = {
@@ -517,7 +517,7 @@ module "chart-rendering-fc-fa" {
   networking = {
     enable_restrictions = module.config.enable_ip_restrictions,
     join_subnet_id      = data.azurerm_subnet.platform-subnet.id
-    allow_subnet_ids    = [
+    allow_subnet_ids = [
       data.azurerm_subnet.web-app-subnet.id,
       data.azurerm_subnet.load-test-subnet.id
     ]

--- a/platform/terraform/modules/config/main.tf
+++ b/platform/terraform/modules/config/main.tf
@@ -39,7 +39,7 @@ variable "env_configs" {
       search                 = { sku = "basic", replica_count = 1 }
       sql                    = { telemetry_enabled = true }
       cache                  = { sku = "Basic", capacity = 1, family = "C" }
-      enable_ip_restrictions = true
+      enable_ip_restrictions = false
     }
     pre-production = {
       search                 = { sku = "basic", replica_count = 1 }

--- a/platform/terraform/modules/config/main.tf
+++ b/platform/terraform/modules/config/main.tf
@@ -39,7 +39,7 @@ variable "env_configs" {
       search                 = { sku = "basic", replica_count = 1 }
       sql                    = { telemetry_enabled = true }
       cache                  = { sku = "Basic", capacity = 1, family = "C" }
-      enable_ip_restrictions = false
+      enable_ip_restrictions = true
     }
     pre-production = {
       search                 = { sku = "basic", replica_count = 1 }

--- a/platform/terraform/modules/fc_function_app/locals.tf
+++ b/platform/terraform/modules/fc_function_app/locals.tf
@@ -19,7 +19,7 @@ locals {
   host = "https://${azurerm_function_app_flex_consumption.func-app.default_hostname}"
 
   ip_default_action = var.networking.enable_restrictions ? "Deny" : "Allow"
-  ip_restrictions   = var.networking.enable_restrictions ? var.networking.subnet_ids : []
+  ip_restrictions   = var.networking.enable_restrictions ? var.networking.allow_subnet_ids : []
 
   redis_contributor_count = var.redis_cache.contributor ? 1 : 0
   redis_owner_count       = var.redis_cache.owner ? 1 : 0

--- a/platform/terraform/modules/fc_function_app/main.tf
+++ b/platform/terraform/modules/fc_function_app/main.tf
@@ -301,7 +301,7 @@ resource "azurerm_monitor_diagnostic_setting" "func-app-service" {
   }
 }
 
-# join the func app onto the platform subnet
+# join the func app onto the required vnet
 resource "azurerm_app_service_virtual_network_swift_connection" "func-app-subnet" {
   app_service_id = azurerm_function_app_flex_consumption.func-app.id
   subnet_id      = var.networking.join_subnet_id

--- a/platform/terraform/modules/fc_function_app/main.tf
+++ b/platform/terraform/modules/fc_function_app/main.tf
@@ -226,6 +226,10 @@ resource "azurerm_function_app_flex_consumption" "func-app" {
   app_settings = local.function-app-settings
   tags         = var.core.tags
 
+  lifecycle {
+    ignore_changes = [virtual_network_subnet_id]
+  }
+
   depends_on = [
     azurerm_role_assignment.storage-data-owner
   ]
@@ -295,4 +299,10 @@ resource "azurerm_monitor_diagnostic_setting" "func-app-service" {
   enabled_metric {
     category = "AllMetrics"
   }
+}
+
+# join the func app onto the platform subnet
+resource "azurerm_app_service_virtual_network_swift_connection" "func-app-subnet" {
+  app_service_id = azurerm_function_app_flex_consumption.func-app.id
+  subnet_id      = var.networking.subnet_id
 }

--- a/platform/terraform/modules/fc_function_app/main.tf
+++ b/platform/terraform/modules/fc_function_app/main.tf
@@ -304,5 +304,5 @@ resource "azurerm_monitor_diagnostic_setting" "func-app-service" {
 # join the func app onto the platform subnet
 resource "azurerm_app_service_virtual_network_swift_connection" "func-app-subnet" {
   app_service_id = azurerm_function_app_flex_consumption.func-app.id
-  subnet_id      = var.networking.subnet_id
+  subnet_id      = var.networking.join_subnet_id
 }

--- a/platform/terraform/modules/fc_function_app/variables.tf
+++ b/platform/terraform/modules/fc_function_app/variables.tf
@@ -46,7 +46,8 @@ variable "service_plan" {
 variable "networking" {
   type = object({
     enable_restrictions = bool
-    subnet_id           = string
+    allow_subnet_ids    = list(string)
+    join_subnet_id      = string
   })
 }
 

--- a/platform/terraform/modules/fc_function_app/variables.tf
+++ b/platform/terraform/modules/fc_function_app/variables.tf
@@ -46,7 +46,7 @@ variable "service_plan" {
 variable "networking" {
   type = object({
     enable_restrictions = bool
-    subnet_ids          = list(string)
+    subnet_id           = string
   })
 }
 

--- a/platform/terraform/modules/function_app/main.tf
+++ b/platform/terraform/modules/function_app/main.tf
@@ -235,3 +235,10 @@ resource "azurerm_monitor_diagnostic_setting" "func-app-service" {
     category = "AllMetrics"
   }
 }
+
+# conditionally join the func app onto a vnet
+resource "azurerm_app_service_virtual_network_swift_connection" "func-app-subnet" {
+  count          = var.networking.join_subnet_id == "" ? 0 : 1
+  app_service_id = local.func_app_id
+  subnet_id      = var.networking.join_subnet_id
+}

--- a/platform/terraform/modules/function_app/variables.tf
+++ b/platform/terraform/modules/function_app/variables.tf
@@ -40,6 +40,7 @@ variable "networking" {
   type = object({
     enable_restrictions = bool
     subnet_ids          = list(string)
+    join_subnet_id      = optional(string, "")
   })
 }
 


### PR DESCRIPTION
## 🧾 Summary
> Briefly describe the changes and why they are needed.

This PR joins platform API function apps to the app service virtual network

[AB#316772](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/316772)
[AB#317228](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/317228)

### ✨ Feature Details
> - **Functionality:**
>    - Joins the new flex consumption function apps to the app service virtual network via the platform subnet
>    - Joins the existing orchestrator function app to a new dedicated subnet of the app service vnet
> - **Implementation:** The terraform resource `azurerm_app_service_virtual_network_swift_connection` is used to join the function apps to the vnet.  For completeness the `virtual_network_subnet_id` is added to `ignore_changes` on the function app itself, to avoid update loops.  A delegation for `Microsoft.App/environments` is added to the platform subnet.  A new optional subnet id variable is added to the variables of the functions module, to allow non-flex consumption func apps to be joined to a vnet, which is used to join the orchestrator.

## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [ ] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes
> Add any additional context for reviewers, required dependencies, or specific testing instructions.

Tested with deployment to feature environment d14