### PR TITLE
fix: add `runUntil` and `generateTransparencyFilesAndPrecursorFiles` parameters to Pipeline start message schema in Orchestrator

### DIFF
--- a/platform/src/abstractions/Platform.Domain/Messages/PipelineStart.cs
+++ b/platform/src/abstractions/Platform.Domain/Messages/PipelineStart.cs
@@ -27,4 +27,8 @@ public abstract record PipelineStart
     /// |
     /// <c>custom</c>
     public string? RunType { get; set; }
+
+    public string? RunUntil { get; set; }
+
+    public bool? GenerateTransparencyFilesAndPrecursorFiles { get; set; }
 }

--- a/platform/src/abstractions/Platform.Domain/Messages/PipelineStartCustom.cs
+++ b/platform/src/abstractions/Platform.Domain/Messages/PipelineStartCustom.cs
@@ -39,7 +39,9 @@ public record PipelineStartCustom : PipelineStart
             RunId = input.RunId?.ToString(),
             Year = year,
             URN = input.URN,
-            Payload = input.Payload
+            Payload = input.Payload,
+            RunUntil = input.RunUntil,
+            GenerateTransparencyFilesAndPrecursorFiles = input.GenerateTransparencyFilesAndPrecursorFiles
         };
     }
 }

--- a/platform/src/abstractions/Platform.Domain/Messages/PipelineStartDefault.cs
+++ b/platform/src/abstractions/Platform.Domain/Messages/PipelineStartDefault.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json.Linq;
 
 // ReSharper disable MemberCanBePrivate.Global
@@ -46,7 +46,9 @@ public record PipelineStartDefault : PipelineStart
             Type = input.Type,
             RunType = input.RunType,
             RunId = runId,
-            Year = year
+            Year = year,
+            RunUntil = input.RunUntil,
+            GenerateTransparencyFilesAndPrecursorFiles = input.GenerateTransparencyFilesAndPrecursorFiles
         };
     }
 }

--- a/platform/src/abstractions/tests/Platform.Domain.Tests/Messages/WhenPipelineStartDefaultCreatesFromPending.cs
+++ b/platform/src/abstractions/tests/Platform.Domain.Tests/Messages/WhenPipelineStartDefaultCreatesFromPending.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using Platform.Domain.Messages;
 using Xunit;
 
@@ -15,6 +15,8 @@ public class WhenPipelineStartDefaultCreatesFromPending
             RunId = 2020,
             RunType = "runType",
             Type = "type",
