### PR TITLE
feat: Add data pipeline `generateTransparencyFilesAndPrecursorFiles` flag

### DIFF
--- a/data-pipeline/README.md
+++ b/data-pipeline/README.md
@@ -111,11 +111,14 @@ To run the pipeline locally, follow these steps:
             "bfr": <year>,
             "s251": <year>
         },
-        "runUntil": "comparators"
+        "runUntil": <runUntilValue>,
+        "generateCFRTransparencyFile": <bool>,
     }
     ```
 
     > **Note:** The `runUntil` parameter is optional. Allowed values are `"transparency-file"`, `"pre-processing"`, or `"comparators"` to stop the pipeline early after the specified stage. Omitting the parameter will run the pipeline to completion (full run).
+
+    > **Note:** The `generateCFRTransparencyFile` parameter is an optional boolean defaulting to `false`. When set to `true`, the pipeline will regenerate the CFR transparency file (including Master List and Download File) from raw inputs during pre-processing. If omitted or set to `false`, the pipeline will skip generation and directly load the pre-existing master list.
 
 ### Testing locally
 

--- a/data-pipeline/README.md
+++ b/data-pipeline/README.md
@@ -112,13 +112,13 @@ To run the pipeline locally, follow these steps:
             "s251": <year>
         },
         "runUntil": <runUntilValue>,
-        "generateCFRTransparencyFile": <bool>
+        "generateTransparencyFilesAndPrecursorFiles": <bool>
     }
     ```
 
     > **Note:** The `runUntil` parameter is optional. Allowed values are `"transparency-file"`, `"pre-processing"`, or `"comparators"` to stop the pipeline early after the specified stage. Omitting the parameter will run the pipeline to completion (full run).
 
-    > **Note:** The `generateCFRTransparencyFile` parameter is an optional boolean defaulting to `false`. When set to `true`, the pipeline will regenerate the CFR transparency file (including Master List and Download File) from raw inputs during pre-processing. If omitted or set to `false`, the pipeline will skip generation and directly load the pre-existing master list.
+    > **Note:** The `generateTransparencyFilesAndPrecursorFiles` parameter is an optional boolean defaulting to `false`. When set to `true`, the pipeline will regenerate the CFR transparency file (including Master List and Download File) from raw inputs during pre-processing. If omitted or set to `false`, the pipeline will skip generation and directly load the pre-existing master list.
 
 ### Testing locally
 

--- a/data-pipeline/README.md
+++ b/data-pipeline/README.md
@@ -112,7 +112,7 @@ To run the pipeline locally, follow these steps:
             "s251": <year>
         },
         "runUntil": <runUntilValue>,
