### PR TITLE
feat: Add `runUntil` option to data pipeline start message for partial runs

### DIFF
--- a/data-pipeline/README.md
+++ b/data-pipeline/README.md
@@ -110,9 +110,13 @@ To run the pipeline locally, follow these steps:
             "cfr": <year>,
             "bfr": <year>,
             "s251": <year>
-        }
+        },
+        "runUntil": "comparators"
     }
     ```
+
+    > **Note:** The `runUntil` parameter is optional. Allowed values are `"transparency-file"`, `"pre-processing"`, or `"comparators"` to stop the pipeline early after the specified stage. Omitting the parameter will run the pipeline to completion (full run).
+
 
 ### Testing locally
 

--- a/data-pipeline/README.md
+++ b/data-pipeline/README.md
@@ -117,7 +117,6 @@ To run the pipeline locally, follow these steps:
 
     > **Note:** The `runUntil` parameter is optional. Allowed values are `"transparency-file"`, `"pre-processing"`, or `"comparators"` to stop the pipeline early after the specified stage. Omitting the parameter will run the pipeline to completion (full run).
 
-
 ### Testing locally
 
 Once the environment is set up as above, and you can successfully run the pipeline it is possible to run the unit and e2e tests locally.

--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -16,7 +16,13 @@ from pipeline.comparator_sets import run_comparator_sets_pipeline
 from pipeline.pre_processing import pre_process_custom_data, pre_process_data
 from pipeline.rag import run_rag_pipeline, run_user_defined_rag_pipeline
 from pipeline.utils.log import setup_logger
-from pipeline.utils.message import MessageType, get_message_type, get_run_until, PipelineEarlyExit, check_run_until_gate
+from pipeline.utils.message import (
+    MessageType,
+    PipelineEarlyExit,
+    check_run_until_gate,
+    get_message_type,
+    get_run_until,
+)
 from pipeline.utils.storage import (
     complete_queue_name,
     connect_to_queue,

--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -16,7 +16,7 @@ from pipeline.comparator_sets import run_comparator_sets_pipeline
 from pipeline.pre_processing import pre_process_custom_data, pre_process_data
 from pipeline.rag import run_rag_pipeline, run_user_defined_rag_pipeline
 from pipeline.utils.log import setup_logger
-from pipeline.utils.message import MessageType, get_message_type
+from pipeline.utils.message import MessageType, get_message_type, get_run_until, PipelineEarlyExit, check_run_until_gate
 from pipeline.utils.storage import (
     complete_queue_name,
     connect_to_queue,
@@ -55,13 +55,7 @@ def handle_msg(
             case MessageType.Default:
                 logger.info("Starting default pipeline run...")
                 stats_collector.start_pipeline_run()
-                run_until = msg_payload.get("runUntil")
-                if run_until is not None:
-                    allowed_values = {"transparency-file", "pre-processing", "comparators"}
-                    if run_until not in allowed_values:
-                        raise ValueError(
-                            f"Invalid runUntil value: '{run_until}'. Must be one of {allowed_values}"
-                        )
+                run_until = get_run_until(msg_payload.get("runUntil", None))
 
                 msg_payload["pre_process_duration"] = pre_process_data(
                     run_id=str(msg_payload["runId"]),
@@ -71,17 +65,13 @@ def handle_msg(
                     s251_year=msg_payload["year"]["s251"],
                     run_until=run_until,
                 )
-                if run_until == "pre-processing":
-                    logger.info("runUntil is set to pre-processing. Stopping execution.")
-                    raise Exception("Pipeline stopped after pre-processing as requested by runUntil.")
+                check_run_until_gate("pre-processing", run_until)
 
                 msg_payload["comparator_set_duration"] = run_comparator_sets_pipeline(
                     run_type=run_type,
                     run_id=str(msg_payload["runId"]),
                 )
-                if run_until == "comparators":
-                    logger.info("runUntil is set to comparators. Stopping execution.")
-                    raise Exception("Pipeline stopped after comparators as requested by runUntil.")
+                check_run_until_gate("comparators", run_until)
 
                 msg_payload["rag_duration"] = run_rag_pipeline(
                     run_type=run_type,
@@ -124,6 +114,9 @@ def handle_msg(
                 msg_payload["stats"] = stats_collector.get_stats()
                 logger.info("Custom pipeline run completed!")
 
+        msg_payload["success"] = True
+    except PipelineEarlyExit as exit_info:
+        logger.info(f"Pipeline stopped early: {exit_info}")
         msg_payload["success"] = True
     except Exception as error:
         logger.exception(

--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -21,7 +21,7 @@ from pipeline.utils.message import (
     PipelineEarlyExit,
     check_run_until_gate,
     get_message_type,
-    get_run_until,
+    validate_run_until,
 )
 from pipeline.utils.storage import (
     complete_queue_name,
@@ -61,7 +61,7 @@ def handle_msg(
             case MessageType.Default:
                 logger.info("Starting default pipeline run...")
                 stats_collector.start_pipeline_run()
-                run_until = get_run_until(msg_payload.get("runUntil", None))
+                run_until = validate_run_until(msg_payload.get("runUntil", None))
 
                 msg_payload["pre_process_duration"] = pre_process_data(
                     run_id=str(msg_payload["runId"]),

--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -55,17 +55,34 @@ def handle_msg(
             case MessageType.Default:
                 logger.info("Starting default pipeline run...")
                 stats_collector.start_pipeline_run()
+                run_until = msg_payload.get("runUntil")
+                if run_until is not None:
+                    allowed_values = {"transparency-file", "pre-processing", "comparators"}
+                    if run_until not in allowed_values:
+                        raise ValueError(
+                            f"Invalid runUntil value: '{run_until}'. Must be one of {allowed_values}"
+                        )
+
                 msg_payload["pre_process_duration"] = pre_process_data(
                     run_id=str(msg_payload["runId"]),
                     aar_year=msg_payload["year"]["aar"],
                     cfr_year=msg_payload["year"]["cfr"],
                     bfr_year=msg_payload["year"]["bfr"],
                     s251_year=msg_payload["year"]["s251"],
+                    run_until=run_until,
                 )
+                if run_until == "pre-processing":
+                    logger.info("runUntil is set to pre-processing. Stopping execution.")
+                    raise Exception("Pipeline stopped after pre-processing as requested by runUntil.")
+
                 msg_payload["comparator_set_duration"] = run_comparator_sets_pipeline(
                     run_type=run_type,
                     run_id=str(msg_payload["runId"]),
                 )
+                if run_until == "comparators":
+                    logger.info("runUntil is set to comparators. Stopping execution.")
+                    raise Exception("Pipeline stopped after comparators as requested by runUntil.")
+
                 msg_payload["rag_duration"] = run_rag_pipeline(
                     run_type=run_type,
                     run_id=str(msg_payload["runId"]),

--- a/data-pipeline/src/pipeline/pre_processing/main.py
+++ b/data-pipeline/src/pipeline/pre_processing/main.py
@@ -19,6 +19,7 @@ from pipeline.utils.database import (
 from pipeline.utils.log import setup_logger
 from pipeline.utils.stats import stats_collector
 from pipeline.utils.storage import get_blob, raw_container, try_get_blob, write_blob
+from pipeline.utils.message import check_run_until_gate
 
 from .aar.academies import build_academy_data, map_academy_data
 from .aar.trusts import build_trust_data
@@ -296,9 +297,7 @@ def pre_process_maintained_schools_data(
             master_list.to_csv(encoding="cp1252", index=False),
         )
 
-    if run_until == "transparency-file":
-        logger.info("runUntil is set to transparency-file. Stopping execution.")
-        raise Exception("Pipeline stopped after transparency-file generation as requested by runUntil.")
+    check_run_until_gate("transparency-file", run_until)
 
     maintained_schools_data = get_blob(
         raw_container,

--- a/data-pipeline/src/pipeline/pre_processing/main.py
+++ b/data-pipeline/src/pipeline/pre_processing/main.py
@@ -1,5 +1,5 @@
 import time
-from typing import Mapping
+from typing import Mapping, Optional
 
 import pandas as pd
 
@@ -59,6 +59,7 @@ def pre_process_data(
     cfr_year: int,
     bfr_year: int,
     s251_year: int,
+    run_until: Optional[str] = None,
 ):
     """
     Process data necessary for Academies, Maintained Schools BFR and Trusts.
@@ -79,6 +80,7 @@ def pre_process_data(
     :param cfr_year: Maintained School financial year/source
     :param bfr_year: BFR year/source
     :param s251_year: Section 251 year/source
+    :param run_until: optional stage at which to stop execution
     :return: duration of processing
     """
     run_type = "default"
@@ -105,6 +107,7 @@ def pre_process_data(
         cfr_year,
         maintained_data_ref,
         maintained_data_ref_for_last_year,
+        run_until=run_until,
     )
     stats_collector.collect_aar_academy_counts(academies, aar_year)
     stats_collector.collect_cfr_la_maintained_school_counts(
@@ -255,6 +258,7 @@ def pre_process_maintained_schools_data(
     year: int,
     cfr_ancillary_data: Mapping,
     cfr_ancillary_data_for_last_year: Mapping,
+    run_until: Optional[str] = None,
 ) -> pd.DataFrame:
     logger.info("Building Maintained School Set")
     logger.info(f"Processing CFR data - {run_id} - {year}.")
@@ -291,6 +295,10 @@ def pre_process_maintained_schools_data(
             f"{run_type}/{year}/maintained_schools_master_list.csv",
             master_list.to_csv(encoding="cp1252", index=False),
         )
+
+    if run_until == "transparency-file":
+        logger.info("runUntil is set to transparency-file. Stopping execution.")
+        raise Exception("Pipeline stopped after transparency-file generation as requested by runUntil.")
 
     maintained_schools_data = get_blob(
         raw_container,

--- a/data-pipeline/src/pipeline/pre_processing/main.py
+++ b/data-pipeline/src/pipeline/pre_processing/main.py
@@ -17,9 +17,9 @@ from pipeline.utils.database import (
     insert_trusts,
 )
 from pipeline.utils.log import setup_logger
+from pipeline.utils.message import check_run_until_gate
 from pipeline.utils.stats import stats_collector
 from pipeline.utils.storage import get_blob, raw_container, try_get_blob, write_blob
-from pipeline.utils.message import check_run_until_gate
 
 from .aar.academies import build_academy_data, map_academy_data
 from .aar.trusts import build_trust_data
@@ -95,7 +95,7 @@ def pre_process_data(
     maintained_data_ref_for_last_year = (
         get_cfr_ancillary_data(run_id, (cfr_year - 1)) if cfr_year >= 2025 else {}
     )
-    
+
     academies = pre_process_academies_data(
         run_type,
         run_id,

--- a/data-pipeline/src/pipeline/utils/message.py
+++ b/data-pipeline/src/pipeline/utils/message.py
@@ -1,4 +1,5 @@
 from enum import Enum, auto
+from typing import Literal
 
 from .log import setup_logger
 
@@ -154,3 +155,30 @@ def get_message_type(message: dict) -> MessageType:
             return MessageType.Custom
         case _:
             return MessageType.Default
+
+
+def get_run_until(run_until) -> None | Literal["transparency-file", "pre-processing", "comparators"]:
+    """runUntil should be one of the 3 allowed gates, or absent to run the full pipeline"""
+    if run_until is not None:
+        allowed_values = {"transparency-file", "pre-processing", "comparators"}
+        if run_until not in allowed_values:
+            raise ValueError(
+                f"Invalid runUntil value: '{run_until}'. Must be one of {allowed_values}"
+            )
+    return run_until
+
+
+class PipelineEarlyExit(Exception):
+    """Raised when the pipeline exits early at a requested runUntil gate."""
+    pass
+
+
+def check_run_until_gate(
+    current_gate: Literal["transparency-file", "pre-processing", "comparators"],
+    target_gate: None | Literal["transparency-file", "pre-processing", "comparators"],
+) -> None:
+    if target_gate == current_gate:
+        logger.info(f"runUntil is set to '{current_gate}'. Stopping execution.")
+        raise PipelineEarlyExit(
+            f"Pipeline stopped after {current_gate} as requested by runUntil."
+        )

--- a/data-pipeline/src/pipeline/utils/message.py
+++ b/data-pipeline/src/pipeline/utils/message.py
@@ -157,7 +157,9 @@ def get_message_type(message: dict) -> MessageType:
             return MessageType.Default
 
 
-def get_run_until(run_until) -> None | Literal["transparency-file", "pre-processing", "comparators"]:
+def get_run_until(
+    run_until,
+) -> None | Literal["transparency-file", "pre-processing", "comparators"]:
     """runUntil should be one of the 3 allowed gates, or absent to run the full pipeline"""
     if run_until is not None:
         allowed_values = {"transparency-file", "pre-processing", "comparators"}
@@ -170,6 +172,7 @@ def get_run_until(run_until) -> None | Literal["transparency-file", "pre-process
 
 class PipelineEarlyExit(Exception):
     """Raised when the pipeline exits early at a requested runUntil gate."""
+
     pass
 
 

--- a/data-pipeline/src/pipeline/utils/message.py
+++ b/data-pipeline/src/pipeline/utils/message.py
@@ -157,7 +157,7 @@ def get_message_type(message: dict) -> MessageType:
             return MessageType.Default
 
 
-def get_run_until(
+def validate_run_until(
     run_until,
 ) -> None | Literal["transparency-file", "pre-processing", "comparators"]:
     """runUntil should be one of the 3 allowed gates, or absent to run the full pipeline"""

--- a/data-pipeline/tests/unit/test_main_run_until.py
+++ b/data-pipeline/tests/unit/test_main_run_until.py
@@ -11,13 +11,8 @@ def test_handle_msg_invalid_run_until():
     # Arrange
     msg_payload = {
         "runId": 2023,
-        "year": {
-            "aar": 2022,
-            "cfr": 2023,
-            "bfr": 2022,
-            "s251": 2021
-        },
-        "runUntil": "invalid-stage"
+        "year": {"aar": 2022, "cfr": 2023, "bfr": 2022, "s251": 2021},
+        "runUntil": "invalid-stage",
     }
 
     mock_msg = MagicMock(spec=QueueMessage)
@@ -41,17 +36,14 @@ def test_handle_msg_invalid_run_until():
 @patch("pipeline.main.pre_process_data")
 @patch("pipeline.main.run_comparator_sets_pipeline")
 @patch("pipeline.main.run_rag_pipeline")
-def test_handle_msg_run_until_preprocessing(mock_rag, mock_comparators, mock_pre_process):
+def test_handle_msg_run_until_preprocessing(
+    mock_rag, mock_comparators, mock_pre_process
+):
     # Arrange
     msg_payload = {
         "runId": 2023,
-        "year": {
-            "aar": 2022,
-            "cfr": 2023,
-            "bfr": 2022,
-            "s251": 2021
-        },
-        "runUntil": "pre-processing"
+        "year": {"aar": 2022, "cfr": 2023, "bfr": 2022, "s251": 2021},
+        "runUntil": "pre-processing",
     }
 
     mock_msg = MagicMock(spec=QueueMessage)
@@ -75,7 +67,7 @@ def test_handle_msg_run_until_preprocessing(mock_rag, mock_comparators, mock_pre
         cfr_year=2023,
         bfr_year=2022,
         s251_year=2021,
-        run_until="pre-processing"
+        run_until="pre-processing",
     )
     # RAG and Comparators should NOT be called
     mock_comparators.assert_not_called()
@@ -94,13 +86,8 @@ def test_handle_msg_run_until_comparators(mock_rag, mock_comparators, mock_pre_p
     # Arrange
     msg_payload = {
         "runId": 2023,
-        "year": {
-            "aar": 2022,
-            "cfr": 2023,
-            "bfr": 2022,
-            "s251": 2021
-        },
-        "runUntil": "comparators"
+        "year": {"aar": 2022, "cfr": 2023, "bfr": 2022, "s251": 2021},
+        "runUntil": "comparators",
     }
 
     mock_msg = MagicMock(spec=QueueMessage)
@@ -137,12 +124,7 @@ def test_handle_msg_normal_execution(mock_rag, mock_comparators, mock_pre_proces
     # Arrange
     msg_payload = {
         "runId": 2023,
-        "year": {
-            "aar": 2022,
-            "cfr": 2023,
-            "bfr": 2022,
-            "s251": 2021
-        }
+        "year": {"aar": 2022, "cfr": 2023, "bfr": 2022, "s251": 2021},
     }
 
     mock_msg = MagicMock(spec=QueueMessage)

--- a/data-pipeline/tests/unit/test_main_run_until.py
+++ b/data-pipeline/tests/unit/test_main_run_until.py
@@ -66,8 +66,8 @@ def test_handle_msg_run_until_preprocessing(mock_rag, mock_comparators, mock_pre
     result = handle_msg(mock_msg, mock_worker_queue, mock_complete_queue)
 
     # Assert
-    assert result["success"] is False
-    assert "Pipeline stopped after pre-processing as requested by runUntil." in result["error"]
+    assert result["success"] is True
+    assert "error" not in result
 
     mock_pre_process.assert_called_once_with(
         run_id="2023",
@@ -116,8 +116,8 @@ def test_handle_msg_run_until_comparators(mock_rag, mock_comparators, mock_pre_p
     result = handle_msg(mock_msg, mock_worker_queue, mock_complete_queue)
 
     # Assert
-    assert result["success"] is False
-    assert "Pipeline stopped after comparators as requested by runUntil." in result["error"]
+    assert result["success"] is True
+    assert "error" not in result
 
     mock_pre_process.assert_called_once()
     mock_comparators.assert_called_once()

--- a/data-pipeline/tests/unit/test_main_run_until.py
+++ b/data-pipeline/tests/unit/test_main_run_until.py
@@ -1,0 +1,172 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from azure.storage.queue import QueueMessage
+
+from pipeline.main import handle_msg
+
+
+def test_handle_msg_invalid_run_until():
+    # Arrange
+    msg_payload = {
+        "runId": 2023,
+        "year": {
+            "aar": 2022,
+            "cfr": 2023,
+            "bfr": 2022,
+            "s251": 2021
+        },
+        "runUntil": "invalid-stage"
+    }
+
+    mock_msg = MagicMock(spec=QueueMessage)
+    mock_msg.content = json.dumps(msg_payload)
+
+    mock_worker_queue = MagicMock()
+    mock_complete_queue = MagicMock()
+
+    # Act
+    result = handle_msg(mock_msg, mock_worker_queue, mock_complete_queue)
+
+    # Assert
+    assert result["success"] is False
+    assert "Invalid runUntil value: 'invalid-stage'" in result["error"]
+    # Verify that worker queue message is still deleted
+    mock_worker_queue.delete_message.assert_called_once_with(mock_msg)
+    # Since any error inside handle_msg goes through the standard error path, a failure message is sent
+    mock_complete_queue.send_message.assert_called_once()
+
+
+@patch("pipeline.main.pre_process_data")
+@patch("pipeline.main.run_comparator_sets_pipeline")
+@patch("pipeline.main.run_rag_pipeline")
+def test_handle_msg_run_until_preprocessing(mock_rag, mock_comparators, mock_pre_process):
+    # Arrange
+    msg_payload = {
+        "runId": 2023,
+        "year": {
+            "aar": 2022,
+            "cfr": 2023,
+            "bfr": 2022,
+            "s251": 2021
+        },
+        "runUntil": "pre-processing"
+    }
+
+    mock_msg = MagicMock(spec=QueueMessage)
+    mock_msg.content = json.dumps(msg_payload)
+
+    mock_worker_queue = MagicMock()
+    mock_complete_queue = MagicMock()
+
+    mock_pre_process.return_value = 10.0
+
+    # Act
+    result = handle_msg(mock_msg, mock_worker_queue, mock_complete_queue)
+
+    # Assert
+    assert result["success"] is False
+    assert "Pipeline stopped after pre-processing as requested by runUntil." in result["error"]
+
+    mock_pre_process.assert_called_once_with(
+        run_id="2023",
+        aar_year=2022,
+        cfr_year=2023,
+        bfr_year=2022,
+        s251_year=2021,
+        run_until="pre-processing"
+    )
+    # RAG and Comparators should NOT be called
+    mock_comparators.assert_not_called()
+    mock_rag.assert_not_called()
+
+    # Message should be deleted from worker queue
+    mock_worker_queue.delete_message.assert_called_once_with(mock_msg)
+    # Complete queue failure message should be sent
+    mock_complete_queue.send_message.assert_called_once()
+
+
+@patch("pipeline.main.pre_process_data")
+@patch("pipeline.main.run_comparator_sets_pipeline")
+@patch("pipeline.main.run_rag_pipeline")
+def test_handle_msg_run_until_comparators(mock_rag, mock_comparators, mock_pre_process):
+    # Arrange
+    msg_payload = {
+        "runId": 2023,
+        "year": {
+            "aar": 2022,
+            "cfr": 2023,
+            "bfr": 2022,
+            "s251": 2021
+        },
+        "runUntil": "comparators"
+    }
+
+    mock_msg = MagicMock(spec=QueueMessage)
+    mock_msg.content = json.dumps(msg_payload)
+
+    mock_worker_queue = MagicMock()
+    mock_complete_queue = MagicMock()
+
+    mock_pre_process.return_value = 10.0
+    mock_comparators.return_value = 5.0
+
+    # Act
+    result = handle_msg(mock_msg, mock_worker_queue, mock_complete_queue)
+
+    # Assert
+    assert result["success"] is False
+    assert "Pipeline stopped after comparators as requested by runUntil." in result["error"]
+
+    mock_pre_process.assert_called_once()
+    mock_comparators.assert_called_once()
+    # RAG should NOT be called
+    mock_rag.assert_not_called()
+
+    # Message should be deleted from worker queue
+    mock_worker_queue.delete_message.assert_called_once_with(mock_msg)
+    # Complete queue failure message should be sent
+    mock_complete_queue.send_message.assert_called_once()
+
+
+@patch("pipeline.main.pre_process_data")
+@patch("pipeline.main.run_comparator_sets_pipeline")
+@patch("pipeline.main.run_rag_pipeline")
+def test_handle_msg_normal_execution(mock_rag, mock_comparators, mock_pre_process):
+    # Arrange
+    msg_payload = {
+        "runId": 2023,
+        "year": {
+            "aar": 2022,
+            "cfr": 2023,
+            "bfr": 2022,
+            "s251": 2021
+        }
+    }
+
+    mock_msg = MagicMock(spec=QueueMessage)
+    mock_msg.content = json.dumps(msg_payload)
+
+    mock_worker_queue = MagicMock()
+    mock_complete_queue = MagicMock()
+
+    mock_pre_process.return_value = 10.0
+    mock_comparators.return_value = 5.0
+    mock_rag.return_value = 8.0
+
+    # Act
+    result = handle_msg(mock_msg, mock_worker_queue, mock_complete_queue)
+
+    # Assert
+    assert result["success"] is True
+    assert "error" not in result
+
+    mock_pre_process.assert_called_once()
+    mock_comparators.assert_called_once()
+    mock_rag.assert_called_once()
+
+    # Message should be deleted from worker queue
+    mock_worker_queue.delete_message.assert_called_once_with(mock_msg)
+    # Complete queue message SHOULD be sent because runUntil is NOT in the payload!
+    mock_complete_queue.send_message.assert_called_once()

--- a/data-pipeline/tests/unit/utils/test_message.py
+++ b/data-pipeline/tests/unit/utils/test_message.py
@@ -2,9 +2,9 @@ import pytest
 
 from pipeline.utils.message import (
     MessageType,
-    get_message_type,
     PipelineEarlyExit,
     check_run_until_gate,
+    get_message_type,
 )
 
 
@@ -25,7 +25,9 @@ def test_message(body: dict, expected: MessageType):
 def test_check_run_until_gate_matches():
     with pytest.raises(PipelineEarlyExit) as exc_info:
         check_run_until_gate("pre-processing", "pre-processing")
-    assert "Pipeline stopped after pre-processing as requested by runUntil." in str(exc_info.value)
+    assert "Pipeline stopped after pre-processing as requested by runUntil." in str(
+        exc_info.value
+    )
 
 
 def test_check_run_until_gate_different():

--- a/data-pipeline/tests/unit/utils/test_message.py
+++ b/data-pipeline/tests/unit/utils/test_message.py
@@ -1,6 +1,11 @@
 import pytest
 
-from pipeline.utils.message import MessageType, get_message_type
+from pipeline.utils.message import (
+    MessageType,
+    get_message_type,
+    PipelineEarlyExit,
+    check_run_until_gate,
+)
 
 
 @pytest.mark.parametrize(
@@ -15,3 +20,19 @@ def test_message(body: dict, expected: MessageType):
     result = get_message_type(message=body)
 
     assert result == expected
+
+
+def test_check_run_until_gate_matches():
+    with pytest.raises(PipelineEarlyExit) as exc_info:
+        check_run_until_gate("pre-processing", "pre-processing")
+    assert "Pipeline stopped after pre-processing as requested by runUntil." in str(exc_info.value)
+
+
+def test_check_run_until_gate_different():
+    # Should not raise any exception
+    check_run_until_gate("pre-processing", "comparators")
+
+
+def test_check_run_until_gate_none():
+    # Should not raise any exception
+    check_run_until_gate("pre-processing", None)

--- a/documentation/data/05_Releases.md
+++ b/documentation/data/05_Releases.md
@@ -64,9 +64,12 @@ Once the respective data has been loaded to the Azure Storage Container, the pip
         "cfr": <YYYY>,
         "bfr": <YYYY>,
         "s251": <YYYY>
-    }
+    },
+    "runUntil": "transparency-file"
 }
  ```
