### PR TITLE
feat: join function apps onto vnet without using swift connection resource

### DIFF
--- a/platform/terraform/modules/fc_function_app/main.tf
+++ b/platform/terraform/modules/fc_function_app/main.tf
@@ -204,7 +204,7 @@ resource "azurerm_function_app_flex_consumption" "func-app" {
   runtime_name                      = var.application_stack.worker_runtime
   runtime_version                   = var.application_stack.runtime_version
   https_only                        = true
-  virtual_network_subnet_id         = var.networking.join_subnet_id
+  virtual_network_subnet_id         = var.networking.join_subnet_id == "" ? null : var.networking.join_subnet_id
 
   identity {
     type         = "SystemAssigned, UserAssigned"

--- a/platform/terraform/modules/fc_function_app/main.tf
+++ b/platform/terraform/modules/fc_function_app/main.tf
@@ -204,6 +204,7 @@ resource "azurerm_function_app_flex_consumption" "func-app" {
   runtime_name                      = var.application_stack.worker_runtime
   runtime_version                   = var.application_stack.runtime_version
   https_only                        = true
+  virtual_network_subnet_id         = var.networking.join_subnet_id
 
   identity {
     type         = "SystemAssigned, UserAssigned"
@@ -224,10 +225,6 @@ resource "azurerm_function_app_flex_consumption" "func-app" {
 
   app_settings = local.function-app-settings
   tags         = var.core.tags
-
-  lifecycle {
-    ignore_changes = [virtual_network_subnet_id]
-  }
 
   depends_on = [
     azurerm_role_assignment.storage-data-owner
@@ -298,10 +295,4 @@ resource "azurerm_monitor_diagnostic_setting" "func-app-service" {
   enabled_metric {
     category = "AllMetrics"
   }
-}
-
-# join the func app onto the required vnet
-resource "azurerm_app_service_virtual_network_swift_connection" "func-app-subnet" {
-  app_service_id = azurerm_function_app_flex_consumption.func-app.id
-  subnet_id      = var.networking.join_subnet_id
 }

--- a/platform/terraform/modules/function_app/main.tf
+++ b/platform/terraform/modules/function_app/main.tf
@@ -78,7 +78,7 @@ resource "azurerm_linux_function_app" "func-app" {
   storage_account_access_key = var.storage_account.key
   https_only                 = true
   builtin_logging_enabled    = false
-  virtual_network_subnet_id  = var.networking.join_subnet_id
+  virtual_network_subnet_id  = var.networking.join_subnet_id == "" ? null : var.networking.join_subnet_id
 
   identity {
     type = "SystemAssigned"

--- a/platform/terraform/modules/function_app/main.tf
+++ b/platform/terraform/modules/function_app/main.tf
@@ -78,6 +78,7 @@ resource "azurerm_linux_function_app" "func-app" {
   storage_account_access_key = var.storage_account.key
   https_only                 = true
   builtin_logging_enabled    = false
+  virtual_network_subnet_id  = var.networking.join_subnet_id
 
   identity {
     type = "SystemAssigned"
@@ -234,11 +235,4 @@ resource "azurerm_monitor_diagnostic_setting" "func-app-service" {
   enabled_metric {
     category = "AllMetrics"
   }
-}
-
-# conditionally join the func app onto a vnet
-resource "azurerm_app_service_virtual_network_swift_connection" "func-app-subnet" {
-  count          = var.networking.join_subnet_id == "" ? 0 : 1
-  app_service_id = local.func_app_id
-  subnet_id      = var.networking.join_subnet_id
 }

--- a/platform/terraform/modules/function_app/main.tf
+++ b/platform/terraform/modules/function_app/main.tf
@@ -28,6 +28,7 @@ resource "azurerm_windows_function_app" "func-app" {
   storage_account_access_key = var.storage_account.key
   https_only                 = true
   builtin_logging_enabled    = false
+  virtual_network_subnet_id  = var.networking.join_subnet_id == "" ? null : var.networking.join_subnet_id
 
   identity {
     type = "SystemAssigned"


### PR DESCRIPTION
## 🧾 Summary
> Briefly describe the changes and why they are needed.

<!-- List related work items -->
[AB#316772](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/316772)
[AB#324024](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/324024)

### 🛠️ Bug Fix Description
> - **Root Cause:** Orchestrator function app was losing its vnet association on subsequent deployments after the first
> - **Changes:** Changed the Terraform such that all function apps use the `virtual_network_subnet_id` property directly in the resource rather than using a separate `azurerm_app_service_virtual_network_swift_connection` resource to join the func app to the vnet


## ✅ Checklist
- [x] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [ ] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes
> Add any additional context for reviewers, required dependencies, or specific testing instructions.

Tested with deployments onto d14 feature environment