-        "generateCFRTransparencyFile": <bool>,
+        "generateCFRTransparencyFile": <bool>
     }
     ```
 

--- a/data-pipeline/src/pipeline/main.py
+++ b/data-pipeline/src/pipeline/main.py
@@ -17,11 +17,11 @@ from pipeline.pre_processing import pre_process_custom_data, pre_process_data
 from pipeline.rag import run_rag_pipeline, run_user_defined_rag_pipeline
 from pipeline.utils.log import setup_logger
 from pipeline.utils.message import (
+    DefaultMessage,
     MessageType,
     PipelineEarlyExit,
     check_run_until_gate,
     get_message_type,
-    validate_run_until,
 )
 from pipeline.utils.storage import (
     complete_queue_name,
@@ -61,27 +61,28 @@ def handle_msg(
             case MessageType.Default:
                 logger.info("Starting default pipeline run...")
                 stats_collector.start_pipeline_run()
-                run_until = validate_run_until(msg_payload.get("runUntil", None))
+                default_msg = DefaultMessage(msg_payload)
 
                 msg_payload["pre_process_duration"] = pre_process_data(
-                    run_id=str(msg_payload["runId"]),
-                    aar_year=msg_payload["year"]["aar"],
-                    cfr_year=msg_payload["year"]["cfr"],
-                    bfr_year=msg_payload["year"]["bfr"],
-                    s251_year=msg_payload["year"]["s251"],
-                    run_until=run_until,
+                    run_id=default_msg.run_id,
+                    aar_year=default_msg.aar_year,
+                    cfr_year=default_msg.cfr_year,
+                    bfr_year=default_msg.bfr_year,
+                    s251_year=default_msg.s251_year,
+                    run_until=default_msg.run_until,
+                    generate_cfr_transparency_file=default_msg.generate_cfr_transparency_file,
                 )
-                check_run_until_gate("pre-processing", run_until)
+                check_run_until_gate("pre-processing", default_msg.run_until)
 
                 msg_payload["comparator_set_duration"] = run_comparator_sets_pipeline(
                     run_type=run_type,
-                    run_id=str(msg_payload["runId"]),
+                    run_id=default_msg.run_id,
                 )
-                check_run_until_gate("comparators", run_until)
+                check_run_until_gate("comparators", default_msg.run_until)
 
                 msg_payload["rag_duration"] = run_rag_pipeline(
                     run_type=run_type,
-                    run_id=str(msg_payload["runId"]),
+                    run_id=default_msg.run_id,
                 )
                 msg_payload["stats"] = stats_collector.get_stats()
                 logger.info("Default pipeline run completed!")

--- a/data-pipeline/src/pipeline/pre_processing/cfr/transparency_file/generator.py
+++ b/data-pipeline/src/pipeline/pre_processing/cfr/transparency_file/generator.py
@@ -3,6 +3,7 @@ import io
 import pandas as pd
 
 from pipeline import input_schemas
+from pipeline.utils.log import setup_logger
 
 from .ancillary_data import build_federation_context
 from .financials import add_financials
@@ -11,6 +12,8 @@ from .formatting import (
     build_maintained_schools_master_list,
     build_sfb_maintained,
 )
+
+logger = setup_logger(__name__)
 
 
 def build_transparency_files(
@@ -31,12 +34,15 @@ def build_transparency_files(
     Coordinates the generation of the CFR transparency files (Master List and Download File).
     Replaces the legacy My_Step1.sql through My_Step5.sql execution.
     """
+    logger.info(f"Generating CFR transparency files for year {year}...")
 
     # 1. Read Raw CFR Data
     schema = input_schemas.cfr_raw_cols.get(year, input_schemas.cfr_raw_cols["default"])
     cfr_raw = pd.read_csv(cfr_raw_blob, usecols=schema.keys(), dtype=schema)
+    logger.info(f"Loaded raw CFR data. Shape: {cfr_raw.shape}")
 
     # 2. Add DNS rows for federations and join ancillary data
+    logger.info("Building federation context...")
     cfr_federations_with_context = build_federation_context(
         cfr_raw=cfr_raw,
         gias=gias,
@@ -51,17 +57,22 @@ def build_transparency_files(
         hospital_schools_last_year=hospital_schools_last_year,
         year=year,
     )
+    logger.info(f"Built federation context. Shape: {cfr_federations_with_context.shape}")
 
     # 3. Create additive columns
+    logger.info("Merging CFR raw data and adding financials...")
     cfr_raw_fin = cfr_raw.copy().rename(columns={"LEAEstab": "LAEstab"})
     merged = cfr_federations_with_context.merge(
         cfr_raw_fin, on="LAEstab", how="left", suffixes=("", "_raw")
     )
     mergedworking = add_financials(merged)
+    logger.info(f"Financials added. Merged working dataframe shape: {mergedworking.shape}")
 
     # 4. Format final dataframe for the transparency file and data pipeline
+    logger.info("Formatting final dataframes for SFB Maintained, Master List, and Download File...")
     sfb_maintained = build_sfb_maintained(mergedworking, lookup_la)
     master_list = build_maintained_schools_master_list(sfb_maintained)
     download_file = build_maintained_schools_download_file(sfb_maintained)
+    logger.info(f"Completed generating CFR transparency files for year {year}. ")
 
     return master_list, download_file

--- a/data-pipeline/src/pipeline/pre_processing/main.py
+++ b/data-pipeline/src/pipeline/pre_processing/main.py
@@ -61,6 +61,7 @@ def pre_process_data(
     bfr_year: int,
     s251_year: int,
     run_until: Optional[str] = None,
+    generate_cfr_transparency_file: bool = False,
 ):
     """
     Process data necessary for Academies, Maintained Schools BFR and Trusts.
@@ -82,6 +83,7 @@ def pre_process_data(
     :param bfr_year: BFR year/source
     :param s251_year: Section 251 year/source
     :param run_until: optional stage at which to stop execution
+    :param generate_cfr_transparency_file: whether to generate the CFR transparency file
     :return: duration of processing
     """
     run_type = "default"
@@ -93,7 +95,7 @@ def pre_process_data(
     maintained_data_ref = get_cfr_ancillary_data(run_id, cfr_year)
     # Last year's data is used as fallbacks for the CFR transparency file
     maintained_data_ref_for_last_year = (
-        get_cfr_ancillary_data(run_id, (cfr_year - 1)) if cfr_year >= 2025 else {}
+        get_cfr_ancillary_data(run_id, (cfr_year - 1)) if generate_cfr_transparency_file else {}
     )
 
     academies = pre_process_academies_data(
@@ -109,6 +111,7 @@ def pre_process_data(
         maintained_data_ref,
         maintained_data_ref_for_last_year,
         run_until=run_until,
+        generate_cfr_transparency_file=generate_cfr_transparency_file,
     )
     stats_collector.collect_aar_academy_counts(academies, aar_year)
     stats_collector.collect_cfr_la_maintained_school_counts(
@@ -260,12 +263,13 @@ def pre_process_maintained_schools_data(
     cfr_ancillary_data: Mapping,
     cfr_ancillary_data_for_last_year: Mapping,
     run_until: Optional[str] = None,
+    generate_cfr_transparency_file: bool = False,
 ) -> pd.DataFrame:
     logger.info("Building Maintained School Set")
     logger.info(f"Processing CFR data - {run_id} - {year}.")
 
-    # From 2025 we will generate the CFR transparency file from raw inputs
-    if year >= 2025:
+    # Generate the CFR transparency file from raw inputs if requested
+    if generate_cfr_transparency_file:
         cfr_raw_filename = cfr_raw_filenames.get(year)
         cfr_raw_blob = get_blob(raw_container, f"{run_type}/{year}/{cfr_raw_filename}")
         master_list, transparency_file = build_transparency_files(

--- a/data-pipeline/src/pipeline/utils/message.py
+++ b/data-pipeline/src/pipeline/utils/message.py
@@ -157,17 +157,59 @@ def get_message_type(message: dict) -> MessageType:
             return MessageType.Default
 
 
-def validate_run_until(
-    run_until,
-) -> None | Literal["transparency-file", "pre-processing", "comparators"]:
-    """runUntil should be one of the 3 allowed gates, or absent to run the full pipeline"""
-    if run_until is not None:
-        allowed_values = {"transparency-file", "pre-processing", "comparators"}
-        if run_until not in allowed_values:
+class DefaultMessage:
+    def __init__(self, payload: dict):
+        self.payload = payload
+
+        # 1. Validate runId
+        raw_run_id = payload.get("runId")
+        if raw_run_id is None or raw_run_id == "":
+            raise ValueError("runId is required for default pipeline runs")
+        self.run_id = str(raw_run_id)
+
+        # 2. Validate year dictionary structure
+        year_payload = payload.get("year", {})
+        if not isinstance(year_payload, dict):
+            raise ValueError("year must be a dictionary")
+
+        required_years = {"aar", "cfr", "bfr", "s251"}
+        missing_years = required_years - year_payload.keys()
+        if missing_years:
+            raise ValueError(f"Missing required years: {missing_years}")
+
+        try:
+            self.aar_year = int(year_payload["aar"])
+            self.cfr_year = int(year_payload["cfr"])
+            self.bfr_year = int(year_payload["bfr"])
+            self.s251_year = int(year_payload["s251"])
+        except (ValueError, TypeError) as e:
+            raise ValueError(f"Year fields must be integers: {e}")
+
+        # 3. Validate runUntil
+        self.run_until = self._validate_run_until(payload.get("runUntil"))
+
+        # 4. Validate generateCFRTransparencyFile
+        self.generate_cfr_transparency_file = self._validate_generate_cfr_transparency_file(
+            payload.get("generateCFRTransparencyFile", False)
+        )
+
+    def _validate_run_until(
+        self, run_until
+    ) -> None | Literal["transparency-file", "pre-processing", "comparators"]:
+        if run_until is not None:
+            allowed_values = {"transparency-file", "pre-processing", "comparators"}
+            if run_until not in allowed_values:
+                raise ValueError(
+                    f"Invalid runUntil value: '{run_until}'. Must be one of {allowed_values}"
+                )
+        return run_until
+
+    def _validate_generate_cfr_transparency_file(self, generate) -> bool:
+        if not isinstance(generate, bool):
             raise ValueError(
-                f"Invalid runUntil value: '{run_until}'. Must be one of {allowed_values}"
+                f"Invalid generateCFRTransparencyFile value: '{generate}'. Must be a boolean (True/False)."
             )
-    return run_until
+        return generate
 
 
 class PipelineEarlyExit(Exception):

--- a/data-pipeline/src/pipeline/utils/message.py
+++ b/data-pipeline/src/pipeline/utils/message.py
@@ -188,10 +188,10 @@ class DefaultMessage:
         # 3. Validate runUntil
         self.run_until = self._validate_run_until(payload.get("runUntil"))
 
-        # 4. Validate generateCFRTransparencyFile
+        # 4. Validate generateTransparencyFilesAndPrecursorFiles
         self.generate_cfr_transparency_file = (
             self._validate_generate_cfr_transparency_file(
-                payload.get("generateCFRTransparencyFile", False)
+                payload.get("generateTransparencyFilesAndPrecursorFiles", False)
             )
         )
 
@@ -209,7 +209,7 @@ class DefaultMessage:
     def _validate_generate_cfr_transparency_file(self, generate) -> bool:
         if not isinstance(generate, bool):
             raise ValueError(
-                f"Invalid generateCFRTransparencyFile value: '{generate}'. Must be a boolean (True/False)."
+                f"Invalid generateTransparencyFilesAndPrecursorFiles value: '{generate}'. Must be a boolean (True/False)."
             )
         return generate
 

--- a/data-pipeline/src/pipeline/utils/message.py
+++ b/data-pipeline/src/pipeline/utils/message.py
@@ -189,8 +189,10 @@ class DefaultMessage:
         self.run_until = self._validate_run_until(payload.get("runUntil"))
 
         # 4. Validate generateCFRTransparencyFile
-        self.generate_cfr_transparency_file = self._validate_generate_cfr_transparency_file(
-            payload.get("generateCFRTransparencyFile", False)
+        self.generate_cfr_transparency_file = (
+            self._validate_generate_cfr_transparency_file(
+                payload.get("generateCFRTransparencyFile", False)
+            )
         )
 
     def _validate_run_until(

--- a/data-pipeline/tests/unit/test_main_run_until.py
+++ b/data-pipeline/tests/unit/test_main_run_until.py
@@ -68,6 +68,7 @@ def test_handle_msg_run_until_preprocessing(
         bfr_year=2022,
         s251_year=2021,
         run_until="pre-processing",
+        generate_cfr_transparency_file=False,
     )
     # RAG and Comparators should NOT be called
     mock_comparators.assert_not_called()
@@ -77,6 +78,44 @@ def test_handle_msg_run_until_preprocessing(
     mock_worker_queue.delete_message.assert_called_once_with(mock_msg)
     # Complete queue failure message should be sent
     mock_complete_queue.send_message.assert_called_once()
+
+
+@patch("pipeline.main.pre_process_data")
+@patch("pipeline.main.run_comparator_sets_pipeline")
+@patch("pipeline.main.run_rag_pipeline")
+def test_handle_msg_generate_cfr_transparency_true(
+    mock_rag, mock_comparators, mock_pre_process
+):
+    # Arrange
+    msg_payload = {
+        "runId": 2023,
+        "year": {"aar": 2022, "cfr": 2023, "bfr": 2022, "s251": 2021},
+        "generateCFRTransparencyFile": True,
+    }
+
+    mock_msg = MagicMock(spec=QueueMessage)
+    mock_msg.content = json.dumps(msg_payload)
+
+    mock_worker_queue = MagicMock()
+    mock_complete_queue = MagicMock()
+
+    mock_pre_process.return_value = 10.0
+    mock_comparators.return_value = 5.0
+    mock_rag.return_value = 8.0
+
+    # Act
+    handle_msg(mock_msg, mock_worker_queue, mock_complete_queue)
+
+    # Assert
+    mock_pre_process.assert_called_once_with(
+        run_id="2023",
+        aar_year=2022,
+        cfr_year=2023,
+        bfr_year=2022,
+        s251_year=2021,
+        run_until=None,
+        generate_cfr_transparency_file=True,
+    )
 
 
 @patch("pipeline.main.pre_process_data")

--- a/data-pipeline/tests/unit/test_main_run_until.py
+++ b/data-pipeline/tests/unit/test_main_run_until.py
@@ -90,7 +90,7 @@ def test_handle_msg_generate_cfr_transparency_true(
     msg_payload = {
         "runId": 2023,
         "year": {"aar": 2022, "cfr": 2023, "bfr": 2022, "s251": 2021},
-        "generateCFRTransparencyFile": True,
+        "generateTransparencyFilesAndPrecursorFiles": True,
     }
 
     mock_msg = MagicMock(spec=QueueMessage)

--- a/data-pipeline/tests/unit/utils/test_message.py
+++ b/data-pipeline/tests/unit/utils/test_message.py
@@ -44,14 +44,9 @@ def test_check_run_until_gate_none():
 def test_default_message_validation_success():
     payload = {
         "runId": 2026,
-        "year": {
-            "aar": 2025,
-            "cfr": 2026,
-            "bfr": 2026,
-            "s251": 2025
-        },
+        "year": {"aar": 2025, "cfr": 2026, "bfr": 2026, "s251": 2025},
         "runUntil": "pre-processing",
-        "generateCFRTransparencyFile": True
+        "generateCFRTransparencyFile": True,
     }
     msg = DefaultMessage(payload)
     assert msg.run_id == "2026"
@@ -66,12 +61,7 @@ def test_default_message_validation_success():
 def test_default_message_defaults():
     payload = {
         "runId": "2026-run",
-        "year": {
-            "aar": "2025",
-            "cfr": "2026",
-            "bfr": "2026",
-            "s251": "2025"
-        }
+        "year": {"aar": "2025", "cfr": "2026", "bfr": "2026", "s251": "2025"},
     }
     msg = DefaultMessage(payload)
     assert msg.run_id == "2026-run"
@@ -80,9 +70,7 @@ def test_default_message_defaults():
 
 
 def test_default_message_missing_run_id():
-    payload = {
-        "year": {"aar": 2025, "cfr": 2026, "bfr": 2026, "s251": 2025}
-    }
+    payload = {"year": {"aar": 2025, "cfr": 2026, "bfr": 2026, "s251": 2025}}
     with pytest.raises(ValueError) as exc:
         DefaultMessage(payload)
     assert "runId is required" in str(exc.value)
@@ -91,7 +79,7 @@ def test_default_message_missing_run_id():
 def test_default_message_explicit_none_run_id():
     payload = {
         "runId": None,
-        "year": {"aar": 2025, "cfr": 2026, "bfr": 2026, "s251": 2025}
+        "year": {"aar": 2025, "cfr": 2026, "bfr": 2026, "s251": 2025},
     }
     with pytest.raises(ValueError) as exc:
         DefaultMessage(payload)
@@ -101,7 +89,7 @@ def test_default_message_explicit_none_run_id():
 def test_default_message_empty_string_run_id():
     payload = {
         "runId": "",
-        "year": {"aar": 2025, "cfr": 2026, "bfr": 2026, "s251": 2025}
+        "year": {"aar": 2025, "cfr": 2026, "bfr": 2026, "s251": 2025},
     }
     with pytest.raises(ValueError) as exc:
         DefaultMessage(payload)
@@ -109,20 +97,14 @@ def test_default_message_empty_string_run_id():
 
 
 def test_default_message_invalid_year_type():
-    payload = {
-        "runId": 2026,
-        "year": "invalid"
-    }
+    payload = {"runId": 2026, "year": "invalid"}
     with pytest.raises(ValueError) as exc:
         DefaultMessage(payload)
     assert "year must be a dictionary" in str(exc.value)
 
 
 def test_default_message_missing_years():
-    payload = {
-        "runId": 2026,
-        "year": {"aar": 2025}
-    }
+    payload = {"runId": 2026, "year": {"aar": 2025}}
     with pytest.raises(ValueError) as exc:
         DefaultMessage(payload)
     assert "Missing required years" in str(exc.value)
@@ -131,7 +113,7 @@ def test_default_message_missing_years():
 def test_default_message_invalid_year_values():
     payload = {
         "runId": 2026,
-        "year": {"aar": "abc", "cfr": 2026, "bfr": 2026, "s251": 2025}
+        "year": {"aar": "abc", "cfr": 2026, "bfr": 2026, "s251": 2025},
     }
     with pytest.raises(ValueError) as exc:
         DefaultMessage(payload)
@@ -142,7 +124,7 @@ def test_default_message_invalid_run_until():
     payload = {
         "runId": 2026,
         "year": {"aar": 2025, "cfr": 2026, "bfr": 2026, "s251": 2025},
-        "runUntil": "invalid-stage"
+        "runUntil": "invalid-stage",
     }
     with pytest.raises(ValueError) as exc:
         DefaultMessage(payload)
@@ -153,7 +135,7 @@ def test_default_message_invalid_generate_cfr():
     payload = {
         "runId": 2026,
         "year": {"aar": 2025, "cfr": 2026, "bfr": 2026, "s251": 2025},
-        "generateCFRTransparencyFile": "not-a-bool"
+        "generateCFRTransparencyFile": "not-a-bool",
     }
     with pytest.raises(ValueError) as exc:
         DefaultMessage(payload)

--- a/data-pipeline/tests/unit/utils/test_message.py
+++ b/data-pipeline/tests/unit/utils/test_message.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pipeline.utils.message import (
+    DefaultMessage,
     MessageType,
     PipelineEarlyExit,
     check_run_until_gate,
@@ -38,3 +39,122 @@ def test_check_run_until_gate_different():
 def test_check_run_until_gate_none():
     # Should not raise any exception
     check_run_until_gate("pre-processing", None)
+
+
+def test_default_message_validation_success():
+    payload = {
+        "runId": 2026,
+        "year": {
+            "aar": 2025,
+            "cfr": 2026,
+            "bfr": 2026,
+            "s251": 2025
+        },
+        "runUntil": "pre-processing",
+        "generateCFRTransparencyFile": True
+    }
+    msg = DefaultMessage(payload)
+    assert msg.run_id == "2026"
+    assert msg.aar_year == 2025
+    assert msg.cfr_year == 2026
+    assert msg.bfr_year == 2026
+    assert msg.s251_year == 2025
+    assert msg.run_until == "pre-processing"
+    assert msg.generate_cfr_transparency_file is True
+
+
+def test_default_message_defaults():
+    payload = {
+        "runId": "2026-run",
+        "year": {
+            "aar": "2025",
+            "cfr": "2026",
+            "bfr": "2026",
+            "s251": "2025"
+        }
+    }
+    msg = DefaultMessage(payload)
+    assert msg.run_id == "2026-run"
+    assert msg.generate_cfr_transparency_file is False
+    assert msg.run_until is None
+
+
+def test_default_message_missing_run_id():
+    payload = {
+        "year": {"aar": 2025, "cfr": 2026, "bfr": 2026, "s251": 2025}
+    }
+    with pytest.raises(ValueError) as exc:
+        DefaultMessage(payload)
+    assert "runId is required" in str(exc.value)
+
+
+def test_default_message_explicit_none_run_id():
+    payload = {
+        "runId": None,
+        "year": {"aar": 2025, "cfr": 2026, "bfr": 2026, "s251": 2025}
+    }
+    with pytest.raises(ValueError) as exc:
+        DefaultMessage(payload)
+    assert "runId is required" in str(exc.value)
+
+
+def test_default_message_empty_string_run_id():
+    payload = {
+        "runId": "",
+        "year": {"aar": 2025, "cfr": 2026, "bfr": 2026, "s251": 2025}
+    }
+    with pytest.raises(ValueError) as exc:
+        DefaultMessage(payload)
+    assert "runId is required" in str(exc.value)
+
+
+def test_default_message_invalid_year_type():
+    payload = {
+        "runId": 2026,
+        "year": "invalid"
+    }
+    with pytest.raises(ValueError) as exc:
+        DefaultMessage(payload)
+    assert "year must be a dictionary" in str(exc.value)
+
+
+def test_default_message_missing_years():
+    payload = {
+        "runId": 2026,
+        "year": {"aar": 2025}
+    }
+    with pytest.raises(ValueError) as exc:
+        DefaultMessage(payload)
+    assert "Missing required years" in str(exc.value)
+
+
+def test_default_message_invalid_year_values():
+    payload = {
+        "runId": 2026,
+        "year": {"aar": "abc", "cfr": 2026, "bfr": 2026, "s251": 2025}
+    }
+    with pytest.raises(ValueError) as exc:
+        DefaultMessage(payload)
+    assert "Year fields must be integers" in str(exc.value)
+
+
+def test_default_message_invalid_run_until():
+    payload = {
+        "runId": 2026,
+        "year": {"aar": 2025, "cfr": 2026, "bfr": 2026, "s251": 2025},
+        "runUntil": "invalid-stage"
+    }
+    with pytest.raises(ValueError) as exc:
+        DefaultMessage(payload)
+    assert "Invalid runUntil value" in str(exc.value)
+
+
+def test_default_message_invalid_generate_cfr():
+    payload = {
+        "runId": 2026,
+        "year": {"aar": 2025, "cfr": 2026, "bfr": 2026, "s251": 2025},
+        "generateCFRTransparencyFile": "not-a-bool"
+    }
+    with pytest.raises(ValueError) as exc:
+        DefaultMessage(payload)
+    assert "generateCFRTransparencyFile value" in str(exc.value)

--- a/data-pipeline/tests/unit/utils/test_message.py
+++ b/data-pipeline/tests/unit/utils/test_message.py
@@ -46,7 +46,7 @@ def test_default_message_validation_success():
         "runId": 2026,
         "year": {"aar": 2025, "cfr": 2026, "bfr": 2026, "s251": 2025},
         "runUntil": "pre-processing",
-        "generateCFRTransparencyFile": True,
+        "generateTransparencyFilesAndPrecursorFiles": True,
     }
     msg = DefaultMessage(payload)
     assert msg.run_id == "2026"
@@ -135,8 +135,8 @@ def test_default_message_invalid_generate_cfr():
     payload = {
         "runId": 2026,
         "year": {"aar": 2025, "cfr": 2026, "bfr": 2026, "s251": 2025},
-        "generateCFRTransparencyFile": "not-a-bool",
+        "generateTransparencyFilesAndPrecursorFiles": "not-a-bool",
     }
     with pytest.raises(ValueError) as exc:
         DefaultMessage(payload)
-    assert "generateCFRTransparencyFile value" in str(exc.value)
+    assert "generateTransparencyFilesAndPrecursorFiles value" in str(exc.value)

--- a/documentation/data/05_Releases.md
+++ b/documentation/data/05_Releases.md
@@ -66,7 +66,7 @@ Once the respective data has been loaded to the Azure Storage Container, the pip
         "s251": <YYYY>
     },
     "runUntil": <runUntilValue>,
-    "generateCFRTransparencyFile": <bool>,
+    "generateCFRTransparencyFile": <bool>
 }
  ```
 