+
+> **Note:** The `runUntil` parameter is optional. Allowed values are `"transparency-file"`, `"pre-processing"`, or `"comparators"` to stop the pipeline early after the specified stage. Omitting the parameter will run the pipeline to completion (full run).
 
 where `<YYYY>` is to be replaced by the respective submission year, for example, for `2022-2023`, `<YYYY>` would take the value of `2023`. Ensure that `Store As` is assigned as `Plain UTF-8`, and set the `Time to live` value to `Expire in` with some period, e.g. 1 Day. Click `OK` to queue the message. This should then be picked up and the pipeline executed. You can monitor the pipeline in the respective Application Insights logs through the Azure portal.
 

--- a/documentation/data/05_Releases.md
+++ b/documentation/data/05_Releases.md
@@ -65,7 +65,7 @@ Once the respective data has been loaded to the Azure Storage Container, the pip
         "bfr": <YYYY>,
         "s251": <YYYY>
     },
-    "runUntil": "transparency-file"
+    "runUntil": "<runUntilValue>"
 }
  ```
 

--- a/documentation/guides/data-release-guide/01_Overview.md
+++ b/documentation/guides/data-release-guide/01_Overview.md
@@ -76,9 +76,12 @@ To trigger a pipeline run once data is prepared, add a message to the `data-pipe
     "cfr": <year>,
     "bfr": <year>,
     "s251": <year>