+            RunUntil = "pre-processing",
+            GenerateTransparencyFilesAndPrecursorFiles = true,
             Year = JObject.FromObject(new PipelineMessageYears
             {
                 Aar = 2021,
@@ -32,6 +34,8 @@ public class WhenPipelineStartDefaultCreatesFromPending
             RunId = 2020,
             RunType = "runType",
             Type = "type",
+            RunUntil = "pre-processing",
+            GenerateTransparencyFilesAndPrecursorFiles = true,
             Year = new PipelineMessageYears
             {
                 Aar = 2021,

--- a/platform/tests/Platform.Orchestrator.Tests/Functions/ActivityTrigger/WhenPipelineStartDefaultJobTriggered.cs
+++ b/platform/tests/Platform.Orchestrator.Tests/Functions/ActivityTrigger/WhenPipelineStartDefaultJobTriggered.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker;
 using Platform.Domain.Messages;
 using Platform.Orchestrator.Functions;
 using Xunit;
@@ -29,6 +29,58 @@ public class WhenPipelineStartDefaultJobTriggered(ITestOutputHelper testOutputHe
         var result = Functions.OnStartDefaultJobTrigger(message);
 
         const string expected = """{"runId":2020,"year":{"aar":2021,"cfr":2023,"bfr":2022,"s251":2024},"jobId":"jobId","type":"type","runType":"runType"}""";
+        Assert.Single(result);
+        Assert.Equal(expected, result.Single());
+    }
+
+    [Fact]
+    public void ShouldReturnSerializedMessageArrayWithRunUntil()
+    {
+        var message = new PipelineStartDefault
+        {
+            JobId = "jobId",
+            RunId = 2020,
+            RunType = "runType",
+            Type = "type",
+            RunUntil = "pre-processing",
+            Year = new PipelineMessageYears
+            {
+                Aar = 2021,
+                Bfr = 2022,
+                Cfr = 2023,
+                S251 = 2024
+            }
+        };
+
+        var result = Functions.OnStartDefaultJobTrigger(message);
+
+        const string expected = """{"runId":2020,"year":{"aar":2021,"cfr":2023,"bfr":2022,"s251":2024},"jobId":"jobId","type":"type","runType":"runType","runUntil":"pre-processing"}""";
+        Assert.Single(result);
+        Assert.Equal(expected, result.Single());
+    }
+
+    [Fact]
+    public void ShouldReturnSerializedMessageArrayWithGenerateTransparencyFilesAndPrecursorFiles()
+    {
+        var message = new PipelineStartDefault
+        {
+            JobId = "jobId",
+            RunId = 2020,
+            RunType = "runType",
+            Type = "type",
+            GenerateTransparencyFilesAndPrecursorFiles = true,
+            Year = new PipelineMessageYears
+            {
+                Aar = 2021,
+                Bfr = 2022,
+                Cfr = 2023,
+                S251 = 2024
+            }
+        };
+
+        var result = Functions.OnStartDefaultJobTrigger(message);
+
+        const string expected = """{"runId":2020,"year":{"aar":2021,"cfr":2023,"bfr":2022,"s251":2024},"jobId":"jobId","type":"type","runType":"runType","generateTransparencyFilesAndPrecursorFiles":true}""";
         Assert.Single(result);
         Assert.Equal(expected, result.Single());
     }

--- a/platform/tests/Platform.Orchestrator.Tests/Search/WhenPipelineStartDefaultMessageCreatesFromPending.cs
+++ b/platform/tests/Platform.Orchestrator.Tests/Search/WhenPipelineStartDefaultMessageCreatesFromPending.cs
@@ -15,12 +15,16 @@ public class WhenPipelineStartDefaultMessageCreatesFromPending
     {
         const int runId = 2024;
         const string type = Pipeline.JobType.Default;
+        const string runUntil = "pre-processing";
+        const bool generateTransparencyFilesAndPrecursorFiles = true;
         var year = _fixture.Create<PipelineMessageYears>();
 
         var input = new PipelinePending
         {
             RunId = runId,
             Type = type,
+            RunUntil = runUntil,
+            GenerateTransparencyFilesAndPrecursorFiles = generateTransparencyFilesAndPrecursorFiles,
             Year = JObject.FromObject(year)
         };
 
@@ -28,6 +32,8 @@ public class WhenPipelineStartDefaultMessageCreatesFromPending
         Assert.Equal(runId, result.RunId);
         Assert.Equal(type, result.Type);
         Assert.Equal(year, result.Year);
+        Assert.Equal(runUntil, result.RunUntil);
+        Assert.Equal(generateTransparencyFilesAndPrecursorFiles, result.GenerateTransparencyFilesAndPrecursorFiles);
     }
 
     [Theory]


### PR DESCRIPTION
## 🧾 Summary
Add `runUntil` and `generateTransparencyFilesAndPrecursorFiles` to orchestrator, to facilitate: #4384 #4390

[AB#323597](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/323597)

Note: Code and tests by Gemini ♊ 

### 🛠️ Bug Fix Description
> - **Root Cause:** The orchestrator didn't expect new variables in the pipeline start message, and so wasn't passing them to the data pipeline correctly between queues
> - **Changes:** Add the new parameters to the orchestrator

## ✅ Checklist
- [ ] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [ ] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes
> Add any additional context for reviewers, required dependencies, or specific testing instructions.
