### PR TITLE
feat: Add `LASchoolRiskIndicators` and `LASchoolRiskIndicatorsHeaders` tables to db

### DIFF
--- a/core-infrastructure/src/db/Core.Database/Scripts/137-CreateLAARiskMetricTables.sql
+++ b/core-infrastructure/src/db/Core.Database/Scripts/137-CreateLAARiskMetricTables.sql
@@ -1,0 +1,40 @@
+IF NOT EXISTS(SELECT *
+              FROM INFORMATION_SCHEMA.TABLES
+              WHERE table_name = 'LASchoolRiskIndicators')
+    BEGIN
+        CREATE TABLE dbo.LASchoolRiskIndicators
+        (
+            URN                        nvarchar(6)  NOT NULL,
+            RunId                      nvarchar(50) NOT NULL,
+            RiskGroup                  nvarchar(50) NULL,
+            RiskIndicator              nvarchar(50) NOT NULL,
+            RiskIndicatorValue         decimal      NULL,
+            RiskIndicatorFlag          nvarchar(50) NULL,
+            RiskIndicatorContribution    decimal      NULL,
+            RiskIndicatorContributionMax decimal      NULL,
+
+            CONSTRAINT PK_LASchoolRiskIndicators PRIMARY KEY (URN, RunId, RiskIndicator)
+        );
+    END;
+
+IF NOT EXISTS(SELECT *
+              FROM INFORMATION_SCHEMA.TABLES
+              WHERE table_name = 'LASchoolRiskIndicatorsHeaders')
+    BEGIN
+        CREATE TABLE dbo.LASchoolRiskIndicatorsHeaders
+        (
+            URN                        nvarchar(6)  NOT NULL,
+            RunId                      nvarchar(50) NOT NULL,
+            EducationalPerformance     decimal      NULL,
+            EducationalPerformanceMax  decimal      NULL,
+            Financial                  decimal      NULL,
+            FinancialMax               decimal      NULL,
+            SchoolAndPupil             decimal      NULL,
+            SchoolAndPupilMax          decimal      NULL,
+            Overall                    decimal      NULL,
+            OverallMax                 decimal      NULL,
+            OverallGrade               nvarchar(50) NULL,
+
+            CONSTRAINT PK_LASchoolRiskIndicatorsHeaders PRIMARY KEY (URN, RunId)
+        );
+    END;


### PR DESCRIPTION
## 🧾 Summary
Add `LASchoolRiskIndicators` and `LASchoolRiskIndicatorsHeaders` tables to db. This allows the frontend work to work on dummy values in the tables while the data pipeline logic to fill the tables is developed.

[AB#319975](https://dfe-ssp.visualstudio.com/a14e55df-4fbf-4a2f-a11d-22b187178343/_workitems/edit/319975)

### ✨ Feature Details
- **Functionality:** Add `LASchoolRiskIndicators` and `LASchoolRiskIndicatorsHeaders` tables to db.

## ✅ Checklist
- [ ] Code follows project coding standards (e.g., Trunk-based guidelines, small PR size).
- [ ] Unit and integration tests added/updated _(if applicable)_.
- [ ] Tested by running locally _(or docs render correctly locally)_.
- [ ] Relevant documentation updated _(if applicable)_.
- [ ] Screenshots or Demo included _(for UI/frontend changes)_.

## 🔍 Notes
> Add any additional context for reviewers, required dependencies, or specific testing instructions.