-  }
+  },
+  "runUntil": "transparency-file"
 }
 ```
+
+> **Note:** The `runUntil` parameter is optional. Allowed values are `"transparency-file"`, `"pre-processing"`, or `"comparators"` to stop the pipeline early after the specified stage. Omitting the parameter will run the pipeline to completion (full run).
 
 ### What year to use in data pipeline runs
 

--- a/documentation/guides/data-release-guide/01_Overview.md
+++ b/documentation/guides/data-release-guide/01_Overview.md
@@ -77,7 +77,7 @@ To trigger a pipeline run once data is prepared, add a message to the `data-pipe
     "bfr": <year>,
     "s251": <year>
   },
-  "runUntil": "transparency-file"
+  "runUntil": "<runUntilValue>"
 }
 ```
 


### PR DESCRIPTION
## 🧾 Summary
Add an optional parameter to the default pipeline run message `runUntil` to allow partial runs of the pipeline. You can now partially run the pipeline to the stage of:

* Transparency file generation (at the moment just CFR)
* Preprocessing
* Comparator sets

RAG is the last step of the pipeline, so omit the `runUntil` variable to run RAG.

[AB#323822](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/323822)
[AB#323600](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/323600)

Gemini helped me out with the tests, docs, and a review ♊ 

### ✨ Feature Details
> - **Functionality:** Allow for partial data pipeline runs
> - **Implementation:** Add and validate value of `runUntil`. Raise new custom exception `PipelineEarlyExit` to exit.

### 📚 Documentation Updates
> - **Changes:** Mention new pipeline parameter in developer documentation.

## ✅ Checklist
- [ ] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [ ] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes
> Add any additional context for reviewers, required dependencies, or specific testing instructions.