--- a/documentation/data/05_Releases.md
+++ b/documentation/data/05_Releases.md
@@ -65,11 +65,14 @@ Once the respective data has been loaded to the Azure Storage Container, the pip
         "bfr": <YYYY>,
         "s251": <YYYY>
     },
-    "runUntil": "<runUntilValue>"
+    "runUntil": <runUntilValue>,
+    "generateCFRTransparencyFile": <bool>,
 }
  ```
 
 > **Note:** The `runUntil` parameter is optional. Allowed values are `"transparency-file"`, `"pre-processing"`, or `"comparators"` to stop the pipeline early after the specified stage. Omitting the parameter will run the pipeline to completion (full run).
+
+> **Note:** The `generateCFRTransparencyFile` parameter is an optional boolean defaulting to `false`. When set to `true`, the pipeline will regenerate the CFR transparency file (including Master List and Download File) from raw inputs during pre-processing. If omitted or set to `false`, the pipeline will skip generation and directly load the pre-existing master list.
 
 where `<YYYY>` is to be replaced by the respective submission year, for example, for `2022-2023`, `<YYYY>` would take the value of `2023`. Ensure that `Store As` is assigned as `Plain UTF-8`, and set the `Time to live` value to `Expire in` with some period, e.g. 1 Day. Click `OK` to queue the message. This should then be picked up and the pipeline executed. You can monitor the pipeline in the respective Application Insights logs through the Azure portal.
 

--- a/documentation/data/05_Releases.md
+++ b/documentation/data/05_Releases.md
@@ -66,13 +66,13 @@ Once the respective data has been loaded to the Azure Storage Container, the pip
         "s251": <YYYY>
     },
     "runUntil": <runUntilValue>,
-    "generateCFRTransparencyFile": <bool>
+    "generateTransparencyFilesAndPrecursorFiles": <bool>
 }
  ```
 
 > **Note:** The `runUntil` parameter is optional. Allowed values are `"transparency-file"`, `"pre-processing"`, or `"comparators"` to stop the pipeline early after the specified stage. Omitting the parameter will run the pipeline to completion (full run).
 
-> **Note:** The `generateCFRTransparencyFile` parameter is an optional boolean defaulting to `false`. When set to `true`, the pipeline will regenerate the CFR transparency file (including Master List and Download File) from raw inputs during pre-processing. If omitted or set to `false`, the pipeline will skip generation and directly load the pre-existing master list.
+> **Note:** The `generateTransparencyFilesAndPrecursorFiles` parameter is an optional boolean defaulting to `false`. When set to `true`, the pipeline will regenerate the CFR transparency file (including Master List and Download File) from raw inputs during pre-processing. If omitted or set to `false`, the pipeline will skip generation and directly load the pre-existing master list.
 
 where `<YYYY>` is to be replaced by the respective submission year, for example, for `2022-2023`, `<YYYY>` would take the value of `2023`. Ensure that `Store As` is assigned as `Plain UTF-8`, and set the `Time to live` value to `Expire in` with some period, e.g. 1 Day. Click `OK` to queue the message. This should then be picked up and the pipeline executed. You can monitor the pipeline in the respective Application Insights logs through the Azure portal.
 

--- a/documentation/guides/data-release-guide/01_Overview.md
+++ b/documentation/guides/data-release-guide/01_Overview.md
@@ -78,7 +78,7 @@ To trigger a pipeline run once data is prepared, add a message to the `data-pipe
     "s251": <year>
   },
   "runUntil": <runUntilValue>,
-  "generateCFRTransparencyFile": <bool>,
+  "generateCFRTransparencyFile": <bool>
 }
 ```
 

--- a/documentation/guides/data-release-guide/01_Overview.md
+++ b/documentation/guides/data-release-guide/01_Overview.md
@@ -78,13 +78,13 @@ To trigger a pipeline run once data is prepared, add a message to the `data-pipe
     "s251": <year>
   },
   "runUntil": <runUntilValue>,
-  "generateCFRTransparencyFile": <bool>
+  "generateTransparencyFilesAndPrecursorFiles": <bool>
 }
 ```
 
 > **Note:** The `runUntil` parameter is optional. Allowed values are `"transparency-file"`, `"pre-processing"`, or `"comparators"` to stop the pipeline early after the specified stage. Omitting the parameter will run the pipeline to completion (full run).
 
-> **Note:** The `generateCFRTransparencyFile` parameter is an optional boolean defaulting to `false`. When set to `true`, the pipeline will regenerate the CFR transparency file (including Master List and Download File) from raw inputs during pre-processing. If omitted or set to `false`, the pipeline will skip generation and directly load the pre-existing master list.
+> **Note:** The `generateTransparencyFilesAndPrecursorFiles` parameter is an optional boolean defaulting to `false`. When set to `true`, the pipeline will regenerate the CFR transparency file (including Master List and Download File) from raw inputs during pre-processing. If omitted or set to `false`, the pipeline will skip generation and directly load the pre-existing master list.
 
 ### What year to use in data pipeline runs
 

--- a/documentation/guides/data-release-guide/01_Overview.md
+++ b/documentation/guides/data-release-guide/01_Overview.md
@@ -77,11 +77,14 @@ To trigger a pipeline run once data is prepared, add a message to the `data-pipe
     "bfr": <year>,
     "s251": <year>
   },
-  "runUntil": "<runUntilValue>"
+  "runUntil": <runUntilValue>,
+  "generateCFRTransparencyFile": <bool>,
 }
 ```
 
 > **Note:** The `runUntil` parameter is optional. Allowed values are `"transparency-file"`, `"pre-processing"`, or `"comparators"` to stop the pipeline early after the specified stage. Omitting the parameter will run the pipeline to completion (full run).
+
+> **Note:** The `generateCFRTransparencyFile` parameter is an optional boolean defaulting to `false`. When set to `true`, the pipeline will regenerate the CFR transparency file (including Master List and Download File) from raw inputs during pre-processing. If omitted or set to `false`, the pipeline will skip generation and directly load the pre-existing master list.
 
 ### What year to use in data pipeline runs
 

--- a/documentation/quality-assurance/release-test-plans/00034_release-test-plan.md
+++ b/documentation/quality-assurance/release-test-plans/00034_release-test-plan.md
@@ -103,4 +103,4 @@ Release completed successfully and all smoke and sanity tests passed. Filters ha
 | Sanity Tests - Pre Prod |      1      |   1    |   0    |   100%    |
 | Total                   |      3      |   3    |   0    |   100%    |
 
-\newpagepage
+\newpage


### PR DESCRIPTION
## Summary 🧾
Introduces a new optional boolean parameter `generateTransparencyFilesAndPrecursorFiles`, in the default data pipeline start message. This allows users to control whether the CFR transparency file (Master List and Download File) is regenerated from raw inputs during the pre-processing stage. When set to `false` or omitted, the pipeline skips transparency file generation, avoiding unnecessary data fetches and reducing pipeline runtime. It also adds logging during CFR transparency file generation.

 [AB#323597](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/323597)
 [AB#323825](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/323825)

Note: PR, Implementation, Tests, and Docs all used Gemini ♊ 

 ## Feature Details ✨ 
  > - Functionality: 
  >   - Adds the optional generateTransparencyFilesAndPrecursorFiles boolean flag (defaulting to false) to the default data pipeline queue message payload.
  >   - When set to true, the pipeline regenerates the CFR transparency files from raw inputs. When false or omitted, the pipeline bypasses this generation and avoids loading last year's ancillary data, speeding up typical runs.
  >   - Introduces granular step-by-step logging within the CFR transparency generator to trace processing stages, DataFrame shapes, and execution milestones.
  > - Implementation:
  >   - Message Parsing & Robust Validation: Replaced the legacy validate_run_until helper with a new structured DefaultMessage class in pipeline.utils.message. This class encapsulates schema parsing, type checks (e.g. integer casting for year fields, boolean
  validation for generateTransparencyFilesAndPrecursorFiles), and structure verification for the incoming queue message.
  >   - Pipeline Integration: Integrated DefaultMessage validation in the pipeline entrypoint (pipeline/main.py) and propagated the flag down to pre_process_data and pre_process_maintained_schools_data in pipeline/pre_processing/main.py.
  >   - Decoupled Generation Logic: Decoupled CFR transparency file generation from the hardcoded year condition (year >= 2025) and conditionalized both generation and the last year's ancillary data fetching on the generateTransparencyFilesAndPrecursorFiles parameter.
  >   - Observability: Added structured loggers to trace the size and progression of dataframes (e.g. raw CFR, federation context, financials, formatting) inside pipeline/pre_processing/cfr/transparency_file/generator.py.

  ## ✅ Checklist
   - [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
   - [x] Unit and integration tests added/updated (if applicable).
   - [x] Tested by running locally (or docs render correctly locally).
   - [x] Relevant documentation updated (if applicable).
   - [ ] Screenshots or Demo included (for UI/frontend changes).